### PR TITLE
Back up site settings in the backup file

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ src/
 - `Players(id, name, color, createdAt)`
 - `Games(id, type, config, playerIds, status, createdAt, finishedAt, winnerIds)`
 - `Rounds(id, gameId, index, inputs, scores, createdAt)`
+- `Settings(key, value)` — your **portable preferences** (theme, OLED, text size, contrast,
+  motion, colour-blind palette, keep-awake, privacy guard). Kept in `localStorage` on the
+  device and mirrored into the backup's `Settings` sheet so they travel with a restore.
+  Device-local OneDrive details (client-ID override, folder location, auto-backup toggle,
+  connection flag, sync timestamps) are deliberately **not** backed up — see
+  [What gets backed up](#what-gets-backed-up).
 
 ---
 
@@ -151,9 +157,9 @@ settings.
 After that, **Settings → Connect OneDrive** is one click for everyone. Power users / forks can
 override with their own client ID under **Settings → Advanced**.
 
-> The workbook has `Players`, `Games`, `Rounds`, and `RoundScores` sheets. The app treats local
-> data as the source of truth during play and syncs the whole snapshot automatically (debounced) —
-> or on demand via **Back up now**.
+> The workbook has `Players`, `Games`, `Rounds`, `RoundScores`, and `Settings` sheets. The app
+> treats local data as the source of truth during play and syncs the whole snapshot
+> automatically (debounced) — or on demand via **Back up now**.
 
 ### How backup & restore behave
 
@@ -165,6 +171,24 @@ override with their own client ID under **Settings → Advanced**.
   workbook — no disconnect/reconnect needed.
 - If you press **Restore** but no backup exists yet, the app offers to **back up your current data**
   there instead, so you're never left in a dead end.
+
+### What gets backed up
+
+A backup carries your game data **and** your portable preferences — theme, OLED, text size, high
+contrast, motion, colour‑blind palette, keep‑awake, and privacy guard — in the `Settings` sheet, so
+restoring on a new device brings your accessibility/display setup along. The local JSON
+export/import covers the same set.
+
+Deliberately **left out**, to avoid dead or conflicting state on another device: the OneDrive
+client‑ID override, the backup file's folder location, the auto‑backup toggle, the "connected" flag,
+and the last‑sync/last‑restore timestamps. (Restore is also defensive — it only ever applies the
+portable keys, so even a hand‑edited workbook can't clobber this device's connection.)
+
+> **Adding a setting?** Categorize it in [`src/lib/stores/settings.ts`](src/lib/stores/settings.ts):
+> add portable user preferences to `PORTABLE_SETTING_KEYS` (so they're included in the backup) and
+> device/connection state to `LOCAL_SETTING_KEYS`. A compile‑time guard fails `npm run check` until
+> every setting is listed in exactly one of the two arrays, so a new preference can't silently miss
+> the backup — the default expectation is that new settings **are** backed up.
 
 ### Google Drive (future)
 

--- a/src/lib/storage/autosync.ts
+++ b/src/lib/storage/autosync.ts
@@ -1,5 +1,5 @@
 import { get, writable } from 'svelte/store';
-import { settings, markSynced } from '../stores/settings';
+import { settings, markSynced, getBackupSettings } from '../stores/settings';
 import { dataVersion } from './changes';
 import { buildSnapshot, getOneDrive, InteractionRequiredError } from './sync';
 import type { SyncProvider } from './sync';
@@ -24,6 +24,7 @@ let pushing = false; // an upload is in flight
 let timer: ReturnType<typeof setTimeout> | undefined;
 let lastVersion = 0;
 let wasActive = false;
+let lastPortableSig: string | undefined; // JSON of the last-seen portable settings
 
 function enabled(): boolean {
   return get(settings).autoSync;
@@ -150,14 +151,27 @@ export function startAutoSync(): void {
   });
 
   settings.subscribe((s) => {
+    // Backed-up preferences live outside the db, so dataVersion never moves when
+    // one changes. Watch them here so e.g. a theme or text-size tweak is pushed
+    // too. Only the portable subset counts — reacting to autoSync/connection or
+    // the lastSync/lastRestore stamps would loop, since a push writes lastSync.
+    const sig = JSON.stringify(getBackupSettings());
+    if (lastPortableSig === undefined) {
+      lastPortableSig = sig; // initial subscribe replay — capture the baseline
+    } else if (sig !== lastPortableSig) {
+      lastPortableSig = sig;
+      onLocalChange();
+    }
+
     const now = s.autoSync && s.oneDriveConnected;
-    if (now === wasActive) return;
-    wasActive = now;
-    if (now) {
-      if (dirty) schedule(); // turned on / just connected with changes waiting
-    } else {
-      cancelTimer(); // turned off or disconnected — stop automatic uploads
-      autoSyncStatus.set('idle');
+    if (now !== wasActive) {
+      wasActive = now;
+      if (now) {
+        if (dirty) schedule(); // turned on / just connected with changes waiting
+      } else {
+        cancelTimer(); // turned off or disconnected — stop automatic uploads
+        autoSyncStatus.set('idle');
+      }
     }
   });
 

--- a/src/lib/storage/onedrive.ts
+++ b/src/lib/storage/onedrive.ts
@@ -5,6 +5,7 @@ import { ONEDRIVE_CLIENT_ID } from '../config';
 import type { Snapshot, SyncProvider } from './sync';
 import { InteractionRequiredError } from './sync';
 import type { Game, Player, Round } from '../types';
+import type { Settings } from '../stores/settings';
 
 const FILE_NAME = 'Score King.xlsx';
 const GRAPH = 'https://graph.microsoft.com/v1.0';
@@ -189,12 +190,19 @@ async function toWorkbook(s: Snapshot): Promise<ArrayBuffer> {
       scores.push({ gameId: r.gameId, round: r.index + 1, player: nameOf(pid), delta });
     }
   }
+  // Portable preferences, one row per key with a JSON-encoded value (matching how
+  // config/inputs are stored in the other sheets) so any value type round-trips.
+  const settings = Object.entries(s.settings ?? {}).map(([key, value]) => ({
+    key,
+    value: JSON.stringify(value),
+  }));
 
   const wb = XLSX.utils.book_new();
   XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(players), 'Players');
   XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(games), 'Games');
   XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(rounds), 'Rounds');
   XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(scores), 'RoundScores');
+  XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(settings), 'Settings');
   return XLSX.write(wb, { bookType: 'xlsx', type: 'array' }) as ArrayBuffer;
 }
 
@@ -231,7 +239,15 @@ async function fromWorkbook(buf: ArrayBuffer): Promise<Snapshot> {
     createdAt: Date.parse(String(r.created)) || Date.now(),
   }));
   for (const g of games) g.roundCount = rounds.filter((r) => r.gameId === g.id).length;
-  return { players, games, rounds, exportedAt: Date.now() };
+
+  // Portable preferences (JSON-encoded values). applyBackupSettings ignores any
+  // non-portable keys, so we read permissively here.
+  const restoredSettings: Partial<Settings> = {};
+  for (const r of sheet('Settings')) {
+    const key = String(r.key ?? '').trim();
+    if (key) (restoredSettings as Record<string, unknown>)[key] = parse<unknown>(r.value, undefined);
+  }
+  return { players, games, rounds, settings: restoredSettings, exportedAt: Date.now() };
 }
 
 /** PUT the workbook bytes to the configured content path (overwrites; last-write-wins). */

--- a/src/lib/storage/sync.ts
+++ b/src/lib/storage/sync.ts
@@ -1,10 +1,18 @@
 import * as db from './db';
 import type { Game, Player, Round } from '../types';
+import type { Settings } from '../stores/settings';
+import { getBackupSettings, applyBackupSettings } from '../stores/settings';
 
 export interface Snapshot {
   players: Player[];
   games: Game[];
   rounds: Round[];
+  /**
+   * Backed-up user preferences (the portable subset of {@link Settings}).
+   * Optional so older backups — and JSON files written before settings sync —
+   * still restore cleanly; when absent, local preferences are left as-is.
+   */
+  settings?: Partial<Settings>;
   exportedAt: number;
 }
 
@@ -56,7 +64,7 @@ export async function buildSnapshot(): Promise<Snapshot> {
     db.getAllGames(),
     db.getAllRounds(),
   ]);
-  return { players, games, rounds, exportedAt: Date.now() };
+  return { players, games, rounds, settings: getBackupSettings(), exportedAt: Date.now() };
 }
 
 export async function restoreSnapshot(snapshot: Snapshot): Promise<void> {
@@ -65,6 +73,7 @@ export async function restoreSnapshot(snapshot: Snapshot): Promise<void> {
     games: snapshot.games,
     rounds: snapshot.rounds,
   });
+  applyBackupSettings(snapshot.settings);
 }
 
 /** Lazy-load the OneDrive provider (keeps MSAL + SheetJS out of the main bundle). */

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 
 export type Theme = 'dark' | 'light';
 
@@ -18,6 +18,9 @@ export const FONT_SCALE_VALUES: Record<FontScale, number> = {
 };
 
 export interface Settings {
+  // ── Portable preferences ──────────────────────────────────────────────────
+  // Device-agnostic user choices. These are stored in the backup file so they
+  // travel with a restore. Keep this group in sync with PORTABLE_SETTING_KEYS.
   theme: Theme;
   /** True-black surfaces for OLED screens (dark theme only). */
   oled: boolean;
@@ -30,6 +33,11 @@ export interface Settings {
   keepAwake: boolean;
   /** Blur scores with a tap-to-reveal veil after the phone is set down. */
   privacyGuard: boolean;
+
+  // ── Device-local sync state ───────────────────────────────────────────────
+  // OneDrive connection, the backup file's own location, and per-device sync
+  // bookkeeping. Deliberately NOT backed up (see LOCAL_SETTING_KEYS) — restoring
+  // these onto another device would create dead/conflicting state.
   oneDriveClientId: string;
   oneDriveFolderMode: OneDriveFolderMode;
   oneDriveCustomPath: string;
@@ -38,6 +46,61 @@ export interface Settings {
   lastSync: number | null;
   lastRestore: number | null;
 }
+
+/**
+ * Settings written to (and restored from) the backup file. These are portable
+ * user preferences with no device- or connection-specific meaning, so carrying
+ * them across devices via a restore is always safe.
+ *
+ * Adding a new setting? If it's a portable preference, list it here so it gets
+ * backed up. If it's device/connection state, list it in LOCAL_SETTING_KEYS
+ * instead. The compile-time guard below fails the build until every key of
+ * {@link Settings} is categorized in exactly one of the two arrays.
+ */
+export const PORTABLE_SETTING_KEYS = [
+  'theme',
+  'oled',
+  'fontScale',
+  'motion',
+  'highContrast',
+  'colorBlind',
+  'keepAwake',
+  'privacyGuard',
+] as const;
+
+/**
+ * Settings intentionally kept OUT of the backup: the OneDrive client-ID override,
+ * the backup file's folder location, the auto-backup toggle, the "connected" flag,
+ * and the last-sync/last-restore stamps. Backing these up risks dead state on
+ * restore (e.g. a custom folder path that doesn't exist on the new device, or a
+ * "connected" flag for an account this device isn't signed into).
+ */
+export const LOCAL_SETTING_KEYS = [
+  'oneDriveClientId',
+  'oneDriveFolderMode',
+  'oneDriveCustomPath',
+  'autoSync',
+  'oneDriveConnected',
+  'lastSync',
+  'lastRestore',
+] as const;
+
+export type PortableSettingKey = (typeof PORTABLE_SETTING_KEYS)[number];
+type LocalSettingKey = (typeof LOCAL_SETTING_KEYS)[number];
+
+/** The portable subset of {@link Settings} that is persisted in a backup. */
+export type BackupSettings = Pick<Settings, PortableSettingKey>;
+
+/**
+ * Compile-time exhaustiveness guard. Every key of {@link Settings} must appear in
+ * either PORTABLE_SETTING_KEYS or LOCAL_SETTING_KEYS. Add a setting and forget to
+ * categorize it, and `UncategorizedSettingKey` becomes that key (not `never`),
+ * so this alias fails to type-check — a forced reminder to decide whether the new
+ * setting belongs in the backup.
+ */
+type AssertNever<T extends never> = T;
+type UncategorizedSettingKey = Exclude<keyof Settings, PortableSettingKey | LocalSettingKey>;
+type _AllSettingsCategorized = AssertNever<UncategorizedSettingKey>;
 
 const KEY = 'sk_settings';
 
@@ -98,4 +161,31 @@ export function markSynced(ts: number) {
 
 export function markRestored(ts: number) {
   settings.update((s) => ({ ...s, lastRestore: ts }));
+}
+
+/** The portable subset of the current settings, ready to embed in a backup. */
+export function getBackupSettings(): BackupSettings {
+  const s = get(settings);
+  const out = {} as Record<PortableSettingKey, unknown>;
+  for (const key of PORTABLE_SETTING_KEYS) out[key] = s[key];
+  return out as BackupSettings;
+}
+
+/**
+ * Merge backed-up preferences from a restored snapshot into the live settings.
+ * Only portable keys are ever applied, so a restore can never overwrite this
+ * device's OneDrive connection, file location, or sync bookkeeping — even if an
+ * old or hand-edited backup happens to contain those fields. A missing/`undefined`
+ * value leaves the current preference untouched.
+ */
+export function applyBackupSettings(incoming: Partial<Settings> | undefined): void {
+  if (!incoming) return;
+  settings.update((s) => {
+    const next: Settings = { ...s };
+    for (const key of PORTABLE_SETTING_KEYS) {
+      const value = incoming[key];
+      if (value !== undefined) next[key] = value as never;
+    }
+    return next;
+  });
 }


### PR DESCRIPTION
## What & why

Backups previously stored only game data (players, games, rounds), so a user's preferences never travelled with a restore. This change stores all **feasible** settings in the backup file — both the OneDrive `.xlsx` and the local JSON export — and restores them, with a clean structure and a guard that keeps future settings honest.

## Categorization (`src/lib/stores/settings.ts`)

Settings are split into two explicit groups:

- **Backed up — `PORTABLE_SETTING_KEYS`**: `theme`, `oled`, `fontScale`, `motion`, `highContrast`, `colorBlind`, `keepAwake`, `privacyGuard`. Device-agnostic preferences that are always safe to carry across devices.
- **Excluded — `LOCAL_SETTING_KEYS`**: `oneDriveClientId`, `oneDriveFolderMode`, `oneDriveCustomPath`, `autoSync`, `oneDriveConnected`, `lastSync`, `lastRestore`. OneDrive connection, the backup file's own location, and per-device sync bookkeeping — restoring these onto another device would create dead/conflicting state (e.g. a custom folder path that doesn't apply, or a "connected" flag for an account this device isn't signed into).

A **compile-time exhaustiveness guard** (`AssertNever<UncategorizedSettingKey>`) fails `npm run check` until every `Settings` key is listed in exactly one of the two arrays — so a new setting can't silently miss the backup. The default expectation is that new preferences **are** backed up.

## Wiring

- **`sync.ts`** — `Snapshot` gains an optional `settings` field; `buildSnapshot` embeds the portable subset, `restoreSnapshot` applies it. Restore only ever applies portable keys, so it can never clobber this device's connection — even from an old or hand-edited file.
- **`onedrive.ts`** — reads/writes a `Settings` sheet (one row per key, JSON-encoded value, matching how `config`/inputs are stored in the other sheets so any value type round-trips).
- **`autosync.ts`** — a portable-preference change now schedules a push too (settings live outside the db, so `dataVersion` never moved for them), scoped so sync bookkeeping (`lastSync`/`lastRestore`) can't loop.
- Both the local **JSON export/import** and **OneDrive** paths are covered (both go through `buildSnapshot`/`restoreSnapshot`).

## Docs (`README.md`)

Updated the data model and the workbook sheet list, plus a new **"What gets backed up"** section spelling out the portable/local split and the rule for adding settings.

## Verification

- `npm run check` (svelte-check + tsc) ✓
- `npm run build` ✓
- Confirmed the exhaustiveness guard fires when a key is un-categorized.
- xlsx round-trip test confirmed booleans/enums survive intact, and an empty `Settings` sheet restores safely.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>