### PR TITLE
Add accessibility & display settings hub

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,30 @@
+# Copilot instructions
+
+## Design Context
+
+This project has committed design context. **Read these before changing any UI:**
+
+- **[PRODUCT.md](../PRODUCT.md)** — strategy: register (`product`), users, purpose,
+  brand personality (*Whimsical, Easy, Game-Night Energy*), anti-references, design
+  principles, and the accessibility/inclusion brief.
+- **[DESIGN.md](../DESIGN.md)** — the visual system: color tokens, typography, elevation,
+  components, and forceful Do's & Don'ts. Creative North Star: **"The Game-Night LARPer"**
+  (consistent chrome underneath, thematic per-game costume on top).
+- **`.impeccable/design.json`** — machine-readable sidecar (tonal ramps, shadows, motion,
+  live component snippets) consumed by the impeccable design skill.
+
+Non-negotiables pulled from DESIGN.md:
+
+- **Royal Violet** (`#7c5cff`) marks exactly one primary action per screen; **Crown Gold**
+  (`#ffd166`) is reserved for the leader and the winner — never buttons or decoration.
+- Build depth by climbing the surface ramp (`surface` → `surface-2` → `surface-3`), not by
+  stacking shadows. One Soft Lift shadow only. Glass (backdrop blur) only on the top app
+  bar and bottom tab bar.
+- Render every changing number with `tabular-nums`; keep touch targets ≥46px (one-handed,
+  dim-light use); never signal state with color alone; honor `prefers-reduced-motion`.
+- Keep the chrome identical game to game — express per-game personality through emoji,
+  copy, and accent moments, not by restyling the shell.
+
+To evolve the design system, use the **impeccable** skill (e.g. `/impeccable critique`,
+`/impeccable craft`, `/impeccable live`). Re-run `/impeccable document` if the visual
+system drifts so DESIGN.md and the sidecar stay accurate.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.impeccable/hook.cache.json

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,204 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-06-29T11:20:36-07:00",
+  "title": "Design System: Score King",
+  "extensions": {
+    "colorMeta": {
+      "primary": {
+        "role": "primary",
+        "displayName": "Royal Violet",
+        "canonical": "#7c5cff",
+        "tonalRamp": ["oklch(0.18 0.06 285)", "oklch(0.28 0.10 285)", "oklch(0.38 0.14 285)", "oklch(0.49 0.18 285)", "oklch(0.60 0.21 285)", "oklch(0.71 0.16 285)", "oklch(0.83 0.10 285)", "oklch(0.94 0.04 285)"]
+      },
+      "primary-strong": {
+        "role": "primary",
+        "displayName": "Deep Violet",
+        "canonical": "#6b46f0",
+        "tonalRamp": ["oklch(0.17 0.07 282)", "oklch(0.27 0.11 282)", "oklch(0.37 0.15 282)", "oklch(0.47 0.19 282)", "oklch(0.55 0.22 282)", "oklch(0.67 0.17 282)", "oklch(0.80 0.11 282)", "oklch(0.92 0.05 282)"]
+      },
+      "accent": {
+        "role": "secondary",
+        "displayName": "Crown Gold",
+        "canonical": "#ffd166",
+        "tonalRamp": ["oklch(0.30 0.05 90)", "oklch(0.42 0.07 90)", "oklch(0.54 0.09 90)", "oklch(0.65 0.11 90)", "oklch(0.76 0.13 90)", "oklch(0.84 0.14 90)", "oklch(0.90 0.10 90)", "oklch(0.96 0.05 90)"]
+      },
+      "good": {
+        "role": "tertiary",
+        "displayName": "Win Green",
+        "canonical": "#34d399",
+        "tonalRamp": ["oklch(0.25 0.05 165)", "oklch(0.36 0.07 165)", "oklch(0.47 0.10 165)", "oklch(0.58 0.12 165)", "oklch(0.69 0.14 165)", "oklch(0.78 0.15 165)", "oklch(0.87 0.10 165)", "oklch(0.95 0.05 165)"]
+      },
+      "bad": {
+        "role": "tertiary",
+        "displayName": "Loss Coral",
+        "canonical": "#f87171",
+        "tonalRamp": ["oklch(0.28 0.06 25)", "oklch(0.39 0.10 25)", "oklch(0.50 0.13 25)", "oklch(0.60 0.16 25)", "oklch(0.71 0.17 25)", "oklch(0.79 0.14 25)", "oklch(0.88 0.09 25)", "oklch(0.95 0.04 25)"]
+      },
+      "warn": {
+        "role": "tertiary",
+        "displayName": "Caution Amber",
+        "canonical": "#fbbf24",
+        "tonalRamp": ["oklch(0.29 0.05 80)", "oklch(0.41 0.08 80)", "oklch(0.53 0.11 80)", "oklch(0.64 0.13 80)", "oklch(0.75 0.15 80)", "oklch(0.83 0.16 80)", "oklch(0.90 0.11 80)", "oklch(0.96 0.05 80)"]
+      },
+      "dark-bg": {
+        "role": "neutral",
+        "displayName": "Midnight Court",
+        "canonical": "#0f1020",
+        "tonalRamp": ["oklch(0.16 0.04 285)", "oklch(0.22 0.04 285)", "oklch(0.30 0.04 285)", "oklch(0.40 0.03 285)", "oklch(0.52 0.03 285)", "oklch(0.66 0.02 285)", "oklch(0.80 0.02 285)", "oklch(0.93 0.01 285)"]
+      },
+      "dark-surface": {
+        "role": "neutral",
+        "displayName": "Indigo Slate",
+        "canonical": "#1a1b2e",
+        "tonalRamp": ["oklch(0.20 0.04 285)", "oklch(0.27 0.04 285)", "oklch(0.35 0.04 285)", "oklch(0.45 0.03 285)", "oklch(0.57 0.03 285)", "oklch(0.70 0.02 285)", "oklch(0.83 0.02 285)", "oklch(0.94 0.01 285)"]
+      },
+      "dark-text": {
+        "role": "neutral",
+        "displayName": "Moonlight",
+        "canonical": "#e9e9f4",
+        "tonalRamp": ["oklch(0.20 0.02 285)", "oklch(0.32 0.02 285)", "oklch(0.44 0.02 285)", "oklch(0.56 0.02 285)", "oklch(0.68 0.02 285)", "oklch(0.79 0.02 285)", "oklch(0.88 0.01 285)", "oklch(0.95 0.01 285)"]
+      },
+      "light-bg": {
+        "role": "neutral",
+        "displayName": "Lilac Mist",
+        "canonical": "#f4f4fb",
+        "tonalRamp": ["oklch(0.22 0.02 285)", "oklch(0.34 0.02 285)", "oklch(0.46 0.02 285)", "oklch(0.58 0.02 285)", "oklch(0.70 0.02 285)", "oklch(0.82 0.01 285)", "oklch(0.91 0.01 285)", "oklch(0.97 0.005 285)"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display / h1", "purpose": "Page titles. The size ceiling — never larger than 1.6rem." },
+      "title": { "displayName": "Title / h2", "purpose": "Section and card headings." },
+      "body": { "displayName": "Body", "purpose": "Default text and list rows; cap prose at 65-75ch." },
+      "label": { "displayName": "Label", "purpose": "Muted form labels and secondary metadata." },
+      "overline": { "displayName": "Overline / section-title", "purpose": "The only sanctioned uppercase-tracked label; quiet group headers." }
+    },
+    "shadows": [
+      { "name": "soft-lift-dark", "value": "0 10px 30px rgba(0,0,0,0.45)", "purpose": "The single shadow in dark theme — floats cards, game tiles, and the toast off the background." },
+      { "name": "soft-lift-light", "value": "0 10px 30px rgba(60,50,120,0.12)", "purpose": "Light-theme equivalent of Soft Lift." },
+      { "name": "inset-hairline", "value": "inset 0 0 0 1px rgba(0,0,0,0.18)", "purpose": "1px inner ring on avatars so light player colors keep their edge." }
+    ],
+    "motion": [
+      { "name": "press", "value": "transform 0.05s ease", "purpose": "Button :active press-down (translateY(1px))." },
+      { "name": "state", "value": "background 0.15s ease, border-color 0.15s ease", "purpose": "Default hover/state color transitions — fast, functional." },
+      { "name": "tile-lift", "value": "0.12s", "purpose": "Game-tile hover lift and border-color shift." }
+    ],
+    "breakpoints": [
+      { "name": "content-max", "value": "760px" },
+      { "name": "tile-min", "value": "150px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The single most important action on a screen — start a game, save a round.",
+      "html": "<button class='ds-btn-primary'>New game</button>",
+      "css": ".ds-btn-primary{display:inline-flex;align-items:center;justify-content:center;gap:8px;min-height:46px;padding:12px 18px;border:1px solid #6b46f0;border-radius:9px;background:#7c5cff;color:#fff;font:600 1rem system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;cursor:pointer;transition:background .15s ease,transform .05s ease;}.ds-btn-primary:hover{background:#6b46f0;}.ds-btn-primary:active{transform:translateY(1px);}.ds-btn-primary:focus-visible{outline:2px solid #7c5cff;outline-offset:1px;}"
+    },
+    {
+      "name": "Default Button",
+      "kind": "button",
+      "refersTo": "button-default",
+      "description": "Standard secondary action; surface-2 fill that climbs to surface-3 on hover.",
+      "html": "<button class='ds-btn-default'>Cancel</button>",
+      "css": ".ds-btn-default{display:inline-flex;align-items:center;justify-content:center;gap:8px;min-height:46px;padding:12px 18px;border:1px solid #313357;border-radius:9px;background:#24263f;color:#e9e9f4;font:600 1rem system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;cursor:pointer;transition:background .15s ease,transform .05s ease;}.ds-btn-default:hover{background:#2c2e4d;}.ds-btn-default:active{transform:translateY(1px);}.ds-btn-default:focus-visible{outline:2px solid #7c5cff;outline-offset:1px;}"
+    },
+    {
+      "name": "Stepper",
+      "kind": "custom",
+      "refersTo": "iconbtn",
+      "description": "Signature round-entry control: minus / tabular number / plus, tuned for one-handed score nudging without the keyboard.",
+      "html": "<div class='ds-stepper'><button class='ds-step-btn' aria-label='decrease'>\u2212</button><input class='ds-step-input' type='number' value='3' inputmode='numeric'/><button class='ds-step-btn' aria-label='increase'>+</button></div>",
+      "css": ".ds-stepper{display:inline-flex;align-items:center;gap:6px;}.ds-step-btn{display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;border-radius:10px;border:1px solid #313357;background:#24263f;color:#e9e9f4;font-size:1.1rem;cursor:pointer;}.ds-step-btn:hover{background:#2c2e4d;}.ds-step-input{width:62px;text-align:center;min-height:46px;padding:11px 4px;border:1px solid #313357;border-radius:9px;background:#1a1b2e;color:#e9e9f4;font:700 1rem system-ui;font-variant-numeric:tabular-nums;}.ds-step-input:focus{outline:2px solid #7c5cff;outline-offset:1px;}"
+    },
+    {
+      "name": "Game Tile",
+      "kind": "card",
+      "refersTo": "gametile",
+      "description": "Signature game-picker card — the primary place per-game theming (emoji, name, tagline) shows up; border turns Royal Violet on hover.",
+      "html": "<a class='ds-gametile'><span class='ds-gametile-emoji'>\ud83c\udff4\u200d\u2620\ufe0f</span><span class='ds-gametile-name'>Skull King</span><span class='ds-gametile-tag'>10 rounds \u00b7 bid vs. tricks</span></a>",
+      "css": ".ds-gametile{display:flex;flex-direction:column;gap:6px;padding:16px;text-align:left;max-width:210px;border:1px solid #313357;border-radius:14px;background:#1a1b2e;color:#e9e9f4;box-shadow:0 10px 30px rgba(0,0,0,.45);cursor:pointer;text-decoration:none;transition:.12s;}.ds-gametile:hover{border-color:#7c5cff;transform:translateY(-1px);}.ds-gametile-emoji{font-size:2rem;}.ds-gametile-name{font-weight:700;}.ds-gametile-tag{font-size:.8rem;color:#a3a6cb;}"
+    },
+    {
+      "name": "Pill",
+      "kind": "chip",
+      "refersTo": "pill",
+      "description": "Compact status/meta token (e.g. 'Round 4'); never used as a button.",
+      "html": "<span class='ds-pill'>Round 4</span>",
+      "css": ".ds-pill{display:inline-flex;align-items:center;gap:6px;padding:3px 10px;border-radius:999px;background:#24263f;border:1px solid #313357;font:0.8rem system-ui;color:#a3a6cb;}"
+    },
+    {
+      "name": "Text Input",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Standard field; surface fill with Royal Violet focus ring shared with buttons.",
+      "html": "<input class='ds-input' type='text' placeholder='Player name'/>",
+      "css": ".ds-input{width:100%;max-width:280px;min-height:46px;padding:11px 12px;border:1px solid #313357;border-radius:9px;background:#1a1b2e;color:#e9e9f4;font:1rem system-ui;}.ds-input::placeholder{color:#a3a6cb;}.ds-input:focus{outline:2px solid #7c5cff;outline-offset:1px;}"
+    },
+    {
+      "name": "Avatar",
+      "kind": "custom",
+      "refersTo": "iconbtn",
+      "description": "Circular player chip filled from the 12-color palette; always shows initials so identity never relies on color alone.",
+      "html": "<span class='ds-avatar'>JD</span>",
+      "css": ".ds-avatar{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:50%;background:#7c5cff;color:#fff;font:700 0.7rem system-ui;box-shadow:inset 0 0 0 1px rgba(0,0,0,.18);}"
+    },
+    {
+      "name": "Bottom Tab Bar",
+      "kind": "nav",
+      "refersTo": "iconbtn",
+      "description": "Fixed glass primary navigation; active tab gets Moonlight text on a surface-2 pill. Built for thumbs.",
+      "html": "<nav class='ds-tabbar'><a class='ds-tab ds-tab-active'><span class='ds-tab-ico'>\ud83c\udfe0</span>Games</a><a class='ds-tab'><span class='ds-tab-ico'>\ud83d\udc65</span>Players</a><a class='ds-tab'><span class='ds-tab-ico'>\ud83d\udcdc</span>History</a><a class='ds-tab'><span class='ds-tab-ico'>\ud83d\udcca</span>Stats</a></nav>",
+      "css": ".ds-tabbar{display:flex;justify-content:space-around;gap:6px;padding:8px 6px;background:rgba(15,16,32,.92);backdrop-filter:blur(12px);border-top:1px solid #313357;border-radius:14px;}.ds-tab{display:flex;flex-direction:column;align-items:center;gap:2px;font:0.7rem system-ui;color:#a3a6cb;text-decoration:none;padding:4px 10px;border-radius:10px;min-width:56px;}.ds-tab-ico{font-size:1.2rem;line-height:1;}.ds-tab-active{color:#e9e9f4;background:#24263f;}"
+    },
+    {
+      "name": "Scoreboard",
+      "kind": "custom",
+      "refersTo": "card",
+      "description": "Signature standings table — tabular numbers, rank-1 score in Crown Gold, winner row washed 14% gold.",
+      "html": "<table class='ds-scoreboard'><thead><tr><th>#</th><th>Player</th><th>Score</th></tr></thead><tbody><tr class='ds-winner'><td>1</td><td>Ada \ud83d\udc51</td><td class='ds-num ds-lead'>112</td></tr><tr><td>2</td><td>Bo</td><td class='ds-num'>98</td></tr><tr><td>3</td><td>Cy</td><td class='ds-num'>74</td></tr></tbody></table>",
+      "css": ".ds-scoreboard{width:100%;max-width:320px;border-collapse:collapse;color:#e9e9f4;font:1rem system-ui;}.ds-scoreboard th,.ds-scoreboard td{padding:9px 8px;text-align:right;border-bottom:1px solid #313357;white-space:nowrap;}.ds-scoreboard th:first-child,.ds-scoreboard td:first-child{text-align:left;}.ds-scoreboard thead th{color:#a3a6cb;font-size:.8rem;font-weight:600;}.ds-num{font-variant-numeric:tabular-nums;font-weight:700;}.ds-lead{color:#ffd166;}.ds-winner td{background:rgba(255,209,102,.14);}"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Game-Night LARPer",
+    "overview": "Score King is a whimsical game-night host that role-plays through thematic elements customized per game, while the interaction underneath stays effortless and identical everywhere. The chrome is the costume; the mechanics are the actor. A self-contained, calm dark-violet shell never changes, so the muscle memory of entering a score is the same in Skull King as in Hearts as in a generic Tally. The theming lives on top of that shell: each game brings its own emoji, accent moments, and round-entry flavor, the way a LARPer swaps costumes but keeps the same easy patter. The single phone is the table, so every surface is built first for a thumb in a dimly lit room. The palette is royal by design: deep indigo-violet fields, a single Royal Violet that marks the one action that matters, and a scarce Crown Gold that appears only on the leader and the winner.",
+    "keyCharacteristics": [
+      "Consistent chrome, thematic costume — one shell, per-game flavor on top.",
+      "Royal violet + scarce crown gold on a deep indigo field.",
+      "Dark-first, OLED-friendly, readable in dim light; light theme is a faithful inversion.",
+      "One-handed, thumb-zone-first, >=46px touch targets.",
+      "Glanceable: tabular numbers, clear standings, the crown tells the story at a glance."
+    ],
+    "rules": [
+      { "name": "The Crown Gold Rule", "body": "Crown Gold (#ffd166) belongs to the leader and the winner — nothing else. The moment gold appears on an ordinary button, link, or flourish, it stops meaning 'you're winning,' and the crown loses its power.", "section": "colors" },
+      { "name": "The One Voice Rule", "body": "Royal Violet marks a single primary action and the active tab. One violet fill per screen. Everything else is surface, neutral, or semantic.", "section": "colors" },
+      { "name": "The Color-Is-Never-Alone Rule", "body": "Standing, win/loss, and state are never carried by hue alone (rank number, the crown, initials, +/- sign, and text always co-signal) so the app stays legible for color-blind players.", "section": "colors" },
+      { "name": "The Tabular Score Rule", "body": "Every number that can change renders with font-variant-numeric: tabular-nums and weight 700, so columns never jitter and the leader is readable at a glance across the table.", "section": "typography" },
+      { "name": "The Quiet-Type Rule", "body": "UI type never tries to be the personality. No display fonts in labels, buttons, or data. Whimsy comes from the motif, the emoji, and the copy — not from the letterforms.", "section": "typography" },
+      { "name": "The Soft-Lift Rule", "body": "One shadow token, used sparingly. If something needs to feel deeper, raise it one step up the surface ramp instead of darkening or stacking shadows.", "section": "elevation" },
+      { "name": "The Glass-Chrome Rule", "body": "Backdrop blur is permitted on exactly two surfaces — the sticky top app bar and the fixed bottom tab bar — because they are persistent navigation floating over scrolling content. Glass appears nowhere else.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do keep Crown Gold (#ffd166) for the leader and winner only — the crown earns its meaning through scarcity.",
+      "Do ship exactly one Royal Violet primary action per screen; everything else is neutral, surface, or semantic.",
+      "Do render every changing number with tabular-nums and weight 700 so columns stay glanceable.",
+      "Do build depth by climbing the surface ramp (surface -> surface-2 -> surface-3), and use the single Soft Lift shadow only for truly floating objects.",
+      "Do keep touch targets >=46px and primary actions in the thumb zone — this is played one-handed in dim light.",
+      "Do co-signal state with shape, number, icon, and text — never color alone — for color-blind players.",
+      "Do keep the chrome identical game to game; express per-game personality through emoji, copy, and accent moments, not by restyling the shell.",
+      "Do give every animation a prefers-reduced-motion alternative (instant or crossfade)."
+    ],
+    "donts": [
+      "Don't ship anything cluttered, confusing, verbose, corporate, sterile, redundant, ad-ridden, or inconsistent — the named anti-references from PRODUCT.md.",
+      "Don't let the UI look like an enterprise/corporate SaaS dashboard — no gray, sterile, density-for-its-own-sake screens.",
+      "Don't import app-store score-keeper habits: ad chrome, banner clutter, upsell rails.",
+      "Don't over-animate or 'gamify' the core loop; motion stays 150-250ms and conveys state, never decoration you wait for.",
+      "Don't use Crown Gold on buttons, links, or flourishes; don't add a second violet fill to compete with the primary action.",
+      "Don't add border-left/border-right colored stripes, gradient text, or decorative glass; glass is only the app bar and tab bar.",
+      "Don't introduce a display font into labels, buttons, or data; the system sans stays quiet so the game can be loud.",
+      "Don't restyle the navigation, button, or stepper vocabulary per game — consistency is the feature that lets new games feel instantly familiar."
+    ]
+  }
+}

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["index.html"],
+  "insertBefore": "</body>",
+  "commentSyntax": "html",
+  "cspChecked": true
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,358 @@
+---
+name: Score King
+description: A whimsical, local-first PWA that keeps score for card & party games.
+colors:
+  primary: "#7c5cff"
+  primary-strong: "#6b46f0"
+  accent: "#ffd166"
+  good: "#34d399"
+  bad: "#f87171"
+  warn: "#fbbf24"
+  dark-bg: "#0f1020"
+  dark-surface: "#1a1b2e"
+  dark-surface-2: "#24263f"
+  dark-surface-3: "#2c2e4d"
+  dark-border: "#313357"
+  dark-text: "#e9e9f4"
+  dark-muted: "#a3a6cb"
+  light-bg: "#f4f4fb"
+  light-surface: "#ffffff"
+  light-surface-2: "#f1f1f9"
+  light-surface-3: "#e7e7f4"
+  light-border: "#dcdcea"
+  light-text: "#1c1d2e"
+  light-muted: "#5b5e7e"
+typography:
+  display:
+    fontFamily: "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+    fontSize: "1.6rem"
+    fontWeight: 700
+    lineHeight: 1.2
+  title:
+    fontFamily: "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+    fontSize: "1.25rem"
+    fontWeight: 700
+    lineHeight: 1.2
+  body:
+    fontFamily: "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.5
+  label:
+    fontFamily: "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+    fontSize: "0.9rem"
+    fontWeight: 400
+    lineHeight: 1.4
+  overline:
+    fontFamily: "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+    fontSize: "0.8rem"
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: "0.08em"
+rounded:
+  sm: "9px"
+  md: "14px"
+  chip: "10px"
+  pill: "999px"
+spacing:
+  xs: "6px"
+  sm: "10px"
+  md: "14px"
+  lg: "16px"
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "#ffffff"
+    rounded: "{rounded.sm}"
+    padding: "12px 18px"
+    height: "46px"
+  button-primary-hover:
+    backgroundColor: "{colors.primary-strong}"
+  button-default:
+    backgroundColor: "{colors.dark-surface-2}"
+    textColor: "{colors.dark-text}"
+    rounded: "{rounded.sm}"
+    padding: "12px 18px"
+    height: "46px"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.dark-text}"
+  button-danger:
+    backgroundColor: "transparent"
+    textColor: "{colors.bad}"
+  card:
+    backgroundColor: "{colors.dark-surface}"
+    textColor: "{colors.dark-text}"
+    rounded: "{rounded.md}"
+    padding: "16px"
+  input:
+    backgroundColor: "{colors.dark-surface}"
+    textColor: "{colors.dark-text}"
+    rounded: "{rounded.sm}"
+    padding: "11px 12px"
+    height: "46px"
+  pill:
+    backgroundColor: "{colors.dark-surface-2}"
+    textColor: "{colors.dark-muted}"
+    rounded: "{rounded.pill}"
+    padding: "3px 10px"
+  gametile:
+    backgroundColor: "{colors.dark-surface}"
+    textColor: "{colors.dark-text}"
+    rounded: "{rounded.md}"
+    padding: "16px"
+  iconbtn:
+    backgroundColor: "{colors.dark-surface-2}"
+    textColor: "{colors.dark-text}"
+    rounded: "{rounded.chip}"
+    size: "42px"
+---
+
+# Design System: Score King
+
+## 1. Overview
+
+**Creative North Star: "The Game-Night LARPer"**
+
+Score King is a whimsical game-night host that role-plays through thematic elements
+customized per game, while the interaction underneath stays effortless and identical
+everywhere. The chrome is the costume; the mechanics are the actor. A self-contained,
+calm dark-violet shell — top app bar, scrollable stage, bottom tab bar — never changes,
+so the muscle memory of entering a score is the same in Skull King as in Hearts as in a
+generic Tally. The theming lives on top of that shell: each game brings its own emoji,
+its own accent moments, its own round-entry flavor (🏴‍☠️, ♥️, 🎲), the way a LARPer
+swaps costumes but keeps the same easy patter. The single phone is the table — held
+one-handed, passed around, propped up for everyone to see, or (ahead) networked across
+devices — so every surface is built first for a thumb in a dimly lit room.
+
+The palette is royal by design: deep indigo-violet fields, a single **Royal Violet**
+that marks the one action that matters, and a scarce **Crown Gold** that appears only on
+the leader and the winner. Personality comes from the 👑 motif, the warmth of the violet,
+and small earned moments — never from noise. Depth is built from layered surfaces, not
+stacked shadows; motion is fast and functional, never choreography you have to wait for.
+
+This system explicitly rejects everything in PRODUCT.md's anti-references: it is never
+**cluttered, confusing, verbose, corporate, sterile, redundant, ad-ridden, or
+inconsistent**. No enterprise-SaaS grayness. No app-store ad chrome. No gamified
+over-animation that gets in the way of typing a number.
+
+**Key Characteristics:**
+- Consistent chrome, thematic costume — one shell, per-game flavor on top.
+- Royal violet + scarce crown gold on a deep indigo field.
+- Dark-first, OLED-friendly, readable in dim light; light theme is a faithful inversion.
+- One-handed, thumb-zone-first, ≥46px touch targets.
+- Glanceable: tabular numbers, clear standings, the crown tells the story at a glance.
+
+## 2. Colors
+
+A royal, low-light palette: saturated violet and gold playing against deep indigo
+neutrals, with a tight semantic set for win/loss/caution. Every component binds to CSS
+custom properties that swap between the **dark** (default) and **light** themes, so the
+roles below are theme-agnostic; the frontmatter carries the dark values as canonical
+because the app boots `data-theme="dark"`.
+
+### Primary
+- **Royal Violet** (`#7c5cff`): The one brand action color. Primary buttons, the active
+  tab, focus rings, links, and the avatar default. Exactly one Royal Violet button per
+  screen — the single most important action.
+- **Deep Violet** (`#6b46f0`): The pressed/hover state of Royal Violet. Never a fill on
+  its own; only the darker echo of a primary action under interaction.
+
+### Secondary
+- **Crown Gold** (`#ffd166`): The crown. Reserved for the current leader, the winner row
+  highlight, and the 👑. Scarcity is the whole point — it is never a button, link, or
+  decoration.
+
+### Tertiary (Semantic)
+- **Win Green** (`#34d399`): Positive deltas, good scores, success/synced states.
+- **Loss Coral** (`#f87171`): Negative deltas, destructive actions (text only), errors.
+- **Caution Amber** (`#fbbf24`): Warnings and pending/attention states.
+
+### Neutral — Dark (default)
+- **Midnight Court** (`#0f1020`): App background, behind a faint violet radial glow
+  (`radial-gradient(1200px 600px at 50% -10%, #1c1d3a, #0f1020)`).
+- **Indigo Slate** (`#1a1b2e`) → **Raised Slate** (`#24263f`) → **Lifted Slate**
+  (`#2c2e4d`): The three-step surface ramp. Depth is built by climbing this ramp, not by
+  adding shadow.
+- **Court Line** (`#313357`): Borders, dividers, table rules.
+- **Moonlight** (`#e9e9f4`): Primary text. **Lavender Gray** (`#a3a6cb`): muted text,
+  labels, secondary metadata.
+
+### Neutral — Light
+- **Lilac Mist** (`#f4f4fb`) bg, **White** (`#ffffff`) surface, **Frost** (`#f1f1f9`) /
+  **Haze** (`#e7e7f4`) raised surfaces, **Cloud Line** (`#dcdcea`) borders, **Ink**
+  (`#1c1d2e`) text, **Slate Gray** (`#5b5e7e`) muted.
+
+### Player Palette
+- A fixed 12-color avatar palette (`#7c5cff, #34d399, #f87171, #fbbf24, #38bdf8, #fb7185,
+  #a78bfa, #4ade80, #f59e0b, #22d3ee, #e879f9, #facc15`), assigned in order so each
+  player at the table is instantly distinguishable. Identity is always reinforced by
+  initials inside the avatar, never color alone.
+
+### Named Rules
+**The Crown Gold Rule.** Crown Gold (`#ffd166`) belongs to the leader and the winner —
+nothing else. The moment gold appears on an ordinary button, link, or flourish, it stops
+meaning "you're winning," and the 👑 loses its power.
+
+**The One Voice Rule.** Royal Violet marks a single primary action and the active tab.
+One violet fill per screen. Everything else is surface, neutral, or semantic.
+
+**The Color-Is-Never-Alone Rule.** Standing, win/loss, and state are never carried by
+hue alone (rank number, the 👑, initials, +/- sign, and text always co-signal) so the app
+stays legible for color-blind players.
+
+## 3. Typography
+
+**Display / Body Font:** System UI stack (`system-ui, -apple-system, "Segoe UI", Roboto,
+Helvetica, Arial, sans-serif`).
+
+**Character:** One native sans does everything — headings, buttons, labels, dense score
+columns. It loads instantly, renders crisply on every phone, and never competes with the
+game's own personality. There is no display/body pairing here on purpose: the *game* is
+the display typeface; the UI type stays quiet.
+
+### Hierarchy
+- **Display / h1** (700, 1.6rem, 1.2): Page titles. The ceiling — Score King never shouts
+  larger than this.
+- **Title / h2** (700, 1.25rem, 1.2): Section and card headings.
+- **Body** (400, 1rem, 1.5): Default text, list rows, descriptions. Cap prose at 65–75ch.
+- **Label** (400, 0.9rem, 1.4, Lavender Gray): Form labels and secondary metadata, always
+  muted, always above their field.
+- **Overline / section-title** (600, 0.8rem, +0.08em tracking, UPPERCASE, muted): The
+  quiet "Continue / Start a game / Recent results" group headers. One short word or
+  phrase — this is the *only* sanctioned uppercase-tracked label in the system.
+
+### Named Rules
+**The Tabular Score Rule.** Every number that can change — scores, totals, round counts —
+renders with `font-variant-numeric: tabular-nums` and weight 700, so columns never jitter
+as values update and the leader is readable at a glance across the table.
+
+**The Quiet-Type Rule.** UI type never tries to be the personality. No display fonts in
+labels, buttons, or data. Whimsy comes from the motif, the emoji, and the copy — not from
+the letterforms.
+
+## 4. Elevation
+
+A layered-surface system with one soft shadow, not a shadow-stack. Depth is built by
+climbing the surface ramp (`surface` → `surface-2` → `surface-3`); the single drop shadow
+exists only to float genuinely floating objects (cards, game tiles, the toast) off the
+background. The faint violet radial glow behind the body adds atmosphere without a single
+box-shadow.
+
+### Shadow Vocabulary
+- **Soft Lift** (`box-shadow: 0 10px 30px rgba(0,0,0,0.45)` dark / `0 10px 30px
+  rgba(60,50,120,0.12)` light): The only shadow. Cards, game tiles, toast.
+- **Inset Hairline** (`inset 0 0 0 1px rgba(0,0,0,0.18)`): A 1px inner ring on avatars so
+  light-colored player dots keep their edge on light surfaces.
+
+### Named Rules
+**The Soft-Lift Rule.** One shadow token, used sparingly. If something needs to feel
+deeper, raise it one step up the surface ramp instead of darkening or stacking shadows.
+
+**The Glass-Chrome Rule.** Backdrop blur (`backdrop-filter: blur(10–12px)`) is permitted
+on exactly two surfaces — the sticky top app bar and the fixed bottom tab bar — because
+they are persistent navigation floating over scrolling content. Glass appears nowhere
+else; it is structural here, never decoration.
+
+## 5. Components
+
+The chrome is consistent and quiet; per-game theming layers on top. Every interactive
+element shares one shape language (9px controls, 14px containers) and one state model
+(hover → active press → focus ring → disabled).
+
+### Buttons
+- **Shape:** Gently rounded (9px / `--radius-sm`), min-height 46px, weight 600, 12×18px
+  padding, 8px gap for icon+label.
+- **Primary:** Royal Violet fill, white text, Deep Violet border; hover deepens to Deep
+  Violet. The single most important action on a screen.
+- **Default:** Raised Slate (`surface-2`) fill with a Court Line border; hover climbs to
+  Lifted Slate (`surface-3`).
+- **Ghost:** Transparent fill, same sizing — for low-emphasis inline actions.
+- **Danger:** Transparent with Loss Coral text and a coral-tinted border — destructive
+  actions only.
+- **States:** `:active` presses down 1px (`translateY(1px)`); `:focus-visible` shows a 2px
+  Royal Violet outline at 1px offset; disabled drops to 50% opacity. `small` variant is
+  36px tall; `block` spans full width.
+
+### Pills
+- **Style:** Raised Slate fill, Court Line border, fully rounded (999px), 0.8rem muted
+  text, 3×10px padding. Used for compact status ("Round 4") and meta tags — never as a
+  button.
+
+### Cards / Tiles
+- **Corner Style:** 14px (`--radius`).
+- **Background:** Indigo Slate (`surface`), Court Line border, Soft Lift shadow, 16px
+  padding.
+- **Game Tile:** A card variant for picking a game — large emoji, bold name, muted
+  tagline; hover lifts 1px and the border becomes Royal Violet. This is the primary place
+  per-game theming shows up.
+
+### Inputs / Fields
+- **Style:** Indigo Slate (`surface`) fill, Court Line border, 9px radius, min-height
+  46px, full-width by default.
+- **Focus:** 2px Royal Violet outline at 1px offset (matches buttons — one focus
+  vocabulary everywhere).
+- **Label:** muted 0.9rem, block, 6px below.
+
+### Stepper (signature)
+- A horizontal − / number / + control for round entry: two 42px Lifted-Slate icon
+  buttons flanking a centered 62px tabular-number input, `inputmode="numeric"`. The
+  fastest way to nudge a score one-handed without summoning the keyboard. Min/max disable
+  the relevant button. This is the heartbeat of round entry — keep it identical across
+  every game.
+
+### Avatar (signature)
+- A circular initials chip filled with the player's palette color, white text, weight 700,
+  Inset Hairline ring. Size-parameterized (24–28px in lists). Always shows initials, so a
+  player is identifiable without relying on color.
+
+### Scoreboard (signature)
+- A right-aligned numeric table (rank · player · score). Header row in muted overline
+  caps; tabular-nums body; the rank-1 score uses Crown Gold (`.lead`); the winner row gets
+  a 14%-opacity Crown Gold wash. The whole standing is legible at a glance from across the
+  table.
+
+### Navigation
+- **Top App Bar:** Sticky, glass (blurred translucent bg), Court Line bottom border; brand
+  lockup (favicon + "Score King", weight 800) left, settings icon-button right.
+- **Bottom Tab Bar:** Fixed, glass, four emoji+label tabs (Games / Players / History /
+  Stats). Inactive tabs are muted; the active tab gets Moonlight text on a Raised Slate
+  pill. Built for thumbs and `env(safe-area-inset-*)`.
+- **Icon Button:** 42px square, 10px radius, Raised Slate fill — settings, steppers, and
+  compact actions.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** keep Crown Gold (`#ffd166`) for the leader and winner only — the crown earns its
+  meaning through scarcity.
+- **Do** ship exactly one Royal Violet primary action per screen; everything else is
+  neutral, surface, or semantic.
+- **Do** render every changing number with `tabular-nums` and weight 700 so columns stay
+  glanceable.
+- **Do** build depth by climbing the surface ramp (`surface` → `surface-2` → `surface-3`),
+  and use the single Soft Lift shadow only for truly floating objects.
+- **Do** keep touch targets ≥46px and primary actions in the thumb zone — this is played
+  one-handed in dim light.
+- **Do** co-signal state with shape, number, icon, and text — never color alone — for
+  color-blind players.
+- **Do** keep the chrome identical game to game; express per-game personality through
+  emoji, copy, and accent moments, not by restyling the shell.
+- **Do** give every animation a `prefers-reduced-motion` alternative (instant or crossfade).
+
+### Don't:
+- **Don't** ship anything **cluttered, confusing, verbose, corporate, sterile, redundant,
+  ad-ridden, or inconsistent** — the named anti-references from PRODUCT.md.
+- **Don't** let the UI look like an enterprise/corporate SaaS dashboard — no gray, sterile,
+  density-for-its-own-sake screens.
+- **Don't** import app-store score-keeper habits: ad chrome, banner clutter, upsell rails.
+- **Don't** over-animate or "gamify" the core loop; motion stays 150–250ms and conveys
+  state, never decoration you wait for.
+- **Don't** use Crown Gold on buttons, links, or flourishes; don't add a second violet
+  fill to compete with the primary action.
+- **Don't** add `border-left`/`border-right` colored stripes, gradient text, or decorative
+  glass — glass is only the app bar and tab bar.
+- **Don't** introduce a display font into labels, buttons, or data; the system sans stays
+  quiet so the game can be loud.
+- **Don't** restyle the navigation, button, or stepper vocabulary per game — consistency
+  is the feature that lets new games feel instantly familiar.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,84 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+People keeping score during live, in-person card & party games — Hearts, Skull King,
+a generic Tally, with more on the way. The person holding the phone is mid-game: at a
+table, often one-handed, sometimes in dim lighting, frequently offline, and usually
+passing or propping the device so others can see. Their job is to track scores across
+rounds quickly and accurately, across a variety of games, with zero setup, no account,
+and no fear of losing data. Players and history are shared across games, so regulars
+(game-night groups, families) come back to the same roster and leaderboard.
+
+## Product Purpose
+
+Score King is a local-first, installable PWA that keeps score for card & party games so
+the math and bookkeeping disappear into the night. Each game is a self-contained,
+pluggable module (config, round entry, scoring, validation); players, history, and stats
+are shared across all of them. Everything saves instantly to the device (IndexedDB) and
+works fully offline, with optional, opt-in OneDrive Excel backup for people who want it.
+Success looks like this: open the app, pick a game, enter rounds, glance at who's
+winning — and never think about the tool itself.
+
+## Brand Personality
+
+Whimsical, Easy, Game-Night Energy. The voice is friendly and light, never corporate or
+verbose. The 👑 "King" motif, emoji-forward game tiles, and a purple-and-gold palette
+carry the warmth and fun; the interaction underneath stays effortless, uncluttered, and
+predictable. Personality shows up in the motif, the copy, and small moments — never in
+noise, decoration, or redundancy.
+
+## Anti-references
+
+This should never feel cluttered, confusing, verbose, corporate, sterile, redundant,
+ad-ridden, or inconsistent. Specifically NOT:
+
+- Enterprise / corporate SaaS dashboards — gray, sterile, dense for density's sake.
+- Ad-heavy, cluttered score-keeper apps from the app stores.
+- Gimmicky, over-animated "gamified" UIs that get in the way of entering a score.
+- Spreadsheet-like walls of numbers with no hierarchy or glanceability.
+
+## Design Principles
+
+- **The tool disappears into the table.** The fastest path from "round happened" to
+  "score entered" wins. Minimal taps, big targets, glanceable standings. If a screen
+  makes someone look down from the game for longer than necessary, it's too much.
+- **Local-first is a trust contract.** Instant saves and full offline reliability are
+  non-negotiable. Nothing — sync, network, accounts — is ever allowed to stand between a
+  player and recording the score.
+- **Whimsy, never clutter.** Personality lives in the motif, the copy, and small
+  moments. It is never an excuse for noise, decoration, redundant controls, or anything
+  that slows the core loop.
+- **One vocabulary across every game.** A new game module should feel instantly familiar:
+  the same buttons, the same round-entry rhythm, the same scoreboard. Consistency is the
+  feature that lets the app grow without growing confusing.
+- **Respect everyone at the table.** Inclusive and readable by default (color-blind-safe,
+  reduced-motion, one-handed, legible in dim light), and respectful of the social moment —
+  privacy when the phone is set down, shared visibility when the table wants it.
+
+## Accessibility & Inclusion
+
+Practical WCAG AA as the floor, with deliberate accommodations surfaced in Settings:
+
+- **Color-blind support.** Color-blind-safe player colors and palette options; never rely
+  on color alone to convey standing, win/loss, or state.
+- **Accessibility settings hub.** A dedicated place in Settings for ability accommodations
+  (contrast, text size, motion, color) rather than burying them.
+- **Reduced motion.** Honor `prefers-reduced-motion` and offer an explicit in-app toggle;
+  every animation needs a calm, instant alternative.
+- **OLED-friendly dark mode.** A true-black option so the app is comfortable and
+  battery-kind on OLED screens in dim rooms.
+- **One-handed first.** Primary actions sit in the thumb zone; the app is usable held in
+  one hand at a table.
+- **Table mode (per game, where it helps).** An optional large, table-wide view so
+  everyone can see standings, for games where shared visibility makes sense.
+- **Privacy toggle.** Let a player hide scores when they set the phone down or step away,
+  so others can't peek or cheat.
+- **Stay-awake option.** An always-on / screen wake-lock setting so the device doesn't
+  sleep mid-game.
+- **Readable contrast and large touch targets** throughout, in both themes and all
+  lighting.

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,11 +2,13 @@
   import { onMount } from 'svelte';
   import { pathStore, parseRoute, link } from './lib/router';
   import { toast } from './lib/stores/toast';
+  import { settings } from './lib/stores/settings';
   import Home from './pages/Home.svelte';
   import Players from './pages/Players.svelte';
   import History from './pages/History.svelte';
   import Stats from './pages/Stats.svelte';
   import Settings from './pages/Settings.svelte';
+  import Accessibility from './pages/Accessibility.svelte';
   import GameType from './pages/GameType.svelte';
   import GamePlay from './pages/GamePlay.svelte';
   import NotFound from './pages/NotFound.svelte';
@@ -15,6 +17,25 @@
   let current = $state(window.location.pathname || '/');
   onMount(() => pathStore.subscribe((v) => (current = v)));
   const route = $derived(parseRoute(current));
+
+  let veiled = $state(false);
+  onMount(() => {
+    const onVis = () => {
+      if (
+        document.visibilityState === 'hidden' &&
+        $settings.privacyGuard &&
+        route.name === 'play'
+      ) {
+        veiled = true;
+      }
+    };
+    document.addEventListener('visibilitychange', onVis);
+    return () => document.removeEventListener('visibilitychange', onVis);
+  });
+
+  function reveal() {
+    veiled = false;
+  }
 </script>
 
 <header class="appbar">
@@ -36,6 +57,8 @@
     <Stats />
   {:else if route.name === 'settings'}
     <Settings />
+  {:else if route.name === 'accessibility'}
+    <Accessibility />
   {:else if route.name === 'gametype'}
     <GameType type={route.params.type} />
   {:else if route.name === 'play'}
@@ -66,4 +89,59 @@
   <div class="toast">{$toast}</div>
 {/if}
 
+{#if veiled}
+  <button class="veil" onclick={reveal} aria-label="Reveal scores">
+    <span class="veil-card">
+      <span class="veil-emoji" aria-hidden="true">🙈</span>
+      <strong>Scores hidden</strong>
+      <span class="veil-hint">Tap anywhere to reveal</span>
+    </span>
+  </button>
+{/if}
+
 <SyncBubble />
+
+<style>
+  .veil {
+    position: fixed;
+    inset: 0;
+    z-index: 80;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    width: 100%;
+    cursor: pointer;
+    color: var(--text);
+    background: color-mix(in srgb, var(--bg) 62%, transparent);
+    backdrop-filter: blur(18px) saturate(120%);
+    -webkit-backdrop-filter: blur(18px) saturate(120%);
+    animation: veil-in 0.18s ease-out;
+  }
+  .veil-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 26px 30px;
+    border-radius: var(--radius);
+    background: color-mix(in srgb, var(--surface) 70%, transparent);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow);
+  }
+  .veil-emoji {
+    font-size: 2.4rem;
+    line-height: 1;
+  }
+  .veil-card strong {
+    font-size: 1.05rem;
+  }
+  .veil-hint {
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+  @keyframes veil-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+</style>

--- a/src/app.css
+++ b/src/app.css
@@ -12,6 +12,7 @@
   --maxw: 760px;
 
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: calc(100% * var(--font-scale, 1));
   line-height: 1.5;
   -webkit-text-size-adjust: 100%;
   -webkit-font-smoothing: antialiased;
@@ -38,6 +39,35 @@ html[data-theme="light"] {
   --text: #1c1d2e;
   --muted: #5b5e7e;
   --shadow: 0 10px 30px rgba(60, 50, 120, 0.12);
+}
+
+/* OLED: true-black surfaces for dark theme to save power and deepen contrast. */
+html[data-theme="dark"][data-oled] {
+  --bg: #000000;
+  --bg-grad: none;
+  --surface: #0a0a12;
+  --surface-2: #14141f;
+  --surface-3: #1c1c2b;
+  --border: #2a2a3d;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.7);
+}
+
+/* High contrast: push text toward the ink end, strengthen borders and focus. */
+html[data-theme="dark"][data-contrast] {
+  --text: #ffffff;
+  --muted: #c8cbef;
+  --border: #5a5d8a;
+}
+html[data-theme="light"][data-contrast] {
+  --text: #000000;
+  --muted: #3a3c54;
+  --border: #9a9ab0;
+}
+html[data-contrast] input:focus,
+html[data-contrast] select:focus,
+html[data-contrast] .btn:focus-visible {
+  outline-width: 3px;
+  outline-offset: 2px;
 }
 
 * { box-sizing: border-box; }
@@ -208,3 +238,24 @@ tbody tr:last-child td { border-bottom: none; }
   color: var(--text); cursor: pointer; font-size: 1.1rem;
 }
 .iconbtn:hover { background: var(--surface-3); }
+
+/* Motion preferences. "full" never reduces; "reduce" always does;
+   "system" defers to the OS. 0.001ms keeps transition/animation end events firing. */
+html[data-motion="reduce"] *,
+html[data-motion="reduce"] *::before,
+html[data-motion="reduce"] *::after {
+  animation-duration: 0.001ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.001ms !important;
+  scroll-behavior: auto !important;
+}
+@media (prefers-reduced-motion: reduce) {
+  html[data-motion="system"] *,
+  html[data-motion="system"] *::before,
+  html[data-motion="system"] *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/lib/components/Avatar.svelte
+++ b/src/lib/components/Avatar.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
-  import { initials } from '../util';
+  import { initials, resolvePlayerColor, textOn } from '../util';
+  import { settings } from '../stores/settings';
   let {
     name,
     color,
     size = 28,
   }: { name: string; color: string; size?: number } = $props();
+
+  const resolved = $derived(resolvePlayerColor(color, $settings.colorBlind));
+  const ink = $derived(textOn(resolved));
 </script>
 
 <span
   class="avatar"
-  style="--c:{color}; width:{size}px; height:{size}px; font-size:{Math.round(size * 0.38)}px"
+  style="--c:{resolved}; --ink:{ink}; width:{size}px; height:{size}px; font-size:{Math.round(size * 0.38)}px"
   title={name}
 >
   {initials(name)}
@@ -22,7 +26,7 @@
     justify-content: center;
     border-radius: 50%;
     background: var(--c);
-    color: #fff;
+    color: var(--ink);
     font-weight: 700;
     flex: none;
     box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.18);

--- a/src/lib/components/Segmented.svelte
+++ b/src/lib/components/Segmented.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  type Option = { value: string; label: string };
+
+  let {
+    label,
+    value = $bindable(),
+    options,
+  }: { label: string; value: string; options: Option[] } = $props();
+
+  let groupEl: HTMLDivElement;
+
+  function move(to: number) {
+    const next = (to + options.length) % options.length;
+    value = options[next].value;
+    const btns = groupEl?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+    btns?.[next]?.focus();
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    const idx = options.findIndex((o) => o.value === value);
+    if (idx < 0) return;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        move(idx + 1);
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        move(idx - 1);
+        break;
+      case 'Home':
+        move(0);
+        break;
+      case 'End':
+        move(options.length - 1);
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+  }
+</script>
+
+<div
+  class="segmented"
+  role="radiogroup"
+  aria-label={label}
+  tabindex="-1"
+  bind:this={groupEl}
+  onkeydown={onKeydown}
+>
+  {#each options as o (o.value)}
+    <button
+      type="button"
+      role="radio"
+      aria-checked={value === o.value}
+      tabindex={value === o.value ? 0 : -1}
+      class="seg"
+      class:on={value === o.value}
+      onclick={() => (value = o.value)}
+    >
+      {o.label}
+    </button>
+  {/each}
+</div>
+
+<style>
+  .segmented {
+    display: flex;
+    gap: 4px;
+    padding: 4px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .seg {
+    flex: 1 1 0;
+    min-height: 46px;
+    padding: 0 10px;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--muted);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+  }
+  .seg:hover {
+    color: var(--text);
+  }
+  .seg.on {
+    background: var(--primary);
+    color: #fff;
+    box-shadow: 0 2px 12px color-mix(in srgb, var(--primary) 38%, transparent);
+  }
+  .seg:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+</style>

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -70,6 +70,7 @@ export type RouteName =
   | 'history'
   | 'stats'
   | 'settings'
+  | 'accessibility'
   | 'play'
   | 'gametype'
   | 'notfound';
@@ -85,6 +86,7 @@ const RESERVED: Record<string, RouteName> = {
   history: 'history',
   stats: 'stats',
   settings: 'settings',
+  accessibility: 'accessibility',
 };
 
 export function parseRoute(path: string): Route {

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -4,8 +4,32 @@ export type Theme = 'dark' | 'light';
 
 export type OneDriveFolderMode = 'app' | 'custom';
 
+/** How motion is handled: follow the OS, always reduce, or never reduce. */
+export type MotionPref = 'system' | 'reduce' | 'full';
+
+export type FontScale = 'sm' | 'md' | 'lg' | 'xl';
+
+/** Multipliers applied to the root font size for each text-size step. */
+export const FONT_SCALE_VALUES: Record<FontScale, number> = {
+  sm: 0.9,
+  md: 1,
+  lg: 1.15,
+  xl: 1.3,
+};
+
 export interface Settings {
   theme: Theme;
+  /** True-black surfaces for OLED screens (dark theme only). */
+  oled: boolean;
+  fontScale: FontScale;
+  motion: MotionPref;
+  highContrast: boolean;
+  /** Remap player colors to a color-blind-friendly palette. */
+  colorBlind: boolean;
+  /** Hold a screen wake lock while a game is being played. */
+  keepAwake: boolean;
+  /** Blur scores with a tap-to-reveal veil after the phone is set down. */
+  privacyGuard: boolean;
   oneDriveClientId: string;
   oneDriveFolderMode: OneDriveFolderMode;
   oneDriveCustomPath: string;
@@ -19,6 +43,13 @@ const KEY = 'sk_settings';
 
 const defaults: Settings = {
   theme: 'dark',
+  oled: false,
+  fontScale: 'md',
+  motion: 'system',
+  highContrast: false,
+  colorBlind: false,
+  keepAwake: false,
+  privacyGuard: false,
   oneDriveClientId: '',
   oneDriveFolderMode: 'app',
   oneDriveCustomPath: '',
@@ -36,20 +67,25 @@ function load(): Settings {
   }
 }
 
-function applyThemeValue(theme: Theme) {
-  document.documentElement.setAttribute('data-theme', theme);
+function apply(s: Settings) {
+  const el = document.documentElement;
+  el.setAttribute('data-theme', s.theme);
+  el.toggleAttribute('data-oled', s.oled);
+  el.setAttribute('data-motion', s.motion);
+  el.toggleAttribute('data-contrast', s.highContrast);
+  el.style.setProperty('--font-scale', String(FONT_SCALE_VALUES[s.fontScale] ?? 1));
 }
 
 export const settings = writable<Settings>(load());
 
 settings.subscribe((v) => {
   localStorage.setItem(KEY, JSON.stringify(v));
-  applyThemeValue(v.theme);
+  apply(v);
 });
 
-/** Apply the persisted theme before the app mounts (avoids a flash). */
-export function applyTheme() {
-  applyThemeValue(load().theme);
+/** Apply persisted settings (theme + accessibility) before the app mounts, avoiding a flash. */
+export function applySettings() {
+  apply(load());
 }
 
 export function toggleTheme() {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -8,9 +8,48 @@ export const PALETTE = [
   '#a78bfa', '#4ade80', '#f59e0b', '#22d3ee', '#e879f9', '#facc15',
 ];
 
+/**
+ * Color-blind-friendly counterparts to PALETTE, index-for-index, drawn from the
+ * Paul Tol "muted" and Okabe-Ito palettes. Chosen to stay distinguishable under
+ * deuteranopia, protanopia, and tritanopia.
+ */
+export const CVD_PALETTE = [
+  '#332288', '#44aa99', '#cc6677', '#e69f00', '#56b4e9', '#882255',
+  '#aa4499', '#117733', '#d55e00', '#88ccee', '#ddcc77', '#999933',
+];
+
 export function pickColor(used: string[]): string {
   const free = PALETTE.find((c) => !used.includes(c));
   return free ?? PALETTE[Math.floor(Math.random() * PALETTE.length)];
+}
+
+/** Map a base palette color to its color-blind-safe equivalent. Custom colors pass through. */
+export function resolvePlayerColor(hex: string, colorBlind: boolean): string {
+  if (!colorBlind) return hex;
+  const i = PALETTE.indexOf(hex.toLowerCase());
+  return i >= 0 ? CVD_PALETTE[i] : hex;
+}
+
+function relativeLuminance(hex: string): number {
+  const h = hex.replace('#', '');
+  const full = h.length === 3 ? h.split('').map((c) => c + c).join('') : h;
+  const n = parseInt(full, 16);
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const r = lin((n >> 16) & 255);
+  const g = lin((n >> 8) & 255);
+  const b = lin(n & 255);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** Pick black or white text for best WCAG contrast against a background color. */
+export function textOn(hex: string): string {
+  const l = relativeLuminance(hex);
+  const contrastWhite = 1.05 / (l + 0.05);
+  const contrastBlack = (l + 0.05) / 0.05;
+  return contrastBlack >= contrastWhite ? '#0b0b12' : '#ffffff';
 }
 
 export function clamp(n: number, min: number, max: number): number {

--- a/src/lib/wakelock.ts
+++ b/src/lib/wakelock.ts
@@ -1,0 +1,44 @@
+/**
+ * Screen Wake Lock manager. Keeps the display awake while desired (e.g. during an
+ * active game) and transparently re-acquires the lock when the tab regains focus,
+ * since the browser releases it automatically when the page is hidden.
+ */
+
+let sentinel: WakeLockSentinel | null = null;
+let desired = false;
+
+export function isWakeLockSupported(): boolean {
+  return typeof navigator !== 'undefined' && 'wakeLock' in navigator;
+}
+
+async function acquire() {
+  if (!desired || sentinel || !isWakeLockSupported()) return;
+  if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+  try {
+    sentinel = await navigator.wakeLock.request('screen');
+    sentinel.addEventListener('release', () => {
+      sentinel = null;
+    });
+  } catch {
+    // Denied, unsupported, or not currently visible — fail silently.
+  }
+}
+
+export function enableWakeLock() {
+  desired = true;
+  void acquire();
+}
+
+export function disableWakeLock() {
+  desired = false;
+  if (sentinel) {
+    void sentinel.release().catch(() => {});
+    sentinel = null;
+  }
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (desired && document.visibilityState === 'visible') void acquire();
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { mount } from 'svelte'
 import { registerSW } from 'virtual:pwa-register'
 import './app.css'
 import App from './App.svelte'
-import { applyTheme } from './lib/stores/settings'
+import { applySettings } from './lib/stores/settings'
 import { startAutoSync } from './lib/storage/autosync'
 
 // A Microsoft sign-in uses a full-page redirect. When the browser returns from Microsoft the
@@ -24,7 +24,7 @@ async function boot() {
       window.history.replaceState({}, '', window.location.pathname)
     }
   }
-  applyTheme()
+  applySettings()
   registerSW({ immediate: true })
   mount(App, { target: document.getElementById('app')! })
   // Background OneDrive auto-backup (push-only, silent; never redirects on its own).

--- a/src/pages/Accessibility.svelte
+++ b/src/pages/Accessibility.svelte
@@ -1,0 +1,311 @@
+<script lang="ts">
+  import { settings } from '../lib/stores/settings';
+  import { PALETTE } from '../lib/util';
+  import { isWakeLockSupported } from '../lib/wakelock';
+  import Segmented from '../lib/components/Segmented.svelte';
+  import Avatar from '../lib/components/Avatar.svelte';
+
+  let theme = $state($settings.theme);
+  let fontScale = $state($settings.fontScale);
+  let motion = $state($settings.motion);
+
+  $effect(() => {
+    settings.update((s) =>
+      s.theme === theme && s.fontScale === fontScale && s.motion === motion
+        ? s
+        : { ...s, theme, fontScale, motion },
+    );
+  });
+
+  const themeOptions = [
+    { value: 'dark', label: '🌙 Dark' },
+    { value: 'light', label: '☀️ Light' },
+  ];
+  const sizeOptions = [
+    { value: 'sm', label: 'S' },
+    { value: 'md', label: 'M' },
+    { value: 'lg', label: 'L' },
+    { value: 'xl', label: 'XL' },
+  ];
+  const motionOptions = [
+    { value: 'system', label: 'System' },
+    { value: 'reduce', label: 'Reduced' },
+    { value: 'full', label: 'Full' },
+  ];
+
+  const oledDisabled = $derived($settings.theme !== 'dark');
+  const wakeSupported = isWakeLockSupported();
+
+  const previewPlayers = [
+    { name: 'Ada Lovelace', color: PALETTE[0], score: 42 },
+    { name: 'Bo Diddley', color: PALETTE[2], score: 38 },
+    { name: 'Cy Young', color: PALETTE[4], score: 31 },
+  ];
+
+  function setBool(key: 'oled' | 'highContrast' | 'colorBlind' | 'keepAwake' | 'privacyGuard', v: boolean) {
+    settings.update((s) => ({ ...s, [key]: v }));
+  }
+</script>
+
+<h1>Accessibility &amp; display</h1>
+<p class="lede muted">Tune Score King to your eyes, your hands, and your table. Changes apply instantly and stick on this device.</p>
+
+<div class="card preview">
+  <div class="row spread">
+    <span class="row" style="gap: 8px">
+      <span class="livedot" aria-hidden="true"></span>
+      <strong>Live preview</strong>
+    </span>
+    <span class="muted sm">Updates as you tweak</span>
+  </div>
+  <table class="mini">
+    <tbody>
+      {#each previewPlayers as p, i (p.name)}
+        <tr class:winner={i === 0}>
+          <td class="rk">{i + 1}</td>
+          <td>
+            <span class="row" style="gap: 8px">
+              <Avatar name={p.name} color={p.color} size={26} />
+              {p.name}
+              {#if i === 0}<span title="Leader">👑</span>{/if}
+            </span>
+          </td>
+          <td class="num" class:lead={i === 0}>{p.score}</td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>
+
+<div class="section-title">Display</div>
+
+<div class="card set-stack">
+  <span class="meta">
+    <span class="name">Theme</span>
+    <span class="muted sm">Dark keeps things calm under low light; light suits bright rooms.</span>
+  </span>
+  <Segmented label="Theme" options={themeOptions} bind:value={theme} />
+</div>
+
+<div class="card set-stack">
+  <span class="meta">
+    <span class="name">Text size</span>
+    <span class="muted sm">Scales every label and score. Buttons stay just as easy to tap.</span>
+  </span>
+  <Segmented label="Text size" options={sizeOptions} bind:value={fontScale} />
+</div>
+
+<label class="card sw-row row spread">
+  <span class="meta">
+    <span class="name">High contrast</span>
+    <span class="muted sm">Bolder text, stronger borders, chunkier focus rings.</span>
+  </span>
+  <span class="switch">
+    <input
+      type="checkbox"
+      checked={$settings.highContrast}
+      onchange={(e) => setBool('highContrast', e.currentTarget.checked)}
+    />
+    <span class="track"><span class="thumb"></span></span>
+  </span>
+</label>
+
+<label class="card sw-row row spread" class:dim={oledDisabled}>
+  <span class="meta">
+    <span class="name">True-black (OLED)</span>
+    <span class="muted sm">
+      {oledDisabled ? 'Switch to the dark theme to use true black.' : 'Pure-black surfaces save power and deepen contrast.'}
+    </span>
+  </span>
+  <span class="switch">
+    <input
+      type="checkbox"
+      checked={$settings.oled}
+      disabled={oledDisabled}
+      onchange={(e) => setBool('oled', e.currentTarget.checked)}
+    />
+    <span class="track"><span class="thumb"></span></span>
+  </span>
+</label>
+
+<div class="section-title">Motion &amp; colour</div>
+
+<div class="card set-stack">
+  <span class="meta">
+    <span class="name">Motion</span>
+    <span class="muted sm">System follows your device. Reduced removes animation; Full always plays it.</span>
+  </span>
+  <Segmented label="Motion" options={motionOptions} bind:value={motion} />
+</div>
+
+<label class="card sw-row row spread">
+  <span class="meta">
+    <span class="name">Colour-blind palette</span>
+    <span class="muted sm">Swaps player colours for a set that stays distinct across colour vision types.</span>
+  </span>
+  <span class="switch">
+    <input
+      type="checkbox"
+      checked={$settings.colorBlind}
+      onchange={(e) => setBool('colorBlind', e.currentTarget.checked)}
+    />
+    <span class="track"><span class="thumb"></span></span>
+  </span>
+</label>
+
+<div class="section-title">While playing</div>
+
+<label class="card sw-row row spread">
+  <span class="meta">
+    <span class="name">Keep screen awake</span>
+    <span class="muted sm">
+      {wakeSupported
+        ? 'Stops the screen dimming while a game is in progress.'
+        : 'Your browser doesn’t support screen wake lock.'}
+    </span>
+  </span>
+  <span class="switch">
+    <input
+      type="checkbox"
+      checked={$settings.keepAwake}
+      disabled={!wakeSupported}
+      onchange={(e) => setBool('keepAwake', e.currentTarget.checked)}
+    />
+    <span class="track"><span class="thumb"></span></span>
+  </span>
+</label>
+
+<label class="card sw-row row spread">
+  <span class="meta">
+    <span class="name">Privacy peek-guard</span>
+    <span class="muted sm">Blurs the board when you set the phone down, so a passer-by can’t read the scores. Tap to reveal.</span>
+  </span>
+  <span class="switch">
+    <input
+      type="checkbox"
+      checked={$settings.privacyGuard}
+      onchange={(e) => setBool('privacyGuard', e.currentTarget.checked)}
+    />
+    <span class="track"><span class="thumb"></span></span>
+  </span>
+</label>
+
+<style>
+  .lede {
+    margin: -2px 4px 18px;
+    max-width: 60ch;
+  }
+
+  .preview {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .livedot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--good, #34d399);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--good, #34d399) 60%, transparent);
+    animation: pulse 1.8s ease-out infinite;
+  }
+  @keyframes pulse {
+    0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--good, #34d399) 55%, transparent); }
+    70% { box-shadow: 0 0 0 8px color-mix(in srgb, var(--good, #34d399) 0%, transparent); }
+    100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--good, #34d399) 0%, transparent); }
+  }
+  .mini {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .mini td {
+    padding: 7px 6px;
+    border-top: 1px solid var(--border);
+  }
+  .mini tr:first-child td {
+    border-top: 0;
+  }
+  .rk {
+    width: 1.5rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+  .winner td {
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+  }
+
+  .set-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .meta {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+  }
+  .name {
+    font-weight: 700;
+  }
+  .sw-row {
+    cursor: pointer;
+    gap: 14px;
+  }
+  .sw-row.dim {
+    opacity: 0.55;
+  }
+
+  .switch {
+    position: relative;
+    display: inline-flex;
+    flex: none;
+  }
+  .switch input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    opacity: 0;
+    cursor: pointer;
+  }
+  .switch input:disabled {
+    cursor: not-allowed;
+  }
+  .track {
+    width: 46px;
+    height: 26px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    display: inline-flex;
+    align-items: center;
+    padding: 2px;
+    transition: background 0.15s ease;
+  }
+  .thumb {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #fff;
+    transition: transform 0.15s ease;
+  }
+  .switch input:checked + .track {
+    background: var(--primary);
+    border-color: var(--primary);
+  }
+  .switch input:checked + .track .thumb {
+    transform: translateX(20px);
+  }
+  .switch input:focus-visible + .track {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+</style>

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -18,6 +18,8 @@
   import { navigate, link } from '../lib/router';
   import { showToast } from '../lib/stores/toast';
   import { relativeTime } from '../lib/util';
+  import { settings } from '../lib/stores/settings';
+  import { enableWakeLock, disableWakeLock } from '../lib/wakelock';
   import Scoreboard from '../lib/components/Scoreboard.svelte';
   import Avatar from '../lib/components/Avatar.svelte';
 
@@ -95,6 +97,15 @@
     const unsub = players.subscribe((v) => (plist = v));
     load();
     return unsub;
+  });
+
+  $effect(() => {
+    if ($settings.keepAwake && game?.status === 'active') {
+      enableWakeLock();
+    } else {
+      disableWakeLock();
+    }
+    return () => disableWakeLock();
   });
 
   async function saveRound() {

--- a/src/pages/Players.svelte
+++ b/src/pages/Players.svelte
@@ -6,7 +6,8 @@
     recolorPlayer,
     removePlayer,
   } from '../lib/stores/players';
-  import { PALETTE } from '../lib/util';
+  import { PALETTE, resolvePlayerColor } from '../lib/util';
+  import { settings } from '../lib/stores/settings';
   import Avatar from '../lib/components/Avatar.svelte';
   import type { Player } from '../lib/types';
 
@@ -72,7 +73,7 @@
             <button
               class="dot"
               class:sel={p.color === c}
-              style="background: {c}"
+              style="background: {resolvePlayerColor(c, $settings.colorBlind)}"
               onclick={() => recolorPlayer(p, c)}
               aria-label="Set colour"
             ></button>

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { settings, toggleTheme, markSynced, markRestored } from '../lib/stores/settings';
+  import { settings, markSynced, markRestored } from '../lib/stores/settings';
+  import { link } from '../lib/router';
   import { buildSnapshot, restoreSnapshot, getOneDrive } from '../lib/storage/sync';
   import { autoSyncStatus, markSyncSettled } from '../lib/storage/autosync';
   import { ONEDRIVE_CLIENT_ID } from '../lib/config';
@@ -204,13 +205,17 @@
 
 <h1>Settings</h1>
 
-<div class="section-title">Appearance</div>
-<div class="card row spread">
-  <span>Theme</span>
-  <button class="btn" onclick={toggleTheme}>
-    {$settings.theme === 'dark' ? '🌙 Dark' : '☀️ Light'}
-  </button>
-</div>
+<div class="section-title">Display & accessibility</div>
+<a class="card navrow row spread" href="/accessibility" use:link>
+  <span class="row" style="gap: 12px">
+    <span class="navico" aria-hidden="true">👁️</span>
+    <span class="navmeta">
+      <span class="navname">Accessibility &amp; display</span>
+      <span class="muted sm">Theme, text size, contrast, motion, colour-blind palette</span>
+    </span>
+  </span>
+  <span class="chev" aria-hidden="true">›</span>
+</a>
 
 <div class="section-title">OneDrive backup (Excel)</div>
 <div class="card stack">
@@ -454,5 +459,32 @@
     background: var(--surface-2, rgba(127, 127, 127, 0.15));
     padding: 1px 5px;
     border-radius: 5px;
+  }
+  .navrow {
+    text-decoration: none;
+    color: var(--text);
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .navrow:hover {
+    border-color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 6%, var(--surface));
+  }
+  .navico {
+    font-size: 1.4rem;
+    line-height: 1;
+    flex: none;
+  }
+  .navmeta {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .navname {
+    font-weight: 700;
+  }
+  .chev {
+    font-size: 1.5rem;
+    color: var(--muted);
+    flex: none;
   }
 </style>


### PR DESCRIPTION
﻿## Accessibility & display hub

Adds a dedicated **/accessibility** page (reached from Settings -> "Accessibility & display") with eight fully-wired controls, plus a live mini-scoreboard preview that reflects every change instantly. All settings persist to `localStorage` and apply pre-mount, so there is no flash on load.

### Controls
| Control | Effect |
|---|---|
| **Theme** | Dark / Light (segmented) |
| **Text size** | S / M / L / XL - scales root `rem` while keeping touch targets fixed |
| **High contrast** | Stronger text & borders, thicker focus rings |
| **True-black (OLED)** | Pure `#000` surfaces; dark-theme only |
| **Motion** | System / Reduced / Full - drives a `prefers-reduced-motion` baseline |
| **Colour-blind palette** | Remaps player colours to an Okabe-Ito / Paul Tol set |
| **Keep screen awake** | Screen Wake Lock during an active game, re-acquired on refocus |
| **Privacy peek-guard** | Blur veil + tap-to-reveal when the phone is set down |

### Notable details
- New reusable **`Segmented`** radiogroup: arrow-key navigation, roving `tabindex`, >=46px targets, on-brand active state.
- Colour-blind work also improves the **base** avatars - initials now compute black/white text via WCAG luminance (`textOn`) instead of always-white.
- Wake Lock lives in a small `wakelock.ts` helper, hooked into `GamePlay` via an effect tied to game status.
- Privacy veil triggers only on the `/play` route (the surface where scores are on screen).

### Verification
- `npm run check` - 0 errors, 0 warnings
- `npm run build` - succeeds
- Headless-browser screenshots across dark / light / OLED / high-contrast / text-XL / colour-blind / privacy-veil states; no console errors.

This branch also includes the initial impeccable `init` artifacts (`PRODUCT.md`, `DESIGN.md`, `.impeccable/`, copilot-instructions).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
