### PR TITLE
Live-play sheet: honest same-browser link boundary (#25) + guest sync feedback (#24)

### DIFF
--- a/src/lib/components/PlaySheet.svelte
+++ b/src/lib/components/PlaySheet.svelte
@@ -184,15 +184,17 @@
       </div>
     {/if}
 
-    <button class="btn {canNativeShare ? '' : 'primary'} block" onclick={() => copy(link, 'Link')}>
-      🔗 Copy link
-    </button>
-    {#if canNativeShare}
-      <button class="btn primary block" onclick={share}>Share…</button>
+    {#if remote}
+      <button class="btn {canNativeShare ? '' : 'primary'} block" onclick={() => copy(link, 'Link')}>
+        🔗 Copy link
+      </button>
+      {#if canNativeShare}
+        <button class="btn primary block" onclick={share}>Share…</button>
+      {/if}
     {/if}
     <div class="row" style="gap: 10px">
       <button class="btn grow" onclick={() => copy(code, 'Code')}>Copy code</button>
-      <button class="btn grow" onclick={openPlayerTab}>Open a player tab</button>
+      <button class="btn {remote ? '' : 'primary'} grow" onclick={openPlayerTab}>Open a player tab</button>
     </div>
 
     {#if remote}
@@ -201,8 +203,8 @@
       </p>
     {:else}
       <p class="note">
-        Others on this browser can join right now — open the link in another tab or window. To play
-        across devices with no internet, switch to nearby below.
+        This game lives in this browser only — “Open a player tab” adds a player on this device. To
+        invite other devices, set a relay URL in Settings → Advanced, or switch to nearby below.
       </p>
     {/if}
   {:else}

--- a/src/lib/components/ReplicaBoard.svelte
+++ b/src/lib/components/ReplicaBoard.svelte
@@ -17,7 +17,14 @@
   let draft = $state<any>(null);
   let lastRoundCount = $state(-1);
   let choosing = $state(true);
+  // Id of the round whose scorecard row should briefly pulse "just saved". Set when a new
+  // round lands via sync so relay/nearby guests get the same confirmation the host shows.
+  let justSavedId = $state<string | null>(null);
+  let seenRounds = $state(-1);
 
+  // Every list below is keyed by a persisted id (player/round) and getModule() is a stable
+  // singleton, so when a new replica arrives Svelte patches rows in place instead of
+  // remounting the board. Keep these keys stable to preserve this no-"flash" sync (#24).
   const replica = $derived($liveReplica);
   const gmodule = $derived(replica ? getModule(replica.game.type) : undefined);
   const totals = $derived(replica ? computeTotals(replica.rounds, replica.game.playerIds) : {});
@@ -79,6 +86,26 @@
       draft = null;
       lastRoundCount = -1;
     }
+  });
+
+  // Pulse the newest scorecard row when a round lands after the board is already showing —
+  // host/guest parity with GamePlay's "round saved" confirmation. The row is patched in
+  // place, not remounted; this only draws the eye, and global reduced-motion (app.css)
+  // settles it instantly. Skips the initial join snapshot (seenRounds < 0) so pre-existing
+  // rounds never flash on first render.
+  $effect(() => {
+    const n = replica ? replica.rounds.length : -1;
+    if (seenRounds >= 0 && n > seenRounds) {
+      const newest = replica!.rounds[n - 1];
+      if (newest) {
+        const fid = newest.id;
+        justSavedId = fid;
+        setTimeout(() => {
+          if (justSavedId === fid) justSavedId = null;
+        }, 1000);
+      }
+    }
+    if (seenRounds !== n) seenRounds = n;
   });
 
   function sendRound() {
@@ -181,7 +208,7 @@
         </thead>
         <tbody>
           {#each replica.rounds as r (r.id)}
-            <tr>
+            <tr class:flash={r.id === justSavedId}>
               <td>{r.index + 1}</td>
               {#each replica.players as p (p.id)}
                 <td class="num">{fmt(r.deltas[p.id])}</td>
@@ -316,5 +343,20 @@
     flex: none;
     font-size: 0.8rem;
     color: var(--muted);
+  }
+  /* Round-saved pulse on the newest scorecard row — the host shows the same green
+     confirmation (GamePlay), so relay/nearby guests get identical feedback. The row is
+     already patched in place; this only draws the eye, and global reduced-motion (app.css)
+     settles it to an instant, motion-free color change. Green = success, never gold. */
+  .matrix tbody tr.flash td {
+    animation: rowflash 0.9s ease-out;
+  }
+  @keyframes rowflash {
+    from {
+      background: color-mix(in srgb, var(--good) 26%, transparent);
+    }
+    to {
+      background: transparent;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary

Two scoped front-end follow-ups to the multi-device live-play work in #20. This branch is **stacked on `jrmoulckers-accounts-play-architecture`** (PR #20's branch), so it targets that branch and the diff is minimal — only `PlaySheet.svelte` and `ReplicaBoard.svelte` change.

## #25 — "Copy link" / "Open a player tab" handed out a dead link in same-browser mode

With no relay configured the session runs over BroadcastChannel (same-browser only) and the `remote` prop is `false`. The QR was already gated on `remote`; the two link actions were not — so the host handed out a `/join/CODE` link that fails with "No live game found" on another device.

- Gate **🔗 Copy link** and native **Share…** behind `{#if remote}` (both imply a cross-device capability the transport lacks).
- Keep **Copy code** (with its confirmation toast) and **Open a player tab** always — a new tab shares the same BroadcastChannel, so it is the legitimate same-browser join path. It becomes the single Royal-Violet primary when `!remote`.
- Rewrite the same-browser note to state the honest boundary: the game lives in this browser only; to invite other devices set a relay URL in **Settings → Advanced**, or switch to nearby.

Preserves the honest-boundary principle from the resilience work — never imply a capability the transport lacks.

Fixes #25

## #24 — Synced-round apply "flashes" the whole board

**Diagnosis:** the committed guest board does **not** remount/flash on a synced apply — it already patches in place. Every list is keyed by a stable persisted id (`p.id` / `r.id`), `getModule()` is a stable singleton, and `LiveJoin`/`NearbyJoin` mount `<ReplicaBoard>` under a plain `{#if}` with no `{#key}`. Verified objectively (headless CDP): applying a new synced round removed **0** DOM nodes, reused every existing scorecard/scoreboard row, and added only the one new row. So PR #20's stable keys already satisfy the issue's "unkeyed `{#each}`" hypothesis — there is no whole-board remount left to remove.

**Change:** the one real gap was feedback parity. The **host** scorecard confirms a saved round with a gentle green row pulse (`justSavedId` → `rowflash`), but the guest board had none, so a synced round appeared abruptly. Added the same reduced-motion-aware "round saved" pulse to the newest guest scorecard row (host/guest parity, per DESIGN's identical-chrome principle), and documented the stable-key anti-flash invariant in-code. The pulse skips the initial join snapshot (so pre-existing rounds never flash) and is settled to an instant, motion-free color change by the global `prefers-reduced-motion` rule in `app.css`.

Verified no flash on both acceptance paths — host→guest broadcast and guest→host→other-guest — since every guest applies state through the same `liveReplica.set`.

Fixes #24

## Checks

- `npm run check` → **0 errors / 0 warnings**
- `npm run build` → clean; **qrcode remains a lazy chunk** (`browser-*.js`, loaded on demand), not in the core bundle
- DESIGN: one Royal-Violet primary per screen in both `remote` and `!remote` states; amber `--warn`/green `--good` for status (never Crown Gold); ≥46px touch targets and `tabular-nums` preserved; reduced-motion honored.
