### PR TITLE
Revamp sync bubble into header pill and redesign OneDrive Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,12 @@ coalescing a burst of rapid edits into a single upload. It is **push‑only** (l
 own file — it never auto‑restores or auto‑pulls) and **silent**: if your sign‑in has expired it just
 shows _"Sync pending — reconnect to OneDrive"_ instead of yanking you to Microsoft mid‑use. It also
 pauses while you're offline and resumes on reconnect. Turn it off any time with **Settings →
-Automatically back up changes**; **Back up now** and **Restore** keep working regardless.
+Automatically back up changes**; **Sync now** and **Restore now** keep working regardless.
 
-A small **status bubble** in the bottom corner shows where your backup stands at a glance — a quiet
-dot when everything's synced, _"Syncing…"_ (with a progress bar if an upload runs long), or a
-_"Sync pending"_ / _"Offline"_ nudge when it needs attention. Tap it to jump to the OneDrive
+A small **status bubble** in the header — just left of the settings cog — shows where your backup
+stands at a glance: a quiet dot when everything's synced, _"Syncing…"_ (with a translucent progress
+fill washing across the bubble if an upload runs long, then a green _"Synced!"_), or a _"Pending"_ /
+_"Offline"_ nudge when it needs attention. Tap it for a little pop and a jump to the OneDrive
 settings.
 
 ### One‑time developer setup (register the shared app)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@azure/msal-browser": "^5.15.0",
         "idb": "^8.0.3",
+        "motion": "^12.42.0",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -3614,6 +3615,33 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.42.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.0.tgz",
+      "integrity": "sha512-wp7EJnfWaaEScVygKv3e20udoRz+LbtxScsuTkakAxfXmt+ReC6WyPW2nINRAGvd+hG9odwcjBLyOTPjH5pBRA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.42.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -4836,6 +4864,47 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/motion": {
+      "version": "12.42.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.0.tgz",
+      "integrity": "sha512-Qhwvu9sVl5/URSq5CNzwMCpSKK8Uhnrwb6VO977kZyj/wOCS7mWebJUnBoHx5cZU1Zv8a9BD5CSICWKAlrLJgA==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.42.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.42.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.0.tgz",
+      "integrity": "sha512-M63h4n8R+quJdNhBwuLlgxM+OLYa9+I/T2pzDRboB9fLXRdbou+Gw7Zury+SkpaCyACP1JHSjHgZ1EgTkBr30w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -5906,9 +5975,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "0.16.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@azure/msal-browser": "^5.15.0",
     "idb": "^8.0.3",
+    "motion": "^12.42.0",
     "xlsx": "^0.18.5"
   }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -22,7 +22,10 @@
     <img src="/favicon.svg" alt="" />
     Score King
   </a>
-  <a class="iconbtn" href="/settings" use:link aria-label="Settings" title="Settings">⚙️</a>
+  <div class="appbar-actions">
+    <SyncBubble />
+    <a class="iconbtn" href="/settings" use:link aria-label="Settings" title="Settings">⚙️</a>
+  </div>
 </header>
 
 <main class="app">
@@ -65,5 +68,3 @@
 {#if $toast}
   <div class="toast">{$toast}</div>
 {/if}
-
-<SyncBubble />

--- a/src/app.css
+++ b/src/app.css
@@ -151,6 +151,7 @@ tbody tr:last-child td { border-bottom: none; }
 }
 .brand { display: flex; align-items: center; gap: 10px; font-weight: 800; letter-spacing: 0.2px; }
 .brand img { width: 30px; height: 30px; }
+.appbar-actions { display: flex; align-items: center; gap: 10px; min-width: 0; }
 
 .tabbar {
   position: fixed; left: 0; right: 0; bottom: 0; z-index: 30;

--- a/src/lib/components/SyncBubble.svelte
+++ b/src/lib/components/SyncBubble.svelte
@@ -1,17 +1,15 @@
 <script lang="ts">
+  import { scale } from 'svelte/transition';
+  import { backOut } from 'svelte/easing';
   import { autoSyncStatus } from '../storage/autosync';
   import { settings } from '../stores/settings';
-  import { pathStore, parseRoute, link } from '../router';
+  import { navigate } from '../router';
   import { relativeTime } from '../util';
 
   const status = $derived($autoSyncStatus);
-  // The bubble represents auto-sync: only show it once the user has connected
-  // OneDrive AND left auto-sync on. The Settings page already has the detailed
-  // indicator, so stay out of the way there.
-  const route = $derived(parseRoute($pathStore));
-  const visible = $derived(
-    $settings.oneDriveConnected && $settings.autoSync && route.name !== 'settings',
-  );
+  // Persistent header indicator: shown once OneDrive is connected and auto-sync
+  // is on. Tapping it takes you to the connection page (Settings).
+  const visible = $derived($settings.oneDriveConnected && $settings.autoSync);
 
   const tone = $derived(
     status === 'syncing'
@@ -25,37 +23,46 @@
             : 'idle',
   );
 
+  // Short label for the compact header pill.
   const label = $derived(
     status === 'syncing'
       ? 'Syncing…'
+      : status === 'synced'
+        ? 'Synced!'
+        : status === 'pending'
+          ? 'Pending'
+          : status === 'offline'
+            ? 'Offline'
+            : status === 'error'
+              ? 'Retrying…'
+              : $settings.lastSync
+                ? 'Backed up'
+                : 'Not backed up',
+  );
+
+  // Full description for the tooltip / screen readers.
+  const fullLabel = $derived(
+    status === 'syncing'
+      ? 'Backing up to OneDrive…'
       : status === 'pending'
-        ? 'Sync pending'
+        ? 'Sync pending — reconnect to OneDrive'
         : status === 'offline'
-          ? 'Offline'
+          ? 'Offline — changes will back up when you reconnect'
           : status === 'error'
-            ? 'Sync failed — retrying'
+            ? 'Sync failed — will retry shortly'
             : $settings.lastSync
               ? 'Backed up · ' + relativeTime($settings.lastSync)
               : 'Not backed up yet',
   );
 
-  const fullLabel = $derived(
-    status === 'pending'
-      ? 'Sync pending — reconnect to OneDrive'
-      : status === 'offline'
-        ? 'Offline — changes will back up when you reconnect'
-        : label,
-  );
-
-  // --- progress + post-sync "sticky" label, driven only by `status` ---
-  let showProgress = $state(false); // reactive: drives the bar in the template
+  // --- progress fill (slow >1s syncs only); never carries into the synced state ---
+  let showFill = $state(false);
   let progress = $state(0); // 0..1
-  let stickySynced = $state(false); // keep "Backed up" visible briefly after a sync
+  let stickySynced = $state(false); // briefly celebrate a completed sync
   // Plain (non-reactive) mirror so the effect can branch on it without
   // subscribing to it — the effect must depend on `status` alone.
   let barShown = false;
 
-  // Expanded = show the text label; collapsed = just the coloured dot.
   const expanded = $derived(
     status === 'syncing' ||
       status === 'pending' ||
@@ -68,19 +75,18 @@
     const s = status;
 
     if (s === 'syncing') {
-      // Fresh upload: clear any leftover bar so the ">1s" rule applies per-sync.
-      showProgress = false;
+      showFill = false;
       progress = 0;
       barShown = false;
-      // Only reveal the progress bar if the upload is genuinely slow (>1s).
+      // Reveal the fill only if the upload is genuinely slow (>1s).
       const slow = setTimeout(() => {
         barShown = true;
-        showProgress = true;
-        progress = 0.08;
+        showFill = true;
+        progress = 0.1;
       }, 1000);
       const tick = setInterval(() => {
-        // Ease toward a cap; we have no real byte-progress from Graph, so this
-        // is a bounded, reassuring approximation that completes on success.
+        // Ease toward a cap — no real byte-progress from Graph, so this is a
+        // bounded, reassuring approximation.
         if (barShown) progress = Math.min(0.92, progress + (0.92 - progress) * 0.16);
       }, 200);
       return () => {
@@ -89,84 +95,84 @@
       };
     }
 
-    // Left the syncing state.
-    const timers: ReturnType<typeof setTimeout>[] = [];
-    if (barShown) {
-      if (s === 'synced') {
-        progress = 1; // snap to full, then fade the bar out
-        timers.push(
-          setTimeout(() => {
-            showProgress = false;
-            progress = 0;
-            barShown = false;
-          }, 450),
-        );
-      } else {
-        showProgress = false;
-        progress = 0;
-        barShown = false;
-      }
-    }
+    // Any non-syncing state: drop the fill immediately (no carry-over into "Synced!").
+    showFill = false;
+    progress = 0;
+    barShown = false;
+
     if (s === 'synced') {
       stickySynced = true;
-      timers.push(setTimeout(() => (stickySynced = false), 2500));
-    } else {
-      stickySynced = false;
+      const t = setTimeout(() => (stickySynced = false), 2200);
+      return () => clearTimeout(t);
     }
-    return () => timers.forEach((t) => clearTimeout(t));
+    stickySynced = false;
   });
+
+  // --- playful click: pop, then navigate to the connection page ---
+  let popping = $state(false);
+  let navTimer: ReturnType<typeof setTimeout> | undefined;
+  function onClick(e: MouseEvent) {
+    e.preventDefault();
+    if (popping) return;
+    popping = true;
+    clearTimeout(navTimer);
+    navTimer = setTimeout(() => {
+      popping = false;
+      navigate('/settings');
+    }, 300);
+  }
 </script>
 
 {#if visible}
   <a
     class="syncbubble {tone}"
     class:expanded
+    class:pop={popping}
+    class:celebrate={stickySynced}
     href="/settings"
-    use:link
+    onclick={onClick}
     title={fullLabel}
     aria-label={'Backup status: ' + fullLabel}
+    transition:scale={{ duration: 260, start: 0.5, opacity: 0, easing: backOut }}
   >
+    {#if showFill}
+      <span class="sb-fill" style="width: {Math.round(progress * 100)}%" aria-hidden="true"></span>
+    {/if}
     <span class="sb-dot" class:spin={status === 'syncing'}></span>
     {#if expanded}<span class="sb-text">{label}</span>{/if}
-    {#if showProgress}
-      <span class="sb-progress" aria-hidden="true">
-        <span class="sb-bar" style="width: {Math.round(progress * 100)}%"></span>
-      </span>
-    {/if}
   </a>
 {/if}
 
 <style>
   .syncbubble {
-    position: fixed;
-    right: 14px;
-    bottom: calc(86px + env(safe-area-inset-bottom));
-    z-index: 40;
+    position: relative;
     display: inline-flex;
     align-items: center;
-    gap: 8px;
-    max-width: min(72vw, 280px);
-    padding: 7px 12px;
+    gap: 7px;
+    max-width: 168px;
+    padding: 6px 11px;
     border-radius: 999px;
-    background: color-mix(in srgb, var(--surface) 90%, transparent);
-    backdrop-filter: blur(8px);
+    background: color-mix(in srgb, var(--surface-2) 80%, transparent);
     border: 1px solid var(--border);
-    box-shadow: var(--shadow);
     color: var(--muted);
-    font-size: 0.8rem;
-    line-height: 1;
+    font-size: 0.78rem;
+    line-height: 1.15;
     text-decoration: none;
     overflow: hidden;
     transition:
-      padding 0.15s ease,
-      background 0.15s ease;
+      padding 0.18s ease,
+      background 0.18s ease,
+      transform 0.12s ease;
   }
   .syncbubble:hover {
     text-decoration: none;
-    background: var(--surface);
+    background: var(--surface-3);
+  }
+  .syncbubble:active {
+    transform: scale(0.94);
   }
   .syncbubble:not(.expanded) {
-    padding: 8px;
+    padding: 7px;
   }
 
   .syncbubble.busy {
@@ -185,7 +191,22 @@
     --tone: var(--muted);
   }
 
+  /* Translucent progress fill across the whole bubble (left -> right).
+     For a bottom -> top fill instead: set `top: auto; height: <pct>; width: 100%`. */
+  .sb-fill {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 0;
+    background: color-mix(in srgb, #f7b955 34%, transparent);
+    transition: width 0.2s ease;
+    z-index: 0;
+  }
+
   .sb-dot {
+    position: relative;
+    z-index: 1;
     width: 9px;
     height: 9px;
     border-radius: 50%;
@@ -202,25 +223,21 @@
   }
 
   .sb-text {
+    position: relative;
+    z-index: 1;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
-  .sb-progress {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    height: 3px;
-    background: color-mix(in srgb, var(--tone) 16%, transparent);
+  .syncbubble.celebrate {
+    border-color: color-mix(in srgb, #29c785 55%, var(--border));
   }
-  .sb-bar {
-    display: block;
-    height: 100%;
-    width: 0;
-    background: var(--tone);
-    transition: width 0.2s ease;
+  .syncbubble.celebrate .sb-dot {
+    animation: sb-bounce 0.5s ease;
+  }
+  .syncbubble.pop {
+    animation: sb-pop 0.3s ease;
   }
 
   @keyframes sb-spin {
@@ -228,13 +245,42 @@
       transform: rotate(360deg);
     }
   }
+  @keyframes sb-bounce {
+    0% {
+      transform: scale(0.4);
+    }
+    55% {
+      transform: scale(1.35);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+  @keyframes sb-pop {
+    0% {
+      transform: scale(1) rotate(0);
+    }
+    35% {
+      transform: scale(1.16) rotate(-5deg);
+    }
+    70% {
+      transform: scale(0.95) rotate(4deg);
+    }
+    100% {
+      transform: scale(1) rotate(0);
+    }
+  }
 
   @media (prefers-reduced-motion: reduce) {
     .sb-dot.spin {
       animation: none;
     }
-    .sb-bar {
+    .sb-fill {
       transition: none;
+    }
+    .syncbubble.pop,
+    .syncbubble.celebrate .sb-dot {
+      animation: none;
     }
   }
 </style>

--- a/src/lib/components/SyncBubble.svelte
+++ b/src/lib/components/SyncBubble.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { scale } from 'svelte/transition';
-  import { backOut } from 'svelte/easing';
+  import { animate } from 'motion/mini';
   import { autoSyncStatus } from '../storage/autosync';
   import { settings } from '../stores/settings';
   import { navigate } from '../router';
@@ -55,6 +55,10 @@
               : 'Not backed up yet',
   );
 
+  const reduce = () =>
+    typeof window !== 'undefined' &&
+    !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
   // --- progress fill (slow >1s syncs only); never carries into the synced state ---
   let showFill = $state(false);
   let progress = $state(0); // 0..1
@@ -62,6 +66,8 @@
   // Plain (non-reactive) mirror so the effect can branch on it without
   // subscribing to it — the effect must depend on `status` alone.
   let barShown = false;
+
+  let dotEl: HTMLSpanElement | undefined = $state();
 
   const expanded = $derived(
     status === 'syncing' ||
@@ -85,7 +91,7 @@
         progress = 0.1;
       }, 1000);
       const tick = setInterval(() => {
-        // Ease toward a cap — no real byte-progress from Graph, so this is a
+        // Ease toward a cap — Graph gives no byte-progress, so this is a
         // bounded, reassuring approximation.
         if (barShown) progress = Math.min(0.92, progress + (0.92 - progress) * 0.16);
       }, 200);
@@ -102,24 +108,49 @@
 
     if (s === 'synced') {
       stickySynced = true;
+      // Springy celebration on the green dot.
+      if (dotEl && !reduce()) {
+        animate(
+          dotEl,
+          { scale: [0.3, 1.4, 0.9, 1] },
+          { duration: 0.5, ease: 'easeOut' },
+        );
+      }
       const t = setTimeout(() => (stickySynced = false), 2200);
       return () => clearTimeout(t);
     }
     stickySynced = false;
   });
 
-  // --- playful click: pop, then navigate to the connection page ---
+  // Springy entrance (Motion) — runs once when the pill mounts.
+  function enter(node: HTMLElement) {
+    if (reduce()) return;
+    animate(
+      node,
+      { opacity: [0, 1], scale: [0.5, 1.08, 1], rotate: [-8, 2, 0] },
+      { duration: 0.5, ease: 'easeOut' },
+    );
+  }
+
+  // --- playful click: pop with a spring, then navigate to the connection page ---
   let popping = $state(false);
-  let navTimer: ReturnType<typeof setTimeout> | undefined;
-  function onClick(e: MouseEvent) {
+  function onClick(e: MouseEvent, node: HTMLElement) {
     e.preventDefault();
     if (popping) return;
     popping = true;
-    clearTimeout(navTimer);
-    navTimer = setTimeout(() => {
+    if (reduce()) {
+      navigate('/settings');
+      return;
+    }
+    const controls = animate(
+      node,
+      { scale: [1, 1.18, 0.92, 1], rotate: [0, -7, 6, 0] },
+      { duration: 0.36, ease: 'easeOut' },
+    );
+    controls.finished.finally(() => {
       popping = false;
       navigate('/settings');
-    }, 300);
+    });
   }
 </script>
 
@@ -127,18 +158,18 @@
   <a
     class="syncbubble {tone}"
     class:expanded
-    class:pop={popping}
     class:celebrate={stickySynced}
     href="/settings"
-    onclick={onClick}
+    onclick={(e) => onClick(e, e.currentTarget)}
+    use:enter
     title={fullLabel}
     aria-label={'Backup status: ' + fullLabel}
-    transition:scale={{ duration: 260, start: 0.5, opacity: 0, easing: backOut }}
+    out:scale={{ duration: 200, start: 0.7, opacity: 0 }}
   >
     {#if showFill}
       <span class="sb-fill" style="width: {Math.round(progress * 100)}%" aria-hidden="true"></span>
     {/if}
-    <span class="sb-dot" class:spin={status === 'syncing'}></span>
+    <span class="sb-dot" class:spin={status === 'syncing'} bind:this={dotEl}></span>
     {#if expanded}<span class="sb-text">{label}</span>{/if}
   </a>
 {/if}
@@ -161,15 +192,11 @@
     overflow: hidden;
     transition:
       padding 0.18s ease,
-      background 0.18s ease,
-      transform 0.12s ease;
+      background 0.18s ease;
   }
   .syncbubble:hover {
     text-decoration: none;
     background: var(--surface-3);
-  }
-  .syncbubble:active {
-    transform: scale(0.94);
   }
   .syncbubble:not(.expanded) {
     padding: 7px;
@@ -233,41 +260,10 @@
   .syncbubble.celebrate {
     border-color: color-mix(in srgb, #29c785 55%, var(--border));
   }
-  .syncbubble.celebrate .sb-dot {
-    animation: sb-bounce 0.5s ease;
-  }
-  .syncbubble.pop {
-    animation: sb-pop 0.3s ease;
-  }
 
   @keyframes sb-spin {
     to {
       transform: rotate(360deg);
-    }
-  }
-  @keyframes sb-bounce {
-    0% {
-      transform: scale(0.4);
-    }
-    55% {
-      transform: scale(1.35);
-    }
-    100% {
-      transform: scale(1);
-    }
-  }
-  @keyframes sb-pop {
-    0% {
-      transform: scale(1) rotate(0);
-    }
-    35% {
-      transform: scale(1.16) rotate(-5deg);
-    }
-    70% {
-      transform: scale(0.95) rotate(4deg);
-    }
-    100% {
-      transform: scale(1) rotate(0);
     }
   }
 
@@ -277,10 +273,6 @@
     }
     .sb-fill {
       transition: none;
-    }
-    .syncbubble.pop,
-    .syncbubble.celebrate .sb-dot {
-      animation: none;
     }
   }
 </style>

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -7,7 +7,7 @@
   import { refreshGames } from '../lib/stores/games';
   import { refreshPlayers } from '../lib/stores/players';
   import { showToast } from '../lib/stores/toast';
-  import { relativeTime, formatDateTime } from '../lib/util';
+  import { relativeTime } from '../lib/util';
 
   let override = $state($settings.oneDriveClientId);
   let busy = $state(false);
@@ -28,7 +28,7 @@
             : '',
   );
 
-  const syncText = $derived(
+  const backupText = $derived(
     $autoSyncStatus === 'syncing'
       ? 'Syncing…'
       : $autoSyncStatus === 'pending'
@@ -38,8 +38,16 @@
           : $autoSyncStatus === 'error'
             ? 'Sync failed — will retry shortly'
             : $settings.lastSync
-              ? 'Backed up · ' + relativeTime($settings.lastSync)
+              ? 'Synced · Backed up ' + relativeTime($settings.lastSync)
               : 'Not backed up yet',
+  );
+
+  // Restore is paired with backup but never shows a "not yet" state: connecting
+  // already pulls the latest file down, so the local data is treated as restored.
+  const restoreText = $derived(
+    $settings.lastRestore
+      ? 'Last restored ' + relativeTime($settings.lastRestore)
+      : 'Up to date with OneDrive',
   );
 
   let folderMode = $state($settings.oneDriveFolderMode);
@@ -223,27 +231,18 @@
   {:else}
     {#if signedIn}
       <div class="row spread">
-        <span class="row" style="gap: 8px">
-          <span class="dot ok"></span> Connected to OneDrive
+        <span class="row provider" style="gap: 9px">
+          <svg class="od-logo" viewBox="0 0 24 24" width="22" height="22" role="img" aria-label="OneDrive">
+            <path
+              fill="#0078D4"
+              d="M19.35 10.04A7.49 7.49 0 0 0 12 4 7.49 7.49 0 0 0 5.1 8.36 5.994 5.994 0 0 0 6 20h13a4.99 4.99 0 0 0 .35-9.96z"
+            />
+          </svg>
+          <strong>Connected to OneDrive</strong>
         </span>
         <button class="btn small ghost" onclick={disconnect}>Disconnect</button>
       </div>
-      <div class="row wrap" style="gap: 10px">
-        <button class="btn primary grow" onclick={backup} disabled={busy}>Back up now</button>
-        <button class="btn grow" onclick={restore} disabled={busy}>Restore</button>
-      </div>
-      <div class="muted sm">
-        {$settings.lastRestore ? 'Last restored ' + formatDateTime($settings.lastRestore) : 'Not restored yet'}
-      </div>
-    {:else}
-      <div class="muted sm">
-        Sign in with your Microsoft account to back up your scores to a <code>Score King.xlsx</code>
-        file in your own OneDrive. You can open it in Excel anytime.
-      </div>
-      <button class="btn primary" onclick={connect} disabled={busy}>Connect OneDrive</button>
-    {/if}
 
-    <div class="autosync stack" style="gap: 8px">
       <label class="sw-row row spread">
         <span>Automatically back up changes</span>
         <span class="switch">
@@ -256,11 +255,33 @@
           <span class="track"><span class="thumb"></span></span>
         </span>
       </label>
-      <div class="row" style="gap: 8px">
-        <span class="dot {dotClass}"></span>
-        <span class="muted sm">{syncText}</span>
+
+      <hr class="sep" />
+
+      <div class="syncrow row spread">
+        <span class="row" style="gap: 8px; min-width: 0">
+          <span class="dot {dotClass}"></span>
+          <span class="sm">{backupText}</span>
+        </span>
+        <button class="btn small primary" onclick={backup} disabled={busy}>Sync now</button>
       </div>
-    </div>
+
+      <div class="syncrow stack" style="gap: 6px">
+        <div class="row spread">
+          <span class="sm">{restoreText}</span>
+          <button class="btn small ghost" onclick={restore} disabled={busy}>Restore now</button>
+        </div>
+        <span class="muted sm">
+          Pulls the latest backup from OneDrive and replaces the data on this device.
+        </span>
+      </div>
+    {:else}
+      <div class="muted sm">
+        Sign in with your Microsoft account to back up your scores to a <code>Score King.xlsx</code>
+        file in your own OneDrive. You can open it in Excel anytime.
+      </div>
+      <button class="btn primary" onclick={connect} disabled={busy}>Connect OneDrive</button>
+    {/if}
 
     <hr class="sep" />
 
@@ -365,6 +386,13 @@
   }
   .dot.off {
     background: var(--muted);
+  }
+  .od-logo {
+    flex: none;
+    display: block;
+  }
+  .provider strong {
+    font-weight: 600;
   }
   .sw-row {
     cursor: pointer;

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -59,6 +59,7 @@
       ? 'OneDrive / ' + (cleanPath ? cleanPath.replace(/\//g, ' / ') + ' / ' : '') + 'Score King.xlsx'
       : 'OneDrive / Apps / Score King / Score King.xlsx',
   );
+  const prettyPath = $derived(locationLabel.replace(/ \/ /g, ' › '));
 
   $effect(() => {
     const mode = folderMode;
@@ -256,6 +257,11 @@
         </span>
       </label>
 
+      <div class="pathchip" title={locationLabel}>
+        <span class="pathchip-ico" aria-hidden="true">📄</span>
+        <code>{prettyPath}</code>
+      </div>
+
       <hr class="sep" />
 
       <div class="syncrow row spread">
@@ -277,12 +283,13 @@
       </div>
     {:else}
       <div class="muted sm">
-        Sign in with your Microsoft account to back up your scores to a <code>Score King.xlsx</code>
-        file in your own OneDrive. You can open it in Excel anytime.
+        Sign in with your Microsoft account to back up your scores to OneDrive.
       </div>
       <button class="btn primary" onclick={connect} disabled={busy}>Connect OneDrive</button>
     {/if}
   {/if}
+
+  <hr class="sep" />
 
   <details>
     <summary class="muted sm">Advanced</summary>
@@ -295,9 +302,10 @@
           <span class="optbody">
             <strong>App folder <span class="tag">recommended</span></strong>
             <span class="muted sm block">
-              Score King can access <strong>only its own folder</strong>
-              (<code>OneDrive › Apps › Score King</code>) — it cannot see or touch anything else in
-              your OneDrive. Grants the sandboxed <code>Files.ReadWrite.AppFolder</code> permission.
+              Score King can access only its own folder
+              (<code>OneDrive › Apps › Score King</code>). It cannot see or touch anything else in
+              your OneDrive. Grants only the sandboxed <code>Files.ReadWrite.AppFolder</code>
+              permission to the Apps folder.
             </span>
           </span>
         </label>
@@ -307,10 +315,10 @@
           <span class="optbody">
             <strong>Custom folder</strong>
             <span class="muted sm block">
-              Store the workbook anywhere you like. Microsoft can't limit access to a single folder,
-              so this grants the broader <code>Files.ReadWrite</code> permission — the app could
-              <strong>technically</strong> reach all of your OneDrive files, even though it only ever
-              reads and writes its own <code>Score King.xlsx</code>.
+              Store the workbook anywhere you like. Score King will <strong>only</strong> read and
+              write to its own <code>Score King.xlsx</code> file. Microsoft can't limit access to a
+              single folder, so this grants the broader <code>Files.ReadWrite</code> permission to
+              your entire OneDrive.
             </span>
           </span>
         </label>
@@ -332,16 +340,20 @@
       <hr class="sep" />
 
       <div class="stack" style="gap: 10px">
-        <div class="fieldlabel">Use your own client ID</div>
+        <div class="fieldlabel">Use your own Azure app Client ID</div>
+        <div class="muted sm">
+          Don't trust us at all? No hard feelings! Override the built-in Azure app registration with
+          your own. See our <a
+            href="https://github.com/jrmoulckers/score-king/blob/main/README.md#onetime-developer-setup-register-the-shared-app"
+            target="_blank"
+            rel="noopener noreferrer">README</a
+          > for registration steps. Leave blank to use the default.
+        </div>
         <input
           type="text"
           bind:value={override}
           placeholder="00000000-0000-0000-0000-000000000000"
         />
-        <div class="muted sm">
-          Override the built-in app with your own Azure app registration. Leave blank to use the
-          default. See the README for registration steps.
-        </div>
         <button class="btn small" onclick={saveOverride}>Save ID</button>
       </div>
     </div>
@@ -396,6 +408,29 @@
   }
   .provider strong {
     font-weight: 600;
+  }
+  .pathchip {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    padding: 7px 10px;
+    border: 1px solid var(--border, rgba(127, 127, 127, 0.2));
+    border-radius: 8px;
+    background: var(--surface-2, rgba(127, 127, 127, 0.08));
+  }
+  .pathchip-ico {
+    flex: none;
+    font-size: 0.95rem;
+  }
+  .pathchip code {
+    background: none;
+    padding: 0;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    color: inherit;
   }
   .sw-row {
     cursor: pointer;

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -282,65 +282,68 @@
       </div>
       <button class="btn primary" onclick={connect} disabled={busy}>Connect OneDrive</button>
     {/if}
-
-    <hr class="sep" />
-
-    <div class="stack" style="gap: 10px">
-      <div class="fieldlabel">Where your data is stored</div>
-
-      <label class="opt">
-        <input type="radio" name="odmode" value="app" bind:group={folderMode} />
-        <span class="optbody">
-          <strong>App folder <span class="tag">recommended</span></strong>
-          <span class="muted sm block">
-            Score King can access <strong>only its own folder</strong>
-            (<code>OneDrive › Apps › Score King</code>) — it cannot see or touch anything else in
-            your OneDrive. Grants the sandboxed <code>Files.ReadWrite.AppFolder</code> permission.
-          </span>
-        </span>
-      </label>
-
-      <label class="opt">
-        <input type="radio" name="odmode" value="custom" bind:group={folderMode} />
-        <span class="optbody">
-          <strong>Custom folder</strong>
-          <span class="muted sm block">
-            Store the workbook anywhere you like. Microsoft can't limit access to a single folder,
-            so this grants the broader <code>Files.ReadWrite</code> permission — the app could
-            <strong>technically</strong> reach all of your OneDrive files, even though it only ever
-            reads and writes its own <code>Score King.xlsx</code>.
-          </span>
-        </span>
-      </label>
-
-      {#if folderMode === 'custom'}
-        <input
-          type="text"
-          bind:value={customPath}
-          placeholder="Folder path, e.g. Documents/Games (blank = OneDrive root)"
-        />
-      {/if}
-
-      <div class="muted sm">📄 <code>{locationLabel}</code></div>
-      <div class="muted sm">
-        Changing this may ask you to approve the new permission the next time you back up.
-      </div>
-    </div>
   {/if}
 
   <details>
-    <summary class="muted sm">Advanced: use your own client ID</summary>
-    <div class="stack" style="margin-top: 10px">
-      <input
-        type="text"
-        bind:value={override}
-        placeholder="00000000-0000-0000-0000-000000000000"
-      />
-      <div class="muted sm">
-        Override the built-in app with your own Azure app registration. Leave blank to use the
-        default. See the README for registration steps.
+    <summary class="muted sm">Advanced</summary>
+    <div class="stack" style="margin-top: 12px; gap: 16px">
+      <div class="stack" style="gap: 10px">
+        <div class="fieldlabel">Where your data is stored</div>
+
+        <label class="opt">
+          <input type="radio" name="odmode" value="app" bind:group={folderMode} />
+          <span class="optbody">
+            <strong>App folder <span class="tag">recommended</span></strong>
+            <span class="muted sm block">
+              Score King can access <strong>only its own folder</strong>
+              (<code>OneDrive › Apps › Score King</code>) — it cannot see or touch anything else in
+              your OneDrive. Grants the sandboxed <code>Files.ReadWrite.AppFolder</code> permission.
+            </span>
+          </span>
+        </label>
+
+        <label class="opt">
+          <input type="radio" name="odmode" value="custom" bind:group={folderMode} />
+          <span class="optbody">
+            <strong>Custom folder</strong>
+            <span class="muted sm block">
+              Store the workbook anywhere you like. Microsoft can't limit access to a single folder,
+              so this grants the broader <code>Files.ReadWrite</code> permission — the app could
+              <strong>technically</strong> reach all of your OneDrive files, even though it only ever
+              reads and writes its own <code>Score King.xlsx</code>.
+            </span>
+          </span>
+        </label>
+
+        {#if folderMode === 'custom'}
+          <input
+            type="text"
+            bind:value={customPath}
+            placeholder="Folder path, e.g. Documents/Games (blank = OneDrive root)"
+          />
+        {/if}
+
+        <div class="muted sm">📄 <code>{locationLabel}</code></div>
+        <div class="muted sm">
+          Changing this may ask you to approve the new permission the next time you back up.
+        </div>
       </div>
-      <button class="btn small" onclick={saveOverride}>Save ID</button>
+
+      <hr class="sep" />
+
+      <div class="stack" style="gap: 10px">
+        <div class="fieldlabel">Use your own client ID</div>
+        <input
+          type="text"
+          bind:value={override}
+          placeholder="00000000-0000-0000-0000-000000000000"
+        />
+        <div class="muted sm">
+          Override the built-in app with your own Azure app registration. Leave blank to use the
+          default. See the README for registration steps.
+        </div>
+        <button class="btn small" onclick={saveOverride}>Save ID</button>
+      </div>
     </div>
   </details>
 </div>

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -142,7 +142,12 @@
   }
 
   async function restore() {
-    if (!confirm('Replace local data with the OneDrive backup?')) return;
+    if (
+      !confirm(
+        'Restore from OneDrive?\n\nThis overwrites the data currently on this device with the latest backup. This cannot be undone.',
+      )
+    )
+      return;
     busy = true;
     try {
       const od = await getOneDrive();
@@ -258,7 +263,7 @@
       </label>
 
       <div class="pathchip" title={locationLabel}>
-        <span class="pathchip-ico" aria-hidden="true">📄</span>
+        <span class="pathchip-ico" aria-hidden="true">📍</span>
         <code>{prettyPath}</code>
       </div>
 
@@ -274,7 +279,20 @@
 
       <div class="syncrow stack" style="gap: 6px">
         <div class="row spread">
-          <span class="sm">{restoreText}</span>
+          <span class="row" style="gap: 8px; min-width: 0">
+            <svg class="rdot" viewBox="0 0 16 16" role="img" aria-label="Restore up to date">
+              <circle cx="8" cy="8" r="8" fill="#29c785" />
+              <path
+                d="M4.5 8.3 7 10.8 11.5 5.6"
+                fill="none"
+                stroke="#04150d"
+                stroke-width="1.9"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <span class="sm">{restoreText}</span>
+          </span>
           <button class="btn small ghost" onclick={restore} disabled={busy}>Restore now</button>
         </div>
         <span class="muted sm">
@@ -401,6 +419,12 @@
   }
   .dot.off {
     background: var(--muted);
+  }
+  .rdot {
+    width: 9px;
+    height: 9px;
+    flex: none;
+    display: block;
   }
   .od-logo {
     flex: none;

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -263,7 +263,7 @@
       </label>
 
       <div class="pathchip" title={locationLabel}>
-        <span class="pathchip-ico" aria-hidden="true">📍</span>
+        <span class="pathchip-ico" aria-hidden="true">📂</span>
         <code>{prettyPath}</code>
       </div>
 


### PR DESCRIPTION
## Sync UX revamp: header bubble + OneDrive Settings redesign

Builds on the auto-sync feature with a friendlier, clearer surface. **Push-only auto-sync behavior is unchanged** — this is presentation/copy plus a few safety tweaks.

### Header sync bubble
- Moved the status bubble into the app header, just left of the settings cog.
- Animated with the **Motion** library (`motion/mini`, ~3 KB gzip): springy entrance, click-to-pop that navigates to Settings, and a translucent amber progress fill that washes across while an upload runs long (>1 s), settling into a green "Synced!" celebration with no leftover bar.
- Honors `prefers-reduced-motion`.

### OneDrive Settings redesign
- Inline OneDrive logo replaces the old green dot in the "Connected" header.
- **Automatically back up changes** toggle sits directly under the title.
- Destination shown as a path chip beneath the toggle (📂 `OneDrive › Apps › Score King › Score King.xlsx`), updating live with folder mode.
- Backup row: green dot + "Synced · Backed up <time>" + **Sync now**.
- Restore row: dot-width green check + status + **Restore now**, with a subtitle clarifying it pulls the latest from OneDrive. Never shows a "not restored yet" state.
- **Restore now** confirms explicitly that it overwrites this device's current data with the latest backup (cannot be undone).
- Reworked sign-in / permission copy; the custom Client-ID note links to the README registration steps.
- **Advanced** collapsible now holds both "Where your data is stored" and "Use your own Azure app Client ID", with section breaks for clearer grouping.

### Notes
- `npm run check` 0 errors / 0 warnings; `npm run build` succeeds.
- README updated to describe the header bubble and renamed actions.
- New dependency: `motion` (used only via the lightweight `motion/mini` entry).

🔎 Not merged / not deployed — opening for review.
