### PR TITLE
Add ARCHITECTURE.md: self-owned World, identity & live-play model

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,132 @@
+# Architecture
+
+> How Score King grows from a local-first score pad into a portable, self-owned,
+> identity-bearing **World** that can be shared and played live — without ever breaking the
+> "open it and play, offline, no signup" promise.
+>
+> Companion docs: [PRODUCT.md](PRODUCT.md) (why & for whom) · [DESIGN.md](DESIGN.md) (visual
+> system). This document is the **target architecture** we build toward; it is intentionally
+> ahead of the code.
+
+## Guiding principle
+
+**An account, and the World it lives in, are local-first documents you _own_ — not a service
+you log into.** Backup, sharing, and live multiplayer are capabilities *layered onto* an owned
+document; none of them is ever a precondition for play. That single rule is what lets identity
+and networked play exist without taxing the local-first trust contract.
+
+```mermaid
+flowchart TB
+  subgraph Device["Each member's device — self-owned, plays offline"]
+    M["Local identity<br/>stable id + claimable handle"]
+    W["The World — an owned document<br/>members · games · rounds · prefs · stats"]
+    M --- W
+  end
+  W <-->|"ASYNC · per-entity merge + ETag<br/>your devices · a shared group World"| Store[("Your own cloud store<br/>OneDrive today · others later")]
+  W <-->|"LIVE · host-authoritative move protocol"| T["SessionTransport<br/>relay now · P2P later"]
+  T -.->|"stateless rendezvous + bus<br/>stores NO game data"| Relay["Dumb relay<br/>code / QR / magic-link"]
+```
+
+## Core concepts
+
+### The World
+
+The single unit of ownership, and the evolution of today's backup file. One versioned
+document holding **members, games, rounds, preferences, and stats**. "Single-device",
+"shared", and "remote" are not different data models — they are only *where the World is
+hosted and who may write to it.*
+
+### Member — unifies "player" and "account"
+
+One entity for "a gamer", replacing the old player-vs-account split:
+
+- **Immutable `id`** — the stable identity; never changes.
+- **Claimable handle** — a friendly auto-generated name (Xbox-style) the gamer can rename to
+  claim. Display only; **never** an identity key.
+- **Optional profile** — preferences, accessibility, stats.
+- **Lifecycle** — a *guest* is `claimed: false, ephemeral: true`; *archive* soft-deletes and
+  frees the handle for reuse; *promote* makes a member the device/party lead.
+
+Rejoining matches on the `id` the joiner carries, never the mutable handle — so renaming or
+reusing a handle can never impersonate or collide.
+
+### Hosting modes
+
+| Mode             | Where the World lives           | Writers                          |
+| ---------------- | ------------------------------- | -------------------------------- |
+| Local            | one device                      | that device                      |
+| Shared (async)   | each member's own cloud store   | one at a time, merged on sync    |
+| Live (real-time) | the leader's device is the truth | leader applies, others propose  |
+
+## Change & merge model
+
+**Per-entity last-writer-wins (LWW) with tombstones — deliberately _not_ event-sourcing.**
+
+- Every record (member, game *including its settings*, round) carries `updatedAt` and a
+  soft-delete tombstone.
+- Sync = **union by `id`, newest wins per record.** Two members touching *different* things —
+  one visits their own profile, another tweaks a game's settings — merge cleanly with no
+  conflict. This is the common case, and it just works.
+- Append-only rounds never conflict.
+
+Why not a global op-log / event sourcing? The domain is append-mostly and low-churn; ordered
+audit and undo are nice-to-haves, not the point of the app. Per-entity LWW delivers correct
+*union* merge at a fraction of the cost, and builds directly on the existing JSON + ETag
+backup: the **ETag stays as transport-level conflict _detection_**, and per-entity metadata
+upgrades that detection into a real **merge**.
+
+### Known limitation — intentional, for now
+
+When two members edit **the same entity's** fields concurrently (both retune the *same* game),
+LWW keeps one and silently drops the other. Accepted as the right 90/10 for a score app.
+
+> **Deferred enhancement:** field-level merge for same-entity edits, plus a "here's what changed
+> elsewhere" summary so a member can see — and repair — a clobbered tweak. Not built until real
+> groups feel the pain.
+
+## Live play
+
+**Host-authoritative.** The party leader's World is the single source of truth for a live
+session; members hold a live replica and send *intents* ("bid 3", "record round"); the leader
+applies them and rebroadcasts. One real writer ⇒ no CRDTs and no merge in the hot path.
+Leadership can transfer ("elect a new leader").
+
+The live wire format is the **same mutation vocabulary** as the durable model — the move stream
+is ephemeral propagation, not a second source of truth.
+
+### Transport — a seam, not a fork
+
+A single `SessionTransport` interface (sibling to the storage `SyncProvider`):
+
+- **Relay first, peer-to-peer later** — the host-authoritative logic above it is unchanged when
+  the transport swaps.
+- Members join by **code / QR / magic-link**.
+
+### The relay — dumb and stateless on purpose
+
+The one piece of always-on shared infrastructure. It **resolves a join code to a session and
+forwards messages — and stores no game data.** This keeps storage genuinely self-owned, keeps
+cost and the privacy surface minimal, and keeps the centralized footprint to a stateless
+message bus.
+
+## Guardrails — explicit non-goals
+
+- **Accounts are local & optional** — never a login, never a precondition to play.
+- **No global event log as the source of truth** — per-entity LWW is the right weight.
+- **The relay never holds game data** — storage stays self-owned.
+- **Never key identity off the mutable handle** — always the stable `id`.
+- **No CRDTs for live concurrency** — host-authority removes the need.
+- **Don't build P2P first** — but keep the transport seam so it is a drop-in later.
+
+## Roadmap — soul first, infrastructure last
+
+| Phase   | Adds                                                                                                       | Server?    |
+| ------- | ---------------------------------------------------------------------------------------------------------- | ---------- |
+| 0 ✅    | Faithful JSON World + ETag conflict *detection* + versioned envelope                                        | none       |
+| 1       | Identity & World: Member model, claim / archive / promote, multiple members per device, active-member prefs | none       |
+| 2       | Per-entity merge (`updatedAt` + tombstones, union-merge) → async shared Worlds, multi-device-you            | none       |
+| 3       | Live co-play: `SessionTransport` + dumb relay + host-authoritative moves; join by code / QR / link; remote  | dumb relay |
+| later   | P2P transport (offline same-room) behind the same seam; field-level merge + "what changed elsewhere"        | none / relay |
+
+Identity and merge — the self-owned, local-first core — land **before** the relay, so the
+product's soul is real before any backend exists.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Requires Node 20.19+ or 22.12+ (Vite 8).
 
 ## 📦 Architecture
 
+> **Where this is heading:** see [ARCHITECTURE.md](ARCHITECTURE.md) for the target system — the
+> self-owned **World**, identity/accounts, the merge model, and the live-play roadmap.
+
 ```
 src/
   lib/


### PR DESCRIPTION
## What

Adds a concise, intentional **`ARCHITECTURE.md`** capturing the target architecture for accounts, sharing, and multi-device / networked play — plus a one-line pointer from the README. Docs only; no code changes.

This is the reference we build toward; it is intentionally ahead of the code.

## The model it pins down

- **Guiding principle** — an account, and the **World** it lives in, are local-first documents you *own*, not a service you log into. Backup, sharing, and live play are layered *onto* an owned document and are never a precondition for play (the trust contract stays intact).
- **The World** — the single unit of ownership; the evolution of today's backup. "Local / shared / remote" are just *where it's hosted and who may write*.
- **Member** — unifies "player" and "account": stable immutable `id`, claimable display handle, guest / archive / promote lifecycle. Identity is keyed off the `id`, never the mutable handle.
- **Merge** — **per-entity last-writer-wins with tombstones** (union by `id`), deliberately *not* event-sourcing. Builds on the JSON + ETag backup from #13 (ETag = conflict *detection* → upgraded to *merge*). The common case (you edit your profile while someone tweaks a game) merges cleanly.
- **Live play** — **host-authoritative** over a pluggable `SessionTransport` (relay now, P2P later); the relay is **dumb and stateless and stores no game data**.
- **Roadmap** — soul first, infrastructure last: identity & merge ship before any backend exists.

## Deferred (noted in the doc)

Field-level merge for concurrent edits to the *same* entity, plus a "what changed elsewhere" summary so a clobbered tweak can be seen and repaired. Not built until real groups feel the pain.

## Notes

- Branch was fast-forwarded onto `main` so the doc reflects the post-#13 (JSON + ETag) reality.
- Companion to `PRODUCT.md` (why/for whom) and `DESIGN.md` (visual system).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>