### PR TITLE
Add toggle-able automatic OneDrive backup (on by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ works fully offline, and can back itself up to an **Excel workbook in your OneDr
   validation). Adding a new game doesn't touch the rest of the app.
 - **Players, history & stats** are shared across every game — reusable players, a full game log,
   and a win‑rate leaderboard.
-- **Optional OneDrive Excel sync.** One‑click backup/restore to a real `.xlsx` you can open in
-  Excel. Uses your own free Azure app registration — *no secrets live in this repo.*
+- **Optional OneDrive Excel sync.** Automatic (and one‑click) backup to a real `.xlsx` you can open
+  in Excel, with one‑click restore. Auto‑backup is on by default, push‑only, and never interrupts
+  you. Uses your own free Azure app registration — *no secrets live in this repo.*
 - **Local JSON export/import** as a zero‑setup backup option.
 - **Dark / light** themes.
 
@@ -118,6 +119,14 @@ comes from PKCE + the redirect‑URI allowlist), so end users never configure an
 **Settings → Connect OneDrive**. Connecting briefly redirects the whole page to Microsoft to sign in,
 then returns you to Settings — there's no popup to allow or unblock.
 
+**Automatic backup is on by default.** Once you're connected, Score King quietly pushes a fresh
+backup a few seconds after you change anything (new game, saved round, finished game, edited player),
+coalescing a burst of rapid edits into a single upload. It is **push‑only** (last‑write‑wins to your
+own file — it never auto‑restores or auto‑pulls) and **silent**: if your sign‑in has expired it just
+shows _"Sync pending — reconnect to OneDrive"_ instead of yanking you to Microsoft mid‑use. It also
+pauses while you're offline and resumes on reconnect. Turn it off any time with **Settings →
+Automatically back up changes**; **Back up now** and **Restore** keep working regardless.
+
 ### One‑time developer setup (register the shared app)
 
 1. [Azure Portal → App registrations](https://portal.azure.com/) → **New registration**.
@@ -137,7 +146,8 @@ After that, **Settings → Connect OneDrive** is one click for everyone. Power u
 override with their own client ID under **Settings → Advanced**.
 
 > The workbook has `Players`, `Games`, `Rounds`, and `RoundScores` sheets. The app treats local
-> data as the source of truth during play and syncs the whole snapshot on demand.
+> data as the source of truth during play and syncs the whole snapshot automatically (debounced) —
+> or on demand via **Back up now**.
 
 ### Google Drive (future)
 

--- a/src/lib/storage/autosync.ts
+++ b/src/lib/storage/autosync.ts
@@ -1,0 +1,177 @@
+import { get, writable } from 'svelte/store';
+import { settings, markSynced } from '../stores/settings';
+import { dataVersion } from './changes';
+import { buildSnapshot, getOneDrive, InteractionRequiredError } from './sync';
+import type { SyncProvider } from './sync';
+
+export type AutoSyncStatus =
+  | 'idle'
+  | 'syncing'
+  | 'synced'
+  | 'pending'
+  | 'offline'
+  | 'error';
+
+/** Live status for the Settings indicator. */
+export const autoSyncStatus = writable<AutoSyncStatus>('idle');
+
+/** Debounce window: coalesce a burst of edits into a single upload. */
+const DEBOUNCE_MS = 2500;
+
+let started = false;
+let dirty = false; // local changes awaiting upload
+let pushing = false; // an upload is in flight
+let timer: ReturnType<typeof setTimeout> | undefined;
+let lastVersion = 0;
+let wasActive = false;
+
+function enabled(): boolean {
+  return get(settings).autoSync;
+}
+
+/** The user has connected OneDrive at least once (and not disconnected). */
+function connected(): boolean {
+  return get(settings).oneDriveConnected;
+}
+
+/** Auto-sync should actually run: enabled by the user AND OneDrive is connected. */
+function active(): boolean {
+  return enabled() && connected();
+}
+
+function isOnline(): boolean {
+  return typeof navigator === 'undefined' || navigator.onLine;
+}
+
+function cancelTimer(): void {
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    timer = undefined;
+  }
+}
+
+function schedule(): void {
+  cancelTimer();
+  timer = setTimeout(() => {
+    timer = undefined;
+    void run();
+  }, DEBOUNCE_MS);
+}
+
+function onLocalChange(): void {
+  dirty = true;
+  if (!active()) return;
+  if (!isOnline()) {
+    autoSyncStatus.set('offline');
+    return;
+  }
+  schedule();
+}
+
+async function run(): Promise<void> {
+  cancelTimer();
+  // `active()` gates loading the (heavy) OneDrive provider: a user who never
+  // connected never pulls MSAL in just to back up.
+  if (pushing || !dirty || !active()) return;
+  if (!isOnline()) {
+    autoSyncStatus.set('offline');
+    return;
+  }
+
+  let od: SyncProvider;
+  try {
+    od = await getOneDrive();
+  } catch {
+    return; // provider failed to load — nothing we can do in the background
+  }
+  if (!od.isConfigured()) return;
+
+  // Reuse the provider's cached session; never start an interactive sign-in here.
+  try {
+    await od.prepare();
+  } catch {
+    /* fall through to the signed-in check below */
+  }
+  if (!od.isSignedIn()) {
+    autoSyncStatus.set('pending');
+    return;
+  }
+
+  pushing = true;
+  dirty = false; // claim current changes; edits during upload re-set this
+  autoSyncStatus.set('syncing');
+  try {
+    await od.push(await buildSnapshot(), { interactive: false });
+    markSynced(Date.now());
+    if (dirty) {
+      schedule(); // more edits arrived mid-upload
+    } else {
+      autoSyncStatus.set('synced');
+    }
+  } catch (e) {
+    dirty = true; // keep the changes pending
+    if (e instanceof InteractionRequiredError) {
+      // Silent token failed — must NOT redirect in the background. Wait for the
+      // user to reconnect, or for the next data change / online event.
+      autoSyncStatus.set('pending');
+    } else {
+      autoSyncStatus.set('error');
+      schedule(); // transient (e.g. network) — retry later
+    }
+  } finally {
+    pushing = false;
+  }
+}
+
+function onOnline(): void {
+  if (dirty && active()) void run();
+}
+
+function onVisibility(): void {
+  // Best-effort flush when the tab is backgrounded, so a pending edit isn't
+  // stranded if the user navigates away before the debounce fires.
+  if (document.visibilityState === 'hidden' && dirty && active() && isOnline()) {
+    void run();
+  }
+}
+
+/** Wire the auto-sync controller once, at app start. Safe to call repeatedly. */
+export function startAutoSync(): void {
+  if (started || typeof window === 'undefined') return;
+  started = true;
+
+  lastVersion = get(dataVersion);
+  wasActive = active();
+
+  dataVersion.subscribe((v) => {
+    if (v === lastVersion) return; // skip the initial replay
+    lastVersion = v;
+    onLocalChange();
+  });
+
+  settings.subscribe((s) => {
+    const now = s.autoSync && s.oneDriveConnected;
+    if (now === wasActive) return;
+    wasActive = now;
+    if (now) {
+      if (dirty) schedule(); // turned on / just connected with changes waiting
+    } else {
+      cancelTimer(); // turned off or disconnected — stop automatic uploads
+      autoSyncStatus.set('idle');
+    }
+  });
+
+  window.addEventListener('online', onOnline);
+  document.addEventListener('visibilitychange', onVisibility);
+}
+
+/**
+ * Clear the pending-changes marker (and reflect success) without scheduling a
+ * push. Call after a manual "Back up now" or a Restore so the controller doesn't
+ * re-upload state that is already — or freshly — in sync.
+ */
+export function markSyncSettled(): void {
+  dirty = false;
+  cancelTimer();
+  autoSyncStatus.set('synced');
+}

--- a/src/lib/storage/changes.ts
+++ b/src/lib/storage/changes.ts
@@ -1,0 +1,15 @@
+import { writable } from 'svelte/store';
+
+/**
+ * Monotonic counter bumped whenever local game data is mutated through the db
+ * write helpers (players, games, rounds — created, edited or deleted).
+ *
+ * A bulk `replaceAll` from a sync *restore* deliberately does NOT bump it, so
+ * pulling a backup can never echo back into an automatic push.
+ */
+export const dataVersion = writable(0);
+
+/** Signal that local data changed and should be backed up. */
+export function markDataChanged(): void {
+  dataVersion.update((n) => n + 1);
+}

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -1,6 +1,7 @@
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
 import type { Game, ID, Player, Round } from '../types';
 import { uid } from '../util';
+import { markDataChanged } from './changes';
 
 interface ScoreKingDB extends DBSchema {
   players: { key: string; value: Player };
@@ -37,15 +38,18 @@ export async function getAllPlayers(): Promise<Player[]> {
 export async function addPlayer(name: string, color: string): Promise<Player> {
   const player: Player = { id: uid(), name: name.trim(), color, createdAt: Date.now() };
   await (await db()).put('players', player);
+  markDataChanged();
   return player;
 }
 
 export async function updatePlayer(player: Player): Promise<void> {
   await (await db()).put('players', raw(player));
+  markDataChanged();
 }
 
 export async function deletePlayer(id: ID): Promise<void> {
   await (await db()).delete('players', id);
+  markDataChanged();
 }
 
 // ---- Games ----
@@ -60,6 +64,7 @@ export async function getGame(id: ID): Promise<Game | undefined> {
 
 export async function putGame(game: Game): Promise<void> {
   await (await db()).put('games', raw(game));
+  markDataChanged();
 }
 
 export async function deleteGame(id: ID): Promise<void> {
@@ -69,6 +74,7 @@ export async function deleteGame(id: ID): Promise<void> {
   const rounds = await tx.objectStore('rounds').index('byGame').getAllKeys(id);
   for (const key of rounds) await tx.objectStore('rounds').delete(key);
   await tx.done;
+  markDataChanged();
 }
 
 // ---- Rounds ----
@@ -79,10 +85,12 @@ export async function getRounds(gameId: ID): Promise<Round[]> {
 
 export async function putRound(round: Round): Promise<void> {
   await (await db()).put('rounds', raw(round));
+  markDataChanged();
 }
 
 export async function deleteRound(id: ID): Promise<void> {
   await (await db()).delete('rounds', id);
+  markDataChanged();
 }
 
 // ---- Bulk (used by sync restore) ----

--- a/src/lib/storage/onedrive.ts
+++ b/src/lib/storage/onedrive.ts
@@ -3,6 +3,7 @@ import { get } from 'svelte/store';
 import { settings } from '../stores/settings';
 import { ONEDRIVE_CLIENT_ID } from '../config';
 import type { Snapshot, SyncProvider } from './sync';
+import { InteractionRequiredError } from './sync';
 import type { Game, Player, Round } from '../types';
 
 const FILE_NAME = 'Score King.xlsx';
@@ -107,9 +108,11 @@ export async function completeRedirect(): Promise<string | null> {
   return ret;
 }
 
-async function token(): Promise<string> {
+async function token(interactive = true): Promise<string> {
   const app = await ensureApp();
   if (!account) {
+    // Background auto-sync must never yank the user to Microsoft — fail quietly.
+    if (!interactive) throw new InteractionRequiredError('Not signed in to OneDrive');
     // Not signed in yet — hand off to a full-page redirect; this call does not return.
     sessionStorage.setItem(RETURN_KEY, window.location.pathname + window.location.search);
     await app.loginRedirect({ scopes: scopes() });
@@ -119,6 +122,8 @@ async function token(): Promise<string> {
     const res = await app.acquireTokenSilent({ scopes: scopes(), account });
     return res.accessToken;
   } catch {
+    if (!interactive)
+      throw new InteractionRequiredError('Silent OneDrive token refresh failed');
     sessionStorage.setItem(RETURN_KEY, window.location.pathname + window.location.search);
     await app.acquireTokenRedirect({ scopes: scopes(), account });
     throw new Error('Redirecting to Microsoft to refresh sign-in…');
@@ -253,8 +258,8 @@ export const oneDrive: SyncProvider = {
     }
     account = null;
   },
-  async push(snapshot) {
-    const accessToken = await token();
+  async push(snapshot, opts) {
+    const accessToken = await token(opts?.interactive ?? true);
     const buf = await toWorkbook(snapshot);
     const res = await graph(
       contentPath(),

--- a/src/lib/storage/sync.ts
+++ b/src/lib/storage/sync.ts
@@ -8,6 +8,25 @@ export interface Snapshot {
   exportedAt: number;
 }
 
+/** Options for a provider push. */
+export interface PushOptions {
+  /**
+   * When false, the provider must NOT trigger any interactive sign-in (e.g. a
+   * full-page redirect to Microsoft). If it can't get a token silently it throws
+   * {@link InteractionRequiredError} instead. Used by background auto-sync so it
+   * never yanks the user away mid-use. Defaults to true (manual backups).
+   */
+  interactive?: boolean;
+}
+
+/** Thrown by a silent (non-interactive) push when the user must sign in again. */
+export class InteractionRequiredError extends Error {
+  constructor(message = 'Interactive sign-in required') {
+    super(message);
+    this.name = 'InteractionRequiredError';
+  }
+}
+
 export interface SyncProvider {
   id: string;
   label: string;
@@ -17,7 +36,7 @@ export interface SyncProvider {
   prepare(): Promise<boolean>;
   signIn(): Promise<void>;
   signOut(): Promise<void>;
-  push(snapshot: Snapshot): Promise<void>;
+  push(snapshot: Snapshot, opts?: PushOptions): Promise<void>;
   pull(): Promise<Snapshot | null>;
 }
 

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -10,6 +10,7 @@ export interface Settings {
   oneDriveFolderMode: OneDriveFolderMode;
   oneDriveCustomPath: string;
   autoSync: boolean;
+  oneDriveConnected: boolean;
   lastSync: number | null;
 }
 
@@ -20,7 +21,8 @@ const defaults: Settings = {
   oneDriveClientId: '',
   oneDriveFolderMode: 'app',
   oneDriveCustomPath: '',
-  autoSync: false,
+  autoSync: true,
+  oneDriveConnected: false,
   lastSync: null,
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { registerSW } from 'virtual:pwa-register'
 import './app.css'
 import App from './App.svelte'
 import { applyTheme } from './lib/stores/settings'
+import { startAutoSync } from './lib/storage/autosync'
 
 // A Microsoft sign-in uses a full-page redirect. When the browser returns from Microsoft the
 // URL carries the auth response (in the hash or query). Detect that, let MSAL consume it, then
@@ -26,6 +27,8 @@ async function boot() {
   applyTheme()
   registerSW({ immediate: true })
   mount(App, { target: document.getElementById('app')! })
+  // Background OneDrive auto-backup (push-only, silent; never redirects on its own).
+  startAutoSync()
 }
 
 boot()

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -2,11 +2,12 @@
   import { onMount } from 'svelte';
   import { settings, toggleTheme, markSynced } from '../lib/stores/settings';
   import { buildSnapshot, restoreSnapshot, getOneDrive } from '../lib/storage/sync';
+  import { autoSyncStatus, markSyncSettled } from '../lib/storage/autosync';
   import { ONEDRIVE_CLIENT_ID } from '../lib/config';
   import { refreshGames } from '../lib/stores/games';
   import { refreshPlayers } from '../lib/stores/players';
   import { showToast } from '../lib/stores/toast';
-  import { formatDateTime } from '../lib/util';
+  import { relativeTime } from '../lib/util';
 
   let override = $state($settings.oneDriveClientId);
   let busy = $state(false);
@@ -14,6 +15,32 @@
   let fileInput: HTMLInputElement;
 
   const configured = $derived(!!(override.trim() || ONEDRIVE_CLIENT_ID));
+
+  const dotClass = $derived(
+    $autoSyncStatus === 'syncing'
+      ? 'busy'
+      : $autoSyncStatus === 'pending' || $autoSyncStatus === 'error'
+        ? 'warn'
+        : $autoSyncStatus === 'offline'
+          ? 'off'
+          : $settings.lastSync
+            ? 'ok'
+            : '',
+  );
+
+  const syncText = $derived(
+    $autoSyncStatus === 'syncing'
+      ? 'Syncing…'
+      : $autoSyncStatus === 'pending'
+        ? 'Sync pending — reconnect to OneDrive'
+        : $autoSyncStatus === 'offline'
+          ? 'Offline — changes will back up when you reconnect'
+          : $autoSyncStatus === 'error'
+            ? 'Sync failed — will retry shortly'
+            : $settings.lastSync
+              ? 'Backed up · ' + relativeTime($settings.lastSync)
+              : 'Not backed up yet',
+  );
 
   let folderMode = $state($settings.oneDriveFolderMode);
   let customPath = $state($settings.oneDriveCustomPath);
@@ -52,6 +79,11 @@
     try {
       const od = await getOneDrive();
       signedIn = await od.prepare();
+      // Arm background auto-sync once OneDrive is connected (persisted, so it keeps
+      // working across reloads; only an explicit Disconnect turns it back off).
+      if (signedIn) {
+        settings.update((s) => (s.oneDriveConnected ? s : { ...s, oneDriveConnected: true }));
+      }
       // Confirm a sign-in that just completed via full-page redirect (shown once).
       if (signedIn && sessionStorage.getItem('sk_od_justConnected')) {
         sessionStorage.removeItem('sk_od_justConnected');
@@ -87,6 +119,7 @@
       await od.push(await buildSnapshot());
       signedIn = od.isSignedIn();
       markSynced(Date.now());
+      markSyncSettled();
       showToast('Backed up to OneDrive');
     } catch (e) {
       showToast(errMsg(e));
@@ -108,6 +141,7 @@
       await restoreSnapshot(snap);
       await refreshPlayers();
       await refreshGames();
+      markSyncSettled();
       showToast('Restored from OneDrive');
     } catch (e) {
       showToast(errMsg(e));
@@ -121,6 +155,8 @@
       const od = await getOneDrive();
       await od.signOut();
       signedIn = false;
+      // Disarm background auto-sync; manual Connect re-arms it.
+      settings.update((s) => ({ ...s, oneDriveConnected: false }));
       showToast('Disconnected from OneDrive');
     } catch (e) {
       showToast(errMsg(e));
@@ -184,9 +220,6 @@
         <button class="btn primary grow" onclick={backup} disabled={busy}>Back up now</button>
         <button class="btn grow" onclick={restore} disabled={busy}>Restore</button>
       </div>
-      <div class="muted sm">
-        {$settings.lastSync ? 'Last backup ' + formatDateTime($settings.lastSync) : 'Not backed up yet'}
-      </div>
     {:else}
       <div class="muted sm">
         Sign in with your Microsoft account to back up your scores to a <code>Score King.xlsx</code>
@@ -194,6 +227,25 @@
       </div>
       <button class="btn primary" onclick={connect} disabled={busy}>Connect OneDrive</button>
     {/if}
+
+    <div class="autosync stack" style="gap: 8px">
+      <label class="sw-row row spread">
+        <span>Automatically back up changes</span>
+        <span class="switch">
+          <input
+            type="checkbox"
+            checked={$settings.autoSync}
+            onchange={(e) =>
+              settings.update((s) => ({ ...s, autoSync: e.currentTarget.checked }))}
+          />
+          <span class="track"><span class="thumb"></span></span>
+        </span>
+      </label>
+      <div class="row" style="gap: 8px">
+        <span class="dot {dotClass}"></span>
+        <span class="muted sm">{syncText}</span>
+      </div>
+    </div>
 
     <hr class="sep" />
 
@@ -289,6 +341,61 @@
   }
   .dot.ok {
     background: #29c785;
+  }
+  .dot.busy {
+    background: #f7b955;
+  }
+  .dot.warn {
+    background: var(--bad, #f87171);
+  }
+  .dot.off {
+    background: var(--muted);
+  }
+  .sw-row {
+    cursor: pointer;
+  }
+  .switch {
+    position: relative;
+    display: inline-flex;
+    flex: none;
+  }
+  .switch input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    opacity: 0;
+    cursor: pointer;
+  }
+  .track {
+    width: 40px;
+    height: 22px;
+    border-radius: 999px;
+    background: var(--surface-3, rgba(127, 127, 127, 0.3));
+    border: 1px solid var(--border, rgba(127, 127, 127, 0.2));
+    display: inline-flex;
+    align-items: center;
+    padding: 2px;
+    transition: background 0.15s ease;
+  }
+  .thumb {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: #fff;
+    transition: transform 0.15s ease;
+  }
+  .switch input:checked + .track {
+    background: var(--primary);
+    border-color: var(--primary);
+  }
+  .switch input:checked + .track .thumb {
+    transform: translateX(18px);
+  }
+  .switch input:focus-visible + .track {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
   }
   details summary {
     cursor: pointer;


### PR DESCRIPTION
## What & why
Adds **automatic, debounced OneDrive backup** so local changes are backed up without clicking **Back up now**. Enabled by default, toggle-able, **push-only**, and — critically — it **never triggers a surprise interactive Microsoft redirect** in the background.

## How it works
- **Data-changed signal** (`src/lib/storage/changes.ts`): a `dataVersion` store bumped by every db write helper (`putGame`/`putRound`/`updatePlayer`/`addPlayer`/deletes). `replaceAll` (used by Restore) deliberately does **not** bump it, so a pull→restore can't echo back into a push.
- **Silent push path**: `SyncProvider.push(snapshot, { interactive })`. The OneDrive `token()` gained an `interactive` flag — when `false` it does `acquireTokenSilent` only and throws a typed `InteractionRequiredError` instead of `loginRedirect`/`acquireTokenRedirect`. Manual **Back up now** keeps the existing interactive behaviour.
- **Controller** (`src/lib/storage/autosync.ts`): wired once in `main.ts`. Subscribes to the data signal + settings, debounced ~2.5s (coalesces bursts into one upload). Skips while `navigator.onLine` is false and retries on the `online` event; best-effort flush on `visibilitychange`. On `InteractionRequiredError` (or signed-out) it sets status `pending` and stops — no redirect. Exposes an `autoSyncStatus` store.
- **Settings UI**: an **"Automatically back up changes"** toggle + a live status indicator (`Syncing…` / `Backed up · <relative>` / `Sync pending — reconnect to OneDrive` / offline / error).
- **MSAL gate**: a persisted `oneDriveConnected` flag means the heavy MSAL bundle is only pulled in once the user has actually connected OneDrive (and stays armed across session expiry, so the genuine signed-out → "pending" case still works).

## Settings added
- `autoSync: boolean` — default **true**, persisted like the other keys.
- `oneDriveConnected: boolean` — set on confirmed sign-in, cleared on Disconnect.

## Verification
- `npm run check` → **0 errors, 0 warnings**
- `npm run build` → **succeeds**; MSAL stays in the lazy `onedrive` chunk (main bundle ~36.8 KB gzip).

## Scope
Push-only (last-write-wins to the user's own file). Does **not** auto-pull/auto-restore; manual Restore is unchanged. Not merged/deployed — opened for review.

## Manual test checklist
- [ ] Connect OneDrive → new game / save round / finish game / edit player → uploads within a few seconds; status shows "Backed up · just now".
- [ ] Toggle off → automatic uploads stop; toggle persists across reload.
- [ ] Auto-sync on but signed-out / silent token failure → status "Sync pending — reconnect", **no redirect**; manual Connect + Back up still work.
- [ ] Restore from OneDrive → no echo upload afterward.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
