### PR TITLE
Phase 3 Slice A: host-authoritative live co-play (same-origin)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -101,6 +101,9 @@ A single `SessionTransport` interface (sibling to the storage `SyncProvider`):
 - **Relay first, peer-to-peer later** — the host-authoritative logic above it is unchanged when
   the transport swaps.
 - Members join by **code / QR / magic-link**.
+- First implementation is a **same-origin `BroadcastChannel`** transport (same-browser,
+  multi-tab) — zero infrastructure, yet it exercises the whole host-authoritative engine.
+  The relay drops in behind the same seam to add cross-device play.
 
 ### The relay — dumb and stateless on purpose
 
@@ -125,7 +128,8 @@ message bus.
 | 0 ✅    | Faithful JSON World + ETag conflict *detection* + versioned envelope                                        | none       |
 | 1 ✅    | Identity & World: Member model, claim / archive / promote, multiple members per device, active-member prefs | none       |
 | 2 ✅    | Per-entity merge (`updatedAt` + tombstones, union-merge) → async shared Worlds, multi-device-you            | none       |
-| 3       | Live co-play: `SessionTransport` + dumb relay + host-authoritative moves; join by code / QR / link; remote  | dumb relay |
+| 3a ✅   | Live co-play engine: host-authoritative `SessionTransport` seam + same-origin (`BroadcastChannel`) transport; join by code / link; record-round intents | none       |
+| 3b      | The dumb relay for cross-device play behind the same seam + join by QR — resolves a code, forwards messages, stores no game data | dumb relay |
 | later   | P2P transport (offline same-room) behind the same seam; field-level merge + "what changed elsewhere"        | none / relay |
 
 Identity and merge — the self-owned, local-first core — land **before** the relay, so the

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ works fully offline, and can back itself up to a **JSON file in your OneDrive**.
   push‑only, and never interrupts you. Uses your own free Azure app registration — *no secrets live in
   this repo.*
 - **Local JSON export/import** as a zero‑setup backup option.
+- **Play together (live).** Host a game and others follow along in real time on a shared board:
+  the host stays the single source of truth and players send round entries as *intents* the host
+  records. Today it links players in the **same browser** (multi‑tab) with **zero infrastructure**;
+  the same engine sits behind a transport seam so a tiny relay can add cross‑device play without
+  touching the game logic. Live play is never required — every game still works fully offline.
 - **Dark / light** themes.
 
 ### Games today
@@ -84,10 +89,15 @@ src/
       db.ts           # IndexedDB (players, games, rounds)
       sync.ts         # Snapshot + SyncProvider interface
       onedrive.ts     # MSAL + Graph (JSON backup) implementation
+    live/             # live co-play: host-authoritative engine + transport seam
+      protocol.ts     # wire messages (hello/welcome/state/intent/…)
+      transport.ts    # SessionTransport interface (relay drops in later)
+      broadcast.ts    # same-origin BroadcastChannel transport
+      session.ts      # the engine: leader applies intents, rebroadcasts state
     stores/           # Svelte stores (games, players, settings, toast)
     types.ts          # GameModule contract + core types
     router.ts         # tiny history-based router
-  pages/              # Home, GameType, GamePlay, History, Stats, Players, Settings
+  pages/              # Home, GameType, GamePlay, LiveJoin, History, Stats, Players, Settings
 ```
 
 **Data model** (mirrored in IndexedDB and the JSON backup):

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,6 +12,7 @@
   import GameplaySettings from './pages/GameplaySettings.svelte';
   import GameType from './pages/GameType.svelte';
   import GamePlay from './pages/GamePlay.svelte';
+  import LiveJoin from './pages/LiveJoin.svelte';
   import NotFound from './pages/NotFound.svelte';
   import SyncBubble from './lib/components/SyncBubble.svelte';
 
@@ -70,6 +71,10 @@
   {:else if route.name === 'play'}
     {#key route.params.id}
       <GamePlay id={route.params.id} />
+    {/key}
+  {:else if route.name === 'join'}
+    {#key route.params.code}
+      <LiveJoin code={route.params.code} />
     {/key}
   {:else}
     <NotFound />

--- a/src/lib/components/LiveShareSheet.svelte
+++ b/src/lib/components/LiveShareSheet.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { showToast } from '../stores/toast';
+
+  let {
+    code,
+    link,
+    count,
+    onclose,
+    onend,
+  }: {
+    code: string;
+    link: string;
+    count: number;
+    onclose: () => void;
+    onend: () => void;
+  } = $props();
+
+  const canNativeShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
+
+  async function copy(text: string, label: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      showToast(`${label} copied`);
+    } catch {
+      showToast(`Couldn’t copy — it’s ${text}`);
+    }
+  }
+
+  async function share() {
+    try {
+      await navigator.share({ title: 'Join my game', text: `Join code ${code}`, url: link });
+    } catch {
+      /* user dismissed the share sheet — nothing to do */
+    }
+  }
+
+  function openPlayerTab() {
+    window.open(link, '_blank', 'noopener');
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onclose();
+  }
+
+  let sheet = $state<HTMLDivElement | null>(null);
+  onMount(() => sheet?.focus());
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+<div
+  class="backdrop"
+  role="button"
+  tabindex="-1"
+  aria-label="Close"
+  onclick={onclose}
+  onkeydown={(e) => e.key === 'Enter' && onclose()}
+></div>
+
+<div
+  class="sheet"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Play together"
+  tabindex="-1"
+  bind:this={sheet}
+>
+  <div class="grabber" aria-hidden="true"></div>
+
+  <div class="row spread">
+    <strong style="font-size: 1.05rem">Play together</strong>
+    <span class="live"><span class="dot" aria-hidden="true"></span>Live · {count}</span>
+  </div>
+
+  <div class="codebox">
+    <span class="codelabel">Join code</span>
+    <span class="code">{code}</span>
+  </div>
+
+  <button class="btn {canNativeShare ? '' : 'primary'} block" onclick={() => copy(link, 'Link')}>
+    🔗 Copy link
+  </button>
+  {#if canNativeShare}
+    <button class="btn primary block" onclick={share}>Share…</button>
+  {/if}
+  <div class="row" style="gap: 10px">
+    <button class="btn grow" onclick={() => copy(code, 'Code')}>Copy code</button>
+    <button class="btn grow" onclick={openPlayerTab}>Open a player tab</button>
+  </div>
+
+  <p class="note">
+    Others on this browser can join right now — open the link in another tab or window.
+    Joining from a different device turns on once a relay is configured.
+  </p>
+
+  <button class="btn danger block" onclick={onend}>End live game</button>
+</div>
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    border: 0;
+    width: 100%;
+    cursor: pointer;
+    background: color-mix(in srgb, var(--bg) 55%, transparent);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    animation: fade 0.16s ease-out;
+  }
+  .sheet {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 61;
+    margin: 0 auto;
+    max-width: var(--maxw);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 12px 16px calc(20px + env(safe-area-inset-bottom));
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-bottom: 0;
+    border-radius: var(--radius) var(--radius) 0 0;
+    box-shadow: var(--shadow);
+    animation: rise 0.2s ease-out;
+  }
+  .sheet:focus {
+    outline: none;
+  }
+  .grabber {
+    align-self: center;
+    width: 40px;
+    height: 4px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    margin-bottom: 2px;
+  }
+  .live {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 0.85rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 999px;
+    background: var(--good);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--good) 22%, transparent);
+  }
+  .codebox {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding: 16px;
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+  }
+  .codelabel {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .code {
+    font-size: 2.1rem;
+    font-weight: 800;
+    letter-spacing: 0.32em;
+    /* trailing letter-spacing pads the right; nudge back to keep it centered */
+    text-indent: 0.32em;
+    font-variant-numeric: tabular-nums;
+  }
+  .note {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+    line-height: 1.45;
+  }
+  @keyframes rise {
+    from {
+      transform: translateY(12px);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+  @keyframes fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .sheet,
+    .backdrop {
+      animation: none;
+    }
+  }
+</style>

--- a/src/lib/live/broadcast.ts
+++ b/src/lib/live/broadcast.ts
@@ -1,0 +1,70 @@
+/**
+ * Same-origin {@link SessionTransport} backed by the browser's `BroadcastChannel`.
+ *
+ * Carries live-play messages between tabs/windows of the **same browser profile** — no
+ * server, no infrastructure. It proves the host-authoritative engine end-to-end and is a
+ * drop-in sibling to the relay transport that adds cross-device play later (Phase 3b):
+ * the engine above this class doesn't change when the transport swaps.
+ *
+ * Note: a `BroadcastChannel` never echoes a sender's own posts back to itself, so the
+ * leader won't receive the frames it broadcasts — exactly what we want.
+ */
+import type { SessionTransport, TransportEnvelope, TransportStatus } from './transport';
+
+const CHANNEL_PREFIX = 'score-king-live:';
+
+/** Whether this browser can run the same-origin transport at all. */
+export function isBroadcastSupported(): boolean {
+  return typeof BroadcastChannel !== 'undefined';
+}
+
+export class BroadcastChannelTransport implements SessionTransport {
+  readonly code: string;
+  private channel: BroadcastChannel | null = null;
+  private messageHandlers = new Set<(env: TransportEnvelope) => void>();
+  private statusHandlers = new Set<(status: TransportStatus) => void>();
+
+  constructor(code: string) {
+    this.code = code;
+  }
+
+  async open(): Promise<void> {
+    if (this.channel) return;
+    if (!isBroadcastSupported()) {
+      this.emitStatus('error');
+      throw new Error('Live play needs a browser that supports BroadcastChannel.');
+    }
+    this.channel = new BroadcastChannel(CHANNEL_PREFIX + this.code);
+    this.channel.onmessage = (e: MessageEvent) => {
+      const env = e.data as TransportEnvelope;
+      for (const handler of this.messageHandlers) handler(env);
+    };
+    this.emitStatus('open');
+  }
+
+  send(env: TransportEnvelope): void {
+    this.channel?.postMessage(env);
+  }
+
+  onMessage(handler: (env: TransportEnvelope) => void): () => void {
+    this.messageHandlers.add(handler);
+    return () => this.messageHandlers.delete(handler);
+  }
+
+  onStatus(handler: (status: TransportStatus) => void): () => void {
+    this.statusHandlers.add(handler);
+    return () => this.statusHandlers.delete(handler);
+  }
+
+  close(): void {
+    this.emitStatus('closed');
+    this.channel?.close();
+    this.channel = null;
+    this.messageHandlers.clear();
+    this.statusHandlers.clear();
+  }
+
+  private emitStatus(status: TransportStatus): void {
+    for (const handler of this.statusHandlers) handler(status);
+  }
+}

--- a/src/lib/live/protocol.ts
+++ b/src/lib/live/protocol.ts
@@ -1,0 +1,62 @@
+/**
+ * Live co-play wire protocol (ARCHITECTURE.md Phase 3).
+ *
+ * Host-authoritative: the party leader's World is the single source of truth for a
+ * live session. Guests hold a live **replica** and send **intents** ("record this
+ * round"); the leader applies them to its durable stores and rebroadcasts the
+ * resulting state. One real writer ⇒ no CRDTs in the hot path. The wire format reuses
+ * the durable mutation vocabulary — the move stream is ephemeral propagation, never a
+ * second source of truth.
+ *
+ * This module is transport-agnostic: the same messages flow over the same-origin
+ * {@link ../live/broadcast.BroadcastChannelTransport} today and a relay later.
+ */
+import type { Game, ID, Player, Round } from '../types';
+
+/** Bumped on any breaking change to the message shapes below. */
+export const PROTOCOL_VERSION = 1;
+
+/** Someone present in a live session — keyed off the stable member id, never the handle. */
+export interface Participant {
+  id: ID;
+  name: string;
+  color: string;
+  role: 'leader' | 'guest';
+}
+
+/** The leader's authoritative view of the live game — the guests' replica. */
+export interface LiveState {
+  game: Game;
+  /** Ordered as `game.playerIds`, resolved to records. */
+  players: Player[];
+  rounds: Round[];
+  /** Stamp of the leader's last broadcast, so a guest can ignore stale frames. */
+  rev: number;
+}
+
+/**
+ * A guest's proposed change, in the durable mutation vocabulary. The leader is free to
+ * reject it (validation) — guests never write directly. The first cut supports recording
+ * a round (the core live action); editing/removing stays with the leader, who has the
+ * full game screen.
+ */
+export type LiveIntent = { kind: 'record-round'; input: unknown };
+
+/** Everything that crosses the wire, discriminated by `t`. */
+export type LiveMessage =
+  // guest → all: "I'm here" (announce on join / reconnect)
+  | { t: 'hello'; protocol: number; participant: Participant }
+  // leader → one guest: accept, hand over the current replica + roster
+  | { t: 'welcome'; participant: Participant; state: LiveState; peers: Participant[] }
+  // leader → all: authoritative state after any change
+  | { t: 'state'; state: LiveState }
+  // leader → all: roster changed (someone joined/left)
+  | { t: 'peers'; peers: Participant[] }
+  // guest → leader: propose a change
+  | { t: 'intent'; intent: LiveIntent }
+  // leader → one guest: a proposed intent was rejected
+  | { t: 'reject'; reason: string }
+  // anyone → all: leaving cleanly
+  | { t: 'bye' }
+  // leader → all: the session is ending
+  | { t: 'closed' };

--- a/src/lib/live/session.ts
+++ b/src/lib/live/session.ts
@@ -1,0 +1,297 @@
+/**
+ * Host-authoritative live-play engine (ARCHITECTURE.md Phase 3).
+ *
+ * A single in-memory session controller, exposed to the UI as Svelte stores. It sits
+ * above the {@link SessionTransport} seam, so it is transport-agnostic: same engine over
+ * the same-origin BroadcastChannel today, a relay later.
+ *
+ * Roles:
+ * - **Leader** (the host): owns the durable World. Applies guests' intents through the
+ *   normal store flows and rebroadcasts authoritative state. The leader keeps using its
+ *   own full game screen; this engine just mirrors and accepts proposals.
+ * - **Guest**: holds a read-only {@link LiveState} replica and proposes intents. Never
+ *   writes locally.
+ */
+import { writable, derived, get } from 'svelte/store';
+import type { Participant, LiveState, LiveIntent, LiveMessage } from './protocol';
+import { PROTOCOL_VERSION } from './protocol';
+import type { SessionTransport, TransportEnvelope } from './transport';
+import { BroadcastChannelTransport, isBroadcastSupported } from './broadcast';
+import type { ID } from '../types';
+import { settings } from '../stores/settings';
+import { players } from '../stores/players';
+import { showToast } from '../stores/toast';
+import { uid, generateHandle, PALETTE } from '../util';
+
+export type LiveStatus = 'off' | 'connecting' | 'hosting' | 'guest' | 'error';
+
+export const liveStatus = writable<LiveStatus>('off');
+export const liveCode = writable<string | null>(null);
+export const liveParticipants = writable<Participant[]>([]);
+/** The guest's replica of the leader's game. Null for the leader (who uses its own screen). */
+export const liveReplica = writable<LiveState | null>(null);
+export const liveError = writable<string | null>(null);
+
+/** Convenience: a session is live when hosting or joined as a guest. */
+export const liveActive = derived(liveStatus, ($s) => $s === 'hosting' || $s === 'guest');
+
+/** Whether this browser can run live play at all (same-origin transport for now). */
+export function isLiveSupported(): boolean {
+  return isBroadcastSupported();
+}
+
+/** Handlers the leader provides so the engine can read + mutate the durable World. */
+export interface HostHandlers {
+  self: Participant;
+  /** Current authoritative snapshot of the live game (rev is filled in by the engine). */
+  buildState: () => LiveState;
+  /** Apply a guest's intent. Resolve to an error string to reject it, or null to accept. */
+  applyIntent: (intent: LiveIntent, from: ID) => Promise<string | null>;
+}
+
+const JOIN_TIMEOUT_MS = 4000;
+
+let transport: SessionTransport | null = null;
+let role: 'leader' | 'guest' | null = null;
+let selfId: ID | null = null;
+let leaderId: ID | null = null;
+let seq = 0;
+let rev = 0;
+let peers: Participant[] = [];
+let host: HostHandlers | null = null;
+let unsubMessage: (() => void) | null = null;
+let joinTimer: ReturnType<typeof setTimeout> | undefined;
+
+/**
+ * Serializes leader-side durable mutations. `appendRound`/`removeRound` are non-atomic
+ * read-modify-writes (read count → write index), so an applied guest intent must never
+ * interleave with another intent or the host's own save — otherwise two writers observe
+ * the same length and produce a duplicate round index. Every leader-side mutation (guest
+ * intents here, the host's local saves via {@link runHostExclusive}) funnels through this
+ * one chain, which is the serialization the "single writer ⇒ no CRDTs" model assumes.
+ */
+let opChain: Promise<unknown> = Promise.resolve();
+
+/** Run a leader-side durable mutation exclusively, after any in-flight one has settled. */
+export function runHostExclusive<T>(fn: () => Promise<T>): Promise<T> {
+  const next = opChain.then(fn, fn);
+  opChain = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  return next;
+}
+
+/** Build a participant for this device: the lead member if there is one, else a guest handle. */
+export function currentSelf(asRole: 'leader' | 'guest'): Participant {
+  const leadId = get(settings).leadMemberId;
+  const roster = get(players);
+  const lead = leadId ? roster.find((p) => p.id === leadId && !p.archived && !p.deleted) : undefined;
+  if (lead) return { id: lead.id, name: lead.name, color: lead.color, role: asRole };
+  const taken = roster.map((p) => p.name);
+  // Skip palette[0] (Royal Violet) — it's the reserved primary-action accent.
+  const color = PALETTE[1 + Math.floor(Math.random() * (PALETTE.length - 1))];
+  return { id: uid(), name: generateHandle(taken), color, role: asRole };
+}
+
+function send(msg: LiveMessage, to?: ID): void {
+  transport?.send({ from: selfId!, to, seq: seq++, msg } satisfies TransportEnvelope);
+}
+
+function setPeers(next: Participant[]): void {
+  peers = next;
+  liveParticipants.set(next);
+}
+
+function upsertPeer(p: Participant): void {
+  const next = peers.filter((x) => x.id !== p.id);
+  next.push(p);
+  setPeers(next);
+}
+
+function makeTransport(code: string): SessionTransport {
+  // The only place that picks a transport — a relay implementation drops in here later.
+  return new BroadcastChannelTransport(code);
+}
+
+/** Broadcast the leader's current authoritative state (call after any local change). */
+export function publish(): void {
+  if (role !== 'leader' || !host) return;
+  const state = host.buildState();
+  state.rev = ++rev;
+  send({ t: 'state', state });
+}
+
+/** Start hosting a live session under `code`. The caller supplies durable read/apply hooks. */
+export async function startHosting(code: string, handlers: HostHandlers): Promise<void> {
+  await teardown();
+  role = 'leader';
+  host = handlers;
+  selfId = handlers.self.id;
+  leaderId = handlers.self.id;
+  rev = 0;
+  setPeers([handlers.self]);
+  liveCode.set(code);
+  liveReplica.set(null);
+  liveError.set(null);
+  liveStatus.set('connecting');
+
+  transport = makeTransport(code);
+  unsubMessage = transport.onMessage(onLeaderMessage);
+  try {
+    await transport.open();
+    liveStatus.set('hosting');
+    attachUnload();
+  } catch (e) {
+    liveError.set(e instanceof Error ? e.message : 'Could not start live play.');
+    liveStatus.set('error');
+    await teardown();
+    throw e;
+  }
+}
+
+/** Join an existing live session by `code` as a guest. */
+export async function joinSession(code: string, self: Participant): Promise<void> {
+  await teardown();
+  role = 'guest';
+  selfId = self.id;
+  rev = 0;
+  setPeers([]);
+  liveCode.set(code);
+  liveReplica.set(null);
+  liveError.set(null);
+  liveStatus.set('connecting');
+
+  transport = makeTransport(code);
+  unsubMessage = transport.onMessage(onGuestMessage);
+  try {
+    await transport.open();
+    attachUnload();
+    send({ t: 'hello', protocol: PROTOCOL_VERSION, participant: self });
+    joinTimer = setTimeout(() => {
+      if (get(liveStatus) === 'connecting') {
+        liveError.set('No live game found for that code. Check it and try again.');
+        liveStatus.set('error');
+        void teardown();
+      }
+    }, JOIN_TIMEOUT_MS);
+  } catch (e) {
+    liveError.set(e instanceof Error ? e.message : 'Could not join live play.');
+    liveStatus.set('error');
+    await teardown();
+    throw e;
+  }
+}
+
+/** Guest: propose a change to the leader. */
+export function sendIntent(intent: LiveIntent): void {
+  if (role !== 'guest') return;
+  send({ t: 'intent', intent }, leaderId ?? undefined);
+}
+
+/** Leave the session cleanly (leader ends it for everyone; a guest just departs). */
+export async function leaveSession(): Promise<void> {
+  if (transport && selfId) {
+    send(role === 'leader' ? { t: 'closed' } : { t: 'bye' });
+  }
+  await teardown();
+  liveStatus.set('off');
+  liveCode.set(null);
+  liveReplica.set(null);
+  setPeers([]);
+}
+
+function onLeaderMessage(env: TransportEnvelope): void {
+  if (env.to && env.to !== selfId) return;
+  const m = env.msg;
+  if (m.t === 'hello') {
+    if (m.protocol !== PROTOCOL_VERSION) {
+      send({ t: 'reject', reason: 'Your app version is out of date — refresh to join.' }, env.from);
+      return;
+    }
+    upsertPeer({ ...m.participant, role: 'guest' });
+    const state = host!.buildState();
+    state.rev = rev;
+    send({ t: 'welcome', participant: host!.self, state, peers }, env.from);
+    send({ t: 'peers', peers });
+  } else if (m.t === 'intent') {
+    const { intent } = m;
+    const from = env.from;
+    // Serialize against other intents and the host's own saves (see opChain).
+    void runHostExclusive(async () => {
+      if (role !== 'leader' || !host) return;
+      const err = await host.applyIntent(intent, from);
+      if (err) send({ t: 'reject', reason: err }, from);
+      else publish();
+    });
+  } else if (m.t === 'bye') {
+    setPeers(peers.filter((p) => p.id !== env.from));
+    send({ t: 'peers', peers });
+  }
+}
+
+function onGuestMessage(env: TransportEnvelope): void {
+  if (env.to && env.to !== selfId) return;
+  const m = env.msg;
+  if (m.t === 'welcome') {
+    clearJoinTimer();
+    leaderId = env.from;
+    rev = m.state.rev;
+    liveReplica.set(m.state);
+    setPeers(m.peers);
+    liveStatus.set('guest');
+  } else if (m.t === 'state') {
+    if (m.state.rev >= rev) {
+      rev = m.state.rev;
+      liveReplica.set(m.state);
+    }
+  } else if (m.t === 'peers') {
+    setPeers(m.peers);
+  } else if (m.t === 'reject') {
+    showToast(m.reason);
+  } else if (m.t === 'closed') {
+    showToast('The host ended the live game.');
+    void teardown();
+    liveStatus.set('off');
+    liveCode.set(null);
+    liveReplica.set(null);
+    setPeers([]);
+  }
+}
+
+function clearJoinTimer(): void {
+  if (joinTimer !== undefined) {
+    clearTimeout(joinTimer);
+    joinTimer = undefined;
+  }
+}
+
+let unloadAttached = false;
+function onUnload(): void {
+  if (transport && selfId) send(role === 'leader' ? { t: 'closed' } : { t: 'bye' });
+}
+function attachUnload(): void {
+  if (unloadAttached || typeof window === 'undefined') return;
+  window.addEventListener('pagehide', onUnload);
+  unloadAttached = true;
+}
+function detachUnload(): void {
+  if (!unloadAttached || typeof window === 'undefined') return;
+  window.removeEventListener('pagehide', onUnload);
+  unloadAttached = false;
+}
+
+async function teardown(): Promise<void> {
+  clearJoinTimer();
+  detachUnload();
+  unsubMessage?.();
+  unsubMessage = null;
+  transport?.close();
+  transport = null;
+  role = null;
+  selfId = null;
+  leaderId = null;
+  host = null;
+  seq = 0;
+  opChain = Promise.resolve();
+}

--- a/src/lib/live/transport.ts
+++ b/src/lib/live/transport.ts
@@ -1,0 +1,36 @@
+/**
+ * `SessionTransport` — the live-play transport seam (sibling to the storage
+ * `SyncProvider`). The host-authoritative engine in {@link ./session} sits *above* this
+ * interface, so swapping the transport (same-origin BroadcastChannel now → a relay, or
+ * P2P, later) leaves the game logic untouched. That's the whole point of the seam.
+ */
+import type { ID } from '../types';
+import type { LiveMessage } from './protocol';
+
+/** One framed message. `to` addresses a single participant; omit it to broadcast. */
+export interface TransportEnvelope {
+  from: ID;
+  to?: ID;
+  /** Per-sender monotonic counter — lets receivers drop duplicates / order frames. */
+  seq: number;
+  msg: LiveMessage;
+}
+
+export type TransportStatus = 'closed' | 'connecting' | 'open' | 'error';
+
+export interface SessionTransport {
+  /** The join code this transport is bound to. */
+  readonly code: string;
+  /** Begin transporting. Resolves once the channel is ready (or rejects on failure). */
+  open(): Promise<void>;
+  /** Post an envelope. Broadcast unless `env.to` is set (receivers still filter on `to`). */
+  send(env: TransportEnvelope): void;
+  /** Subscribe to inbound envelopes. Returns an unsubscribe. */
+  onMessage(handler: (env: TransportEnvelope) => void): () => void;
+  /** Subscribe to transport status changes. Returns an unsubscribe. */
+  onStatus(handler: (status: TransportStatus) => void): () => void;
+  /** Tear down the channel and drop all subscribers. */
+  close(): void;
+}
+
+export type { ID };

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -20,6 +20,11 @@ function toUrl(appPath: string): string {
   return BASE + clean;
 }
 
+/** Absolute, shareable URL for an app-relative path (includes origin + deploy base). */
+export function absoluteUrl(appPath: string): string {
+  return window.location.origin + toUrl(appPath);
+}
+
 export const pathStore = writable<string>(toAppPath(window.location.pathname));
 
 export function navigate(to: string) {
@@ -73,6 +78,7 @@ export type RouteName =
   | 'accessibility'
   | 'gameplay'
   | 'play'
+  | 'join'
   | 'gametype'
   | 'notfound';
 
@@ -103,6 +109,9 @@ export function parseRoute(path: string): Route {
   }
   if (segs[0] === 'play' && segs[1]) {
     return { name: 'play', params: { id: segs[1] } };
+  }
+  if (segs[0] === 'join' && segs[1]) {
+    return { name: 'join', params: { code: segs[1] } };
   }
   return { name: 'notfound', params: {} };
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -112,6 +112,33 @@ export function generateHandle(taken: string[] = []): string {
   return `${make()} ${Math.floor(Math.random() * 90) + 10}`;
 }
 
+const JOIN_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'; // no I, L, O, 0, 1 — unambiguous
+
+/** A short, unambiguous join code (e.g. "K7QP4") for a live session. */
+export function generateJoinCode(len = 5): string {
+  const a = JOIN_CODE_ALPHABET;
+  const pick = (n: number) => {
+    if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+      const buf = new Uint32Array(1);
+      crypto.getRandomValues(buf);
+      return buf[0] % n;
+    }
+    return Math.floor(Math.random() * n);
+  };
+  let out = '';
+  for (let i = 0; i < len; i++) out += a[pick(a.length)];
+  return out;
+}
+
+/** Normalize user-typed codes: uppercase, strip non-alphabet chars (handles paste/typos). */
+export function normalizeJoinCode(raw: string): string {
+  return (raw || '')
+    .toUpperCase()
+    .split('')
+    .filter((c) => JOIN_CODE_ALPHABET.includes(c))
+    .join('');
+}
+
 export function initials(name: string): string {
   return name
     .split(/\s+/)

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import type { Game, Player, Round, RoundContext } from '../lib/types';
   import { resolveLower } from '../lib/types';
   import * as db from '../lib/storage/db';
@@ -17,13 +17,29 @@
   } from '../lib/stores/games';
   import { getModule } from '../lib/games/registry';
   import { computeTotals } from '../lib/scoring';
-  import { navigate, link } from '../lib/router';
+  import { navigate, link, absoluteUrl } from '../lib/router';
   import { showToast, showActionToast } from '../lib/stores/toast';
-  import { relativeTime } from '../lib/util';
+  import { relativeTime, generateJoinCode } from '../lib/util';
   import { settings } from '../lib/stores/settings';
   import { enableWakeLock, disableWakeLock } from '../lib/wakelock';
   import Scoreboard from '../lib/components/Scoreboard.svelte';
   import Avatar from '../lib/components/Avatar.svelte';
+  import LiveShareSheet from '../lib/components/LiveShareSheet.svelte';
+  import { get } from 'svelte/store';
+  import {
+    startHosting,
+    leaveSession,
+    publish,
+    runHostExclusive,
+    currentSelf,
+    isLiveSupported,
+    liveActive,
+    liveStatus,
+    liveParticipants,
+    liveCode,
+  } from '../lib/live/session';
+  import type { HostHandlers } from '../lib/live/session';
+  import type { LiveState, LiveIntent } from '../lib/live/protocol';
 
   let { id }: { id: string } = $props();
 
@@ -121,16 +137,22 @@
 
   async function saveRound() {
     if (!game || !module || !draft) return;
-    const ctx = buildCtx(rounds.length, computeTotals(rounds, game.playerIds));
     const snap = $state.snapshot(draft);
-    const err = module.validateRound(snap, ctx);
-    if (err) {
-      showToast(err);
-      return;
-    }
-    const deltas = module.scoreRound(snap, ctx);
-    await appendRound(game, snap, deltas);
-    await load();
+    const saved = await hostSerial(async () => {
+      if (!game || !module) return false;
+      const ctx = buildCtx(rounds.length, computeTotals(rounds, game.playerIds));
+      const err = module.validateRound(snap, ctx);
+      if (err) {
+        showToast(err);
+        return false;
+      }
+      const deltas = module.scoreRound(snap, ctx);
+      await appendRound(game, snap, deltas);
+      await load();
+      publish();
+      return true;
+    });
+    if (!saved) return;
     const newest = rounds[rounds.length - 1];
     if (newest) {
       justSavedId = newest.id;
@@ -151,38 +173,58 @@
   }
   async function saveEdit() {
     if (!game || !module || !editing) return;
-    const ctx = buildCtx(editing.index, totalsBefore(editing.index));
     const snap = $state.snapshot(editDraft);
-    const err = module.validateRound(snap, ctx);
-    if (err) {
-      showToast(err);
-      return;
-    }
-    const deltas = module.scoreRound(snap, ctx);
-    await updateRound(editing, snap, deltas);
-    await load();
+    const ed = editing;
+    await hostSerial(async () => {
+      if (!game || !module) return;
+      const ctx = buildCtx(ed.index, totalsBefore(ed.index));
+      const err = module.validateRound(snap, ctx);
+      if (err) {
+        showToast(err);
+        return;
+      }
+      const deltas = module.scoreRound(snap, ctx);
+      await updateRound(ed, snap, deltas);
+      await load();
+      publish();
+    });
   }
 
   async function del(r: Round) {
     if (!game) return;
     const gameSnap = $state.snapshot(game);
     const roundSnap = $state.snapshot(r);
-    await removeRound(r, game);
-    await load();
-    showActionToast(`Round ${r.index + 1} deleted`, 'Undo', async () => {
-      await restoreRound(gameSnap, roundSnap);
+    await hostSerial(async () => {
+      if (!game) return;
+      await removeRound(r, game);
       await load();
+      publish();
+    });
+    showActionToast(`Round ${r.index + 1} deleted`, 'Undo', async () => {
+      await hostSerial(async () => {
+        await restoreRound(gameSnap, roundSnap);
+        await load();
+        publish();
+      });
     });
   }
 
   async function doFinish() {
     if (!game) return;
-    game = await finishGame(game);
+    await hostSerial(async () => {
+      if (!game) return;
+      game = await finishGame(game);
+      publish();
+    });
   }
   async function doReopen() {
     if (!game) return;
-    game = await reopenGame(game);
-    resetDraft();
+    await hostSerial(async () => {
+      if (!game) return;
+      game = await reopenGame(game);
+      resetDraft();
+      publish();
+    });
   }
   async function playAgain() {
     if (!game) return;
@@ -208,6 +250,71 @@
   const winnerNames = $derived(
     (game?.winnerIds ?? []).map((wid) => plist.find((p) => p.id === wid)?.name ?? '?').join(' & '),
   );
+
+  // ── Live co-play (host-authoritative) ──────────────────────────────────
+  // The leader keeps using this very screen; the engine just mirrors the game
+  // to guests and feeds their round proposals back through the same store flow.
+  const liveSupported = isLiveSupported();
+  let sheetOpen = $state(false);
+  const liveLink = $derived($liveCode ? absoluteUrl(`/join/${$liveCode}`) : '');
+
+  // While hosting, route the host's own durable writes through the engine's serial queue
+  // so a guest's intent can't interleave with a local save on the non-atomic append/reindex.
+  function hostSerial<T>(fn: () => Promise<T>): Promise<T> {
+    return get(liveStatus) === 'hosting' ? runHostExclusive(fn) : fn();
+  }
+
+  function buildLiveState(): LiveState {
+    return {
+      game: $state.snapshot(game)!,
+      players: $state.snapshot(orderedPlayers),
+      rounds: $state.snapshot(rounds),
+      rev: 0,
+    };
+  }
+
+  async function applyLiveIntent(intent: LiveIntent): Promise<string | null> {
+    if (intent.kind !== 'record-round') return 'That action isn’t supported.';
+    if (!game || !module) return 'The game isn’t ready yet.';
+    if (game.status !== 'active') return 'This game has finished.';
+    if (!canAddRound) return `All ${maxR} rounds have been played.`;
+    const ctx = buildCtx(rounds.length, computeTotals(rounds, game.playerIds));
+    const err = module.validateRound(intent.input, ctx);
+    if (err) return err;
+    const deltas = module.scoreRound(intent.input, ctx);
+    await appendRound(game, intent.input, deltas);
+    await load();
+    return null;
+  }
+
+  async function startLive() {
+    if (!game) return;
+    const self = currentSelf('leader');
+    const handlers: HostHandlers = {
+      self,
+      buildState: buildLiveState,
+      applyIntent: applyLiveIntent,
+    };
+    try {
+      await startHosting(generateJoinCode(), handlers);
+      sheetOpen = true;
+    } catch {
+      showToast('Couldn’t start live play on this device.');
+    }
+  }
+
+  async function stopLive() {
+    await leaveSession();
+    sheetOpen = false;
+  }
+
+  $effect(() => {
+    if (!$liveActive) sheetOpen = false;
+  });
+
+  onDestroy(() => {
+    if (get(liveStatus) === 'hosting') void leaveSession();
+  });
 </script>
 
 {#if loading}
@@ -236,6 +343,25 @@
     </span>
     <button class="iconbtn" onclick={deleteGame} aria-label="Delete game" title="Delete game">🗑</button>
   </div>
+
+  {#if liveSupported && game.status === 'active'}
+    {#if $liveActive}
+      <button class="card row spread livebar" onclick={() => (sheetOpen = true)}>
+        <span class="row" style="gap: 10px">
+          <span class="livedot" aria-hidden="true"></span>
+          <span style="display: flex; flex-direction: column; text-align: left">
+            <strong>Live game</strong>
+            <span class="muted" style="font-size: 0.8rem">
+              {$liveParticipants.length} here · tap to share
+            </span>
+          </span>
+        </span>
+        <span class="pill">Share</span>
+      </button>
+    {:else}
+      <button class="btn ghost block playtogether" onclick={startLive}>👋 Play together</button>
+    {/if}
+  {/if}
 
   <Scoreboard players={orderedPlayers} {totals} lowerIsBetter={lower} winners={game.winnerIds ?? []} />
 
@@ -331,7 +457,38 @@
   {/if}
 {/if}
 
+{#if sheetOpen && $liveActive && $liveCode}
+  <LiveShareSheet
+    code={$liveCode}
+    link={liveLink}
+    count={$liveParticipants.length}
+    onclose={() => (sheetOpen = false)}
+    onend={stopLive}
+  />
+{/if}
+
 <style>
+  .playtogether {
+    margin-top: 12px;
+  }
+  .livebar {
+    margin-top: 12px;
+    width: 100%;
+    cursor: pointer;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+  }
+  .livebar:hover {
+    border-color: var(--primary);
+  }
+  .livedot {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: var(--good);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--good) 22%, transparent);
+  }
   .banner {
     margin-top: 12px;
     font-size: 1.15rem;

--- a/src/pages/Home.svelte
+++ b/src/pages/Home.svelte
@@ -2,8 +2,17 @@
   import { MODULES, getModule } from '../lib/games/registry';
   import { games } from '../lib/stores/games';
   import { players } from '../lib/stores/players';
-  import { link } from '../lib/router';
-  import { relativeTime } from '../lib/util';
+  import { link, navigate } from '../lib/router';
+  import { relativeTime, normalizeJoinCode } from '../lib/util';
+  import { isLiveSupported } from '../lib/live/session';
+
+  const liveSupported = isLiveSupported();
+  let codeInput = $state('');
+  function submitJoin(e: Event) {
+    e.preventDefault();
+    const c = normalizeJoinCode(codeInput);
+    if (c) navigate(`/join/${c}`);
+  }
 
   const active = $derived($games.filter((g) => g.status === 'active'));
   const recent = $derived($games.filter((g) => g.status === 'finished').slice(0, 4));
@@ -46,6 +55,25 @@
   {/each}
 </div>
 
+{#if liveSupported}
+  <div class="section-title">Join a live game</div>
+  <form class="card row" onsubmit={submitJoin}>
+    <input
+      class="joincode"
+      type="text"
+      autocapitalize="characters"
+      autocomplete="off"
+      autocorrect="off"
+      spellcheck="false"
+      maxlength="8"
+      placeholder="Enter code"
+      aria-label="Live game join code"
+      bind:value={codeInput}
+    />
+    <button class="btn" type="submit" disabled={!codeInput.trim()}>Join</button>
+  </form>
+{/if}
+
 {#if recent.length}
   <div class="section-title">Recent results</div>
   <div class="stack">
@@ -80,5 +108,16 @@
   }
   .sm {
     font-size: 0.85rem;
+  }
+  .joincode {
+    flex: 1;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-weight: 700;
+  }
+  .joincode::placeholder {
+    text-transform: none;
+    letter-spacing: normal;
+    font-weight: 400;
   }
 </style>

--- a/src/pages/LiveJoin.svelte
+++ b/src/pages/LiveJoin.svelte
@@ -1,0 +1,245 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import type { RoundContext } from '../lib/types';
+  import { resolveLower } from '../lib/types';
+  import { getModule } from '../lib/games/registry';
+  import { computeTotals } from '../lib/scoring';
+  import { navigate, link } from '../lib/router';
+  import { showToast } from '../lib/stores/toast';
+  import { normalizeJoinCode } from '../lib/util';
+  import {
+    joinSession,
+    leaveSession,
+    sendIntent,
+    currentSelf,
+    isLiveSupported,
+    liveStatus,
+    liveReplica,
+    liveParticipants,
+    liveError,
+  } from '../lib/live/session';
+  import Scoreboard from '../lib/components/Scoreboard.svelte';
+  import Avatar from '../lib/components/Avatar.svelte';
+
+  let { code }: { code: string } = $props();
+  const joinCode = $derived(normalizeJoinCode(code));
+  const supported = isLiveSupported();
+
+  let draft = $state<any>(null);
+  let lastRoundCount = $state(-1);
+  let everConnected = $state(false);
+
+  const replica = $derived($liveReplica);
+  const gmodule = $derived(replica ? getModule(replica.game.type) : undefined);
+  const totals = $derived(replica ? computeTotals(replica.rounds, replica.game.playerIds) : {});
+  const lower = $derived(replica && gmodule ? resolveLower(gmodule, replica.game.config) : false);
+  const maxR = $derived(
+    replica && gmodule?.maxRounds
+      ? gmodule.maxRounds(replica.game.config, replica.game.playerIds.length)
+      : null,
+  );
+  const canAdd = $derived(
+    !!replica &&
+      replica.game.status === 'active' &&
+      (maxR == null || replica.rounds.length < maxR),
+  );
+  const winnerNames = $derived(
+    !replica
+      ? ''
+      : (replica.game.winnerIds ?? [])
+          .map((wid) => replica.players.find((p) => p.id === wid)?.name ?? '?')
+          .join(' & '),
+  );
+
+  function buildCtx(): RoundContext {
+    return {
+      game: replica!.game,
+      players: replica!.players,
+      config: replica!.game.config,
+      roundIndex: replica!.rounds.length,
+      totals,
+      rounds: replica!.rounds,
+    };
+  }
+
+  // Rebuild the draft whenever a new round lands (mine or anyone's) or the game opens up.
+  $effect(() => {
+    if (replica && gmodule && canAdd) {
+      if (replica.rounds.length !== lastRoundCount) {
+        draft = gmodule.createRoundInput(buildCtx());
+        lastRoundCount = replica.rounds.length;
+      }
+    } else {
+      draft = null;
+      lastRoundCount = -1;
+    }
+  });
+
+  $effect(() => {
+    if ($liveStatus === 'guest') everConnected = true;
+  });
+
+  function sendRound() {
+    if (!replica || !gmodule || !draft) return;
+    const ctx = buildCtx();
+    const snap = $state.snapshot(draft);
+    const err = gmodule.validateRound(snap, ctx);
+    if (err) {
+      showToast(err);
+      return;
+    }
+    sendIntent({ kind: 'record-round', input: snap });
+  }
+
+  function fmt(d: number | undefined): string {
+    if (d === undefined || d === null) return '·';
+    return d > 0 ? `+${d}` : `${d}`;
+  }
+
+  async function leave() {
+    await leaveSession();
+    navigate('/');
+  }
+
+  onMount(() => {
+    if (!supported) return;
+    void joinSession(joinCode, currentSelf('guest'));
+  });
+  onDestroy(() => {
+    void leaveSession();
+  });
+</script>
+
+{#if !supported}
+  <div class="empty">
+    <h2>Live play isn’t available here</h2>
+    <p class="muted">This browser can’t run live games. You can still keep score on your own.</p>
+    <a class="btn primary" href="/" use:link>Back to games</a>
+  </div>
+{:else if $liveStatus === 'guest' && replica && gmodule}
+  <div class="row spread" style="margin: 10px 4px 6px">
+    <span class="row" style="gap: 10px">
+      <span style="font-size: 1.7rem">{gmodule.emoji}</span>
+      <span>
+        <div><strong>{gmodule.name}</strong></div>
+        <div class="muted" style="font-size: 0.8rem">Live game · code {joinCode}</div>
+      </span>
+    </span>
+    <span class="live"><span class="dot" aria-hidden="true"></span>{$liveParticipants.length}</span>
+  </div>
+
+  <Scoreboard players={replica.players} {totals} lowerIsBetter={lower} winners={replica.game.winnerIds ?? []} />
+
+  {#if replica.game.status === 'finished'}
+    <div class="card center banner">
+      🏆 {winnerNames || 'Nobody'} {(replica.game.winnerIds?.length ?? 0) > 1 ? 'tie!' : 'wins!'}
+    </div>
+  {:else if canAdd && draft}
+    {@const RoundEditor = gmodule.RoundEditor}
+    <div class="card stack" style="margin-top: 12px">
+      <strong>Round {replica.rounds.length + 1}{maxR ? ` of ${maxR}` : ''}</strong>
+      <RoundEditor bind:input={draft} ctx={buildCtx()} />
+      <button class="btn primary block" onclick={sendRound}>Send round to host</button>
+      <span class="muted" style="font-size: 0.8rem; text-align: center">
+        The host records it and everyone’s board updates.
+      </span>
+    </div>
+  {:else}
+    <div class="card center" style="margin-top: 12px">Waiting for the host…</div>
+  {/if}
+
+  {#if replica.rounds.length}
+    <div class="section-title">Scorecard</div>
+    <div class="scroll">
+      <table class="matrix">
+        <thead>
+          <tr>
+            <th scope="col">Rd</th>
+            {#each replica.players as p (p.id)}
+              <th scope="col"><Avatar name={p.name} color={p.color} size={22} /></th>
+            {/each}
+          </tr>
+        </thead>
+        <tbody>
+          {#each replica.rounds as r (r.id)}
+            <tr>
+              <td>{r.index + 1}</td>
+              {#each replica.players as p (p.id)}
+                <td class="num">{fmt(r.deltas[p.id])}</td>
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+        <tfoot>
+          <tr>
+            <th scope="row">Total</th>
+            {#each replica.players as p (p.id)}
+              <td class="num">{totals[p.id] ?? 0}</td>
+            {/each}
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  {/if}
+
+  <button class="btn ghost block" style="margin-top: 14px" onclick={leave}>Leave game</button>
+{:else if $liveStatus === 'error'}
+  <div class="empty">
+    <h2>Couldn’t join</h2>
+    <p class="muted">{$liveError ?? 'That live game isn’t reachable.'}</p>
+    <a class="btn primary" href="/" use:link>Back to games</a>
+  </div>
+{:else if everConnected}
+  <div class="empty">
+    <h2>The live game ended</h2>
+    <p class="muted">The host closed the session.</p>
+    <a class="btn primary" href="/" use:link>Back to games</a>
+  </div>
+{:else}
+  <div class="empty">
+    <div class="spinner" aria-hidden="true"></div>
+    <h2>Joining game {joinCode}…</h2>
+    <p class="muted">Connecting you to the host.</p>
+  </div>
+{/if}
+
+<style>
+  .live {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 0.85rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 999px;
+    background: var(--good);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--good) 22%, transparent);
+  }
+  .banner {
+    margin-top: 12px;
+    font-weight: 700;
+  }
+  .spinner {
+    width: 30px;
+    height: 30px;
+    margin: 0 auto 10px;
+    border-radius: 999px;
+    border: 3px solid var(--surface-3);
+    border-top-color: var(--primary);
+    animation: spin 0.8s linear infinite;
+  }
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .spinner {
+      animation-duration: 2.4s;
+    }
+  }
+</style>


### PR DESCRIPTION
## Phase 3 Slice A — live co-play (host-authoritative, same-origin)

Implements the first slice of the `ARCHITECTURE.md` Phase 3 row: the **live co-play engine** and its transport seam, shipped with a **same-origin `BroadcastChannel`** transport so the whole thing works **without any server**.

### Model

**Host-authoritative.** The party leader's World is the single source of truth. Guests hold a read-only replica and send **intents** ("record this round"); the leader applies them through the normal store flow (`appendRound`) and rebroadcasts authoritative `LiveState`. One real writer ⇒ no CRDTs in the hot path. The live wire format reuses the durable mutation vocabulary.

```mermaid
flowchart LR
  G["Guest · read-only replica"] -- "intent: record-round" --> L["Leader · durable World (sole writer)"]
  L -- "authoritative LiveState (rev++)" --> G
  L -. SessionTransport seam .-> T["BroadcastChannel now · relay later"]
```

### What's here

| Area | |
| --- | --- |
| `src/lib/live/protocol.ts` | Versioned wire messages: hello / welcome / state / peers / intent / reject / bye / closed |
| `src/lib/live/transport.ts` | `SessionTransport` interface — the seam (sibling to storage's `SyncProvider`) |
| `src/lib/live/broadcast.ts` | Same-origin `BroadcastChannel` transport (multi-tab, one browser profile) |
| `src/lib/live/session.ts` | The engine: per-page singleton + Svelte stores; leader applies & rebroadcasts, guests ignore stale frames; a single serial queue (`opChain`) funnels guest-intent applies and the host's own saves |
| `src/pages/GamePlay.svelte` | Host: **Play together** button, live banner, share sheet, `publish()` after each local change |
| `src/pages/LiveJoin.svelte` | Guest `/join/:code` screen: replica scoreboard + scorecard, submits rounds via the game's own `RoundEditor` |
| `src/lib/components/LiveShareSheet.svelte` | Code + copy-link + open-a-player-tab (honest about same-browser scope) |
| `src/pages/Home.svelte`, `router.ts`, `App.svelte` | "Join a live game" entry + the `join` route |
| `src/lib/util.ts` | crypto-backed `generateJoinCode` + `normalizeJoinCode` |

### Scope & honesty

- **Same browser only, for now.** `BroadcastChannel` links tabs/windows of one browser profile — great for proving the engine end-to-end and for shared-screen play. **Cross-device** needs the relay (**Slice B**); the share sheet says so plainly rather than showing a QR that wouldn't connect yet.
- **Additive & low-regret.** No existing offline/local flow changes; live play is never a precondition to play. The transport seam is the *only* place a transport is chosen, so the relay drops in with the engine above it unchanged.

### Concurrency

The leader can have two writers racing: a guest's intent and the host's own save (or two guests). `appendRound`/`removeRound` are non-atomic read-modify-writes (read count → `await` IndexedDB → write `index = count`), so overlapping applies could reuse a round index and corrupt `roundCount`. Both paths now funnel through one promise-chained serial queue (`opChain` in `session.ts`; the host's local saves enter it via a `hostSerial` helper in GamePlay), so applies run one-at-a-time and each reads fresh state inside the lock. Offline play skips the queue entirely (zero overhead).

### Verification

- `npm run check` → **0 errors / 0 warnings**
- `npm run build` → clean; OneDrive/MSAL stays a lazy chunk; core bundle unaffected
- A `BroadcastChannel` choreography test (handshake → intent → authoritative rebroadcast, monotonic `rev`, stale-frame rejection, roster updates) plus a serialization check (unserialized concurrent appends collide; queued ones get distinct, contiguous indices) → **15/15**

### Design

DESIGN.md-compliant: one primary action per surface (Royal Violet reserved for it), Crown Gold left for leader/winner only (live status uses green + a text label, never colour alone), `tabular-nums` on the code and counts, ≥46px touch targets, `prefers-reduced-motion` honoured, chrome unchanged game-to-game.

### Next

**Slice B** adds the dumb relay behind the same seam (and brings QR back for real cross-device joins). That PR will surface the one genuine external dependency — the hosting decision.
