### PR TITLE
Clarify send-round UX in live play

### DIFF
--- a/src/lib/components/ReplicaBoard.svelte
+++ b/src/lib/components/ReplicaBoard.svelte
@@ -10,13 +10,31 @@
   import { getModule } from '../games/registry';
   import { computeTotals } from '../scoring';
   import { showToast } from '../stores/toast';
-  import { liveReplica, sendIntent, liveSelf, liveParticipants, claimSeat, liveConnection } from '../live/session';
+  import {
+    liveReplica,
+    sendIntent,
+    liveSelf,
+    liveParticipants,
+    claimSeat,
+    liveConnection,
+    liveIntentRejected,
+  } from '../live/session';
   import Scoreboard from './Scoreboard.svelte';
   import Avatar from './Avatar.svelte';
 
   let draft = $state<any>(null);
   let lastRoundCount = $state(-1);
   let choosing = $state(true);
+
+  // Optimistic send state. The guest only *proposes* a round, so reflect in-flight vs. landed
+  // locally: `sending` disables the action (no accidental double-record) until the round lands
+  // (rounds.length grows past `sentAtRoundCount`), the host rejects it, or a timeout elapses.
+  let sending = $state(false);
+  let justLandedId = $state<string | null>(null);
+  let sentAtRoundCount = -1;
+  let seenRoundCount = -1;
+  let sendTimer: ReturnType<typeof setTimeout> | undefined;
+  let lastRejectTick = -1;
 
   const replica = $derived($liveReplica);
   const gmodule = $derived(replica ? getModule(replica.game.type) : undefined);
@@ -81,8 +99,54 @@
     }
   });
 
+  // A round landing (mine or anyone's) is the guest's confirmation: pulse the newest scorecard
+  // row (mirrors the host's "round saved" flash) and settle any optimistic "sending" state.
+  $effect(() => {
+    if (!replica) {
+      seenRoundCount = -1;
+      return;
+    }
+    const n = replica.rounds.length;
+    if (seenRoundCount === -1) {
+      seenRoundCount = n;
+      return;
+    }
+    if (n > seenRoundCount) {
+      const landed = replica.rounds[n - 1];
+      if (landed) flashRow(landed.id);
+      if (sending && n > sentAtRoundCount) clearSending();
+    }
+    seenRoundCount = n;
+  });
+
+  // The host rejected this guest's proposed round (e.g. the game finished first). The reason is
+  // toasted by the session layer; here we just stop the spinner so the guest can try again.
+  $effect(() => {
+    const tick = $liveIntentRejected;
+    if (lastRejectTick === -1) {
+      lastRejectTick = tick;
+      return;
+    }
+    if (tick !== lastRejectTick) {
+      lastRejectTick = tick;
+      clearSending();
+    }
+  });
+
+  function clearSending(): void {
+    sending = false;
+    clearTimeout(sendTimer);
+  }
+
+  function flashRow(id: string): void {
+    justLandedId = id;
+    setTimeout(() => {
+      if (justLandedId === id) justLandedId = null;
+    }, 900);
+  }
+
   function sendRound() {
-    if (!replica || !gmodule || !draft) return;
+    if (!replica || !gmodule || !draft || sending) return;
     const ctx = buildCtx();
     const snap = $state.snapshot(draft);
     const err = gmodule.validateRound(snap, ctx);
@@ -90,6 +154,16 @@
       showToast(err);
       return;
     }
+    sending = true;
+    sentAtRoundCount = replica.rounds.length;
+    clearTimeout(sendTimer);
+    // No ack in the protocol: if no state arrives, re-enable so a stuck send can be retried.
+    sendTimer = setTimeout(() => {
+      if (sending) {
+        sending = false;
+        showToast('Still sending… tap to try again.');
+      }
+    }, 6000);
     sendIntent({ kind: 'record-round', input: snap });
   }
 
@@ -158,10 +232,16 @@
     <div class="card stack" style="margin-top: 12px">
       <strong>Round {replica.rounds.length + 1}{maxR ? ` of ${maxR}` : ''}</strong>
       <RoundEditor bind:input={draft} ctx={buildCtx()} />
-      <button class="btn primary block" onclick={sendRound}>Send round to host</button>
+      <button class="btn primary block" onclick={sendRound} disabled={sending}>
+        {sending ? 'Sending…' : `Add round ${replica.rounds.length + 1}`}
+      </button>
       <span class="muted" style="font-size: 0.8rem; text-align: center">
-        The host records it and everyone’s board updates.
+        The host records it — every board updates.
       </span>
+    </div>
+  {:else if !canAdd}
+    <div class="card center" style="margin-top: 12px">
+      All rounds in — waiting for the host to finish.
     </div>
   {:else}
     <div class="card center" style="margin-top: 12px">Waiting for the host…</div>
@@ -181,7 +261,7 @@
         </thead>
         <tbody>
           {#each replica.rounds as r (r.id)}
-            <tr>
+            <tr class:flash={r.id === justLandedId}>
               <td>{r.index + 1}</td>
               {#each replica.players as p (p.id)}
                 <td class="num">{fmt(r.deltas[p.id])}</td>
@@ -316,5 +396,24 @@
     flex: none;
     font-size: 0.8rem;
     color: var(--muted);
+  }
+  /* "It landed" confirmation: the same Win-Green pulse the host uses, so a recorded round reads
+     identically on every board. The row is already visible; the pulse points to where the entry
+     landed, and reduced motion drops the animation entirely. */
+  .matrix tbody tr.flash td {
+    animation: rowflash 0.9s ease-out;
+  }
+  @keyframes rowflash {
+    from {
+      background: color-mix(in srgb, var(--good) 26%, transparent);
+    }
+    to {
+      background: transparent;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .matrix tbody tr.flash td {
+      animation: none;
+    }
   }
 </style>

--- a/src/lib/live/session.ts
+++ b/src/lib/live/session.ts
@@ -44,6 +44,12 @@ export const liveError = writable<string | null>(null);
 export const liveRemote = writable<boolean>(false);
 
 /**
+ * Bumped each time the host rejects one of *this guest's* intents. Lets the guest UI settle
+ * an optimistic "sending…" state promptly; the reject reason is also surfaced via toast.
+ */
+export const liveIntentRejected = writable<number>(0);
+
+/**
  * Health of the live connection, kept *separate* from {@link liveStatus} (the game lifecycle).
  * A dropped socket never ends the game — the host stays authoritative and local-first — it just
  * flips this to 'reconnecting' (auto-healing) or 'offline' (still retrying, game safe).

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import type { Game, Player, Round, RoundContext } from '../lib/types';
+  import type { Game, ID, Player, Round, RoundContext } from '../lib/types';
   import { resolveLower } from '../lib/types';
   import * as db from '../lib/storage/db';
   import { players } from '../lib/stores/players';
@@ -159,13 +159,16 @@
     });
     if (!saved) return;
     const newest = rounds[rounds.length - 1];
-    if (newest) {
-      justSavedId = newest.id;
-      const fid = newest.id;
-      setTimeout(() => {
-        if (justSavedId === fid) justSavedId = null;
-      }, 1000);
-    }
+    if (newest) pulseRow(newest.id);
+  }
+
+  // Briefly pulse a scorecard row green to confirm it just landed. The host's own saves and
+  // guests' accepted rounds share this, so every recorded round reads the same on the board.
+  function pulseRow(id: string): void {
+    justSavedId = id;
+    setTimeout(() => {
+      if (justSavedId === id) justSavedId = null;
+    }, 1000);
   }
 
   function startEdit(r: Round) {
@@ -283,7 +286,7 @@
     };
   }
 
-  async function applyLiveIntent(intent: LiveIntent): Promise<string | null> {
+  async function applyLiveIntent(intent: LiveIntent, from: ID): Promise<string | null> {
     if (intent.kind !== 'record-round') return 'That action isn’t supported.';
     if (!game || !module) return 'The game isn’t ready yet.';
     if (game.status !== 'active') return 'This game has finished.';
@@ -294,6 +297,12 @@
     const deltas = module.scoreRound(intent.input, ctx);
     await appendRound(game, intent.input, deltas);
     await load();
+    // Surface the guest's contribution on the host (the source of truth): pulse the new row and
+    // name who added it, so a round arriving from another device never lands silently.
+    const landed = rounds[rounds.length - 1];
+    if (landed) pulseRow(landed.id);
+    const who = get(liveParticipants).find((p) => p.id === from)?.name;
+    showToast(`${who ?? 'A player'} added Round ${rounds.length}`);
     return null;
   }
 
@@ -620,6 +629,11 @@
     }
     to {
       background: transparent;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .matrix tbody tr.flash td {
+      animation: none;
     }
   }
   .acts {


### PR DESCRIPTION
Design-first follow-up to the multi-device live-play work in #20. Closes #23.

> **Stacked PR.** Base is `jrmoulckers-accounts-play-architecture` (PR #20), not `main`, so this diff shows only the send-round UX changes.

## Problem

When a guest fills in a round on the shared board and taps **"Send round to host"**, it was unclear what the action did, when it happened, and what confirmed it landed (raised repeatedly during same-browser and nearby testing). The plumbing worked — guests send a `record-round` intent, the host applies it and rebroadcasts — but the guest-facing experience gave almost no feedback, and an impatient re-tap could record the round twice.

The host-authoritative model is unchanged: **guests still only propose; the host applies and rebroadcasts.**

## What changed

**Guest — `ReplicaBoard.svelte`**
- The one primary action reflects state: **"Add round N"** → disabled **"Sending…"** while in flight. That disable also **fixes a double-submit → duplicate-round bug** (there was no in-flight guard).
- "Sending" settles when the round lands (`rounds.length` grows past the count at send time), when the host rejects it (new `liveIntentRejected` signal), or after a 6s retry timeout.
- A **Win-Green confirm pulse** now fires on the newest scorecard row, mirroring the host, with a `prefers-reduced-motion` guard.
- Clearer copy when all rounds are in: **"All rounds in — waiting for the host to finish."**

**Host — `GamePlay.svelte`**
- `applyLiveIntent` now pulses the new row **and toasts "Alice added Round N"** (via the `from` id it already receives), so a round arriving from another device never lands silently. Extracted a shared `pulseRow()` helper (used by the host's own save too).
- Added the missing `prefers-reduced-motion` guard for the row-flash pulse.

**Session — `session.ts`**
- Added `liveIntentRejected`, bumped when the host rejects one of *this guest's* intents, so the guest UI can settle its optimistic state promptly (the reason is still toasted).

## Design notes

No protocol change. Confirmation reuses the existing Win-Green "round-saved" vocabulary (Crown Gold untouched); one Royal Violet primary action per screen; ≥46px targets; state is co-signed by text + pulse (never colour alone); reduced-motion honoured; chrome unchanged.

**Accepted tradeoff:** confirmation is inferred from the next state broadcast (there is no ack), so a re-tap in the exact sub-second window another guest's round lands could still double-record. Closing that fully would need a protocol-level ack + idempotency key (deliberately out of scope here).

## Verification

- `npm run check` → **0 errors / 0 warnings**
- `npm run build` → **clean**
- Host path smoke-tested live (create game → start live → save round, exercising the shared `pulseRow`). The guest→host round-trip couldn't be driven in the test harness (isolated browser contexts + no relay running); it's covered by the type-check/build and a reactivity review.
