### PR TITLE
Add Gameplay settings page and Excel workbook icons

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -9,6 +9,7 @@
   import Stats from './pages/Stats.svelte';
   import Settings from './pages/Settings.svelte';
   import Accessibility from './pages/Accessibility.svelte';
+  import GameplaySettings from './pages/GameplaySettings.svelte';
   import GameType from './pages/GameType.svelte';
   import GamePlay from './pages/GamePlay.svelte';
   import NotFound from './pages/NotFound.svelte';
@@ -62,6 +63,8 @@
     <Settings />
   {:else if route.name === 'accessibility'}
     <Accessibility />
+  {:else if route.name === 'gameplay'}
+    <GameplaySettings />
   {:else if route.name === 'gametype'}
     <GameType type={route.params.type} />
   {:else if route.name === 'play'}

--- a/src/lib/components/ExcelIcon.svelte
+++ b/src/lib/components/ExcelIcon.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  let { size = 20 }: { size?: number } = $props();
+</script>
+
+<svg
+  class="xlsx"
+  viewBox="0 0 24 24"
+  width={size}
+  height={size}
+  role="img"
+  aria-label="Excel workbook"
+>
+  <path
+    d="M6.5 3 H14.5 L19 7.5 V19.5 A1.5 1.5 0 0 1 17.5 21 H6.5 A1.5 1.5 0 0 1 5 19.5 V4.5 A1.5 1.5 0 0 1 6.5 3 Z"
+    fill="#ffffff"
+    stroke="#d7dae3"
+    stroke-width="0.7"
+  />
+  <path d="M14.5 3 L19 7.5 H14.5 Z" fill="#e4e7ef" />
+  <rect x="2" y="12" width="12" height="8" rx="1.6" fill="#107c41" />
+  <path
+    d="M5.7 13.9 L10.3 18.1 M10.3 13.9 L5.7 18.1"
+    stroke="#ffffff"
+    stroke-width="1.7"
+    stroke-linecap="round"
+    fill="none"
+  />
+</svg>
+
+<style>
+  .xlsx {
+    flex: none;
+    display: block;
+  }
+</style>

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -71,6 +71,7 @@ export type RouteName =
   | 'stats'
   | 'settings'
   | 'accessibility'
+  | 'gameplay'
   | 'play'
   | 'gametype'
   | 'notfound';
@@ -87,6 +88,7 @@ const RESERVED: Record<string, RouteName> = {
   stats: 'stats',
   settings: 'settings',
   accessibility: 'accessibility',
+  gameplay: 'gameplay',
 };
 
 export function parseRoute(path: string): Route {

--- a/src/pages/Accessibility.svelte
+++ b/src/pages/Accessibility.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { settings } from '../lib/stores/settings';
   import { PALETTE } from '../lib/util';
-  import { isWakeLockSupported } from '../lib/wakelock';
   import Segmented from '../lib/components/Segmented.svelte';
   import Avatar from '../lib/components/Avatar.svelte';
 
@@ -34,7 +33,6 @@
   ];
 
   const oledDisabled = $derived($settings.theme !== 'dark');
-  const wakeSupported = isWakeLockSupported();
 
   const previewPlayers = [
     { name: 'Ada Lovelace', color: PALETTE[0], score: 42 },
@@ -42,7 +40,7 @@
     { name: 'Cy Young', color: PALETTE[4], score: 31 },
   ];
 
-  function setBool(key: 'oled' | 'highContrast' | 'colorBlind' | 'keepAwake' | 'privacyGuard', v: boolean) {
+  function setBool(key: 'oled' | 'highContrast' | 'colorBlind', v: boolean) {
     settings.update((s) => ({ ...s, [key]: v }));
   }
 </script>
@@ -148,43 +146,6 @@
       type="checkbox"
       checked={$settings.colorBlind}
       onchange={(e) => setBool('colorBlind', e.currentTarget.checked)}
-    />
-    <span class="track"><span class="thumb"></span></span>
-  </span>
-</label>
-
-<div class="section-title">While playing</div>
-
-<label class="card sw-row row spread">
-  <span class="meta">
-    <span class="name">Keep screen awake</span>
-    <span class="muted sm">
-      {wakeSupported
-        ? 'Stops the screen dimming while a game is in progress.'
-        : 'Your browser doesn’t support screen wake lock.'}
-    </span>
-  </span>
-  <span class="switch">
-    <input
-      type="checkbox"
-      checked={$settings.keepAwake}
-      disabled={!wakeSupported}
-      onchange={(e) => setBool('keepAwake', e.currentTarget.checked)}
-    />
-    <span class="track"><span class="thumb"></span></span>
-  </span>
-</label>
-
-<label class="card sw-row row spread">
-  <span class="meta">
-    <span class="name">Privacy peek-guard</span>
-    <span class="muted sm">Blurs the board when you set the phone down, so a passer-by can’t read the scores. Tap to reveal.</span>
-  </span>
-  <span class="switch">
-    <input
-      type="checkbox"
-      checked={$settings.privacyGuard}
-      onchange={(e) => setBool('privacyGuard', e.currentTarget.checked)}
     />
     <span class="track"><span class="thumb"></span></span>
   </span>

--- a/src/pages/GameplaySettings.svelte
+++ b/src/pages/GameplaySettings.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import { settings } from '../lib/stores/settings';
+  import { isWakeLockSupported } from '../lib/wakelock';
+
+  const wakeSupported = isWakeLockSupported();
+
+  function setBool(key: 'keepAwake' | 'privacyGuard', v: boolean) {
+    settings.update((s) => ({ ...s, [key]: v }));
+  }
+</script>
+
+<h1>Gameplay</h1>
+<p class="lede muted">Tune how Score King behaves while a game is in play. Changes apply instantly and stick on this device.</p>
+
+<div class="section-title">While playing</div>
+
+<label class="card sw-row row spread">
+  <span class="meta">
+    <span class="name">Keep screen awake</span>
+    <span class="muted sm">
+      {wakeSupported
+        ? 'Stops the screen dimming while a game is in progress.'
+        : 'Your browser doesn’t support screen wake lock.'}
+    </span>
+  </span>
+  <span class="switch">
+    <input
+      type="checkbox"
+      checked={$settings.keepAwake}
+      disabled={!wakeSupported}
+      onchange={(e) => setBool('keepAwake', e.currentTarget.checked)}
+    />
+    <span class="track"><span class="thumb"></span></span>
+  </span>
+</label>
+
+<label class="card sw-row row spread">
+  <span class="meta">
+    <span class="name">Privacy peek-guard</span>
+    <span class="muted sm">Blurs the board when you set the phone down, so a passer-by can’t read the scores. Tap to reveal.</span>
+  </span>
+  <span class="switch">
+    <input
+      type="checkbox"
+      checked={$settings.privacyGuard}
+      onchange={(e) => setBool('privacyGuard', e.currentTarget.checked)}
+    />
+    <span class="track"><span class="thumb"></span></span>
+  </span>
+</label>
+
+<style>
+  .lede {
+    margin: -2px 4px 18px;
+    max-width: 60ch;
+  }
+
+  .meta {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+  }
+  .name {
+    font-weight: 700;
+  }
+  .sw-row {
+    cursor: pointer;
+    gap: 14px;
+  }
+
+  .switch {
+    position: relative;
+    display: inline-flex;
+    flex: none;
+  }
+  .switch input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    opacity: 0;
+    cursor: pointer;
+  }
+  .switch input:disabled {
+    cursor: not-allowed;
+  }
+  .track {
+    width: 46px;
+    height: 26px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    display: inline-flex;
+    align-items: center;
+    padding: 2px;
+    transition: background 0.15s ease;
+  }
+  .thumb {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #fff;
+    transition: transform 0.15s ease;
+  }
+  .switch input:checked + .track {
+    background: var(--primary);
+    border-color: var(--primary);
+  }
+  .switch input:checked + .track .thumb {
+    transform: translateX(20px);
+  }
+  .switch input:focus-visible + .track {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+</style>

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -9,6 +9,7 @@
   import { refreshPlayers } from '../lib/stores/players';
   import { showToast } from '../lib/stores/toast';
   import { relativeTime } from '../lib/util';
+  import ExcelIcon from '../lib/components/ExcelIcon.svelte';
 
   let override = $state($settings.oneDriveClientId);
   let busy = $state(false);
@@ -219,6 +220,18 @@
 
 <h1>Settings</h1>
 
+<div class="section-title">Gameplay</div>
+<a class="card navrow row spread" href="/gameplay" use:link>
+  <span class="row" style="gap: 12px">
+    <span class="navico" aria-hidden="true">🎲</span>
+    <span class="navmeta">
+      <span class="navname">Gameplay</span>
+      <span class="muted sm">Keep screen awake, privacy peek-guard</span>
+    </span>
+  </span>
+  <span class="chev" aria-hidden="true">›</span>
+</a>
+
 <div class="section-title">Display & accessibility</div>
 <a class="card navrow row spread" href="/accessibility" use:link>
   <span class="row" style="gap: 12px">
@@ -268,7 +281,7 @@
       </label>
 
       <div class="pathchip" title={locationLabel}>
-        <span class="pathchip-ico" aria-hidden="true">📂</span>
+        <ExcelIcon size={18} />
         <code>{prettyPath}</code>
       </div>
 
@@ -354,7 +367,10 @@
           />
         {/if}
 
-        <div class="muted sm">📄 <code>{locationLabel}</code></div>
+        <div class="muted sm row" style="gap: 8px">
+          <ExcelIcon size={16} />
+          <code>{locationLabel}</code>
+        </div>
         <div class="muted sm">
           Changing this may ask you to approve the new permission the next time you back up.
         </div>
@@ -447,10 +463,6 @@
     border: 1px solid var(--border, rgba(127, 127, 127, 0.2));
     border-radius: 8px;
     background: var(--surface-2, rgba(127, 127, 127, 0.08));
-  }
-  .pathchip-ico {
-    flex: none;
-    font-size: 0.95rem;
   }
   .pathchip code {
     background: none;


### PR DESCRIPTION
## What & why

Two requested changes to Settings.

### 1. Gameplay settings section
- Adds a **Gameplay** section in Settings, directly **above** the *Display & accessibility* section, with a matching nav row (🎲) linking to a new `/gameplay` page.
- Migrates the **While playing** settings — *Keep screen awake* and *Privacy peek-guard* — out of the Accessibility page and onto the new Gameplay page, which mirrors the Accessibility page's look (heading, lede, switch cards).
- Wires the new `gameplay` route in the router and `App.svelte`.
- The Accessibility page keeps Display + Motion & colour; its now-unused wake-lock import/derived were removed and `setBool` narrowed.

> Note: the existing `GamePlay.svelte` is the in-game scoring page (route `play`), so the new settings page is named `GameplaySettings.svelte` to avoid a case-insensitive filename clash.

### 2. Excel thumbnail
- Replaces the folder/page emoji (`📂` / `📄`) with a reusable **Excel workbook thumbnail** (`ExcelIcon.svelte`, inline SVG matching the existing inlined OneDrive logo style) in **both** spots in the OneDrive backup card: the top-level path chip and the Advanced "where your data is stored" line.

## Verification
- `npm run check` (svelte-check): 0 errors, 0 warnings
- `npm run build`: succeeds
- Excel icon rasterized and eyeballed at small sizes on dark + light surfaces; reads clearly as an `.xlsx` file.
- `/gameplay` route serves and renders.

## Design notes
Follows DESIGN.md: reuses existing card/switch/section-title vocabulary, no new Crown Gold or second Royal Violet fill, touch targets ≥46px preserved. Pre-existing color/radius lint findings in untouched style blocks were left as-is.