### PR TITLE
Phase 1: Member identity — claim, archive & per-device lead prefs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -123,7 +123,7 @@ message bus.
 | Phase   | Adds                                                                                                       | Server?    |
 | ------- | ---------------------------------------------------------------------------------------------------------- | ---------- |
 | 0 ✅    | Faithful JSON World + ETag conflict *detection* + versioned envelope                                        | none       |
-| 1       | Identity & World: Member model, claim / archive / promote, multiple members per device, active-member prefs | none       |
+| 1 ✅    | Identity & World: Member model, claim / archive / promote, multiple members per device, active-member prefs | none       |
 | 2       | Per-entity merge (`updatedAt` + tombstones, union-merge) → async shared Worlds, multi-device-you            | none       |
 | 3       | Live co-play: `SessionTransport` + dumb relay + host-authoritative moves; join by code / QR / link; remote  | dumb relay |
 | later   | P2P transport (offline same-room) behind the same seam; field-level merge + "what changed elsewhere"        | none / relay |

--- a/src/lib/components/PlayerSelect.svelte
+++ b/src/lib/components/PlayerSelect.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { players as roster, createPlayer } from '../stores/players';
+  import { activePlayers as roster, createPlayer, generatePlayer } from '../stores/players';
   import type { ID } from '../types';
   import Avatar from './Avatar.svelte';
 
@@ -20,6 +20,11 @@
     if (!name) return;
     const p = await createPlayer(name);
     newName = '';
+    if (selected.length < max) selected = [...selected, p.id];
+  }
+
+  async function addRandom() {
+    const p = await generatePlayer();
     if (selected.length < max) selected = [...selected, p.id];
   }
 </script>
@@ -45,6 +50,7 @@
 
   <form class="row" onsubmit={(e) => { e.preventDefault(); add(); }}>
     <input class="grow" type="text" placeholder="Add a player…" bind:value={newName} />
+    <button class="btn" type="button" onclick={addRandom} aria-label="Add a random player" title="Surprise me">🎲</button>
     <button class="btn" type="submit">Add</button>
   </form>
 </div>

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -30,20 +30,34 @@ function db(): Promise<IDBPDatabase<ScoreKingDB>> {
 }
 
 // ---- Players ----
-export async function getAllPlayers(): Promise<Player[]> {
-  const all = await (await db()).getAll('players');
-  return all.sort((a, b) => a.name.localeCompare(b.name));
+/** Default identity fields that legacy records (pre-Member) won't have on disk. */
+function normalizePlayer(p: Player): Player {
+  return { ...p, claimed: p.claimed ?? true, archived: p.archived ?? false };
 }
 
-export async function addPlayer(name: string, color: string): Promise<Player> {
-  const player: Player = { id: uid(), name: name.trim(), color, createdAt: Date.now() };
+export async function getAllPlayers(): Promise<Player[]> {
+  const all = await (await db()).getAll('players');
+  return all.map(normalizePlayer).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function addPlayer(name: string, color: string, claimed: boolean): Promise<Player> {
+  const now = Date.now();
+  const player: Player = {
+    id: uid(),
+    name: name.trim(),
+    color,
+    createdAt: now,
+    updatedAt: now,
+    claimed,
+    archived: false,
+  };
   await (await db()).put('players', player);
   markDataChanged();
   return player;
 }
 
 export async function updatePlayer(player: Player): Promise<void> {
-  await (await db()).put('players', raw(player));
+  await (await db()).put('players', raw({ ...player, updatedAt: Date.now() }));
   markDataChanged();
 }
 

--- a/src/lib/stores/identity.ts
+++ b/src/lib/stores/identity.ts
@@ -1,0 +1,88 @@
+import { get, derived } from 'svelte/store';
+import {
+  settings,
+  getBackupSettings,
+  applyBackupSettings,
+  type BackupSettings,
+} from './settings';
+import { players, savePlayerPrefs, refreshPlayers } from './players';
+
+/**
+ * Active/lead member on THIS device — the gamer whose portable preferences are
+ * applied here. Optional: with no lead, the device just uses its own settings.
+ * This is the local seat of the unified Member model (see ARCHITECTURE.md): one
+ * member can lead different devices, and their look follows them.
+ */
+export const leadMember = derived([settings, players], ([$settings, $players]) =>
+  $settings.leadMemberId
+    ? $players.find((m) => m.id === $settings.leadMemberId) ?? null
+    : null,
+);
+
+// While we push a member's prefs INTO settings, the settings subscriber must not
+// treat the resulting change as a fresh user edit and mirror it back out.
+let applying = false;
+let started = false;
+
+function prefsEqual(a: Partial<BackupSettings>, b: Partial<BackupSettings>): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function applyMemberPrefs(prefs: Partial<BackupSettings>): void {
+  applying = true;
+  try {
+    applyBackupSettings(prefs);
+  } finally {
+    applying = false;
+  }
+}
+
+/**
+ * Make `id` the lead member on this device (or clear it with `null`). Switching to
+ * a member with saved prefs applies them; a member without prefs yet is seeded from
+ * the device's current look, so that look becomes theirs from here on.
+ */
+export function setLeadMember(id: string | null): void {
+  applying = true;
+  try {
+    settings.update((s) => ({ ...s, leadMemberId: id }));
+    if (id) {
+      const member = get(players).find((m) => m.id === id);
+      if (member?.prefs) {
+        applyBackupSettings(member.prefs);
+      } else if (member) {
+        void savePlayerPrefs(member, getBackupSettings());
+      }
+    }
+  } finally {
+    applying = false;
+  }
+}
+
+/**
+ * Wire the lead member <-> device-settings link. Call once at startup, AFTER the
+ * players store has loaded: it applies the lead's saved prefs to this device, then
+ * mirrors later preference edits back onto that member (auto-save ownership).
+ */
+export async function initIdentity(): Promise<void> {
+  if (started) return;
+  started = true;
+
+  await refreshPlayers();
+
+  const initial = get(settings);
+  if (initial.leadMemberId) {
+    const member = get(players).find((m) => m.id === initial.leadMemberId);
+    if (member?.prefs) applyMemberPrefs(member.prefs);
+  }
+
+  settings.subscribe(($settings) => {
+    if (applying || !$settings.leadMemberId) return;
+    const member = get(players).find((m) => m.id === $settings.leadMemberId);
+    if (!member) return;
+    const current = getBackupSettings();
+    if (!prefsEqual(member.prefs ?? {}, current)) {
+      void savePlayerPrefs(member, current);
+    }
+  });
+}

--- a/src/lib/stores/players.ts
+++ b/src/lib/stores/players.ts
@@ -1,23 +1,41 @@
-import { writable } from 'svelte/store';
+import { writable, derived } from 'svelte/store';
 import type { Player, ID } from '../types';
+import type { BackupSettings } from './settings';
 import * as db from '../storage/db';
-import { pickColor } from '../util';
+import { pickColor, generateHandle } from '../util';
 
+/** Every member, archived included — Stats and History need the full roster. */
 export const players = writable<Player[]>([]);
+
+/** Active (non-archived) members: the roster shown for play and selection. */
+export const activePlayers = derived(players, ($players) =>
+  $players.filter((p) => !p.archived),
+);
 
 export async function refreshPlayers(): Promise<void> {
   players.set(await db.getAllPlayers());
 }
 
+/** Create a claimed member from a name the user typed. */
 export async function createPlayer(name: string): Promise<Player> {
   const existing = await db.getAllPlayers();
-  const player = await db.addPlayer(name, pickColor(existing.map((p) => p.color)));
+  const player = await db.addPlayer(name, pickColor(existing.map((p) => p.color)), true);
   await refreshPlayers();
   return player;
 }
 
+/** Create an unclaimed member with a generated whimsical handle. */
+export async function generatePlayer(): Promise<Player> {
+  const existing = await db.getAllPlayers();
+  const handle = generateHandle(existing.map((p) => p.name));
+  const player = await db.addPlayer(handle, pickColor(existing.map((p) => p.color)), false);
+  await refreshPlayers();
+  return player;
+}
+
+/** Renaming the handle claims the identity. */
 export async function renamePlayer(player: Player, name: string): Promise<void> {
-  await db.updatePlayer({ ...player, name: name.trim() });
+  await db.updatePlayer({ ...player, name: name.trim(), claimed: true });
   await refreshPlayers();
 }
 
@@ -26,6 +44,27 @@ export async function recolorPlayer(player: Player, color: string): Promise<void
   await refreshPlayers();
 }
 
+/** Soft-delete: hide from the active roster while keeping history and stats intact. */
+export async function archivePlayer(player: Player): Promise<void> {
+  await db.updatePlayer({ ...player, archived: true, archivedAt: Date.now() });
+  await refreshPlayers();
+}
+
+export async function restorePlayer(player: Player): Promise<void> {
+  await db.updatePlayer({ ...player, archived: false, archivedAt: undefined });
+  await refreshPlayers();
+}
+
+/** Persist a member's portable preferences (used by the identity store). */
+export async function savePlayerPrefs(
+  player: Player,
+  prefs: Partial<BackupSettings>,
+): Promise<void> {
+  await db.updatePlayer({ ...player, prefs });
+  await refreshPlayers();
+}
+
+/** Permanently remove a member and forget them entirely. */
 export async function removePlayer(id: ID): Promise<void> {
   await db.deletePlayer(id);
   await refreshPlayers();

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -49,6 +49,12 @@ export interface Settings {
   oneDriveConnected: boolean;
   lastSync: number | null;
   lastRestore: number | null;
+
+  // ── Device identity ───────────────────────────────────────────────────────
+  // Which member is the active "lead" on THIS device; their portable prefs are
+  // applied to the device. Device-specific (each device picks its own lead), so it
+  // is NOT backed up — the members themselves (each carrying their own prefs) are.
+  leadMemberId: string | null;
 }
 
 /**
@@ -89,6 +95,7 @@ export const LOCAL_SETTING_KEYS = [
   'oneDriveConnected',
   'lastSync',
   'lastRestore',
+  'leadMemberId',
 ] as const;
 
 export type PortableSettingKey = (typeof PORTABLE_SETTING_KEYS)[number];
@@ -128,6 +135,7 @@ const defaults: Settings = {
   oneDriveConnected: false,
   lastSync: null,
   lastRestore: null,
+  leadMemberId: null,
 };
 
 function load(): Settings {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,12 +1,30 @@
 import type { Component } from 'svelte';
+import type { BackupSettings } from './stores/settings';
 
 export type ID = string;
 
+/**
+ * A gamer — the unified "Member" entity from ARCHITECTURE.md (one record for a
+ * person: their seat in a game *and* their identity). Named `Player` because that's
+ * what it is inside a game, and the name is woven through the GameModule contract.
+ */
 export interface Player {
   id: ID;
+  /** Display handle. Auto-generated and whimsical until the gamer claims it. */
   name: string;
   color: string;
   createdAt: number;
+  /** True once the gamer renames the auto-generated handle to claim this identity. */
+  claimed?: boolean;
+  /** Soft-delete: hidden from the active roster + selection, kept in history & stats. */
+  archived?: boolean;
+  archivedAt?: number;
+  /** A temporary, session-only member (networked guest join). Reserved; no UI yet. */
+  ephemeral?: boolean;
+  /** This member's portable preferences, applied to a device when they're its lead. */
+  prefs?: Partial<BackupSettings>;
+  /** Last local mutation time — groundwork for per-entity merge (Phase 2). */
+  updatedAt?: number;
 }
 
 export type GameStatus = 'active' | 'finished';

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -85,6 +85,33 @@ export function relativeTime(ts: number): string {
   return formatDate(ts);
 }
 
+const HANDLE_ADJECTIVES = [
+  'Royal', 'Crowned', 'Sneaky', 'Lucky', 'Mighty', 'Jolly', 'Dapper', 'Cosmic',
+  'Turbo', 'Wily', 'Brave', 'Cheeky', 'Noble', 'Zany', 'Swift', 'Grand',
+  'Merry', 'Bold', 'Sly', 'Epic', 'Plucky', 'Gilded', 'Rowdy', 'Fuzzy',
+];
+
+const HANDLE_NOUNS = [
+  'Otter', 'Wizard', 'Badger', 'Comet', 'Monarch', 'Jester', 'Phoenix', 'Walrus',
+  'Goose', 'Raccoon', 'Dragon', 'Penguin', 'Yeti', 'Narwhal', 'Falcon', 'Hedgehog',
+  'Bandit', 'Maverick', 'Champion', 'Gremlin', 'Knight', 'Wombat', 'Llama', 'Pixel',
+];
+
+/**
+ * A whimsical, on-brand display handle (e.g. "Royal Otter") for a not-yet-claimed
+ * member. Avoids handles already in `taken`, falling back to a numbered variant.
+ */
+export function generateHandle(taken: string[] = []): string {
+  const used = new Set(taken.map((n) => n.toLowerCase()));
+  const pick = (list: string[]) => list[Math.floor(Math.random() * list.length)];
+  const make = () => `${pick(HANDLE_ADJECTIVES)} ${pick(HANDLE_NOUNS)}`;
+  for (let i = 0; i < 24; i++) {
+    const handle = make();
+    if (!used.has(handle.toLowerCase())) return handle;
+  }
+  return `${make()} ${Math.floor(Math.random() * 90) + 10}`;
+}
+
 export function initials(name: string): string {
   return name
     .split(/\s+/)

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { registerSW } from 'virtual:pwa-register'
 import './app.css'
 import App from './App.svelte'
 import { applySettings } from './lib/stores/settings'
+import { initIdentity } from './lib/stores/identity'
 import { startAutoSync } from './lib/storage/autosync'
 
 // A Microsoft sign-in uses a full-page redirect. When the browser returns from Microsoft the
@@ -27,6 +28,8 @@ async function boot() {
   applySettings()
   registerSW({ immediate: true })
   mount(App, { target: document.getElementById('app')! })
+  // Apply the lead member's saved look to this device, then keep them in sync.
+  await initIdentity()
   // Background OneDrive auto-backup (push-only, silent; never redirects on its own).
   startAutoSync()
 }

--- a/src/pages/Players.svelte
+++ b/src/pages/Players.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
   import {
     players,
+    activePlayers,
     createPlayer,
+    generatePlayer,
     renamePlayer,
     recolorPlayer,
+    archivePlayer,
+    restorePlayer,
     removePlayer,
   } from '../lib/stores/players';
+  import { leadMember, setLeadMember } from '../lib/stores/identity';
   import { PALETTE, resolvePlayerColor } from '../lib/util';
   import { settings } from '../lib/stores/settings';
   import Avatar from '../lib/components/Avatar.svelte';
@@ -14,6 +19,9 @@
   let newName = $state('');
   let editingId = $state<string | null>(null);
   let editName = $state('');
+  let showArchived = $state(false);
+
+  const archived = $derived($players.filter((p) => p.archived));
 
   async function add() {
     const n = newName.trim();
@@ -29,8 +37,16 @@
     if (editName.trim()) await renamePlayer(p, editName);
     editingId = null;
   }
+  function toggleLead(p: Player) {
+    setLeadMember($leadMember?.id === p.id ? null : p.id);
+  }
+  async function archive(p: Player) {
+    if ($leadMember?.id === p.id) setLeadMember(null);
+    await archivePlayer(p);
+  }
   async function remove(p: Player) {
-    if (confirm(`Delete ${p.name}? Past games keep their recorded scores.`)) {
+    if (confirm(`Delete ${p.name} for good? Past games keep their recorded scores.`)) {
+      if ($leadMember?.id === p.id) setLeadMember(null);
       await removePlayer(p.id);
     }
   }
@@ -40,22 +56,31 @@
 
 <form class="row" onsubmit={(e) => { e.preventDefault(); add(); }} style="margin-bottom: 14px">
   <input class="grow" type="text" placeholder="New player name…" bind:value={newName} />
+  <button class="iconbtn" type="button" onclick={generatePlayer} aria-label="Generate a player" title="Surprise me with a name">🎲</button>
   <button class="btn primary" type="submit">Add</button>
 </form>
 
-{#if $players.length === 0}
+{#if $activePlayers.length === 0 && archived.length === 0}
   <div class="empty">No players yet — add your regulars above.</div>
-{:else}
+{:else if $activePlayers.length > 0}
   <div class="stack">
-    {#each $players as p (p.id)}
-      <div class="card">
+    {#each $activePlayers as p (p.id)}
+      <div class="card" class:lead={$leadMember?.id === p.id}>
         <div class="row spread">
           <span class="row" style="gap: 10px">
             <Avatar name={p.name} color={p.color} size={34} />
             {#if editingId === p.id}
               <input type="text" bind:value={editName} style="width: auto" />
             {:else}
-              <strong>{p.name}</strong>
+              <span class="who">
+                <strong>{p.name}</strong>
+                {#if $leadMember?.id === p.id || !p.claimed}
+                  <span class="tags">
+                    {#if $leadMember?.id === p.id}<span class="tag lead-tag">👑 On this device</span>{/if}
+                    {#if !p.claimed}<span class="tag muted-tag">Unclaimed</span>{/if}
+                  </span>
+                {/if}
+              </span>
             {/if}
           </span>
           <span class="row" style="gap: 6px">
@@ -63,8 +88,16 @@
               <button class="btn small primary" onclick={() => saveEdit(p)}>Save</button>
               <button class="btn small ghost" onclick={() => (editingId = null)}>Cancel</button>
             {:else}
+              <button
+                class="iconbtn"
+                class:on={$leadMember?.id === p.id}
+                onclick={() => toggleLead(p)}
+                aria-pressed={$leadMember?.id === p.id}
+                aria-label={$leadMember?.id === p.id ? 'Stop playing on this device' : 'Play as this member on this device'}
+                title="Play on this device"
+              >👑</button>
               <button class="iconbtn" onclick={() => startEdit(p)} aria-label="Rename">✎</button>
-              <button class="iconbtn" onclick={() => remove(p)} aria-label="Delete">🗑</button>
+              <button class="iconbtn" onclick={() => archive(p)} aria-label="Archive">🗄</button>
             {/if}
           </span>
         </div>
@@ -84,6 +117,32 @@
   </div>
 {/if}
 
+{#if archived.length > 0}
+  <button
+    class="archtoggle"
+    onclick={() => (showArchived = !showArchived)}
+    aria-expanded={showArchived}
+  >{showArchived ? '▾' : '▸'} Archived ({archived.length})</button>
+  {#if showArchived}
+    <div class="stack">
+      {#each archived as p (p.id)}
+        <div class="card arch">
+          <div class="row spread">
+            <span class="row" style="gap: 10px">
+              <Avatar name={p.name} color={p.color} size={28} />
+              <span class="muted">{p.name}</span>
+            </span>
+            <span class="row" style="gap: 6px">
+              <button class="btn small ghost" onclick={() => restorePlayer(p)}>Restore</button>
+              <button class="iconbtn" onclick={() => remove(p)} aria-label="Delete for good">🗑</button>
+            </span>
+          </div>
+        </div>
+      {/each}
+    </div>
+  {/if}
+{/if}
+
 <style>
   .dot {
     width: 24px;
@@ -94,5 +153,50 @@
   }
   .dot.sel {
     border-color: var(--text);
+  }
+  .card.lead {
+    border-color: var(--accent);
+  }
+  .iconbtn.on {
+    border-color: var(--text);
+    background: var(--surface-3);
+  }
+  .who {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .tags {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .tag {
+    font-size: 0.72rem;
+    font-weight: 600;
+    padding: 1px 8px;
+    border-radius: 999px;
+  }
+  .lead-tag {
+    color: var(--accent-ink);
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+  }
+  .muted-tag {
+    color: var(--muted);
+    border: 1px solid var(--border);
+  }
+  .archtoggle {
+    display: block;
+    margin-top: 14px;
+    padding: 10px 2px;
+    background: none;
+    border: none;
+    color: var(--muted);
+    font-weight: 600;
+    font-size: 0.92rem;
+    cursor: pointer;
+  }
+  .card.arch {
+    opacity: 0.82;
   }
 </style>


### PR DESCRIPTION
Implements **Phase 1 (Identity & World)** from `ARCHITECTURE.md`. Entirely local — no server, no networking. This makes the app's "soul" real: a gamer is now a first-class **Member** whose look and stats can follow them, while the zero-setup/offline trust contract is untouched.

## The core decision: enrich `Player`, don't rename it

`ARCHITECTURE.md` calls the unified entity a **Member**. Rather than rename the type, this enriches the existing `Player`:

- `Player` flows through the `GameModule` plugin contract and **every** game module. A rename is a large, churny blast radius for zero behavioural gain.
- One record already means both "a seat in a game" *and* "a person." That's exactly the Member concept.

So `Player` **is** the Member. UI keeps the friendly "Players" vocabulary.

## What's in

**Model** (`types.ts`) — `Player` gains optional identity fields, all backward-compatible and auto-round-tripped through the JSON backup:
- `claimed` — has the gamer claimed this handle (renamed it)?
- `archived` / `archivedAt` — soft-delete lifecycle
- `ephemeral` — reserved for networked guest joins (no UI yet; Phase 3)
- `prefs` — the member's portable preferences (theme, text size, a11y…)
- `updatedAt` — stamped on every write; groundwork for Phase 2 per-entity merge

Legacy records default to `claimed: true`, `archived: false` on read — no destructive migration, no DB version bump.

**Whimsical handles** (`util.ts`) — `generateHandle()` produces on-brand names like *"Royal Otter"* / *"Sneaky Jester"*. Used by the 🎲 affordance on the Players page and in player selection. Typing a real name (or renaming a generated one) **claims** the identity.

**Archive / restore** (`db.ts`, `players.ts`) — archiving hides a member from the active roster and game selection while keeping them in **History & Stats** (their record is preserved, restorable). Permanent delete still available from the Archived section. New `activePlayers` derived store backs the roster; `players` stays the full list for name resolution.

**Active member + per-device prefs** (new `stores/identity.ts`) — this is the heart of Situation B:
- Each device picks a **lead member** (device-local `leadMemberId`, kept out of the backup).
- Setting the lead **applies their saved prefs** to the device. A member with no prefs yet is seeded from the device's current look — so it becomes theirs.
- While a lead is active, editing a portable setting **writes back** to that member (auto-save ownership), so their look follows them to any device.
- A re-entrancy guard + value-equality check + init-then-subscribe ordering prevent feedback loops between settings ⇆ member prefs.

## Design

The lead member is this device's "leader," so they wear **Crown Gold** (`--accent`) — a gold card border + a "👑 On this device" tag — exactly the sanctioned leader/winner use from `DESIGN.md`. Gold is **not** used to tint buttons; the lead toggle uses a neutral pressed state. Royal Violet stays on the single primary action (Add). State is always conveyed with text/icon, never color alone.

## Intentionally deferred

- Guest/`ephemeral` join UI → Phase 3 (networked join).
- Per-entity merge of concurrent edits + "what changed elsewhere" summary → Phase 2 / later.
- Any relay/networking → Phase 3.

## Verification

- `npm run check` (svelte-check + tsc) → **0 errors, 0 warnings**
- `npm run build` → **green**
- Smoke-tested in the dev server (add/claim/generate/archive/restore/lead-toggle).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>