### PR TITLE
Add unobtrusive sync status bubble with slow-sync progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ shows _"Sync pending — reconnect to OneDrive"_ instead of yanking you to Micro
 pauses while you're offline and resumes on reconnect. Turn it off any time with **Settings →
 Automatically back up changes**; **Back up now** and **Restore** keep working regardless.
 
+A small **status bubble** in the bottom corner shows where your backup stands at a glance — a quiet
+dot when everything's synced, _"Syncing…"_ (with a progress bar if an upload runs long), or a
+_"Sync pending"_ / _"Offline"_ nudge when it needs attention. Tap it to jump to the OneDrive
+settings.
+
 ### One‑time developer setup (register the shared app)
 
 1. [Azure Portal → App registrations](https://portal.azure.com/) → **New registration**.

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,6 +10,7 @@
   import GameType from './pages/GameType.svelte';
   import GamePlay from './pages/GamePlay.svelte';
   import NotFound from './pages/NotFound.svelte';
+  import SyncBubble from './lib/components/SyncBubble.svelte';
 
   let current = $state(window.location.pathname || '/');
   onMount(() => pathStore.subscribe((v) => (current = v)));
@@ -64,3 +65,5 @@
 {#if $toast}
   <div class="toast">{$toast}</div>
 {/if}
+
+<SyncBubble />

--- a/src/lib/components/SyncBubble.svelte
+++ b/src/lib/components/SyncBubble.svelte
@@ -1,0 +1,240 @@
+<script lang="ts">
+  import { autoSyncStatus } from '../storage/autosync';
+  import { settings } from '../stores/settings';
+  import { pathStore, parseRoute, link } from '../router';
+  import { relativeTime } from '../util';
+
+  const status = $derived($autoSyncStatus);
+  // The bubble represents auto-sync: only show it once the user has connected
+  // OneDrive AND left auto-sync on. The Settings page already has the detailed
+  // indicator, so stay out of the way there.
+  const route = $derived(parseRoute($pathStore));
+  const visible = $derived(
+    $settings.oneDriveConnected && $settings.autoSync && route.name !== 'settings',
+  );
+
+  const tone = $derived(
+    status === 'syncing'
+      ? 'busy'
+      : status === 'pending' || status === 'error'
+        ? 'warn'
+        : status === 'offline'
+          ? 'off'
+          : $settings.lastSync
+            ? 'ok'
+            : 'idle',
+  );
+
+  const label = $derived(
+    status === 'syncing'
+      ? 'Syncing…'
+      : status === 'pending'
+        ? 'Sync pending'
+        : status === 'offline'
+          ? 'Offline'
+          : status === 'error'
+            ? 'Sync failed — retrying'
+            : $settings.lastSync
+              ? 'Backed up · ' + relativeTime($settings.lastSync)
+              : 'Not backed up yet',
+  );
+
+  const fullLabel = $derived(
+    status === 'pending'
+      ? 'Sync pending — reconnect to OneDrive'
+      : status === 'offline'
+        ? 'Offline — changes will back up when you reconnect'
+        : label,
+  );
+
+  // --- progress + post-sync "sticky" label, driven only by `status` ---
+  let showProgress = $state(false); // reactive: drives the bar in the template
+  let progress = $state(0); // 0..1
+  let stickySynced = $state(false); // keep "Backed up" visible briefly after a sync
+  // Plain (non-reactive) mirror so the effect can branch on it without
+  // subscribing to it — the effect must depend on `status` alone.
+  let barShown = false;
+
+  // Expanded = show the text label; collapsed = just the coloured dot.
+  const expanded = $derived(
+    status === 'syncing' ||
+      status === 'pending' ||
+      status === 'offline' ||
+      status === 'error' ||
+      stickySynced,
+  );
+
+  $effect(() => {
+    const s = status;
+
+    if (s === 'syncing') {
+      // Fresh upload: clear any leftover bar so the ">1s" rule applies per-sync.
+      showProgress = false;
+      progress = 0;
+      barShown = false;
+      // Only reveal the progress bar if the upload is genuinely slow (>1s).
+      const slow = setTimeout(() => {
+        barShown = true;
+        showProgress = true;
+        progress = 0.08;
+      }, 1000);
+      const tick = setInterval(() => {
+        // Ease toward a cap; we have no real byte-progress from Graph, so this
+        // is a bounded, reassuring approximation that completes on success.
+        if (barShown) progress = Math.min(0.92, progress + (0.92 - progress) * 0.16);
+      }, 200);
+      return () => {
+        clearTimeout(slow);
+        clearInterval(tick);
+      };
+    }
+
+    // Left the syncing state.
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    if (barShown) {
+      if (s === 'synced') {
+        progress = 1; // snap to full, then fade the bar out
+        timers.push(
+          setTimeout(() => {
+            showProgress = false;
+            progress = 0;
+            barShown = false;
+          }, 450),
+        );
+      } else {
+        showProgress = false;
+        progress = 0;
+        barShown = false;
+      }
+    }
+    if (s === 'synced') {
+      stickySynced = true;
+      timers.push(setTimeout(() => (stickySynced = false), 2500));
+    } else {
+      stickySynced = false;
+    }
+    return () => timers.forEach((t) => clearTimeout(t));
+  });
+</script>
+
+{#if visible}
+  <a
+    class="syncbubble {tone}"
+    class:expanded
+    href="/settings"
+    use:link
+    title={fullLabel}
+    aria-label={'Backup status: ' + fullLabel}
+  >
+    <span class="sb-dot" class:spin={status === 'syncing'}></span>
+    {#if expanded}<span class="sb-text">{label}</span>{/if}
+    {#if showProgress}
+      <span class="sb-progress" aria-hidden="true">
+        <span class="sb-bar" style="width: {Math.round(progress * 100)}%"></span>
+      </span>
+    {/if}
+  </a>
+{/if}
+
+<style>
+  .syncbubble {
+    position: fixed;
+    right: 14px;
+    bottom: calc(86px + env(safe-area-inset-bottom));
+    z-index: 40;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    max-width: min(72vw, 280px);
+    padding: 7px 12px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--surface) 90%, transparent);
+    backdrop-filter: blur(8px);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow);
+    color: var(--muted);
+    font-size: 0.8rem;
+    line-height: 1;
+    text-decoration: none;
+    overflow: hidden;
+    transition:
+      padding 0.15s ease,
+      background 0.15s ease;
+  }
+  .syncbubble:hover {
+    text-decoration: none;
+    background: var(--surface);
+  }
+  .syncbubble:not(.expanded) {
+    padding: 8px;
+  }
+
+  .syncbubble.busy {
+    --tone: #f7b955;
+  }
+  .syncbubble.warn {
+    --tone: var(--bad, #f87171);
+  }
+  .syncbubble.off {
+    --tone: var(--muted);
+  }
+  .syncbubble.ok {
+    --tone: #29c785;
+  }
+  .syncbubble.idle {
+    --tone: var(--muted);
+  }
+
+  .sb-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--tone);
+    flex: none;
+  }
+  .sb-dot.spin {
+    width: 12px;
+    height: 12px;
+    background: none;
+    border: 2px solid color-mix(in srgb, var(--tone) 28%, transparent);
+    border-top-color: var(--tone);
+    animation: sb-spin 0.7s linear infinite;
+  }
+
+  .sb-text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .sb-progress {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 3px;
+    background: color-mix(in srgb, var(--tone) 16%, transparent);
+  }
+  .sb-bar {
+    display: block;
+    height: 100%;
+    width: 0;
+    background: var(--tone);
+    transition: width 0.2s ease;
+  }
+
+  @keyframes sb-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sb-dot.spin {
+      animation: none;
+    }
+    .sb-bar {
+      transition: none;
+    }
+  }
+</style>


### PR DESCRIPTION
Follow-up to the auto-sync toggle (#3): surface the OneDrive auto-sync state in a small, unobtrusive **status bubble** so the user always knows where their backup stands, plus a bounded progress indicator for slow uploads.

## What it does
- **Global bubble** (`src/lib/components/SyncBubble.svelte`, rendered once in `App.svelte`): fixed bottom-right, above the tab bar.
  - **Collapsed** to a quiet coloured dot when synced/idle (green when backed up).
  - **Expands** with a label for the states that matter: `Syncing…`, `Sync pending`, `Offline`, `Sync failed — retrying`. Hover/`title` and `aria-label` always carry the full text.
  - **Spinner** dot while syncing.
  - **Tap -> `/settings`** (the detailed OneDrive section).
- **Slow-sync progress:** if an upload runs **longer than 1s**, a thin progress bar is revealed *inside* the bubble. We have no real byte-progress from Microsoft Graph, so it's a bounded, eased approximation that snaps to 100% on success then fades. Fast syncs (<1s) show **no** bar - just the spinner.
- **Unobtrusive by design:** only shown when OneDrive is connected **and** auto-sync is on, and **hidden on the Settings page** (which already has the full indicator).

## Implementation notes
- Pure presentation - subscribes to the existing `autoSyncStatus` store and `settings`; no changes to the sync engine.
- The progress `$effect` depends only on `status`; a plain (non-reactive) mirror flag drives its branching so there's no feedback re-run loop. Each sync resets bar state, so the ">1s" rule applies per-upload.
- Respects `prefers-reduced-motion` (no spin/transition).

## Verification
- `npm run check` -> **0 errors, 0 warnings**.
- `npm run build` -> succeeds; MSAL stays in the lazy `onedrive` chunk; main bundle ~37.5 KB gzip.
- Built on top of current `main` (single commit; diff is only the bubble).

## Manual checks (need a real Microsoft account)
1. Connect + auto-sync on -> dot sits in the corner; make a change -> spinner, then `Backed up - just now`.
2. Throttle the network / large data so an upload >1s -> progress bar fills within the bubble, completes to 100%.
3. Expired sign-in -> bubble shows `Sync pending` (no redirect).
4. Go offline -> `Offline`; back online -> resumes.
5. Toggle auto-sync off -> bubble disappears.

Push-only, no surprise redirects - unchanged from #3. **Please review; do not merge on my behalf.**
