### PR TITLE
Add multiple titled OneDrive backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ works fully offline, and can back itself up to an **Excel workbook in your OneDr
 - **Players, history & stats** are shared across every game — reusable players, a full game log,
   and a win‑rate leaderboard.
 - **Optional OneDrive Excel sync.** Automatic (and one‑click) backup to a real `.xlsx` you can open
-  in Excel, with one‑click restore. Auto‑backup is on by default, push‑only, and never interrupts
+  in Excel, with one‑click restore. Keep **multiple titled backups** in the folder (one per group or
+  occasion) and switch between them. Auto‑backup is on by default, push‑only, and never interrupts
   you. Uses your own free Azure app registration — *no secrets live in this repo.*
 - **Local JSON export/import** as a zero‑setup backup option.
 - **Dark / light** themes.
@@ -110,7 +111,7 @@ That's it — routing (`/<id>`), players, history, stats, and persistence all wo
 ## ☁️ OneDrive / Excel sync setup (optional)
 
 Sync is **opt‑in** — the app is fully usable offline without it. When enabled, each user signs in
-with **their own** Microsoft account and the app writes a `Score King.xlsx` to **their own**
+with **their own** Microsoft account and the app writes a `Main.xlsx` workbook to **their own**
 OneDrive. By default the file lives in a **sandboxed app folder** (`OneDrive → Apps → Score King`)
 that the app is the *only* thing able to read — it can't see the rest of your OneDrive. Power users
 can switch to a **custom folder** in Settings (which needs broader access — see below). There's a
@@ -118,6 +119,15 @@ single shared app registration; the client ID is **public** (for SPAs it isn't a
 comes from PKCE + the redirect‑URI allowlist), so end users never configure anything. They just open
 **Settings → Connect OneDrive**. Connecting briefly redirects the whole page to Microsoft to sign in,
 then returns you to Settings — there's no popup to allow or unblock.
+
+**Multiple titled backups.** The chosen folder is the source of truth: Score King treats every
+`.xlsx` workbook in it as a backup, so you can keep more than one — say one for the *Friday Night
+Crew* and one for *Family*. A backup's title is exactly what you type, saved as **`<Title>.xlsx`**
+(e.g. `Friday Night Crew.xlsx`) so it reads naturally in OneDrive and Excel. New connections start
+on **`Main.xlsx`**. In **Settings → Backups** you can add a new titled backup (a copy of your current
+scores), rename or delete one, and pick which backup is **active**. Switching the active backup loads
+its contents onto this device; everything below — the status bubble, **Sync now**, **Restore now**,
+and auto‑backup — always targets the active one.
 
 **Automatic backup is on by default.** Once you're connected, Score King quietly pushes a fresh
 backup a few seconds after you change anything (new game, saved round, finished game, edited player),
@@ -157,14 +167,18 @@ override with their own client ID under **Settings → Advanced**.
 
 ### How backup & restore behave
 
-- **Back up now** overwrites the remote `Score King.xlsx` with your current data (last‑write‑wins).
+- **Back up now** overwrites the **active** backup workbook with your current data (last‑write‑wins).
   If the file was deleted — or, in custom‑folder mode, the whole folder was deleted — the next
   backup **recreates the file (and folder)** automatically.
-- **Restore** always fetches the **latest** remote copy. The download bypasses the browser cache
-  (`cache: 'no-store'`), so a single Restore reflects edits you (or Excel) just made to the
-  workbook — no disconnect/reconnect needed.
+- **Restore** always fetches the **latest** remote copy of the active backup. The download bypasses
+  the browser cache (`cache: 'no-store'`), so a single Restore reflects edits you (or Excel) just
+  made to the workbook — no disconnect/reconnect needed.
 - If you press **Restore** but no backup exists yet, the app offers to **back up your current data**
   there instead, so you're never left in a dead end.
+- **Backups are independent save slots.** Adding a backup snapshots your current scores under a new
+  title and makes it active; your other backups are untouched. Auto‑backup keeps pushing to whichever
+  backup is active, so switching first (which loads that backup onto the device) keeps each slot
+  separate.
 
 ### Google Drive (future)
 

--- a/src/lib/storage/onedrive.ts
+++ b/src/lib/storage/onedrive.ts
@@ -2,11 +2,16 @@ import { PublicClientApplication, type AccountInfo } from '@azure/msal-browser';
 import { get } from 'svelte/store';
 import { settings } from '../stores/settings';
 import { ONEDRIVE_CLIENT_ID } from '../config';
-import type { Snapshot, SyncProvider } from './sync';
-import { InteractionRequiredError } from './sync';
+import type { BackupInfo, PushOptions, Snapshot, SyncProvider } from './sync';
+import {
+  DEFAULT_BACKUP_FILE,
+  InteractionRequiredError,
+  fileNameForTitle,
+  isBackupFile,
+  titleFromFileName,
+} from './sync';
 import type { Game, Player, Round } from '../types';
 
-const FILE_NAME = 'Score King.xlsx';
 const GRAPH = 'https://graph.microsoft.com/v1.0';
 
 // Where to send the user back to after a full-page Microsoft sign-in redirect.
@@ -48,14 +53,33 @@ function customFolderSegments(): string[] {
     .filter(Boolean);
 }
 
-/** Graph addressing for the workbook's content, per the chosen storage location. */
-function contentPath(): string {
-  const file = encodeURIComponent(FILE_NAME);
+/** The backup file the user is currently syncing to (default = Main.xlsx). */
+function activeFile(): string {
+  return (get(settings).oneDriveBackupFile || '').trim() || DEFAULT_BACKUP_FILE;
+}
+
+/** Graph path addressing the configured folder's children collection. */
+function childrenPath(): string {
   if (folderMode() === 'custom') {
     const folder = encodePath(get(settings).oneDriveCustomPath || '');
-    return `/me/drive/root:${folder ? '/' + folder : ''}/${file}:/content`;
+    return folder ? `/me/drive/root:/${folder}:/children` : '/me/drive/root/children';
   }
-  return `/me/drive/special/approot:/${file}:/content`;
+  return '/me/drive/special/approot/children';
+}
+
+/** Graph path addressing a backup *item* (metadata: GET/DELETE/PATCH) in the chosen folder. */
+function itemPath(file: string): string {
+  const name = encodeURIComponent(file);
+  if (folderMode() === 'custom') {
+    const folder = encodePath(get(settings).oneDriveCustomPath || '');
+    return `/me/drive/root:${folder ? '/' + folder : ''}/${name}`;
+  }
+  return `/me/drive/special/approot:/${name}`;
+}
+
+/** Graph addressing for a backup workbook's content, per the chosen storage location. */
+function contentPath(file: string = activeFile()): string {
+  return `${itemPath(file)}:/content`;
 }
 
 let pca: PublicClientApplication | null = null;
@@ -337,5 +361,84 @@ export const oneDrive: SyncProvider = {
     if (res.status === 404) return null;
     if (!res.ok) throw new Error(`Download failed (HTTP ${res.status}).`);
     return fromWorkbook(await res.arrayBuffer());
+  },
+  async listBackups(opts?: PushOptions): Promise<BackupInfo[]> {
+    const accessToken = await token(opts?.interactive ?? true);
+    // Trim the payload and bypass caches so the list reflects just-made changes.
+    const query = '?$top=999&$select=name,size,lastModifiedDateTime,file';
+    const res = await graph(
+      `${childrenPath()}${query}`,
+      { method: 'GET', cache: 'no-store' },
+      accessToken,
+    );
+    // The folder simply doesn't exist yet (nothing backed up) — no backups, not an error.
+    if (res.status === 404) return [];
+    if (!res.ok) throw new Error(`Could not list backups (HTTP ${res.status}).`);
+    const data = (await res.json()) as {
+      value?: Array<{
+        name?: string;
+        size?: number;
+        lastModifiedDateTime?: string;
+        file?: unknown;
+      }>;
+    };
+    return (data.value ?? [])
+      .filter((it) => !!it.file && !!it.name && isBackupFile(it.name))
+      .map((it) => ({
+        file: it.name as string,
+        title: titleFromFileName(it.name as string),
+        isDefault: it.name === DEFAULT_BACKUP_FILE,
+        modifiedAt: it.lastModifiedDateTime ? Date.parse(it.lastModifiedDateTime) || null : null,
+        size: typeof it.size === 'number' ? it.size : null,
+      }))
+      .sort((a, b) => (b.modifiedAt ?? 0) - (a.modifiedAt ?? 0));
+  },
+  async removeBackup(file: string): Promise<void> {
+    const accessToken = await token();
+    const res = await graph(itemPath(file), { method: 'DELETE' }, accessToken);
+    // 404 = already gone; treat as success so the UI converges.
+    if (!res.ok && res.status !== 404) {
+      throw new Error(`Could not delete backup (HTTP ${res.status}).`);
+    }
+  },
+  async renameBackup(file: string, newTitle: string): Promise<BackupInfo> {
+    const accessToken = await token();
+    const newFile = fileNameForTitle(newTitle);
+    if (newFile === file) {
+      return {
+        file,
+        title: titleFromFileName(file),
+        isDefault: file === DEFAULT_BACKUP_FILE,
+        modifiedAt: null,
+        size: null,
+      };
+    }
+    const res = await graph(
+      itemPath(file),
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        // 'fail' so we never silently clobber an existing backup of the same name.
+        body: JSON.stringify({ name: newFile, '@microsoft.graph.conflictBehavior': 'fail' }),
+      },
+      accessToken,
+    );
+    if (res.status === 409) {
+      throw new Error(`A backup named "${titleFromFileName(newFile)}" already exists.`);
+    }
+    if (!res.ok) throw new Error(`Could not rename backup (HTTP ${res.status}).`);
+    const item = (await res.json()) as {
+      name?: string;
+      size?: number;
+      lastModifiedDateTime?: string;
+    };
+    const name = item.name || newFile;
+    return {
+      file: name,
+      title: titleFromFileName(name),
+      isDefault: name === DEFAULT_BACKUP_FILE,
+      modifiedAt: item.lastModifiedDateTime ? Date.parse(item.lastModifiedDateTime) || null : null,
+      size: typeof item.size === 'number' ? item.size : null,
+    };
   },
 };

--- a/src/lib/storage/sync.ts
+++ b/src/lib/storage/sync.ts
@@ -8,6 +8,66 @@ export interface Snapshot {
   exportedAt: number;
 }
 
+/**
+ * Backup file naming
+ * ------------------
+ * The configured OneDrive folder (App folder or a custom folder) is the source of
+ * truth: every workbook in it is a backup the user can keep alongside others.
+ *
+ * - A backup's title is exactly what the user types and the file is stored as
+ *   `<Title>.xlsx`, so it reads naturally in OneDrive and Excel.
+ * - New connections start on `Main.xlsx` ("Main"), which also stays the fallback
+ *   when every other backup has been removed.
+ */
+export const BACKUP_EXT = '.xlsx';
+/** The default backup, used for new connections and as the last-resort fallback. */
+export const DEFAULT_BACKUP_FILE = `Main${BACKUP_EXT}`;
+
+/** Metadata for one detected backup workbook in the configured folder. */
+export interface BackupInfo {
+  /** File name within the folder, e.g. "Friday Crew.xlsx". */
+  file: string;
+  /** Human-readable title derived from the file name. */
+  title: string;
+  /** True for the default `Main.xlsx`. */
+  isDefault: boolean;
+  /** Last modified time (ms epoch), or null when not backed up yet. */
+  modifiedAt: number | null;
+  /** Size in bytes, or null when unknown. */
+  size: number | null;
+}
+
+/** Characters OneDrive/SharePoint forbid in a file name. */
+const ILLEGAL_NAME_CHARS = /[\\/:*?"<>|]/g;
+
+/** Clean a user title into something safe to use as a file name. */
+export function sanitizeBackupTitle(title: string): string {
+  return title
+    .replace(ILLEGAL_NAME_CHARS, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 60);
+}
+
+/** Build the file name for a user title (the title is the file name). */
+export function fileNameForTitle(title: string): string {
+  const clean = sanitizeBackupTitle(title);
+  if (!clean) return DEFAULT_BACKUP_FILE;
+  return `${clean}${BACKUP_EXT}`;
+}
+
+/** Derive a display title from a backup file name. */
+export function titleFromFileName(file: string): string {
+  return file.replace(/\.xlsx$/i, '').trim();
+}
+
+/** Whether a folder child looks like one of our backup workbooks. */
+export function isBackupFile(file: string): boolean {
+  if (!/\.xlsx$/i.test(file)) return false;
+  // Skip Excel's lock/owner temp files (e.g. "~$Main.xlsx").
+  return !/^~\$/.test(file);
+}
+
 /** Options for a provider push. */
 export interface PushOptions {
   /**
@@ -48,6 +108,19 @@ export interface SyncProvider {
    * exists yet — e.g. the file was never created or was deleted.
    */
   pull(): Promise<Snapshot | null>;
+  /**
+   * List every backup workbook detected in the configured folder, newest first. Resolves to an
+   * empty array when the folder doesn't exist yet. Pass `{ interactive: false }` so a background /
+   * on-mount refresh never triggers a sign-in redirect (throws {@link InteractionRequiredError}).
+   */
+  listBackups(opts?: PushOptions): Promise<BackupInfo[]>;
+  /** Permanently delete a backup workbook from the configured folder. */
+  removeBackup(file: string): Promise<void>;
+  /**
+   * Rename a backup workbook to carry a new title, returning its updated info. Throws if a backup
+   * with the target name already exists.
+   */
+  renameBackup(file: string, newTitle: string): Promise<BackupInfo>;
 }
 
 export async function buildSnapshot(): Promise<Snapshot> {

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -33,6 +33,8 @@ export interface Settings {
   oneDriveClientId: string;
   oneDriveFolderMode: OneDriveFolderMode;
   oneDriveCustomPath: string;
+  /** File name of the active backup within the configured folder (the sync target). */
+  oneDriveBackupFile: string;
   autoSync: boolean;
   oneDriveConnected: boolean;
   lastSync: number | null;
@@ -53,6 +55,7 @@ const defaults: Settings = {
   oneDriveClientId: '',
   oneDriveFolderMode: 'app',
   oneDriveCustomPath: '',
+  oneDriveBackupFile: 'Main.xlsx',
   autoSync: true,
   oneDriveConnected: false,
   lastSync: null,

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -2,7 +2,15 @@
   import { onMount } from 'svelte';
   import { settings, markSynced, markRestored } from '../lib/stores/settings';
   import { link } from '../lib/router';
-  import { buildSnapshot, restoreSnapshot, getOneDrive } from '../lib/storage/sync';
+  import {
+    buildSnapshot,
+    restoreSnapshot,
+    getOneDrive,
+    DEFAULT_BACKUP_FILE,
+    fileNameForTitle,
+    titleFromFileName,
+  } from '../lib/storage/sync';
+  import type { BackupInfo } from '../lib/storage/sync';
   import { autoSyncStatus, markSyncSettled } from '../lib/storage/autosync';
   import { ONEDRIVE_CLIENT_ID } from '../lib/config';
   import { refreshGames } from '../lib/stores/games';
@@ -14,6 +22,16 @@
   let busy = $state(false);
   let signedIn = $state(false);
   let fileInput: HTMLInputElement;
+
+  // --- multiple backups ---
+  let backups = $state<BackupInfo[]>([]);
+  let loadingBackups = $state(false);
+  let backupBusy = $state(false);
+  let newTitle = $state('');
+  let renamingFile = $state<string | null>(null);
+  let renameTitle = $state('');
+
+  const activeFileName = $derived($settings.oneDriveBackupFile || DEFAULT_BACKUP_FILE);
 
   const configured = $derived(!!(override.trim() || ONEDRIVE_CLIENT_ID));
 
@@ -57,8 +75,8 @@
   const cleanPath = $derived(customPath.trim().replace(/^\/+|\/+$/g, ''));
   const locationLabel = $derived(
     folderMode === 'custom'
-      ? 'OneDrive / ' + (cleanPath ? cleanPath.replace(/\//g, ' / ') + ' / ' : '') + 'Score King.xlsx'
-      : 'OneDrive / Apps / Score King / Score King.xlsx',
+      ? 'OneDrive / ' + (cleanPath ? cleanPath.replace(/\//g, ' / ') + ' / ' : '') + activeFileName
+      : 'OneDrive / Apps / Score King / ' + activeFileName,
   );
   const prettyPath = $derived(locationLabel.replace(/ \/ /g, ' › '));
 
@@ -99,10 +117,185 @@
         sessionStorage.removeItem('sk_od_justConnected');
         showToast('Connected to OneDrive');
       }
+      // Detect the backups already sitting in the folder. Non-interactive so a stale
+      // token can't bounce the user to Microsoft just for opening Settings.
+      if (signedIn) void loadBackups(false);
     } catch {
       /* not signed in yet */
     }
   });
+
+  /** Build the on-screen list, always surfacing the active backup even if it isn't on OneDrive yet. */
+  function withActive(list: BackupInfo[]): BackupInfo[] {
+    if (list.some((b) => b.file === activeFileName)) return list;
+    return [
+      {
+        file: activeFileName,
+        title: titleFromFileName(activeFileName),
+        isDefault: activeFileName === DEFAULT_BACKUP_FILE,
+        modifiedAt: null,
+        size: null,
+      },
+      ...list,
+    ];
+  }
+
+  const displayBackups = $derived(withActive(backups));
+
+  async function loadBackups(interactive = false) {
+    if (!signedIn) return;
+    loadingBackups = true;
+    try {
+      const od = await getOneDrive();
+      backups = await od.listBackups({ interactive });
+    } catch (e) {
+      // A background refresh that needs re-auth fails quietly; only surface on a user action.
+      if (interactive) showToast(errMsg(e));
+    } finally {
+      loadingBackups = false;
+    }
+  }
+
+  function backupMeta(b: BackupInfo): string {
+    const when = b.modifiedAt ? 'Backed up ' + relativeTime(b.modifiedAt) : 'Not backed up yet';
+    return b.size != null ? `${when} · ${formatSize(b.size)}` : when;
+  }
+
+  function formatSize(n: number): string {
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(n < 10 * 1024 ? 1 : 0)} KB`;
+    return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  }
+
+  /** Create a new titled backup from the current device data and make it active. */
+  async function addBackup() {
+    const title = newTitle.trim();
+    if (!title || backupBusy) return;
+    const file = fileNameForTitle(title);
+    if (displayBackups.some((b) => b.file === file)) {
+      showToast('A backup with that name already exists');
+      return;
+    }
+    backupBusy = true;
+    const prev = activeFileName;
+    try {
+      settings.update((s) => ({ ...s, oneDriveBackupFile: file }));
+      await performBackup();
+      newTitle = '';
+      await loadBackups(true);
+      showToast('Created backup “' + titleFromFileName(file) + '”');
+    } catch (e) {
+      settings.update((s) => ({ ...s, oneDriveBackupFile: prev }));
+      showToast(errMsg(e));
+    } finally {
+      backupBusy = false;
+    }
+  }
+
+  /** Switch the active backup, loading its contents onto this device. */
+  async function useBackup(b: BackupInfo) {
+    if (backupBusy || b.file === activeFileName) return;
+    if (
+      !confirm(
+        'Switch to “' +
+          b.title +
+          '”?\n\nThis loads that backup and replaces the data on this device. Your other backups are left untouched.',
+      )
+    )
+      return;
+    backupBusy = true;
+    const prev = activeFileName;
+    try {
+      settings.update((s) => ({ ...s, oneDriveBackupFile: b.file }));
+      const od = await getOneDrive();
+      const snap = await od.pull();
+      if (snap) {
+        await restoreSnapshot(snap);
+        await refreshPlayers();
+        await refreshGames();
+        markRestored(Date.now());
+      }
+      markSyncSettled();
+      await loadBackups(true);
+      showToast('Now using “' + b.title + '”');
+    } catch (e) {
+      settings.update((s) => ({ ...s, oneDriveBackupFile: prev }));
+      showToast(errMsg(e));
+    } finally {
+      backupBusy = false;
+    }
+  }
+
+  function startRename(b: BackupInfo) {
+    renamingFile = b.file;
+    renameTitle = b.title;
+  }
+
+  function cancelRename() {
+    renamingFile = null;
+    renameTitle = '';
+  }
+
+  async function commitRename(b: BackupInfo) {
+    const title = renameTitle.trim();
+    if (!title || backupBusy) return;
+    const newFile = fileNameForTitle(title);
+    if (newFile === b.file) {
+      cancelRename();
+      return;
+    }
+    if (displayBackups.some((x) => x.file === newFile)) {
+      showToast('A backup with that name already exists');
+      return;
+    }
+    backupBusy = true;
+    try {
+      const od = await getOneDrive();
+      const info = await od.renameBackup(b.file, title);
+      // The file name changed — keep pointing at it if it was the active backup.
+      if (b.file === activeFileName) {
+        settings.update((s) => ({ ...s, oneDriveBackupFile: info.file }));
+      }
+      cancelRename();
+      await loadBackups(true);
+      showToast('Renamed to “' + info.title + '”');
+    } catch (e) {
+      showToast(errMsg(e));
+    } finally {
+      backupBusy = false;
+    }
+  }
+
+  async function deleteBackup(b: BackupInfo) {
+    if (backupBusy) return;
+    if (
+      !confirm(
+        'Delete backup “' +
+          b.title +
+          '”?\nThe workbook will be removed from OneDrive.\nWARNING: This cannot be undone.',
+      )
+    )
+      return;
+    backupBusy = true;
+    try {
+      const od = await getOneDrive();
+      await od.removeBackup(b.file);
+      if (b.file === activeFileName) {
+        // Fall back to another remaining backup, or the default file.
+        const next = backups.find((x) => x.file !== b.file);
+        settings.update((s) => ({
+          ...s,
+          oneDriveBackupFile: next ? next.file : DEFAULT_BACKUP_FILE,
+        }));
+      }
+      await loadBackups(true);
+      showToast('Deleted backup “' + b.title + '”');
+    } catch (e) {
+      showToast(errMsg(e));
+    } finally {
+      backupBusy = false;
+    }
+  }
 
   function saveOverride() {
     settings.update((s) => ({ ...s, oneDriveClientId: override.trim() }));
@@ -134,6 +327,7 @@
     busy = true;
     try {
       await performBackup();
+      void loadBackups(false);
       showToast('Backed up to OneDrive');
     } catch (e) {
       showToast(errMsg(e));
@@ -304,6 +498,108 @@
           Pulls the latest backup from OneDrive and replaces the data on this device.
         </span>
       </div>
+
+      <hr class="sep" />
+
+      <div class="stack" style="gap: 10px">
+        <div class="row spread">
+          <div class="fieldlabel" style="margin: 0">Backups</div>
+          <button class="btn small ghost" onclick={() => loadBackups(true)} disabled={loadingBackups}>
+            {loadingBackups ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+        <span class="muted sm">
+          Each backup is its own workbook in this folder — keep one per group or occasion. The active
+          one is what auto-sync, Sync now, and Restore now use.
+        </span>
+
+        <div class="bklist" role="list">
+          {#each displayBackups as b (b.file)}
+            {@const isActive = b.file === activeFileName}
+            <div class="bkrow" class:active={isActive} role="listitem">
+              {#if renamingFile === b.file}
+                <input
+                  class="bkrename"
+                  type="text"
+                  maxlength="60"
+                  bind:value={renameTitle}
+                  aria-label="Backup title"
+                  onkeydown={(e) => {
+                    if (e.key === 'Enter') commitRename(b);
+                    if (e.key === 'Escape') cancelRename();
+                  }}
+                />
+                <div class="bkactions">
+                  <button class="btn small" onclick={() => commitRename(b)} disabled={backupBusy}>
+                    Save
+                  </button>
+                  <button class="btn small ghost" onclick={cancelRename} disabled={backupBusy}>
+                    Cancel
+                  </button>
+                </div>
+              {:else}
+                <button
+                  class="bkmain"
+                  onclick={() => useBackup(b)}
+                  disabled={backupBusy || isActive}
+                  aria-pressed={isActive}
+                  title={isActive ? 'Active backup' : 'Switch to this backup'}
+                >
+                  <span class="bkmark" class:on={isActive} aria-hidden="true"></span>
+                  <span class="bkmeta">
+                    <span class="bktitle">
+                      <span class="bkname">{b.title}</span>
+                      {#if isActive}<span class="pill bkpill">Active</span>{/if}
+                      {#if b.isDefault}<span class="pill">Default</span>{/if}
+                    </span>
+                    <span class="muted sm">{backupMeta(b)}</span>
+                  </span>
+                </button>
+                <div class="bkactions">
+                  <button
+                    class="iconbtn bkicon"
+                    onclick={() => startRename(b)}
+                    disabled={backupBusy}
+                    title="Rename backup"
+                    aria-label={'Rename ' + b.title}
+                  >
+                    ✏️
+                  </button>
+                  <button
+                    class="iconbtn bkicon"
+                    onclick={() => deleteBackup(b)}
+                    disabled={backupBusy}
+                    title="Delete backup"
+                    aria-label={'Delete ' + b.title}
+                  >
+                    🗑️
+                  </button>
+                </div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+
+        <form
+          class="bkadd row"
+          onsubmit={(e) => {
+            e.preventDefault();
+            addBackup();
+          }}
+        >
+          <input
+            class="bkadd-input"
+            type="text"
+            maxlength="60"
+            bind:value={newTitle}
+            placeholder="New backup title, e.g. Friday Night Crew"
+            aria-label="New backup title"
+          />
+          <button class="btn small" type="submit" disabled={backupBusy || !newTitle.trim()}>
+            Add backup
+          </button>
+        </form>
+      </div>
     {:else}
       <div class="muted sm">
         Sign in with your Microsoft account to back up your scores to OneDrive.
@@ -338,10 +634,10 @@
           <span class="optbody">
             <strong>Custom folder</strong>
             <span class="muted sm block">
-              Store the workbook anywhere you like. Score King will <strong>only</strong> read and
-              write to its own <code>Score King.xlsx</code> file. Microsoft can't limit access to a
-              single folder, so this grants the broader <code>Files.ReadWrite</code> permission to
-              your entire OneDrive.
+              Store your backups anywhere you like — Score King treats every
+              <code>.xlsx</code> workbook in this folder as a backup it can read and write.
+              Microsoft can't limit access to a single folder, so this grants the broader
+              <code>Files.ReadWrite</code> permission to your entire OneDrive.
             </span>
           </span>
         </label>
@@ -576,5 +872,107 @@
     font-size: 1.5rem;
     color: var(--muted);
     flex: none;
+  }
+
+  /* --- multiple backups --- */
+  .bklist {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .bkrow {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 6px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+  }
+  .bkrow.active {
+    border-color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 8%, var(--surface-2));
+  }
+  .bkmain {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: none;
+    color: var(--text);
+    text-align: left;
+    cursor: pointer;
+  }
+  .bkmain:not(:disabled):hover {
+    background: var(--surface-3);
+  }
+  .bkmain:disabled {
+    cursor: default;
+  }
+  .bkmark {
+    flex: none;
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    border: 2px solid var(--muted);
+    box-sizing: border-box;
+  }
+  .bkmark.on {
+    border-color: var(--primary);
+    background: var(--primary);
+    box-shadow: inset 0 0 0 3px var(--surface);
+  }
+  .bkmeta {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+  }
+  .bktitle {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .bkname {
+    font-weight: 600;
+    max-width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+  .bkpill {
+    color: var(--primary);
+    border-color: color-mix(in srgb, var(--primary) 45%, var(--border));
+    background: color-mix(in srgb, var(--primary) 12%, var(--surface-2));
+  }
+  .bkactions {
+    display: flex;
+    gap: 4px;
+    flex: none;
+  }
+  .bkicon {
+    width: 38px;
+    height: 38px;
+    font-size: 1rem;
+  }
+  .bkicon:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .bkrename {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .bkadd {
+    gap: 8px;
+  }
+  .bkadd-input {
+    flex: 1 1 auto;
+    min-width: 0;
   }
 </style>


### PR DESCRIPTION
Adds the ability to keep **multiple titled backups** in the configured OneDrive folder (the sandboxed Apps folder or a custom folder), instead of syncing to a single hard-coded workbook. The folder is the source of truth: every `.xlsx` in it is detected as an independent save-slot.

## What's new
- **Titled backups** — a backup's title is exactly what you type, stored as `<Title>.xlsx` (e.g. `Friday Night.xlsx`). New connections default to **`Main.xlsx`**.
- **Add / rename / switch / delete** from **Settings → Backups**:
  - **Add** snapshots your current scores to a new titled file and makes it active.
  - **Switch** loads that backup onto the device (save-slot semantics), so push-only auto-sync never clobbers another slot.
  - **Rename** / **Delete** via inline controls (delete shows an explicit "this cannot be undone" warning).
- **Detection** — `listBackups` lists the folder and treats every workbook as a backup (skipping Excel `~$` temp files).
- New `oneDriveBackupFile` setting tracks the active backup; the status bubble, **Sync now**, **Restore now**, and auto-backup all target it.

## Implementation notes
- Naming helpers (`fileNameForTitle`, `titleFromFileName`, `isBackupFile`, …) live in `sync.ts`, which only imports `./db` — so the Settings UI can use them **without** pulling MSAL/SheetJS into the main bundle.
- `listBackups` / `removeBackup` / `renameBackup` added to the OneDrive provider via Microsoft Graph (rename uses `conflictBehavior: fail` → friendly "already exists" on 409; list/delete tolerate 404).

## Backwards compatibility
Existing users' `oneDriveBackupFile` is unset, so new connections start on `Main.xlsx`. Any pre-existing `Score King.xlsx` still appears in the list (title "Score King") and stays fully usable.

## Verification
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — succeeds; code-splitting intact (`onedrive`/`xlsx` stay separate chunks, main bundle ~47.6 kB gzip)
- README updated to document the new naming, default, and behavior.