### PR TITLE
Fix reduced-motion setting to also disable JS animations

### DIFF
--- a/src/lib/components/SyncBubble.svelte
+++ b/src/lib/components/SyncBubble.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { scale } from 'svelte/transition';
-  import { animate } from 'motion/mini';
   import { autoSyncStatus } from '../storage/autosync';
   import { settings } from '../stores/settings';
   import { navigate } from '../router';
+  import { animateMotion } from '../motion';
   import { relativeTime } from '../util';
 
   const status = $derived($autoSyncStatus);
@@ -55,10 +55,6 @@
               : 'Not backed up yet',
   );
 
-  const reduce = () =>
-    typeof window !== 'undefined' &&
-    !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
-
   // --- progress fill (slow >1s syncs only); never carries into the synced state ---
   let showFill = $state(false);
   let progress = $state(0); // 0..1
@@ -109,8 +105,8 @@
     if (s === 'synced') {
       stickySynced = true;
       // Springy celebration on the green dot.
-      if (dotEl && !reduce()) {
-        animate(
+      if (dotEl) {
+        animateMotion(
           dotEl,
           { scale: [0.3, 1.4, 0.9, 1] },
           { duration: 0.5, ease: 'easeOut' },
@@ -124,8 +120,7 @@
 
   // Springy entrance (Motion) — runs once when the pill mounts.
   function enter(node: HTMLElement) {
-    if (reduce()) return;
-    animate(
+    animateMotion(
       node,
       { opacity: [0, 1], scale: [0.5, 1.08, 1], rotate: [-8, 2, 0] },
       { duration: 0.5, ease: 'easeOut' },
@@ -138,11 +133,7 @@
     e.preventDefault();
     if (popping) return;
     popping = true;
-    if (reduce()) {
-      navigate('/settings');
-      return;
-    }
-    const controls = animate(
+    const controls = animateMotion(
       node,
       { scale: [1, 1.18, 0.92, 1], rotate: [0, -7, 6, 0] },
       { duration: 0.36, ease: 'easeOut' },

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,67 @@
+import { get } from 'svelte/store';
+import { animate } from 'motion/mini';
+import { settings } from './stores/settings';
+
+/**
+ * The single source of truth for whether motion should be reduced.
+ *
+ * Honors the in-app Motion setting (Accessibility screen) first, and only
+ * defers to the OS `prefers-reduced-motion` when the setting is 'system':
+ *   - 'reduce' → always reduced, regardless of the OS
+ *   - 'full'   → never reduced, regardless of the OS
+ *   - 'system' → follow the OS preference
+ *
+ * Reads the store synchronously via `get` so it can gate imperative
+ * (JS/WAAPI) animations, which CSS overrides cannot reach.
+ */
+export function prefersReducedMotion(): boolean {
+  const pref = get(settings).motion;
+  if (pref === 'reduce') return true;
+  if (pref === 'full') return false;
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+type AnimateControls = ReturnType<typeof animate>;
+
+/**
+ * A finished, no-op stand-in for `animate`'s controls, returned when motion is
+ * reduced. `.finished` is already resolved so callers that chain on it (e.g.
+ * `controls.finished.finally(...)`) still run their follow-up — instantly.
+ */
+function skippedAnimation(): AnimateControls {
+  const finished = Promise.resolve();
+  const noop = () => {};
+  return {
+    time: 0,
+    speed: 1,
+    startTime: null,
+    state: 'finished',
+    duration: 0,
+    iterationDuration: 0,
+    stop: noop,
+    play: noop,
+    pause: noop,
+    complete: noop,
+    cancel: noop,
+    attachTimeline: () => noop,
+    finished,
+    then: (onResolve: VoidFunction, onReject?: VoidFunction) =>
+      finished.then(onResolve, onReject),
+  } as unknown as AnimateControls;
+}
+
+/**
+ * Drop-in wrapper around `motion`'s `animate` that bakes the reduced-motion
+ * preference in at the library boundary. When motion is reduced the animation
+ * is skipped and a finished, controls-compatible object is returned, leaving
+ * the element at its resting (final) state. Routing every `animate` call
+ * through here keeps current and future imperative animations automatically
+ * safe, while preserving the `controls.finished` contract callers rely on.
+ */
+export function animateMotion(...args: Parameters<typeof animate>): AnimateControls {
+  if (prefersReducedMotion()) return skippedAnimation();
+  return animate(...args);
+}


### PR DESCRIPTION
## Problem

The in-app **Motion = Reduced** setting (Accessibility screen) did not disable JavaScript-driven animations. A user reported: *"I don't really see reduced motion taking effect when the setting is enabled."*

## Root cause

Two issues, both bypassing the in-app preference:

1. **CSS overrides can't reach JS animations.** The `motion` library animates via the **Web Animations API**, whose durations are not set by CSS. The global `html[data-motion="reduce"] *` rules in `src/app.css` neutralize CSS transitions/keyframes (and Svelte's CSS transitions), but have no effect on WAAPI animations.
2. **The only consumer checked the OS, not the setting.** `SyncBubble.svelte` gated its `motion` animations on a local helper that read **only** `window.matchMedia('(prefers-reduced-motion: reduce)')`, ignoring `$settings.motion`. So choosing "Reduced" in-app did nothing when the OS had no reduced-motion preference, and "Full" couldn't force motion on.

## Fix

New `src/lib/motion.ts` as a single source of truth, baking the preference in **at the library boundary** so any current or future `animate` call is automatically safe:

- **`prefersReducedMotion()`** — honors the in-app setting first (`reduce` → always true, `full` → always false) and only defers to the OS `prefers-reduced-motion` when motion is `system`. Reads the store synchronously via `get(settings)` and guards for no-window/SSR.
- **`animateMotion(...)`** — drop-in wrapper around `motion`'s `animate`. When reduced, it **skips** the animation and returns a finished, controls-compatible object whose `.finished` is already resolved, preserving the `controls.finished.finally(...)` contract existing call sites depend on (the element is left at its resting/final state). Otherwise it passes straight through to `animate`.

`SyncBubble.svelte` now routes its entrance, click-pop, and synced-celebration animations through `animateMotion` and drops its OS-only `reduce()` helper.

### Behavior after the fix
- **Reduced** (regardless of OS): SyncBubble's JS animations don't play — it appears and navigates instantly.
- **Full** (regardless of OS): they always play.
- **System**: follows the OS preference.

CSS-driven motion is unchanged and remains covered by the existing `data-motion` overrides (e.g. the Accessibility "Live preview" pulse dot). Audit confirms `motion`/`animate` was only used in `SyncBubble`; the `svelte/transition` `scale` there is CSS-based and already handled.

## Verification
- `npm install` && `npm run check` (svelte-check + tsc): **0 errors, 0 warnings**
- `npm run build`: production build succeeds
- Ran the real (transpiled) module against a DOM shim: the `reduce`/`full`/`system`×OS decision table and the skip-path contract (`.finished` resolves, `.finally` runs, real `animate` not invoked) all pass
- Dev server compiles and serves both changed files cleanly

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>