### PR TITLE
Phase 2: per-entity merge -> async shared Worlds

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -124,7 +124,7 @@ message bus.
 | ------- | ---------------------------------------------------------------------------------------------------------- | ---------- |
 | 0 ✅    | Faithful JSON World + ETag conflict *detection* + versioned envelope                                        | none       |
 | 1 ✅    | Identity & World: Member model, claim / archive / promote, multiple members per device, active-member prefs | none       |
-| 2       | Per-entity merge (`updatedAt` + tombstones, union-merge) → async shared Worlds, multi-device-you            | none       |
+| 2 ✅    | Per-entity merge (`updatedAt` + tombstones, union-merge) → async shared Worlds, multi-device-you            | none       |
 | 3       | Live co-play: `SessionTransport` + dumb relay + host-authoritative moves; join by code / QR / link; remote  | dumb relay |
 | later   | P2P transport (offline same-room) behind the same seam; field-level merge + "what changed elsewhere"        | none / relay |
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ works fully offline, and can back itself up to a **JSON file in your OneDrive**.
   and a win‑rate leaderboard.
 - **Optional OneDrive sync.** Automatic (and one‑click) backup to a compact `.json` file in your own
   OneDrive, with one‑click restore. Keep **multiple titled backups** in the folder (one per group or
-  occasion) and switch between them. Writes are guarded by an **ETag**, so a backup changed on another
-  device surfaces a conflict instead of being silently overwritten. Auto‑backup is on by default,
+  occasion) and switch between them. Writes are guarded by an **ETag** and reconciled by a **per‑entity
+  merge** (newest edit wins per player, game, and round), so two devices that change different things
+  combine cleanly instead of one silently overwriting the other. Auto‑backup is on by default,
   push‑only, and never interrupts you. Uses your own free Azure app registration — *no secrets live in
   this repo.*
 - **Local JSON export/import** as a zero‑setup backup option.
@@ -179,9 +180,12 @@ override with their own client ID under **Settings → Advanced**.
 ### How backup & restore behave
 
 - **Sync now** writes your current data to the **active** backup. The write is **conditional on an
-  ETag**: if the file changed on another device since this one last synced, the app stops and asks
-  whether to **load the other version** or **overwrite** it — so a concurrent edit is never silently
-  lost. The first write of a connection (no ETag baseline yet) is unconditional. If the file was
+  ETag**: if the file changed on another device since this one last synced, the app **merges** the two
+  copies **per entity** — the newest write wins for each player, game, and round (deletions, which are
+  kept as tombstones, included) — saves the combined World to both sides, and shows _“Merged changes
+  from your other device.”_ So edits made on different devices both survive; only two edits to the
+  **same** record settle last‑writer‑wins (a field‑level merge and a “what changed” summary are
+  planned). The first write of a connection (no ETag baseline yet) is unconditional. If the file was
   deleted — or, in custom‑folder mode, the whole folder was deleted — the next backup **recreates the
   file (and folder)** automatically.
 - **Restore** always fetches the **latest** remote copy of the active backup. The download bypasses
@@ -193,10 +197,12 @@ override with their own client ID under **Settings → Advanced**.
   title and makes it active; your other backups are untouched. Auto‑backup keeps pushing to whichever
   backup is active, so switching first (which loads that backup onto the device) keeps each slot
   separate.
-- **Conflicts pause auto‑backup, never clobber.** If automatic backup meets a file that changed
-  elsewhere, the status bubble switches to a **conflict** state and auto‑pushing stops until you
-  resolve it from **Settings** (load the other version, or overwrite) — your local edits stay safe on
-  the device meanwhile.
+- **Auto‑backup merges in the background, never clobbers.** If automatic backup meets a file that
+  changed elsewhere, the app quietly **merges** per entity and pushes the combined World — no
+  interruption, and records from the other device appear on screen as soon as the merge lands. Only if
+  the merge can't settle (the remote keeps moving, or a sign‑in is needed) does the status bubble
+  switch to a **conflict**/**pending** state you finish from **Settings** with a single **Merge** —
+  your local edits stay safe on the device meanwhile.
 
 ### What gets backed up
 

--- a/src/lib/storage/autosync.ts
+++ b/src/lib/storage/autosync.ts
@@ -1,8 +1,10 @@
 import { get, writable } from 'svelte/store';
 import { settings, markSynced, getBackupSettings, setActiveBackupEtag } from '../stores/settings';
 import { dataVersion } from './changes';
-import { buildSnapshot, getOneDrive, ConflictError, InteractionRequiredError } from './sync';
+import { buildSnapshot, getOneDrive, reconcile, ConflictError, InteractionRequiredError } from './sync';
 import type { SyncProvider } from './sync';
+import { refreshPlayers } from '../stores/players';
+import { refreshGames } from '../stores/games';
 
 export type AutoSyncStatus =
   | 'idle'
@@ -120,10 +122,10 @@ async function run(): Promise<void> {
   } catch (e) {
     dirty = true; // keep the changes pending
     if (e instanceof ConflictError) {
-      // The remote backup changed under us (another device). Do NOT clobber it in the
-      // background — surface a conflict and stop auto-pushing until the user resolves it.
-      conflicted = true;
-      autoSyncStatus.set('conflict');
+      // The remote backup changed under us (another device). Instead of stopping to
+      // ask the user to pick a side, merge per-entity (union by id, newest wins) and
+      // push the result — a background reconcile that loses no untouched records.
+      await mergeRemote(od);
     } else if (e instanceof InteractionRequiredError) {
       // Silent token failed — must NOT redirect in the background. Wait for the
       // user to reconnect, or for the next data change / online event.
@@ -134,6 +136,42 @@ async function run(): Promise<void> {
     }
   } finally {
     pushing = false;
+  }
+}
+
+/**
+ * Resolve a background push conflict by merging rather than choosing a side. Pull the
+ * remote World, union it with ours per entity, persist + push the merge, then refresh
+ * the open stores so any records that arrived from the other device appear immediately.
+ * Only if the merge itself can't settle (or needs sign-in) do we fall back to a held
+ * conflict / pending state for the user to handle from Settings.
+ */
+async function mergeRemote(od: SyncProvider): Promise<void> {
+  dirty = false; // fold the current edits into this merge; edits during it re-set dirty
+  try {
+    const { etag } = await reconcile(od, { interactive: false });
+    await Promise.all([refreshPlayers(), refreshGames()]);
+    markSynced(Date.now());
+    setActiveBackupEtag(etag);
+    conflicted = false;
+    if (dirty) {
+      schedule(); // more edits arrived while merging
+    } else {
+      autoSyncStatus.set('synced');
+    }
+  } catch (e) {
+    dirty = true;
+    if (e instanceof InteractionRequiredError) {
+      autoSyncStatus.set('pending');
+    } else if (e instanceof ConflictError) {
+      // The remote kept moving and we couldn't win the conditional push after several
+      // tries — hand off to a manual resolve so we never spin or clobber.
+      conflicted = true;
+      autoSyncStatus.set('conflict');
+    } else {
+      autoSyncStatus.set('error');
+      schedule(); // transient (e.g. network) — retry later
+    }
   }
 }
 

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -37,7 +37,10 @@ function normalizePlayer(p: Player): Player {
 
 export async function getAllPlayers(): Promise<Player[]> {
   const all = await (await db()).getAll('players');
-  return all.map(normalizePlayer).sort((a, b) => a.name.localeCompare(b.name));
+  return all
+    .filter((p) => !p.deleted)
+    .map(normalizePlayer)
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export async function addPlayer(name: string, color: string, claimed: boolean): Promise<Player> {
@@ -62,31 +65,42 @@ export async function updatePlayer(player: Player): Promise<void> {
 }
 
 export async function deletePlayer(id: ID): Promise<void> {
-  await (await db()).delete('players', id);
+  const database = await db();
+  const existing = await database.get('players', id);
+  if (existing) {
+    const now = Date.now();
+    await database.put('players', raw({ ...existing, deleted: now, updatedAt: now }));
+  }
   markDataChanged();
 }
 
 // ---- Games ----
 export async function getAllGames(): Promise<Game[]> {
   const all = await (await db()).getAllFromIndex('games', 'byCreated');
-  return all.reverse();
+  return all.filter((g) => !g.deleted).reverse();
 }
 
 export async function getGame(id: ID): Promise<Game | undefined> {
-  return (await db()).get('games', id);
+  const game = await (await db()).get('games', id);
+  return game && !game.deleted ? game : undefined;
 }
 
 export async function putGame(game: Game): Promise<void> {
-  await (await db()).put('games', raw(game));
+  await (await db()).put('games', raw({ ...game, updatedAt: Date.now() }));
   markDataChanged();
 }
 
 export async function deleteGame(id: ID): Promise<void> {
   const database = await db();
+  const now = Date.now();
   const tx = database.transaction(['games', 'rounds'], 'readwrite');
-  await tx.objectStore('games').delete(id);
-  const rounds = await tx.objectStore('rounds').index('byGame').getAllKeys(id);
-  for (const key of rounds) await tx.objectStore('rounds').delete(key);
+  const game = await tx.objectStore('games').get(id);
+  if (game) await tx.objectStore('games').put(raw({ ...game, deleted: now, updatedAt: now }));
+  // Tombstone the game's rounds too, so the cascade delete propagates on merge.
+  const rounds = await tx.objectStore('rounds').index('byGame').getAll(id);
+  for (const r of rounds) {
+    await tx.objectStore('rounds').put(raw({ ...r, deleted: now, updatedAt: now }));
+  }
   await tx.done;
   markDataChanged();
 }
@@ -94,16 +108,21 @@ export async function deleteGame(id: ID): Promise<void> {
 // ---- Rounds ----
 export async function getRounds(gameId: ID): Promise<Round[]> {
   const all = await (await db()).getAllFromIndex('rounds', 'byGame', gameId);
-  return all.sort((a, b) => a.index - b.index);
+  return all.filter((r) => !r.deleted).sort((a, b) => a.index - b.index);
 }
 
 export async function putRound(round: Round): Promise<void> {
-  await (await db()).put('rounds', raw(round));
+  await (await db()).put('rounds', raw({ ...round, updatedAt: Date.now() }));
   markDataChanged();
 }
 
 export async function deleteRound(id: ID): Promise<void> {
-  await (await db()).delete('rounds', id);
+  const database = await db();
+  const existing = await database.get('rounds', id);
+  if (existing) {
+    const now = Date.now();
+    await database.put('rounds', raw({ ...existing, deleted: now, updatedAt: now }));
+  }
   markDataChanged();
 }
 
@@ -125,5 +144,25 @@ export async function replaceAll(data: {
 }
 
 export async function getAllRounds(): Promise<Round[]> {
-  return (await db()).getAll('rounds');
+  const all = await (await db()).getAll('rounds');
+  return all.filter((r) => !r.deleted);
+}
+
+/**
+ * Everything in the World, tombstones INCLUDED — the raw material for a backup
+ * snapshot and per-entity merge. The live getters above hide tombstones; sync must
+ * keep them so deletions propagate to (and survive a merge with) other devices.
+ */
+export async function getAllForSync(): Promise<{
+  players: Player[];
+  games: Game[];
+  rounds: Round[];
+}> {
+  const database = await db();
+  const [players, games, rounds] = await Promise.all([
+    database.getAll('players'),
+    database.getAll('games'),
+    database.getAll('rounds'),
+  ]);
+  return { players: players.map(normalizePlayer), games, rounds };
 }

--- a/src/lib/storage/sync.ts
+++ b/src/lib/storage/sync.ts
@@ -1,5 +1,5 @@
 import * as db from './db';
-import type { Game, Player, Round } from '../types';
+import type { Game, ID, Player, Round } from '../types';
 import type { Settings } from '../stores/settings';
 import { getBackupSettings, applyBackupSettings } from '../stores/settings';
 
@@ -218,11 +218,7 @@ export interface SyncProvider {
 }
 
 export async function buildSnapshot(): Promise<Snapshot> {
-  const [players, games, rounds] = await Promise.all([
-    db.getAllPlayers(),
-    db.getAllGames(),
-    db.getAllRounds(),
-  ]);
+  const { players, games, rounds } = await db.getAllForSync();
   return { players, games, rounds, settings: getBackupSettings(), exportedAt: Date.now() };
 }
 
@@ -233,6 +229,85 @@ export async function restoreSnapshot(snapshot: Snapshot): Promise<void> {
     rounds: snapshot.rounds,
   });
   applyBackupSettings(snapshot.settings);
+}
+
+// ── Per-entity merge (Phase 2) ───────────────────────────────────────────────
+// The World is a set of records keyed by stable `id`, each carrying `updatedAt`
+// and a soft-delete tombstone. Merging two copies is a union by id where, per
+// record, the newest write wins — so two devices that touched *different* things
+// (one edits a profile, another retunes a game) combine cleanly. Two edits to the
+// *same* record fall back to last-writer-wins (the accepted limitation).
+
+type Mergeable = { id: ID; updatedAt?: number; createdAt?: number };
+
+/** Effective merge timestamp; falls back to creation time, then 0, for legacy records. */
+function mergeStamp(e: Mergeable): number {
+  return e.updatedAt ?? e.createdAt ?? 0;
+}
+
+/** Pick the surviving version of one record. Ties break on content so all devices converge. */
+function pickWinner<T extends Mergeable>(a: T, b: T): T {
+  const sa = mergeStamp(a);
+  const sb = mergeStamp(b);
+  if (sa !== sb) return sa > sb ? a : b;
+  return JSON.stringify(a) >= JSON.stringify(b) ? a : b;
+}
+
+/** Union two record lists by id, newest-per-id winning. Tombstones are kept (and can win). */
+function mergeById<T extends Mergeable>(local: T[], remote: T[]): T[] {
+  const byId = new Map<ID, T>();
+  for (const e of local) byId.set(e.id, e);
+  for (const e of remote) {
+    const cur = byId.get(e.id);
+    byId.set(e.id, cur ? pickWinner(cur, e) : e);
+  }
+  return [...byId.values()];
+}
+
+/**
+ * Merge a remote World into the local one: union every entity by id, newest wins.
+ * Tombstones are preserved so deletions propagate. Portable device prefs are taken
+ * from `local` — a background merge must never silently restyle this device (per-member
+ * prefs, which DO merge, travel inside `players`).
+ */
+export function mergeSnapshots(local: Snapshot, remote: Snapshot): Snapshot {
+  return {
+    players: mergeById(local.players, remote.players),
+    games: mergeById(local.games, remote.games),
+    rounds: mergeById(local.rounds, remote.rounds),
+    settings: local.settings,
+    exportedAt: Date.now(),
+  };
+}
+
+/**
+ * Reconcile local and remote into one merged World and write it to both. Used when a
+ * conditional push hits a {@link ConflictError}: pull the remote, merge per-entity,
+ * persist the merge locally, then push it (conditional on the version we merged from).
+ * If the remote moves again mid-flight, re-pull and re-merge up to `maxAttempts`.
+ * Callers refresh their stores afterward so open screens reflect the merged-in records.
+ */
+export async function reconcile(
+  provider: SyncProvider,
+  opts: { interactive?: boolean; maxAttempts?: number } = {},
+): Promise<PushResult> {
+  const interactive = opts.interactive ?? true;
+  const maxAttempts = opts.maxAttempts ?? 4;
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const pulled = await provider.pull();
+    const local = await buildSnapshot();
+    const merged = pulled ? mergeSnapshots(local, pulled.snapshot) : local;
+    if (pulled) await restoreSnapshot(merged);
+    try {
+      return await provider.push(merged, { interactive, baseEtag: pulled?.etag ?? null });
+    } catch (e) {
+      lastErr = e;
+      if (e instanceof ConflictError) continue; // remote moved again — re-pull & re-merge
+      throw e;
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new ConflictError();
 }
 
 /** Lazy-load the OneDrive provider (keeps MSAL out of the main bundle). */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,8 +23,14 @@ export interface Player {
   ephemeral?: boolean;
   /** This member's portable preferences, applied to a device when they're its lead. */
   prefs?: Partial<BackupSettings>;
-  /** Last local mutation time — groundwork for per-entity merge (Phase 2). */
+  /** Last local mutation time — drives per-entity merge (Phase 2). */
   updatedAt?: number;
+  /**
+   * Sync tombstone: when set, this record was permanently deleted and is retained
+   * only so the deletion propagates on merge. Distinct from {@link archived} (a
+   * recoverable, still-present member). Tombstoned records are hidden everywhere.
+   */
+  deleted?: number;
 }
 
 export type GameStatus = 'active' | 'finished';
@@ -40,6 +46,10 @@ export interface Game {
   finishedAt?: number;
   winnerIds?: ID[];
   roundCount: number;
+  /** Last local mutation time — drives per-entity merge (Phase 2). */
+  updatedAt?: number;
+  /** Sync tombstone: deletion time, retained so the delete propagates on merge. */
+  deleted?: number;
 }
 
 export interface Round {
@@ -49,6 +59,10 @@ export interface Round {
   input: unknown; // game-specific payload
   deltas: Record<ID, number>; // per-player points for this round
   createdAt: number;
+  /** Last local mutation time — drives per-entity merge (Phase 2). */
+  updatedAt?: number;
+  /** Sync tombstone: deletion time, retained so the delete propagates on merge. */
+  deleted?: number;
 }
 
 /** Context handed to a game module when editing/scoring a round. */

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -8,6 +8,7 @@
     serializeSnapshot,
     deserializeSnapshot,
     getOneDrive,
+    reconcile,
     DEFAULT_BACKUP_FILE,
     fileNameForTitle,
     titleFromFileName,
@@ -57,7 +58,7 @@
     $autoSyncStatus === 'syncing'
       ? 'Syncing…'
       : $autoSyncStatus === 'conflict'
-        ? 'Backup changed on another device — tap Resolve'
+        ? 'Backup changed on another device — tap Merge'
         : $autoSyncStatus === 'pending'
           ? 'Sync pending — reconnect to OneDrive'
           : $autoSyncStatus === 'offline'
@@ -364,38 +365,23 @@
   }
 
   /**
-   * The active backup changed on another device since our last sync. Let the user pick a
-   * side: load the OneDrive copy (replacing local data) or overwrite it with this device's.
+   * The active backup changed on another device since our last sync. Merge the two
+   * copies per entity (union by id, newest write wins) and write the result to both
+   * sides — so edits from this device and the other one both survive. Only a same-record
+   * collision falls back to last-writer-wins.
    */
   async function resolveConflict() {
-    const loadTheirs = confirm(
-      'This backup was changed on another device since you last synced here.\n\n' +
-        'OK — Load the OneDrive version (replaces the data on this device).\n' +
-        'Cancel — Overwrite OneDrive with this device’s data.',
-    );
     try {
       const od = await getOneDrive();
-      if (loadTheirs) {
-        const pulled = await od.pull();
-        if (pulled) {
-          await restoreSnapshot(pulled.snapshot);
-          await refreshPlayers();
-          await refreshGames();
-          markRestored(Date.now());
-          setActiveBackupEtag(pulled.etag);
-        }
-        markSyncSettled();
-        showToast('Loaded the version from OneDrive');
-      } else {
-        // Force the overwrite with an unconditional write (no baseEtag).
-        const { etag } = await od.push(await buildSnapshot(), { baseEtag: null });
-        signedIn = od.isSignedIn();
-        markSynced(Date.now());
-        setActiveBackupEtag(etag);
-        markSyncSettled();
-        showToast('Backed up to OneDrive');
-      }
+      const { etag } = await reconcile(od, { interactive: true });
+      await refreshPlayers();
+      await refreshGames();
+      signedIn = od.isSignedIn();
+      markSynced(Date.now());
+      setActiveBackupEtag(etag);
+      markSyncSettled();
       void loadBackups(false);
+      showToast('Merged changes from your other device');
     } catch (e) {
       showToast(errMsg(e));
     }
@@ -566,7 +552,7 @@
           <span class="sm">{backupText}</span>
         </span>
         {#if $autoSyncStatus === 'conflict'}
-          <button class="btn small primary" onclick={resolveNow} disabled={busy}>Resolve</button>
+          <button class="btn small primary" onclick={resolveNow} disabled={busy}>Merge</button>
         {:else}
           <button class="btn small primary" onclick={backup} disabled={busy}>Sync now</button>
         {/if}


### PR DESCRIPTION
Implements the **Phase 2** row of `ARCHITECTURE.md`: upgrade OneDrive sync from ETag conflict *detection* into a per-entity *merge*, so the same World can live on multiple devices and combine cleanly. Fully local — **no server**. Stacked on Phase 1 (#15, merged).

## Why
Today a backup that changed on another device forces a **pick-a-side** choice (load theirs *or* overwrite) — one side's edits are lost. That blocks the "multi-device you" story. Phase 2 makes the World a set of records that **merge by id**: two devices that touch *different* things (one renames a player, the other retunes a game) now combine without losing either.

## The merge model
Per-entity **last-writer-wins with tombstones** — deliberately *not* event-sourcing (see ARCHITECTURE.md "Change & merge model").

- **`updatedAt` on every record** (`Player`/`Game`/`Round`), stamped on every write.
- **Tombstones**: delete sets `deleted: <time>` instead of removing the row, so the deletion can propagate on merge. `deleteGame` cascades tombstones to its rounds in one transaction. Live getters hide tombstones everywhere; only sync sees them.
- **`mergeById`**: union two record lists by id; per id the newest `updatedAt ?? createdAt` wins, ties broken on content so **both devices converge to an identical result**.
- **`reconcile`**: on a conditional-push conflict, pull → merge → persist locally → push (conditional on the merged-from version); re-pull/re-merge up to N times if the remote keeps moving.

`Player.deleted` (tombstone, hidden everywhere) is distinct from `Player.archived` (recoverable, still shown in history/stats) — a deliberate two-tier model.

## Behavior changes
- **Auto-sync** now *merges in the background* on conflict and refreshes the open Players/Games stores, so records from the other device appear immediately — instead of stopping at a conflict. It only falls back to a held `conflict`/`pending` state if the merge genuinely can't settle (remote keeps moving) or a sign-in is needed.
- **Settings** "Resolve" becomes a one-tap **Merge** (no more data-losing pick-a-side); toast: _"Merged changes from your other device."_
- Portable **device prefs are kept local** during a merge (a background sync must never restyle your device) — per-member prefs, which *do* merge, travel inside `players` (Phase 1).

## Builds on PR #13
ETag stays as transport-level conflict **detection**; the new per-entity metadata turns that detection into a **merge**. Backward compatible: records from older backups lack `updatedAt`/tombstones, so `mergeStamp` falls back to `createdAt` and a recent local tombstone still beats an old remote live record.

## Known / accepted limitation
Two edits to the **same** record settle last-writer-wins (one is dropped). A field-level merge and a "what changed elsewhere" summary are deferred and tracked in the roadmap (`later` row).

## Verification
- `npm run check` — **0 errors, 0 warnings**
- `npm run build` — clean; OneDrive/MSAL stays in its own lazy chunk (no new import cycle)
- **Merge algorithm unit-tested** (8/8): disjoint-edit union, order-independent convergence, tombstone-wins, undo-resurrects-record, legacy-record fallback, idempotent re-merge

## Files
- `types.ts` — `updatedAt` + `deleted` tombstones on Game/Round; `deleted` on Player
- `storage/db.ts` — stamp `updatedAt`; tombstone deletes; cascade; `getAllForSync()` (raw, includes tombstones)
- `storage/sync.ts` — `mergeById` / `mergeSnapshots` / `reconcile`; `buildSnapshot` sources tombstones
- `storage/autosync.ts` — background auto-merge on conflict + store refresh
- `pages/Settings.svelte` — one-tap Merge resolve flow + copy
- `README.md`, `ARCHITECTURE.md` — merge-model docs; Phase 2 marked done

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
