### PR TITLE
Fix inconsistent vertical spacing between stacked cards

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -9,6 +9,7 @@
   --radius: 14px;
   --radius-sm: 9px;
   --gap: 14px;
+  --card-gap: 6px;
   --maxw: 760px;
 
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -141,6 +142,13 @@ label,
   box-shadow: var(--shadow);
   padding: 16px;
 }
+
+/* Cards stacked directly in the page flow (e.g. Settings, Accessibility) share
+   one uniform gap, owned here rather than left to the incidental label
+   margin-bottom. Flex lists (.stack/.grid) keep managing their own spacing via
+   `gap`, and cards separated by a .section-title keep the larger section rhythm. */
+.app > .card { margin-bottom: 0; }
+.app > .card + .card { margin-top: var(--card-gap); }
 
 .stack { display: flex; flex-direction: column; gap: var(--gap); }
 .row { display: flex; gap: 10px; align-items: center; }


### PR DESCRIPTION
## Problem

On the **Accessibility & display** screen, consecutive cards within a section had inconsistent vertical gaps — some pairs touched (0px) while others had a ~6px gap. The 6px gap (between **High contrast** and **True-black (OLED)**) was the desired look; the touching pairs were the bug.

### Before (within-section gaps on `/accessibility`)
| Pair | Gap |
| --- | --- |
| Theme → Text size | **0px** ❌ |
| Text size → High contrast | **0px** ❌ |
| High contrast → True-black | 6px ✅ (the reference) |
| Motion → Colour-blind palette | **0px** ❌ |
| Keep screen awake → Privacy peek-guard | 6px ✅ |

### After
Every adjacent pair within a section shares a uniform **6px** gap; spacing **between** sections is unchanged (18px `.section-title` rhythm).

## Root cause

Page cards render as direct children of `<main class="app">`. `.app` is a plain block container — not flex, no `gap` — so inter-card spacing came only from element margins. Cards authored as `<label class="card …">` (High contrast, True-black, Colour-blind, Keep awake, Privacy) incidentally picked up the global `label, .fieldlabel { margin-bottom: 6px }` rule, whereas `<div class="card …">` cards (Theme, Text size, Motion) had no margin at all → 0px. The "good" 6px gap was an accident of which element happened to be a `<label>`.

## The fix (`src/app.css`, +8 lines)

Own the spacing intentionally instead of leaning on the accidental label margin:

```css
--card-gap: 6px; /* design system spacing.xs; the High-contrast↔True-black reference */

.app > .card { margin-bottom: 0; }
.app > .card + .card { margin-top: var(--card-gap); }
```

- Consecutive cards in the page flow now get a single, uniform top-margin gap.
- The incidental `margin-bottom` is zeroed on page-flow cards, so the gap is **deterministic** regardless of margin-collapse behavior (`0 + 6 = 6` either way) and no longer depends on the global label rule.
- Cards separated by a `.section-title` are not adjacent, so the larger section rhythm is preserved untouched.

## Why this is safe app-wide

`6px` matches the design system's `spacing.xs` token in `DESIGN.md`, so it's an intentional value, not a magic number. The rule is global, so any current or future page that stacks cards directly in the flow gets consistent spacing automatically. Audit of every page:

- **Accessibility** — was the only page with the bug; now uniform.
- **Settings** — cards are separated by `.section-title`, so `.card + .card` never matches → unchanged (already correct).
- **Home / History / Players** — vertical card lists use `.stack` (flex `gap: 14px`); those cards aren't direct `.app` children, so the new rule doesn't touch them and gaps are **not** doubled.
- **Stats / GameType** — cards split by `.section-title` / wrapped in `.stack` → unchanged.
- **GamePlay** — keeps its deliberate, internally-consistent 12px section rhythm: those cards set `margin-top: 12px` inline (which wins over the rule), and the only class-based gap (`.banner`) follows the `<table>`-rooted `Scoreboard`, so it isn't a `.card + .card` match. No regression on the play screen.

This intentionally keeps three context-appropriate rhythms (6px dense settings rows, 12px play-screen sections, 14px content lists) rather than collapsing everything to one value — matching the request, which called the `.stack` section spacing "good" and only flagged the settings cards.

## Verification

- `npm run check` (svelte-check + tsc): **0 errors, 0 warnings**.
- Rendered `/accessibility` on the dev server and confirmed uniform within-section gaps with section breaks unchanged.
- Spot-checked Home, GamePlay, History, Players, Stats for no collapsed/doubled gaps.

Diff is a single file, +8 lines.