### PR TITLE
Harden OneDrive sync lifecycle: fresh restore + self-healing backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ override with their own client ID under **Settings → Advanced**.
 > The workbook has `Players`, `Games`, `Rounds`, and `RoundScores` sheets. The app treats local
 > data as the source of truth during play and syncs the whole snapshot on demand.
 
+### How backup & restore behave
+
+- **Back up now** overwrites the remote `Score King.xlsx` with your current data (last‑write‑wins).
+  If the file was deleted — or, in custom‑folder mode, the whole folder was deleted — the next
+  backup **recreates the file (and folder)** automatically.
+- **Restore** always fetches the **latest** remote copy. The download bypasses the browser cache
+  (`cache: 'no-store'`), so a single Restore reflects edits you (or Excel) just made to the
+  workbook — no disconnect/reconnect needed.
+- If you press **Restore** but no backup exists yet, the app offers to **back up your current data**
+  there instead, so you're never left in a dead end.
+
 ### Google Drive (future)
 
 The `SyncProvider` interface (`src/lib/storage/sync.ts`) is storage‑agnostic, so a Google Drive

--- a/src/lib/storage/onedrive.ts
+++ b/src/lib/storage/onedrive.ts
@@ -39,6 +39,14 @@ function encodePath(p: string): string {
     .join('/');
 }
 
+/** Folder segments for custom mode, trimmed and emptied of blanks (root => []). */
+function customFolderSegments(): string[] {
+  return (get(settings).oneDriveCustomPath || '')
+    .split('/')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
 /** Graph addressing for the workbook's content, per the chosen storage location. */
 function contentPath(): string {
   const file = encodeURIComponent(FILE_NAME);
@@ -221,6 +229,55 @@ async function fromWorkbook(buf: ArrayBuffer): Promise<Snapshot> {
   return { players, games, rounds, exportedAt: Date.now() };
 }
 
+/** PUT the workbook bytes to the configured content path (overwrites; last-write-wins). */
+function putContent(buf: ArrayBuffer, accessToken: string): Promise<Response> {
+  return graph(
+    contentPath(),
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type':
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      },
+      body: buf,
+    },
+    accessToken,
+  );
+}
+
+/**
+ * Create the custom-folder path if it's missing — e.g. the user deleted the folder in OneDrive —
+ * so a subsequent upload to a file inside it succeeds. Each segment is created with
+ * conflictBehavior 'fail', so existing folders (and their contents) are left untouched (a 409 just
+ * means "already there"). App-folder mode needs nothing here: Graph provisions the sandboxed
+ * approot automatically on write.
+ */
+async function ensureCustomFolder(accessToken: string): Promise<void> {
+  let parentPath = '';
+  for (const name of customFolderSegments()) {
+    const childrenPath = parentPath
+      ? `/me/drive/root:/${encodePath(parentPath)}:/children`
+      : '/me/drive/root/children';
+    const res = await graph(
+      childrenPath,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          folder: {},
+          '@microsoft.graph.conflictBehavior': 'fail',
+        }),
+      },
+      accessToken,
+    );
+    if (!res.ok && res.status !== 409) {
+      throw new Error(`Could not create OneDrive folder "${name}" (HTTP ${res.status}).`);
+    }
+    parentPath = parentPath ? `${parentPath}/${name}` : name;
+  }
+}
+
 export const oneDrive: SyncProvider = {
   id: 'onedrive',
   label: 'OneDrive',
@@ -256,27 +313,22 @@ export const oneDrive: SyncProvider = {
   async push(snapshot) {
     const accessToken = await token();
     const buf = await toWorkbook(snapshot);
-    const res = await graph(
-      contentPath(),
-      {
-        method: 'PUT',
-        headers: {
-          'Content-Type':
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-        },
-        body: buf,
-      },
-      accessToken,
-    );
+    let res = await putContent(buf, accessToken);
+    // A custom-folder target 404s when its parent folder was deleted (or never created).
+    // Recreate the folder hierarchy and retry once so backup self-heals. App-folder mode
+    // doesn't need this — writing to approot re-provisions the sandboxed folder automatically.
+    if (res.status === 404 && folderMode() === 'custom') {
+      await ensureCustomFolder(accessToken);
+      res = await putContent(buf, accessToken);
+    }
     if (!res.ok) throw new Error(`Upload failed (HTTP ${res.status}).`);
   },
   async pull() {
     const accessToken = await token();
-    const res = await graph(
-      contentPath(),
-      { method: 'GET' },
-      accessToken,
-    );
+    // cache: 'no-store' bypasses the browser HTTP cache for this GET *and* the CDN download URL
+    // that Graph 302-redirects to (the cache mode is inherited across the redirect chain), so a
+    // single Restore always returns the latest remote content — no disconnect/reconnect needed.
+    const res = await graph(contentPath(), { method: 'GET', cache: 'no-store' }, accessToken);
     if (res.status === 404) return null;
     if (!res.ok) throw new Error(`Download failed (HTTP ${res.status}).`);
     return fromWorkbook(await res.arrayBuffer());

--- a/src/lib/storage/sync.ts
+++ b/src/lib/storage/sync.ts
@@ -17,7 +17,17 @@ export interface SyncProvider {
   prepare(): Promise<boolean>;
   signIn(): Promise<void>;
   signOut(): Promise<void>;
+  /**
+   * Upload a full snapshot, overwriting any existing remote copy (last-write-wins; no conflict
+   * errors). Implementations MUST create the backing file — and any missing parent folders — if
+   * it doesn't exist yet, so a backup succeeds even after the file/folder was deleted remotely.
+   */
   push(snapshot: Snapshot): Promise<void>;
+  /**
+   * Fetch the latest remote snapshot, bypassing any HTTP/CDN caches so a single call always
+   * reflects the most recent remote edit. Resolves to null (rather than throwing) when no backup
+   * exists yet — e.g. the file was never created or was deleted.
+   */
   pull(): Promise<Snapshot | null>;
 }
 

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -80,13 +80,17 @@
     }
   }
 
+  async function performBackup() {
+    const od = await getOneDrive();
+    await od.push(await buildSnapshot());
+    signedIn = od.isSignedIn();
+    markSynced(Date.now());
+  }
+
   async function backup() {
     busy = true;
     try {
-      const od = await getOneDrive();
-      await od.push(await buildSnapshot());
-      signedIn = od.isSignedIn();
-      markSynced(Date.now());
+      await performBackup();
       showToast('Backed up to OneDrive');
     } catch (e) {
       showToast(errMsg(e));
@@ -102,7 +106,14 @@
       const od = await getOneDrive();
       const snap = await od.pull();
       if (!snap) {
-        showToast('No backup found in OneDrive');
+        // The file is missing on OneDrive (never created, or deleted). We're still connected —
+        // offer to create the backup from local data instead of leaving the user stuck.
+        if (confirm('No backup found in OneDrive. Back up your current data there now?')) {
+          await performBackup();
+          showToast('Backed up to OneDrive');
+        } else {
+          showToast('No backup found in OneDrive');
+        }
         return;
       }
       await restoreSnapshot(snap);


### PR DESCRIPTION
## Summary
Robustness pass on the storage layer and Settings sync UI, fixing the confirmed **stale-restore** bug and hardening the connect/sync lifecycle against real-world file-state scenarios. Fixes are made at the `SyncProvider` contract level so future backends (Google Drive, etc.) inherit the same behavior.

## Confirmed bug — Restore shows STALE data (Scenario 4)
**Root cause:** `pull()` issued `GET …/content` with no cache directive. Microsoft Graph responds with a **302 redirect to a cacheable CDN download URL**, so the browser HTTP cache served stale bytes on a second Restore — external edits only appeared after a full disconnect → reconnect → restore cycle. (Confirmed the PWA service worker is *not* involved: workbox has no `runtimeCaching` for `graph.microsoft.com` — only static-asset precache + navigation fallback.)

**Fix:** `pull()` now fetches with `{ cache: 'no-store' }`. Per the Fetch spec the cache mode is **inherited across the redirect chain**, so both the Graph request and the redirected CDN request bypass (and never populate) the HTTP cache. A single Restore now always returns the latest remote content — repeatably, with no reconnect. No request headers or query params are added, avoiding any CORS-preflight risk. The restore handler already calls `refreshPlayers()` / `refreshGames()`, so restored data appears in the UI immediately.

## Other scenarios
- **Scenario 1 — file/folder deleted:** `push()` now self-heals. In custom-folder mode, if the PUT 404s because the parent folder was deleted, it recreates the folder hierarchy (`ensureCustomFolder`, conflictBehavior `fail` so existing folders/contents are never clobbered) and retries once. App-folder mode re-provisions the sandboxed approot automatically on write. No crashes or stuck state.
- **Scenario 2 — restore when no remote file:** `pull()` returns `null` on 404; the app stays connected (no stale "connected-but-broken" state) and now **offers to back up local data instead** of dead-ending.
- **Scenario 3 — overwrite with new data:** unchanged PUT to `…/content` is a clean last-write-wins overwrite (no `If-Match`/conflictBehavior → no 409/412). Codified in the contract.

## Provider-contract changes
`SyncProvider.push`/`pull` JSDoc now specifies the required behavior — push must create the file and any missing parent folders and overwrite last-write-wins; pull must bypass caches for a fresh read and return `null` (not throw) when no backup exists — so all backends behave consistently.

## Files
- `src/lib/storage/onedrive.ts` — `cache: 'no-store'` in `pull()`; `putContent` + `ensureCustomFolder` helpers; 404 folder-recreate-and-retry in `push()`.
- `src/lib/storage/sync.ts` — contract docs for `push`/`pull`.
- `src/pages/Settings.svelte` — extracted `performBackup()`; restore offers to back up when no remote file exists.
- `README.md` — OneDrive section documents the new backup/restore behavior.

## Verification
- `npm run check` → 0 errors, 0 warnings.
- `npm run build` → clean.
- Real Microsoft-account OAuth can't be exercised headlessly; verified via code reasoning + typecheck/build.

### Manual verification steps (live app)
1. **Stale restore fixed:** Connect OneDrive, Back up. Edit `Score King.xlsx` in Excel/OneDrive (e.g. rename a player), Save. Press **Restore** once → change appears. Edit again, **Restore** again → second change appears, all with no disconnect/reconnect.
2. **Deleted file:** Delete `Score King.xlsx` in OneDrive → **Back up now** recreates it; app status stays consistent.
3. **Deleted folder (custom mode):** Set a custom folder, back up, delete the whole folder in OneDrive → **Back up now** recreates folder + file.
4. **Restore with no file:** Delete the file, press **Restore** → prompted to back up current data instead; confirm recreates it.
5. **Overwrite:** Change local data, **Back up now** → workbook overwritten with no conflict error.

> Note: a parallel session is also editing `onedrive.ts` / `Settings.svelte` (silent auto-sync push path). Diffs here are kept surgical to ease rebasing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
