### PR TITLE
Switch OneDrive backups from Excel to JSON with ETags

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -20,7 +20,7 @@ Score King is a local-first, installable PWA that keeps score for card & party g
 the math and bookkeeping disappear into the night. Each game is a self-contained,
 pluggable module (config, round entry, scoring, validation); players, history, and stats
 are shared across all of them. Everything saves instantly to the device (IndexedDB) and
-works fully offline, with optional, opt-in OneDrive Excel backup for people who want it.
+works fully offline, with optional, opt‑in OneDrive JSON backup for people who want it.
 Success looks like this: open the app, pick a game, enter rounds, glance at who's
 winning — and never think about the tool itself.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A lightweight, local‑first **score‑keeping PWA** for card & party games — 
 Cribbage, Finding Friends, Skull King, and a generic tally for *any* game you can think of.
 
 Live at **[score.jrmoulckers.com](https://score.jrmoulckers.com)**. Installable on phone & desktop,
-works fully offline, and can back itself up to an **Excel workbook in your OneDrive**.
+works fully offline, and can back itself up to a **JSON file in your OneDrive**.
 
 ---
 
@@ -17,10 +17,12 @@ works fully offline, and can back itself up to an **Excel workbook in your OneDr
   validation). Adding a new game doesn't touch the rest of the app.
 - **Players, history & stats** are shared across every game — reusable players, a full game log,
   and a win‑rate leaderboard.
-- **Optional OneDrive Excel sync.** Automatic (and one‑click) backup to a real `.xlsx` you can open
-  in Excel, with one‑click restore. Keep **multiple titled backups** in the folder (one per group or
-  occasion) and switch between them. Auto‑backup is on by default, push‑only, and never interrupts
-  you. Uses your own free Azure app registration — *no secrets live in this repo.*
+- **Optional OneDrive sync.** Automatic (and one‑click) backup to a compact `.json` file in your own
+  OneDrive, with one‑click restore. Keep **multiple titled backups** in the folder (one per group or
+  occasion) and switch between them. Writes are guarded by an **ETag**, so a backup changed on another
+  device surfaces a conflict instead of being silently overwritten. Auto‑backup is on by default,
+  push‑only, and never interrupts you. Uses your own free Azure app registration — *no secrets live in
+  this repo.*
 - **Local JSON export/import** as a zero‑setup backup option.
 - **Dark / light** themes.
 
@@ -44,10 +46,9 @@ Spades (bags/nil), Cribbage (121 pegboard + skunks), Finding Friends / Zhao Peng
 - **[idb](https://github.com/jakearchibald/idb)** for IndexedDB
 - **[@azure/msal-browser](https://github.com/AzureAD/microsoft-authentication-library-for-js)** +
   **Microsoft Graph** for OneDrive sync
-- **[SheetJS / xlsx](https://sheetjs.com)** to read/write the Excel workbook
 - Hosted on **GitHub Pages** (static), deployed by GitHub Actions
 
-The MSAL and SheetJS libraries are **code‑split** and only downloaded when you actually use
+The MSAL library is **code‑split** and only downloaded when you actually use
 OneDrive sync, so the core app stays ~34 KB gzipped.
 
 ---
@@ -78,21 +79,21 @@ src/
     storage/
       db.ts           # IndexedDB (players, games, rounds)
       sync.ts         # Snapshot + SyncProvider interface
-      onedrive.ts     # MSAL + Graph + xlsx implementation
+      onedrive.ts     # MSAL + Graph (JSON backup) implementation
     stores/           # Svelte stores (games, players, settings, toast)
     types.ts          # GameModule contract + core types
     router.ts         # tiny history-based router
   pages/              # Home, GameType, GamePlay, History, Stats, Players, Settings
 ```
 
-**Data model** (mirrored in IndexedDB and the Excel sheets):
+**Data model** (mirrored in IndexedDB and the JSON backup):
 
 - `Players(id, name, color, createdAt)`
 - `Games(id, type, config, playerIds, status, createdAt, finishedAt, winnerIds)`
 - `Rounds(id, gameId, index, inputs, scores, createdAt)`
 - `Settings(key, value)` — your **portable preferences** (theme, OLED, text size, contrast,
   motion, colour-blind palette, keep-awake, privacy guard). Kept in `localStorage` on the
-  device and mirrored into the backup's `Settings` sheet so they travel with a restore.
+  device and included in the backup's `settings` object so they travel with a restore.
   Device-local OneDrive details (client-ID override, folder location, auto-backup toggle,
   connection flag, sync timestamps) are deliberately **not** backed up — see
   [What gets backed up](#what-gets-backed-up).
@@ -114,10 +115,10 @@ That's it — routing (`/<id>`), players, history, stats, and persistence all wo
 
 ---
 
-## ☁️ OneDrive / Excel sync setup (optional)
+## ☁️ OneDrive sync setup (optional)
 
 Sync is **opt‑in** — the app is fully usable offline without it. When enabled, each user signs in
-with **their own** Microsoft account and the app writes a `Main.xlsx` workbook to **their own**
+with **their own** Microsoft account and the app writes a `Main.json` file to **their own**
 OneDrive. By default the file lives in a **sandboxed app folder** (`OneDrive → Apps → Score King`)
 that the app is the *only* thing able to read — it can't see the rest of your OneDrive. Power users
 can switch to a **custom folder** in Settings (which needs broader access — see below). There's a
@@ -127,10 +128,10 @@ comes from PKCE + the redirect‑URI allowlist), so end users never configure an
 then returns you to Settings — there's no popup to allow or unblock.
 
 **Multiple titled backups.** The chosen folder is the source of truth: Score King treats every
-`.xlsx` workbook in it as a backup, so you can keep more than one — say one for the *Friday Night
-Crew* and one for *Family*. A backup's title is exactly what you type, saved as **`<Title>.xlsx`**
-(e.g. `Friday Night Crew.xlsx`) so it reads naturally in OneDrive and Excel. New connections start
-on **`Main.xlsx`**. In **Settings → Backups** you can add a new titled backup (a copy of your current
+`.json` file in it as a backup, so you can keep more than one — say one for the *Friday Night
+Crew* and one for *Family*. A backup's title is exactly what you type, saved as **`<Title>.json`**
+(e.g. `Friday Night Crew.json`) so it reads naturally in OneDrive. New connections start
+on **`Main.json`**. In **Settings → Backups** you can add a new titled backup (a copy of your current
 scores), rename or delete one, and pick which backup is **active**. Switching the active backup loads
 its contents onto this device; everything below — the status bubble, **Sync now**, **Restore now**,
 and auto‑backup — always targets the active one.
@@ -146,8 +147,8 @@ Automatically back up changes**; **Sync now** and **Restore now** keep working r
 A small **status bubble** in the header — just left of the settings cog — shows where your backup
 stands at a glance: a quiet dot when everything's synced, _"Syncing…"_ (with a translucent progress
 fill washing across the bubble if an upload runs long, then a green _"Synced!"_), or a _"Pending"_ /
-_"Offline"_ nudge when it needs attention. Tap it for a little pop and a jump to the OneDrive
-settings.
+_"Offline"_ / _"Conflict"_ nudge when it needs attention. Tap it for a little pop and a jump to the
+OneDrive settings.
 
 ### One‑time developer setup (register the shared app)
 
@@ -167,36 +168,45 @@ settings.
 After that, **Settings → Connect OneDrive** is one click for everyone. Power users / forks can
 override with their own client ID under **Settings → Advanced**.
 
-> The workbook has `Players`, `Games`, `Rounds`, `RoundScores`, and `Settings` sheets. The app
-> treats local data as the source of truth during play and syncs the whole snapshot
-> automatically (debounced) — or on demand via **Back up now**.
+> Each backup is a single JSON file: a small envelope (`schema`, `version`, `exportedAt`) wrapping
+> the `players`, `games`, `rounds`, and `settings` it contains. The app treats local data as the
+> source of truth during play and syncs the whole snapshot automatically (debounced) — or on demand
+> via **Sync now**.
 
 ### How backup & restore behave
 
-- **Back up now** overwrites the **active** backup workbook with your current data (last‑write‑wins).
-  If the file was deleted — or, in custom‑folder mode, the whole folder was deleted — the next
-  backup **recreates the file (and folder)** automatically.
+- **Sync now** writes your current data to the **active** backup. The write is **conditional on an
+  ETag**: if the file changed on another device since this one last synced, the app stops and asks
+  whether to **load the other version** or **overwrite** it — so a concurrent edit is never silently
+  lost. The first write of a connection (no ETag baseline yet) is unconditional. If the file was
+  deleted — or, in custom‑folder mode, the whole folder was deleted — the next backup **recreates the
+  file (and folder)** automatically.
 - **Restore** always fetches the **latest** remote copy of the active backup. The download bypasses
-  the browser cache (`cache: 'no-store'`), so a single Restore reflects edits you (or Excel) just
-  made to the workbook — no disconnect/reconnect needed.
+  the browser cache (`cache: 'no-store'`), so a single Restore reflects the most recent remote edit —
+  no disconnect/reconnect needed.
 - If you press **Restore** but no backup exists yet, the app offers to **back up your current data**
   there instead, so you're never left in a dead end.
 - **Backups are independent save slots.** Adding a backup snapshots your current scores under a new
   title and makes it active; your other backups are untouched. Auto‑backup keeps pushing to whichever
   backup is active, so switching first (which loads that backup onto the device) keeps each slot
   separate.
+- **Conflicts pause auto‑backup, never clobber.** If automatic backup meets a file that changed
+  elsewhere, the status bubble switches to a **conflict** state and auto‑pushing stops until you
+  resolve it from **Settings** (load the other version, or overwrite) — your local edits stay safe on
+  the device meanwhile.
 
 ### What gets backed up
 
 A backup carries your game data **and** your portable preferences — theme, OLED, text size, high
-contrast, motion, colour‑blind palette, keep‑awake, and privacy guard — in the `Settings` sheet, so
+contrast, motion, colour‑blind palette, keep‑awake, and privacy guard — in the `settings` object, so
 restoring on a new device brings your accessibility/display setup along. The local JSON
 export/import covers the same set.
 
 Deliberately **left out**, to avoid dead or conflicting state on another device: the OneDrive
-client‑ID override, the backup file's folder location, the auto‑backup toggle, the "connected" flag,
-and the last‑sync/last‑restore timestamps. (Restore is also defensive — it only ever applies the
-portable keys, so even a hand‑edited workbook can't clobber this device's connection.)
+client‑ID override, the backup file's folder location, the active backup file and its ETag, the
+auto‑backup toggle, the "connected" flag, and the last‑sync/last‑restore timestamps. (Restore is also
+defensive — it only ever applies the portable keys, and a file that isn't a recognizable Score King
+backup is ignored, so neither a hand‑edited nor a foreign file can clobber this device.)
 
 > **Adding a setting?** Categorize it in [`src/lib/stores/settings.ts`](src/lib/stores/settings.ts):
 > add portable user preferences to `PORTABLE_SETTING_KEYS` (so they're included in the backup) and

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "@azure/msal-browser": "^5.15.0",
         "idb": "^8.0.3",
-        "motion": "^12.42.0",
-        "xlsx": "^0.18.5"
+        "motion": "^12.42.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -2647,15 +2646,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -2965,19 +2955,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -3002,15 +2979,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/commander": {
@@ -3049,18 +3017,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -3604,15 +3560,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/framer-motion": {
@@ -5691,18 +5638,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -6470,24 +6405,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/workbox-background-sync": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.1.tgz",
@@ -6720,27 +6637,6 @@
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "7.4.1"
-      }
-    },
-    "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@azure/msal-browser": "^5.15.0",
     "idb": "^8.0.3",
-    "motion": "^12.42.0",
-    "xlsx": "^0.18.5"
+    "motion": "^12.42.0"
   }
 }

--- a/src/lib/components/JsonIcon.svelte
+++ b/src/lib/components/JsonIcon.svelte
@@ -3,12 +3,12 @@
 </script>
 
 <svg
-  class="xlsx"
+  class="jsondoc"
   viewBox="0 0 24 24"
   width={size}
   height={size}
   role="img"
-  aria-label="Excel workbook"
+  aria-label="JSON backup file"
 >
   <path
     d="M6.5 3 H14.5 L19 7.5 V19.5 A1.5 1.5 0 0 1 17.5 21 H6.5 A1.5 1.5 0 0 1 5 19.5 V4.5 A1.5 1.5 0 0 1 6.5 3 Z"
@@ -17,18 +17,27 @@
     stroke-width="0.7"
   />
   <path d="M14.5 3 L19 7.5 H14.5 Z" fill="#e4e7ef" />
-  <rect x="2" y="12" width="12" height="8" rx="1.6" fill="#107c41" />
+  <rect x="2" y="12" width="12" height="8" rx="1.6" fill="#475569" />
   <path
-    d="M5.7 13.9 L10.3 18.1 M10.3 13.9 L5.7 18.1"
-    stroke="#ffffff"
-    stroke-width="1.7"
-    stroke-linecap="round"
+    d="M6.8 13.6 q-1.2 0 -1.2 1.1 v0.6 q0 0.7 -0.8 0.7 q0.8 0 0.8 0.7 v0.6 q0 1.1 1.2 1.1"
     fill="none"
+    stroke="#ffffff"
+    stroke-width="1"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M9.2 13.6 q1.2 0 1.2 1.1 v0.6 q0 0.7 0.8 0.7 q-0.8 0 -0.8 0.7 v0.6 q0 1.1 -1.2 1.1"
+    fill="none"
+    stroke="#ffffff"
+    stroke-width="1"
+    stroke-linecap="round"
+    stroke-linejoin="round"
   />
 </svg>
 
 <style>
-  .xlsx {
+  .jsondoc {
     flex: none;
     display: block;
   }

--- a/src/lib/components/SyncBubble.svelte
+++ b/src/lib/components/SyncBubble.svelte
@@ -14,7 +14,7 @@
   const tone = $derived(
     status === 'syncing'
       ? 'busy'
-      : status === 'pending' || status === 'error'
+      : status === 'pending' || status === 'error' || status === 'conflict'
         ? 'warn'
         : status === 'offline'
           ? 'off'
@@ -29,30 +29,34 @@
       ? 'Syncing…'
       : status === 'synced'
         ? 'Synced!'
-        : status === 'pending'
-          ? 'Pending'
-          : status === 'offline'
-            ? 'Offline'
-            : status === 'error'
-              ? 'Retrying…'
-              : $settings.lastSync
-                ? 'Backed up'
-                : 'Not backed up',
+        : status === 'conflict'
+          ? 'Conflict'
+          : status === 'pending'
+            ? 'Pending'
+            : status === 'offline'
+              ? 'Offline'
+              : status === 'error'
+                ? 'Retrying…'
+                : $settings.lastSync
+                  ? 'Backed up'
+                  : 'Not backed up',
   );
 
   // Full description for the tooltip / screen readers.
   const fullLabel = $derived(
     status === 'syncing'
       ? 'Backing up to OneDrive…'
-      : status === 'pending'
-        ? 'Sync pending — reconnect to OneDrive'
-        : status === 'offline'
-          ? 'Offline — changes will back up when you reconnect'
-          : status === 'error'
-            ? 'Sync failed — will retry shortly'
-            : $settings.lastSync
-              ? 'Backed up · ' + relativeTime($settings.lastSync)
-              : 'Not backed up yet',
+      : status === 'conflict'
+        ? 'Backup changed on another device — tap to resolve'
+        : status === 'pending'
+          ? 'Sync pending — reconnect to OneDrive'
+          : status === 'offline'
+            ? 'Offline — changes will back up when you reconnect'
+            : status === 'error'
+              ? 'Sync failed — will retry shortly'
+              : $settings.lastSync
+                ? 'Backed up · ' + relativeTime($settings.lastSync)
+                : 'Not backed up yet',
   );
 
   // --- progress fill (slow >1s syncs only); never carries into the synced state ---
@@ -70,6 +74,7 @@
       status === 'pending' ||
       status === 'offline' ||
       status === 'error' ||
+      status === 'conflict' ||
       stickySynced,
   );
 

--- a/src/lib/storage/autosync.ts
+++ b/src/lib/storage/autosync.ts
@@ -1,7 +1,7 @@
 import { get, writable } from 'svelte/store';
-import { settings, markSynced, getBackupSettings } from '../stores/settings';
+import { settings, markSynced, getBackupSettings, setActiveBackupEtag } from '../stores/settings';
 import { dataVersion } from './changes';
-import { buildSnapshot, getOneDrive, InteractionRequiredError } from './sync';
+import { buildSnapshot, getOneDrive, ConflictError, InteractionRequiredError } from './sync';
 import type { SyncProvider } from './sync';
 
 export type AutoSyncStatus =
@@ -10,6 +10,7 @@ export type AutoSyncStatus =
   | 'synced'
   | 'pending'
   | 'offline'
+  | 'conflict'
   | 'error';
 
 /** Live status for the Settings indicator. */
@@ -21,6 +22,7 @@ const DEBOUNCE_MS = 2500;
 let started = false;
 let dirty = false; // local changes awaiting upload
 let pushing = false; // an upload is in flight
+let conflicted = false; // remote diverged — hold auto-pushes until the user resolves
 let timer: ReturnType<typeof setTimeout> | undefined;
 let lastVersion = 0;
 let wasActive = false;
@@ -61,7 +63,9 @@ function schedule(): void {
 
 function onLocalChange(): void {
   dirty = true;
-  if (!active()) return;
+  // While a conflict is unresolved we keep recording edits locally but never schedule a
+  // push — the user must pick a side first (which clears `conflicted`).
+  if (!active() || conflicted) return;
   if (!isOnline()) {
     autoSyncStatus.set('offline');
     return;
@@ -73,7 +77,7 @@ async function run(): Promise<void> {
   cancelTimer();
   // `active()` gates loading the (heavy) OneDrive provider: a user who never
   // connected never pulls MSAL in just to back up.
-  if (pushing || !dirty || !active()) return;
+  if (pushing || !dirty || !active() || conflicted) return;
   if (!isOnline()) {
     autoSyncStatus.set('offline');
     return;
@@ -102,8 +106,12 @@ async function run(): Promise<void> {
   dirty = false; // claim current changes; edits during upload re-set this
   autoSyncStatus.set('syncing');
   try {
-    await od.push(await buildSnapshot(), { interactive: false });
+    const { etag } = await od.push(await buildSnapshot(), {
+      interactive: false,
+      baseEtag: get(settings).oneDriveBackupEtag || null,
+    });
     markSynced(Date.now());
+    setActiveBackupEtag(etag); // remember the new version for the next conditional write
     if (dirty) {
       schedule(); // more edits arrived mid-upload
     } else {
@@ -111,7 +119,12 @@ async function run(): Promise<void> {
     }
   } catch (e) {
     dirty = true; // keep the changes pending
-    if (e instanceof InteractionRequiredError) {
+    if (e instanceof ConflictError) {
+      // The remote backup changed under us (another device). Do NOT clobber it in the
+      // background — surface a conflict and stop auto-pushing until the user resolves it.
+      conflicted = true;
+      autoSyncStatus.set('conflict');
+    } else if (e instanceof InteractionRequiredError) {
       // Silent token failed — must NOT redirect in the background. Wait for the
       // user to reconnect, or for the next data change / online event.
       autoSyncStatus.set('pending');
@@ -170,6 +183,7 @@ export function startAutoSync(): void {
         if (dirty) schedule(); // turned on / just connected with changes waiting
       } else {
         cancelTimer(); // turned off or disconnected — stop automatic uploads
+        conflicted = false; // a fresh connection starts without a stale conflict
         autoSyncStatus.set('idle');
       }
     }
@@ -182,10 +196,12 @@ export function startAutoSync(): void {
 /**
  * Clear the pending-changes marker (and reflect success) without scheduling a
  * push. Call after a manual "Back up now" or a Restore so the controller doesn't
- * re-upload state that is already — or freshly — in sync.
+ * re-upload state that is already — or freshly — in sync. Also clears any conflict
+ * flag, since a manual back-up/restore is how the user resolves one.
  */
 export function markSyncSettled(): void {
   dirty = false;
+  conflicted = false;
   cancelTimer();
   autoSyncStatus.set('synced');
 }

--- a/src/lib/storage/onedrive.ts
+++ b/src/lib/storage/onedrive.ts
@@ -2,16 +2,17 @@ import { PublicClientApplication, type AccountInfo } from '@azure/msal-browser';
 import { get } from 'svelte/store';
 import { settings } from '../stores/settings';
 import { ONEDRIVE_CLIENT_ID } from '../config';
-import type { BackupInfo, PushOptions, Snapshot, SyncProvider } from './sync';
+import type { BackupInfo, PushOptions, SyncProvider } from './sync';
 import {
+  ConflictError,
   DEFAULT_BACKUP_FILE,
   InteractionRequiredError,
+  deserializeSnapshot,
   fileNameForTitle,
   isBackupFile,
+  serializeSnapshot,
   titleFromFileName,
 } from './sync';
-import type { Game, Player, Round } from '../types';
-import type { Settings } from '../stores/settings';
 
 const GRAPH = 'https://graph.microsoft.com/v1.0';
 
@@ -54,7 +55,7 @@ function customFolderSegments(): string[] {
     .filter(Boolean);
 }
 
-/** The backup file the user is currently syncing to (default = Main.xlsx). */
+/** The backup file the user is currently syncing to (default = Main.json). */
 function activeFile(): string {
   return (get(settings).oneDriveBackupFile || '').trim() || DEFAULT_BACKUP_FILE;
 }
@@ -78,7 +79,7 @@ function itemPath(file: string): string {
   return `/me/drive/special/approot:/${name}`;
 }
 
-/** Graph addressing for a backup workbook's content, per the chosen storage location. */
+/** Graph addressing for a backup file's content, per the chosen storage location. */
 function contentPath(file: string = activeFile()): string {
   return `${itemPath(file)}:/content`;
 }
@@ -170,121 +171,18 @@ async function graph(path: string, init: RequestInit, accessToken: string): Prom
   });
 }
 
-function parse<T>(value: unknown, fallback: T): T {
-  try {
-    return value ? (JSON.parse(String(value)) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-async function toWorkbook(s: Snapshot): Promise<ArrayBuffer> {
-  const XLSX = await import('xlsx');
-  const nameOf = (id: string) => s.players.find((p) => p.id === id)?.name ?? id;
-
-  const players = s.players.map((p) => ({
-    id: p.id,
-    name: p.name,
-    color: p.color,
-    createdAt: new Date(p.createdAt).toISOString(),
-  }));
-  const games = s.games.map((g) => ({
-    id: g.id,
-    type: g.type,
-    name: g.name ?? '',
-    status: g.status,
-    created: new Date(g.createdAt).toISOString(),
-    finished: g.finishedAt ? new Date(g.finishedAt).toISOString() : '',
-    players: g.playerIds.map(nameOf).join(', '),
-    winners: (g.winnerIds ?? []).map(nameOf).join(', '),
-    config: JSON.stringify(g.config),
-    playerIds: JSON.stringify(g.playerIds),
-  }));
-  const rounds = s.rounds.map((r) => ({
-    id: r.id,
-    gameId: r.gameId,
-    round: r.index + 1,
-    created: new Date(r.createdAt).toISOString(),
-    input: JSON.stringify(r.input),
-    deltas: JSON.stringify(r.deltas),
-  }));
-  const scores: Array<Record<string, unknown>> = [];
-  for (const r of s.rounds) {
-    for (const [pid, delta] of Object.entries(r.deltas)) {
-      scores.push({ gameId: r.gameId, round: r.index + 1, player: nameOf(pid), delta });
-    }
-  }
-  // Portable preferences, one row per key with a JSON-encoded value (matching how
-  // config/inputs are stored in the other sheets) so any value type round-trips.
-  const settings = Object.entries(s.settings ?? {}).map(([key, value]) => ({
-    key,
-    value: JSON.stringify(value),
-  }));
-
-  const wb = XLSX.utils.book_new();
-  XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(players), 'Players');
-  XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(games), 'Games');
-  XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(rounds), 'Rounds');
-  XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(scores), 'RoundScores');
-  XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(settings), 'Settings');
-  return XLSX.write(wb, { bookType: 'xlsx', type: 'array' }) as ArrayBuffer;
-}
-
-async function fromWorkbook(buf: ArrayBuffer): Promise<Snapshot> {
-  const XLSX = await import('xlsx');
-  const wb = XLSX.read(buf, { type: 'array' });
-  const sheet = (name: string): Record<string, unknown>[] =>
-    wb.Sheets[name] ? XLSX.utils.sheet_to_json<Record<string, unknown>>(wb.Sheets[name]) : [];
-
-  const players: Player[] = sheet('Players').map((r) => ({
-    id: String(r.id),
-    name: String(r.name ?? ''),
-    color: String(r.color ?? '#7c5cff'),
-    createdAt: Date.parse(String(r.createdAt)) || Date.now(),
-  }));
-  const games: Game[] = sheet('Games').map((r) => ({
-    id: String(r.id),
-    type: String(r.type),
-    name: r.name ? String(r.name) : undefined,
-    status: r.status === 'finished' ? 'finished' : 'active',
-    config: parse(r.config, {}),
-    playerIds: parse(r.playerIds, [] as string[]),
-    createdAt: Date.parse(String(r.created)) || Date.now(),
-    finishedAt: r.finished ? Date.parse(String(r.finished)) || undefined : undefined,
-    winnerIds: undefined,
-    roundCount: 0,
-  }));
-  const rounds: Round[] = sheet('Rounds').map((r) => ({
-    id: String(r.id),
-    gameId: String(r.gameId),
-    index: (Number(r.round) || 1) - 1,
-    input: parse(r.input, null),
-    deltas: parse(r.deltas, {} as Record<string, number>),
-    createdAt: Date.parse(String(r.created)) || Date.now(),
-  }));
-  for (const g of games) g.roundCount = rounds.filter((r) => r.gameId === g.id).length;
-
-  // Portable preferences (JSON-encoded values). applyBackupSettings ignores any
-  // non-portable keys, so we read permissively here.
-  const restoredSettings: Partial<Settings> = {};
-  for (const r of sheet('Settings')) {
-    const key = String(r.key ?? '').trim();
-    if (key) (restoredSettings as Record<string, unknown>)[key] = parse<unknown>(r.value, undefined);
-  }
-  return { players, games, rounds, settings: restoredSettings, exportedAt: Date.now() };
-}
-
-/** PUT the workbook bytes to the configured content path (overwrites; last-write-wins). */
-function putContent(buf: ArrayBuffer, accessToken: string): Promise<Response> {
+/** PUT the JSON backup to the configured content path, with optional concurrency headers. */
+function putContent(
+  body: string,
+  accessToken: string,
+  extraHeaders: Record<string, string> = {},
+): Promise<Response> {
   return graph(
     contentPath(),
     {
       method: 'PUT',
-      headers: {
-        'Content-Type':
-          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      },
-      body: buf,
+      headers: { 'Content-Type': 'application/json', ...extraHeaders },
+      body,
     },
     accessToken,
   );
@@ -357,31 +255,85 @@ export const oneDrive: SyncProvider = {
   },
   async push(snapshot, opts) {
     const accessToken = await token(opts?.interactive ?? true);
-    const buf = await toWorkbook(snapshot);
-    let res = await putContent(buf, accessToken);
+    const body = serializeSnapshot(snapshot);
+    const mode = opts?.mode ?? 'update';
+    // create → require absence; update with a baseline → require the eTag still matches;
+    // update without a baseline → unconditional (the first write of a connection).
+    const conditional: Record<string, string> =
+      mode === 'create'
+        ? { 'If-None-Match': '*' }
+        : opts?.baseEtag
+          ? { 'If-Match': opts.baseEtag }
+          : {};
+    let res = await putContent(body, accessToken, conditional);
     // A custom-folder target 404s when its parent folder was deleted (or never created).
-    // Recreate the folder hierarchy and retry once so backup self-heals. App-folder mode
+    // Recreate the hierarchy and retry unconditionally so backup self-heals. App-folder mode
     // doesn't need this — writing to approot re-provisions the sandboxed folder automatically.
     if (res.status === 404 && folderMode() === 'custom') {
       await ensureCustomFolder(accessToken);
-      res = await putContent(buf, accessToken);
+      res = await putContent(body, accessToken);
+    }
+    if (res.status === 412) {
+      if (mode === 'create') {
+        throw new Error(`A backup named "${titleFromFileName(activeFile())}" already exists.`);
+      }
+      // If-Match failed: the file was either deleted (stale baseline) or genuinely changed
+      // elsewhere. A quick existence check tells them apart, so a remote *deletion* still
+      // self-heals (recreate) instead of nagging about a phantom conflict.
+      const meta = await graph(
+        itemPath(activeFile()),
+        { method: 'GET', cache: 'no-store' },
+        accessToken,
+      );
+      if (meta.status === 404) {
+        if (folderMode() === 'custom') await ensureCustomFolder(accessToken);
+        res = await putContent(body, accessToken);
+      } else {
+        throw new ConflictError();
+      }
     }
     if (!res.ok) throw new Error(`Upload failed (HTTP ${res.status}).`);
+    const item = (await res.json().catch(() => ({}))) as { eTag?: string };
+    return { etag: item.eTag ?? null };
   },
   async pull() {
     const accessToken = await token();
-    // cache: 'no-store' bypasses the browser HTTP cache for this GET *and* the CDN download URL
-    // that Graph 302-redirects to (the cache mode is inherited across the redirect chain), so a
-    // single Restore always returns the latest remote content — no disconnect/reconnect needed.
-    const res = await graph(contentPath(), { method: 'GET', cache: 'no-store' }, accessToken);
-    if (res.status === 404) return null;
-    if (!res.ok) throw new Error(`Download failed (HTTP ${res.status}).`);
-    return fromWorkbook(await res.arrayBuffer());
+    // Read item metadata (eTag + a short-lived pre-authenticated download URL). cache:'no-store'
+    // keeps both fresh, so a single Restore always reflects the latest remote edit.
+    const meta = await graph(
+      itemPath(activeFile()),
+      { method: 'GET', cache: 'no-store' },
+      accessToken,
+    );
+    if (meta.status === 404) return null;
+    if (!meta.ok) throw new Error(`Download failed (HTTP ${meta.status}).`);
+    const item = (await meta.json()) as {
+      eTag?: string;
+      '@microsoft.graph.downloadUrl'?: string;
+    };
+    const url = item['@microsoft.graph.downloadUrl'];
+    let text: string;
+    if (url) {
+      // The download URL is pre-authenticated — fetch it directly (no Authorization header).
+      const dl = await fetch(url, { cache: 'no-store' });
+      if (!dl.ok) throw new Error(`Download failed (HTTP ${dl.status}).`);
+      text = await dl.text();
+    } else {
+      const res = await graph(contentPath(), { method: 'GET', cache: 'no-store' }, accessToken);
+      if (res.status === 404) return null;
+      if (!res.ok) throw new Error(`Download failed (HTTP ${res.status}).`);
+      text = await res.text();
+    }
+    const snapshot = deserializeSnapshot(text);
+    // Not one of our backups (foreign/corrupt file) — treat as "nothing to restore" rather than
+    // wiping local data with unrelated content.
+    if (!snapshot) return null;
+    return { snapshot, etag: item.eTag ?? null };
   },
   async listBackups(opts?: PushOptions): Promise<BackupInfo[]> {
     const accessToken = await token(opts?.interactive ?? true);
     // Trim the payload and bypass caches so the list reflects just-made changes.
-    const query = '?$top=999&$select=name,size,lastModifiedDateTime,file';
+    const query = '?$top=999&$select=name,size,lastModifiedDateTime,file,eTag';
     const res = await graph(
       `${childrenPath()}${query}`,
       { method: 'GET', cache: 'no-store' },
@@ -396,6 +348,7 @@ export const oneDrive: SyncProvider = {
         size?: number;
         lastModifiedDateTime?: string;
         file?: unknown;
+        eTag?: string;
       }>;
     };
     return (data.value ?? [])
@@ -406,6 +359,7 @@ export const oneDrive: SyncProvider = {
         isDefault: it.name === DEFAULT_BACKUP_FILE,
         modifiedAt: it.lastModifiedDateTime ? Date.parse(it.lastModifiedDateTime) || null : null,
         size: typeof it.size === 'number' ? it.size : null,
+        etag: it.eTag ?? null,
       }))
       .sort((a, b) => (b.modifiedAt ?? 0) - (a.modifiedAt ?? 0));
   },
@@ -427,6 +381,7 @@ export const oneDrive: SyncProvider = {
         isDefault: file === DEFAULT_BACKUP_FILE,
         modifiedAt: null,
         size: null,
+        etag: null,
       };
     }
     const res = await graph(
@@ -447,6 +402,7 @@ export const oneDrive: SyncProvider = {
       name?: string;
       size?: number;
       lastModifiedDateTime?: string;
+      eTag?: string;
     };
     const name = item.name || newFile;
     return {
@@ -455,6 +411,7 @@ export const oneDrive: SyncProvider = {
       isDefault: name === DEFAULT_BACKUP_FILE,
       modifiedAt: item.lastModifiedDateTime ? Date.parse(item.lastModifiedDateTime) || null : null,
       size: typeof item.size === 'number' ? item.size : null,
+      etag: item.eTag ?? null,
     };
   },
 };

--- a/src/lib/storage/sync.ts
+++ b/src/lib/storage/sync.ts
@@ -20,29 +20,36 @@ export interface Snapshot {
  * Backup file naming
  * ------------------
  * The configured OneDrive folder (App folder or a custom folder) is the source of
- * truth: every workbook in it is a backup the user can keep alongside others.
+ * truth: every backup file in it is one the user can keep alongside others.
  *
  * - A backup's title is exactly what the user types and the file is stored as
- *   `<Title>.xlsx`, so it reads naturally in OneDrive and Excel.
- * - New connections start on `Main.xlsx` ("Main"), which also stays the fallback
+ *   `<Title>.json`, so it reads naturally in OneDrive.
+ * - New connections start on `Main.json` ("Main"), which also stays the fallback
  *   when every other backup has been removed.
  */
-export const BACKUP_EXT = '.xlsx';
+export const BACKUP_EXT = '.json';
 /** The default backup, used for new connections and as the last-resort fallback. */
 export const DEFAULT_BACKUP_FILE = `Main${BACKUP_EXT}`;
 
-/** Metadata for one detected backup workbook in the configured folder. */
+/** Marker identifying a file as a Score King backup (guards against restoring foreign files). */
+export const BACKUP_SCHEMA = 'score-king/backup';
+/** Current backup envelope version. */
+export const BACKUP_VERSION = 1;
+
+/** Metadata for one detected backup file in the configured folder. */
 export interface BackupInfo {
-  /** File name within the folder, e.g. "Friday Crew.xlsx". */
+  /** File name within the folder, e.g. "Friday Crew.json". */
   file: string;
   /** Human-readable title derived from the file name. */
   title: string;
-  /** True for the default `Main.xlsx`. */
+  /** True for the default `Main.json`. */
   isDefault: boolean;
   /** Last modified time (ms epoch), or null when not backed up yet. */
   modifiedAt: number | null;
   /** Size in bytes, or null when unknown. */
   size: number | null;
+  /** OneDrive item eTag for optimistic concurrency, or null when unknown. */
+  etag: string | null;
 }
 
 /** Characters OneDrive/SharePoint forbid in a file name. */
@@ -66,14 +73,57 @@ export function fileNameForTitle(title: string): string {
 
 /** Derive a display title from a backup file name. */
 export function titleFromFileName(file: string): string {
-  return file.replace(/\.xlsx$/i, '').trim();
+  return file.replace(/\.json$/i, '').trim();
 }
 
-/** Whether a folder child looks like one of our backup workbooks. */
+/** Whether a folder child looks like one of our backup files. */
 export function isBackupFile(file: string): boolean {
-  if (!/\.xlsx$/i.test(file)) return false;
-  // Skip Excel's lock/owner temp files (e.g. "~$Main.xlsx").
-  return !/^~\$/.test(file);
+  if (!/\.json$/i.test(file)) return false;
+  // Skip hidden/temp files (e.g. ".~lock", "~$…").
+  return !/^[.~]/.test(file);
+}
+
+/** Serialize a snapshot into the JSON backup envelope written to the cloud/local file. */
+export function serializeSnapshot(snapshot: Snapshot): string {
+  const envelope = {
+    schema: BACKUP_SCHEMA,
+    version: BACKUP_VERSION,
+    exportedAt: snapshot.exportedAt,
+    players: snapshot.players,
+    games: snapshot.games,
+    rounds: snapshot.rounds,
+    settings: snapshot.settings ?? {},
+  };
+  return JSON.stringify(envelope, null, 2);
+}
+
+/**
+ * Parse a backup file back into a Snapshot. Returns null when the text isn't a
+ * recognizable Score King backup (foreign/empty file), so a restore can never wipe
+ * local data with unrelated content. Accepts both the current envelope and a legacy
+ * bare-snapshot JSON (older local exports) for backward-compatible import.
+ */
+export function deserializeSnapshot(text: string): Snapshot | null {
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!data || typeof data !== 'object') return null;
+  const obj = data as Record<string, unknown>;
+  const looksLikeSnapshot =
+    Array.isArray(obj.players) && Array.isArray(obj.games) && Array.isArray(obj.rounds);
+  // Accept our envelope and legacy bare-snapshot exports (both carry the three core
+  // arrays); reject anything else so a foreign file can never wipe local data.
+  if (!looksLikeSnapshot) return null;
+  return {
+    players: obj.players as Snapshot['players'],
+    games: obj.games as Snapshot['games'],
+    rounds: obj.rounds as Snapshot['rounds'],
+    settings: (obj.settings as Snapshot['settings']) ?? {},
+    exportedAt: typeof obj.exportedAt === 'number' ? obj.exportedAt : Date.now(),
+  };
 }
 
 /** Options for a provider push. */
@@ -85,6 +135,31 @@ export interface PushOptions {
    * never yanks the user away mid-use. Defaults to true (manual backups).
    */
   interactive?: boolean;
+  /**
+   * Last-known item eTag for optimistic concurrency. When provided (with the default
+   * 'update' mode) the provider sends `If-Match`, so a remote change since this eTag
+   * fails with {@link ConflictError} instead of silently overwriting. When omitted, the
+   * write is unconditional (last-write-wins) — used for the first write of a connection,
+   * before any eTag baseline exists.
+   */
+  baseEtag?: string | null;
+  /**
+   * 'create' requires the file not to exist yet (`If-None-Match: *`) — used when adding a
+   * brand-new titled backup so a same-named file isn't clobbered. 'update' (default)
+   * overwrites the existing active backup.
+   */
+  mode?: 'create' | 'update';
+}
+
+/** Result of a successful push: the new item eTag (for the next conditional write). */
+export interface PushResult {
+  etag: string | null;
+}
+
+/** A pulled snapshot together with the item eTag it was read at. */
+export interface PulledSnapshot {
+  snapshot: Snapshot;
+  etag: string | null;
 }
 
 /** Thrown by a silent (non-interactive) push when the user must sign in again. */
@@ -92,6 +167,14 @@ export class InteractionRequiredError extends Error {
   constructor(message = 'Interactive sign-in required') {
     super(message);
     this.name = 'InteractionRequiredError';
+  }
+}
+
+/** Thrown by a conditional push when the remote backup changed since `baseEtag`. */
+export class ConflictError extends Error {
+  constructor(message = 'The backup was changed elsewhere') {
+    super(message);
+    this.name = 'ConflictError';
   }
 }
 
@@ -105,27 +188,30 @@ export interface SyncProvider {
   signIn(): Promise<void>;
   signOut(): Promise<void>;
   /**
-   * Upload a full snapshot, overwriting any existing remote copy (last-write-wins; no conflict
-   * errors). Implementations MUST create the backing file — and any missing parent folders — if
-   * it doesn't exist yet, so a backup succeeds even after the file/folder was deleted remotely.
+   * Upload a full snapshot to the active backup file, returning the new item eTag. With
+   * `opts.baseEtag` (update mode) the write is conditional and throws {@link ConflictError}
+   * when the remote changed since that eTag; otherwise it's last-write-wins. Implementations
+   * MUST create the backing file — and any missing parent folders — if it doesn't exist yet,
+   * so a backup succeeds even after the file/folder was deleted remotely.
    */
-  push(snapshot: Snapshot, opts?: PushOptions): Promise<void>;
+  push(snapshot: Snapshot, opts?: PushOptions): Promise<PushResult>;
   /**
-   * Fetch the latest remote snapshot, bypassing any HTTP/CDN caches so a single call always
-   * reflects the most recent remote edit. Resolves to null (rather than throwing) when no backup
-   * exists yet — e.g. the file was never created or was deleted.
+   * Fetch the latest remote snapshot plus its item eTag, bypassing any HTTP/CDN caches so a
+   * single call always reflects the most recent remote edit. Resolves to null (rather than
+   * throwing) when no backup exists yet, or when the file isn't a recognizable Score King
+   * backup (so a foreign file can't wipe local data).
    */
-  pull(): Promise<Snapshot | null>;
+  pull(): Promise<PulledSnapshot | null>;
   /**
-   * List every backup workbook detected in the configured folder, newest first. Resolves to an
+   * List every backup file detected in the configured folder, newest first. Resolves to an
    * empty array when the folder doesn't exist yet. Pass `{ interactive: false }` so a background /
    * on-mount refresh never triggers a sign-in redirect (throws {@link InteractionRequiredError}).
    */
   listBackups(opts?: PushOptions): Promise<BackupInfo[]>;
-  /** Permanently delete a backup workbook from the configured folder. */
+  /** Permanently delete a backup file from the configured folder. */
   removeBackup(file: string): Promise<void>;
   /**
-   * Rename a backup workbook to carry a new title, returning its updated info. Throws if a backup
+   * Rename a backup file to carry a new title, returning its updated info. Throws if a backup
    * with the target name already exists.
    */
   renameBackup(file: string, newTitle: string): Promise<BackupInfo>;
@@ -149,7 +235,7 @@ export async function restoreSnapshot(snapshot: Snapshot): Promise<void> {
   applyBackupSettings(snapshot.settings);
 }
 
-/** Lazy-load the OneDrive provider (keeps MSAL + SheetJS out of the main bundle). */
+/** Lazy-load the OneDrive provider (keeps MSAL out of the main bundle). */
 export async function getOneDrive(): Promise<SyncProvider> {
   const mod = await import('./onedrive');
   return mod.oneDrive;

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -43,6 +43,8 @@ export interface Settings {
   oneDriveCustomPath: string;
   /** File name of the active backup within the configured folder (the sync target). */
   oneDriveBackupFile: string;
+  /** OneDrive eTag of the active backup, for optimistic-concurrency writes (device-local). */
+  oneDriveBackupEtag: string;
   autoSync: boolean;
   oneDriveConnected: boolean;
   lastSync: number | null;
@@ -71,16 +73,18 @@ export const PORTABLE_SETTING_KEYS = [
 ] as const;
 
 /**
- * Settings intentionally kept OUT of the backup: the OneDrive client-ID override,
- * the backup file's folder location, the auto-backup toggle, the "connected" flag,
- * and the last-sync/last-restore stamps. Backing these up risks dead state on
- * restore (e.g. a custom folder path that doesn't exist on the new device, or a
- * "connected" flag for an account this device isn't signed into).
+ * Settings intentionally kept OUT of the backup: the OneDrive client-ID override, the
+ * backup file's folder location, the active backup file and its eTag, the auto-backup
+ * toggle, the "connected" flag, and the last-sync/last-restore stamps. Backing these up
+ * risks dead state on restore (e.g. a custom folder path or active file that doesn't exist
+ * on the new device, or a "connected" flag for an account this device isn't signed into).
  */
 export const LOCAL_SETTING_KEYS = [
   'oneDriveClientId',
   'oneDriveFolderMode',
   'oneDriveCustomPath',
+  'oneDriveBackupFile',
+  'oneDriveBackupEtag',
   'autoSync',
   'oneDriveConnected',
   'lastSync',
@@ -118,7 +122,8 @@ const defaults: Settings = {
   oneDriveClientId: '',
   oneDriveFolderMode: 'app',
   oneDriveCustomPath: '',
-  oneDriveBackupFile: 'Main.xlsx',
+  oneDriveBackupFile: 'Main.json',
+  oneDriveBackupEtag: '',
   autoSync: true,
   oneDriveConnected: false,
   lastSync: null,
@@ -127,7 +132,14 @@ const defaults: Settings = {
 
 function load(): Settings {
   try {
-    return { ...defaults, ...JSON.parse(localStorage.getItem(KEY) || '{}') };
+    const merged = { ...defaults, ...JSON.parse(localStorage.getItem(KEY) || '{}') };
+    // Clean break from the old Excel format: any non-.json active file (e.g. a "Main.xlsx"
+    // persisted by a previous version) is reset to the JSON default, and its stale eTag cleared.
+    if (!/\.json$/i.test(merged.oneDriveBackupFile || '')) {
+      merged.oneDriveBackupFile = 'Main.json';
+      merged.oneDriveBackupEtag = '';
+    }
+    return merged;
   } catch {
     return defaults;
   }
@@ -164,6 +176,14 @@ export function markSynced(ts: number) {
 
 export function markRestored(ts: number) {
   settings.update((s) => ({ ...s, lastRestore: ts }));
+}
+
+/** Remember the active backup's OneDrive eTag (device-local) for the next conditional write. */
+export function setActiveBackupEtag(etag: string | null) {
+  settings.update((s) => {
+    const next = etag ?? '';
+    return s.oneDriveBackupEtag === next ? s : { ...s, oneDriveBackupEtag: next };
+  });
 }
 
 /** The portable subset of the current settings, ready to embed in a backup. */

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { settings, markSynced, markRestored } from '../lib/stores/settings';
+  import { settings, markSynced, markRestored, setActiveBackupEtag } from '../lib/stores/settings';
   import { link } from '../lib/router';
   import {
     buildSnapshot,
     restoreSnapshot,
+    serializeSnapshot,
+    deserializeSnapshot,
     getOneDrive,
     DEFAULT_BACKUP_FILE,
     fileNameForTitle,
     titleFromFileName,
+    ConflictError,
   } from '../lib/storage/sync';
   import type { BackupInfo } from '../lib/storage/sync';
   import { autoSyncStatus, markSyncSettled } from '../lib/storage/autosync';
@@ -17,7 +20,7 @@
   import { refreshPlayers } from '../lib/stores/players';
   import { showToast } from '../lib/stores/toast';
   import { relativeTime } from '../lib/util';
-  import ExcelIcon from '../lib/components/ExcelIcon.svelte';
+  import JsonIcon from '../lib/components/JsonIcon.svelte';
 
   let override = $state($settings.oneDriveClientId);
   let busy = $state(false);
@@ -39,7 +42,9 @@
   const dotClass = $derived(
     $autoSyncStatus === 'syncing'
       ? 'busy'
-      : $autoSyncStatus === 'pending' || $autoSyncStatus === 'error'
+      : $autoSyncStatus === 'pending' ||
+          $autoSyncStatus === 'error' ||
+          $autoSyncStatus === 'conflict'
         ? 'warn'
         : $autoSyncStatus === 'offline'
           ? 'off'
@@ -51,15 +56,17 @@
   const backupText = $derived(
     $autoSyncStatus === 'syncing'
       ? 'Syncing…'
-      : $autoSyncStatus === 'pending'
-        ? 'Sync pending — reconnect to OneDrive'
-        : $autoSyncStatus === 'offline'
-          ? 'Offline — changes will back up when you reconnect'
-          : $autoSyncStatus === 'error'
-            ? 'Sync failed — will retry shortly'
-            : $settings.lastSync
-              ? 'Synced · Backed up ' + relativeTime($settings.lastSync)
-              : 'Not backed up yet',
+      : $autoSyncStatus === 'conflict'
+        ? 'Backup changed on another device — tap Resolve'
+        : $autoSyncStatus === 'pending'
+          ? 'Sync pending — reconnect to OneDrive'
+          : $autoSyncStatus === 'offline'
+            ? 'Offline — changes will back up when you reconnect'
+            : $autoSyncStatus === 'error'
+              ? 'Sync failed — will retry shortly'
+              : $settings.lastSync
+                ? 'Synced · Backed up ' + relativeTime($settings.lastSync)
+                : 'Not backed up yet',
   );
 
   // Restore is paired with backup but never shows a "not yet" state: connecting
@@ -136,6 +143,7 @@
         isDefault: activeFileName === DEFAULT_BACKUP_FILE,
         modifiedAt: null,
         size: null,
+        etag: null,
       },
       ...list,
     ];
@@ -179,14 +187,16 @@
     }
     backupBusy = true;
     const prev = activeFileName;
+    const prevEtag = $settings.oneDriveBackupEtag;
     try {
-      settings.update((s) => ({ ...s, oneDriveBackupFile: file }));
-      await performBackup();
+      // New file: no eTag baseline yet, and 'create' refuses to clobber a same-named file.
+      settings.update((s) => ({ ...s, oneDriveBackupFile: file, oneDriveBackupEtag: '' }));
+      await performBackup({ mode: 'create' });
       newTitle = '';
       await loadBackups(true);
       showToast('Created backup “' + titleFromFileName(file) + '”');
     } catch (e) {
-      settings.update((s) => ({ ...s, oneDriveBackupFile: prev }));
+      settings.update((s) => ({ ...s, oneDriveBackupFile: prev, oneDriveBackupEtag: prevEtag }));
       showToast(errMsg(e));
     } finally {
       backupBusy = false;
@@ -206,21 +216,25 @@
       return;
     backupBusy = true;
     const prev = activeFileName;
+    const prevEtag = $settings.oneDriveBackupEtag;
     try {
-      settings.update((s) => ({ ...s, oneDriveBackupFile: b.file }));
+      settings.update((s) => ({ ...s, oneDriveBackupFile: b.file, oneDriveBackupEtag: '' }));
       const od = await getOneDrive();
-      const snap = await od.pull();
-      if (snap) {
-        await restoreSnapshot(snap);
+      const pulled = await od.pull();
+      if (pulled) {
+        await restoreSnapshot(pulled.snapshot);
         await refreshPlayers();
         await refreshGames();
         markRestored(Date.now());
+        setActiveBackupEtag(pulled.etag);
+      } else {
+        setActiveBackupEtag(null);
       }
       markSyncSettled();
       await loadBackups(true);
       showToast('Now using “' + b.title + '”');
     } catch (e) {
-      settings.update((s) => ({ ...s, oneDriveBackupFile: prev }));
+      settings.update((s) => ({ ...s, oneDriveBackupFile: prev, oneDriveBackupEtag: prevEtag }));
       showToast(errMsg(e));
     } finally {
       backupBusy = false;
@@ -256,6 +270,7 @@
       // The file name changed — keep pointing at it if it was the active backup.
       if (b.file === activeFileName) {
         settings.update((s) => ({ ...s, oneDriveBackupFile: info.file }));
+        setActiveBackupEtag(info.etag);
       }
       cancelRename();
       await loadBackups(true);
@@ -273,7 +288,7 @@
       !confirm(
         'Delete backup “' +
           b.title +
-          '”?\nThe workbook will be removed from OneDrive.\nWARNING: This cannot be undone.',
+          '”?\nThe backup file will be removed from OneDrive.\nWARNING: This cannot be undone.',
       )
     )
       return;
@@ -287,6 +302,7 @@
         settings.update((s) => ({
           ...s,
           oneDriveBackupFile: next ? next.file : DEFAULT_BACKUP_FILE,
+          oneDriveBackupEtag: next?.etag ?? '',
         }));
       }
       await loadBackups(true);
@@ -316,11 +332,17 @@
     }
   }
 
-  async function performBackup() {
+  async function performBackup(opts: { mode?: 'create' | 'update' } = {}) {
     const od = await getOneDrive();
-    await od.push(await buildSnapshot());
+    const mode = opts.mode ?? 'update';
+    const { etag } = await od.push(await buildSnapshot(), {
+      mode,
+      // Update writes are conditional on our last-known eTag; a brand-new 'create' has none.
+      baseEtag: mode === 'update' ? $settings.oneDriveBackupEtag || null : null,
+    });
     signedIn = od.isSignedIn();
     markSynced(Date.now());
+    setActiveBackupEtag(etag);
     markSyncSettled();
   }
 
@@ -331,7 +353,58 @@
       void loadBackups(false);
       showToast('Backed up to OneDrive');
     } catch (e) {
+      if (e instanceof ConflictError) {
+        await resolveConflict();
+      } else {
+        showToast(errMsg(e));
+      }
+    } finally {
+      busy = false;
+    }
+  }
+
+  /**
+   * The active backup changed on another device since our last sync. Let the user pick a
+   * side: load the OneDrive copy (replacing local data) or overwrite it with this device's.
+   */
+  async function resolveConflict() {
+    const loadTheirs = confirm(
+      'This backup was changed on another device since you last synced here.\n\n' +
+        'OK — Load the OneDrive version (replaces the data on this device).\n' +
+        'Cancel — Overwrite OneDrive with this device’s data.',
+    );
+    try {
+      const od = await getOneDrive();
+      if (loadTheirs) {
+        const pulled = await od.pull();
+        if (pulled) {
+          await restoreSnapshot(pulled.snapshot);
+          await refreshPlayers();
+          await refreshGames();
+          markRestored(Date.now());
+          setActiveBackupEtag(pulled.etag);
+        }
+        markSyncSettled();
+        showToast('Loaded the version from OneDrive');
+      } else {
+        // Force the overwrite with an unconditional write (no baseEtag).
+        const { etag } = await od.push(await buildSnapshot(), { baseEtag: null });
+        signedIn = od.isSignedIn();
+        markSynced(Date.now());
+        setActiveBackupEtag(etag);
+        markSyncSettled();
+        showToast('Backed up to OneDrive');
+      }
+      void loadBackups(false);
+    } catch (e) {
       showToast(errMsg(e));
+    }
+  }
+
+  async function resolveNow() {
+    busy = true;
+    try {
+      await resolveConflict();
     } finally {
       busy = false;
     }
@@ -347,8 +420,8 @@
     busy = true;
     try {
       const od = await getOneDrive();
-      const snap = await od.pull();
-      if (!snap) {
+      const pulled = await od.pull();
+      if (!pulled) {
         // The file is missing on OneDrive (never created, or deleted). We're still connected —
         // offer to create the backup from local data instead of leaving the user stuck.
         if (confirm('No backup found in OneDrive. Back up your current data there now?')) {
@@ -359,10 +432,11 @@
         }
         return;
       }
-      await restoreSnapshot(snap);
+      await restoreSnapshot(pulled.snapshot);
       await refreshPlayers();
       await refreshGames();
       markRestored(Date.now());
+      setActiveBackupEtag(pulled.etag);
       markSyncSettled();
       showToast('Restored from OneDrive');
     } catch (e) {
@@ -386,8 +460,9 @@
   }
 
   async function exportJson() {
-    const snap = await buildSnapshot();
-    const blob = new Blob([JSON.stringify(snap, null, 2)], { type: 'application/json' });
+    const blob = new Blob([serializeSnapshot(await buildSnapshot())], {
+      type: 'application/json',
+    });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -400,7 +475,11 @@
     const file = (e.target as HTMLInputElement).files?.[0];
     if (!file) return;
     try {
-      const snap = JSON.parse(await file.text());
+      const snap = deserializeSnapshot(await file.text());
+      if (!snap) {
+        showToast('Invalid backup file');
+        return;
+      }
       if (!confirm('Replace local data with this file?')) return;
       await restoreSnapshot(snap);
       await refreshPlayers();
@@ -438,7 +517,7 @@
   <span class="chev" aria-hidden="true">›</span>
 </a>
 
-<div class="section-title">OneDrive backup (Excel)</div>
+<div class="section-title">OneDrive backup</div>
 <div class="card stack">
   {#if !configured}
     <div class="muted sm">
@@ -475,7 +554,7 @@
       </label>
 
       <div class="pathchip" title={locationLabel}>
-        <ExcelIcon size={18} />
+        <JsonIcon size={18} />
         <code>{prettyPath}</code>
       </div>
 
@@ -486,7 +565,11 @@
           <span class="dot {dotClass}"></span>
           <span class="sm">{backupText}</span>
         </span>
-        <button class="btn small primary" onclick={backup} disabled={busy}>Sync now</button>
+        {#if $autoSyncStatus === 'conflict'}
+          <button class="btn small primary" onclick={resolveNow} disabled={busy}>Resolve</button>
+        {:else}
+          <button class="btn small primary" onclick={backup} disabled={busy}>Sync now</button>
+        {/if}
       </div>
 
       <div class="syncrow stack" style="gap: 6px">
@@ -522,7 +605,7 @@
           </button>
         </div>
         <span class="muted sm">
-          Each backup is its own workbook in this folder — keep one per group or occasion. The active
+          Each backup is its own JSON file in this folder — keep one per group or occasion. The active
           one is what auto-sync, Sync now, and Restore now use.
         </span>
 
@@ -648,7 +731,7 @@
             <strong>Custom folder</strong>
             <span class="muted sm block">
               Store your backups anywhere you like — Score King treats every
-              <code>.xlsx</code> workbook in this folder as a backup it can read and write.
+              <code>.json</code> file in this folder as a backup it can read and write.
               Microsoft can't limit access to a single folder, so this grants the broader
               <code>Files.ReadWrite</code> permission to your entire OneDrive.
             </span>
@@ -664,7 +747,7 @@
         {/if}
 
         <div class="muted sm row" style="gap: 8px">
-          <ExcelIcon size={16} />
+          <JsonIcon size={16} />
           <code>{locationLabel}</code>
         </div>
         <div class="muted sm">
@@ -711,7 +794,7 @@
 <div class="section-title">About</div>
 <div class="card muted sm">
   Score King · a local-first scorekeeping PWA. Your data lives on this device and, when you connect
-  it, your own OneDrive Excel workbook.
+  it, a JSON backup in your own OneDrive.
 </div>
 
 <style>


### PR DESCRIPTION
## Summary

Replaces the `.xlsx` workbook backup format with a versioned **JSON envelope** and adds **ETag-based optimistic concurrency**, so a backup changed on another device surfaces a conflict instead of being silently overwritten. Clean break — existing `.xlsx` files are left untouched in OneDrive; SheetJS is dropped entirely.

New backup format:
```json
{ "schema": "score-king/backup", "version": 1, "exportedAt": 0,
  "players": [], "games": [], "rounds": [], "settings": {} }
```

## What changed

- **`sync.ts`** — JSON format constants; `serializeSnapshot`/`deserializeSnapshot` with a schema-marker validity guard (foreign/corrupt files return `null`, **fixing the restore-wipe footgun**); `ConflictError`, `PushResult`, `PulledSnapshot`; `etag` on `BackupInfo`.
- **`onedrive.ts`** — drop SheetJS; JSON body; conditional writes (`If-None-Match` for create / `If-Match` for update); eTag capture via item metadata + `@microsoft.graph.downloadUrl`; 404/412 self-heal and conflict disambiguation.
- **`settings.ts`** — add device-local `oneDriveBackupEtag`, default `Main.json`, reset any stale `.xlsx` pointer, and **fix the categorization guard** (`oneDriveBackupFile` + `oneDriveBackupEtag` now in `LOCAL_SETTING_KEYS`, so `npm run check` passes again).
- **`autosync.ts` + `SyncBubble.svelte` + `Settings.svelte`** — thread eTags through every push/pull; add a `conflict` status with **Load-theirs / Overwrite-mine** resolution.
- Swap `ExcelIcon` → neutral `JsonIcon`; remove the `xlsx` dependency.
- **Docs** — README + PRODUCT updated to JSON, ETag, and conflict behavior.

## Functionality preserved

Multiple titled backups, add/rename/delete/switch-active, app + custom folder modes, settings-in-backup, and delete/self-heal all work as before.

## Validation

- `npm run check` → **0 errors** (the previously-broken settings guard is fixed)
- `npm run build` → clean; **no xlsx chunk** (OneDrive path is now MSAL-only, ~60 KB gzip vs the old ~141 KB SheetJS bundle)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>