### PR TITLE
Add 'Last restored' subtitle under Restore button

### DIFF
--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -11,6 +11,7 @@ export interface Settings {
   oneDriveCustomPath: string;
   autoSync: boolean;
   lastSync: number | null;
+  lastRestore: number | null;
 }
 
 const KEY = 'sk_settings';
@@ -22,6 +23,7 @@ const defaults: Settings = {
   oneDriveCustomPath: '',
   autoSync: false,
   lastSync: null,
+  lastRestore: null,
 };
 
 function load(): Settings {
@@ -54,4 +56,8 @@ export function toggleTheme() {
 
 export function markSynced(ts: number) {
   settings.update((s) => ({ ...s, lastSync: ts }));
+}
+
+export function markRestored(ts: number) {
+  settings.update((s) => ({ ...s, lastRestore: ts }));
 }

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { settings, toggleTheme, markSynced } from '../lib/stores/settings';
+  import { settings, toggleTheme, markSynced, markRestored } from '../lib/stores/settings';
   import { buildSnapshot, restoreSnapshot, getOneDrive } from '../lib/storage/sync';
   import { ONEDRIVE_CLIENT_ID } from '../lib/config';
   import { refreshGames } from '../lib/stores/games';
@@ -108,6 +108,7 @@
       await restoreSnapshot(snap);
       await refreshPlayers();
       await refreshGames();
+      markRestored(Date.now());
       showToast('Restored from OneDrive');
     } catch (e) {
       showToast(errMsg(e));
@@ -186,6 +187,9 @@
       </div>
       <div class="muted sm">
         {$settings.lastSync ? 'Last backup ' + formatDateTime($settings.lastSync) : 'Not backed up yet'}
+      </div>
+      <div class="muted sm">
+        {$settings.lastRestore ? 'Last restored ' + formatDateTime($settings.lastRestore) : 'Not restored yet'}
       </div>
     {:else}
       <div class="muted sm">


### PR DESCRIPTION
Adds a **'Last restored'** subtitle under the **Restore** button, mirroring the existing **'Last backup'** subtitle under **Back up now**.

### Changes
- `src/lib/stores/settings.ts`: add `lastRestore: number | null` to the `Settings` type + defaults, and a `markRestored(ts)` helper that mirrors `markSynced(ts)` exactly.
- `src/pages/Settings.svelte`: call `markRestored(Date.now())` after a successful restore, and render `Last restored <time>` (placeholder `Not restored yet`) below the Restore button using the same `muted sm` markup and `formatDateTime` helper as the backup subtitle.

### Verification
- `npm run check` → 0 errors, 0 warnings
- `npm run build` → clean

Surgical diff (11 insertions, 1 deletion). No auth/sync behavior changed, no new deps, no popups.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>