### PR TITLE
Make OneDrive sync two-way: background pull-merge + demote destructive Restore

### DIFF
--- a/src/lib/storage/autosync.ts
+++ b/src/lib/storage/autosync.ts
@@ -1,7 +1,7 @@
 import { get, writable } from 'svelte/store';
 import { settings, markSynced, getBackupSettings, setActiveBackupEtag } from '../stores/settings';
 import { dataVersion } from './changes';
-import { buildSnapshot, getOneDrive, reconcile, ConflictError, InteractionRequiredError } from './sync';
+import { buildSnapshot, getOneDrive, reconcile, pullMerge, ConflictError, InteractionRequiredError } from './sync';
 import type { SyncProvider } from './sync';
 import { refreshPlayers } from '../stores/players';
 import { refreshGames } from '../stores/games';
@@ -21,6 +21,9 @@ export const autoSyncStatus = writable<AutoSyncStatus>('idle');
 /** Debounce window: coalesce a burst of edits into a single upload. */
 const DEBOUNCE_MS = 2500;
 
+/** Minimum gap between foreground catch-up pulls, so rapid focus/online events don't thrash. */
+const CATCHUP_MIN_GAP_MS = 3000;
+
 let started = false;
 let dirty = false; // local changes awaiting upload
 let pushing = false; // an upload is in flight
@@ -29,6 +32,7 @@ let timer: ReturnType<typeof setTimeout> | undefined;
 let lastVersion = 0;
 let wasActive = false;
 let lastPortableSig: string | undefined; // JSON of the last-seen portable settings
+let lastCatchUp = 0; // last foreground pull time, to throttle focus/online bursts
 
 function enabled(): boolean {
   return get(settings).autoSync;
@@ -175,15 +179,87 @@ async function mergeRemote(od: SyncProvider): Promise<void> {
   }
 }
 
+/**
+ * Foreground catch-up — the *read* side of sync. Unlike {@link run} (which only fires when this
+ * device has local edits to push), this pulls the remote World and merges it in even with no
+ * pending changes, so a passive device converges to other devices' edits on
+ * focus/visibility/online/connect. Never starts an interactive sign-in; a pure catch-up doesn't
+ * write back (see {@link pullMerge}), so two idle devices don't ping-pong.
+ */
+async function catchUp(): Promise<void> {
+  if (pushing || !active() || conflicted) return;
+  const now = Date.now();
+  if (now - lastCatchUp < CATCHUP_MIN_GAP_MS) return; // throttle focus/online bursts
+  lastCatchUp = now;
+  if (!isOnline()) {
+    autoSyncStatus.set('offline');
+    return;
+  }
+
+  let od: SyncProvider;
+  try {
+    od = await getOneDrive();
+  } catch {
+    return; // provider failed to load — nothing we can do in the background
+  }
+  if (!od.isConfigured()) return;
+
+  // Reuse the provider's cached session; never start an interactive sign-in here.
+  try {
+    await od.prepare();
+  } catch {
+    /* fall through to the signed-in check below */
+  }
+  if (!od.isSignedIn()) {
+    autoSyncStatus.set('pending');
+    return;
+  }
+
+  pushing = true;
+  autoSyncStatus.set('syncing');
+  try {
+    const res = await pullMerge(od, { interactive: false });
+    if (res) {
+      setActiveBackupEtag(res.etag); // track the version we're now aligned to
+      if (res.changedLocal) await Promise.all([refreshPlayers(), refreshGames()]);
+      markSynced(Date.now());
+    }
+    if (dirty) {
+      schedule(); // edits arrived during catch-up — push them next
+    } else if (res) {
+      autoSyncStatus.set('synced');
+    } else {
+      autoSyncStatus.set('idle'); // connected but nothing backed up yet
+    }
+  } catch (e) {
+    if (e instanceof ConflictError) {
+      // The remote kept moving and we couldn't win the conditional push — hand off to a
+      // manual resolve so we never spin or clobber.
+      conflicted = true;
+      autoSyncStatus.set('conflict');
+    } else if (e instanceof InteractionRequiredError) {
+      autoSyncStatus.set('pending');
+    } else {
+      autoSyncStatus.set('error');
+    }
+  } finally {
+    pushing = false;
+  }
+}
+
 function onOnline(): void {
-  if (dirty && active()) void run();
+  // Reconnected — pull others' changes; catchUp also re-pushes our own pending edits.
+  if (active()) void catchUp();
 }
 
 function onVisibility(): void {
-  // Best-effort flush when the tab is backgrounded, so a pending edit isn't
-  // stranded if the user navigates away before the debounce fires.
-  if (document.visibilityState === 'hidden' && dirty && active() && isOnline()) {
-    void run();
+  if (document.visibilityState === 'hidden') {
+    // Best-effort flush when the tab is backgrounded, so a pending edit isn't stranded
+    // if the user navigates away before the debounce fires.
+    if (dirty && active() && isOnline()) void run();
+  } else {
+    // Foregrounded — pull in whatever changed on other devices while we were away.
+    void catchUp();
   }
 }
 
@@ -218,7 +294,8 @@ export function startAutoSync(): void {
     if (now !== wasActive) {
       wasActive = now;
       if (now) {
-        if (dirty) schedule(); // turned on / just connected with changes waiting
+        void catchUp(); // just connected/enabled — pull whatever is already in the cloud
+        if (dirty) schedule(); // and push changes made while we were disconnected
       } else {
         cancelTimer(); // turned off or disconnected — stop automatic uploads
         conflicted = false; // a fresh connection starts without a stale conflict
@@ -229,6 +306,9 @@ export function startAutoSync(): void {
 
   window.addEventListener('online', onOnline);
   document.addEventListener('visibilitychange', onVisibility);
+
+  // On launch, catch up to anything other devices backed up while this one was closed.
+  if (active()) void catchUp();
 }
 
 /**

--- a/src/lib/storage/autosync.ts
+++ b/src/lib/storage/autosync.ts
@@ -24,6 +24,13 @@ const DEBOUNCE_MS = 2500;
 /** Minimum gap between foreground catch-up pulls, so rapid focus/online events don't thrash. */
 const CATCHUP_MIN_GAP_MS = 3000;
 
+/**
+ * Foreground poll cadence. While the tab is visible and sync is active, we cheaply check the
+ * remote eTag on this interval so two devices both left open still converge without anyone
+ * touching them — see {@link poll}. Not a full pull: an unchanged eTag costs one small request.
+ */
+const POLL_INTERVAL_MS = 30_000;
+
 let started = false;
 let dirty = false; // local changes awaiting upload
 let pushing = false; // an upload is in flight
@@ -33,6 +40,7 @@ let lastVersion = 0;
 let wasActive = false;
 let lastPortableSig: string | undefined; // JSON of the last-seen portable settings
 let lastCatchUp = 0; // last foreground pull time, to throttle focus/online bursts
+let pollTimer: ReturnType<typeof setInterval> | undefined; // foreground eTag poll, when visible
 
 function enabled(): boolean {
   return get(settings).autoSync;
@@ -247,6 +255,58 @@ async function catchUp(): Promise<void> {
   }
 }
 
+/**
+ * Foreground poll — the lightweight companion to {@link catchUp}. On a cadence, while the tab is
+ * visible and active, cheaply read *just* the remote eTag (a metadata request, no download) and
+ * only when it differs from the version this device is aligned to do we run a full {@link catchUp}
+ * to pull + merge. An unchanged eTag touches nothing locally, so two devices both left open
+ * converge within a cycle without polling the whole World or risking ping-pong. Never interactive.
+ */
+async function poll(): Promise<void> {
+  if (pushing || !active() || conflicted || !isOnline()) return;
+  if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+
+  let od: SyncProvider;
+  try {
+    od = await getOneDrive();
+  } catch {
+    return; // provider failed to load — try again next tick
+  }
+  if (!od.isConfigured()) return;
+  try {
+    await od.prepare();
+  } catch {
+    /* fall through to the signed-in check below */
+  }
+  if (!od.isSignedIn()) return; // silent session gone — a catch-up/edit will surface 'pending'
+
+  let remoteEtag: string | null;
+  try {
+    remoteEtag = await od.peekEtag({ interactive: false });
+  } catch {
+    return; // silent-auth or transient network failure — retry next tick
+  }
+  if (remoteEtag === null) return; // nothing backed up yet — nothing to catch up to
+  if (remoteEtag === get(settings).oneDriveBackupEtag) return; // already aligned — skip the pull
+
+  await catchUp(); // remote moved — pay for the full pull + merge now
+}
+
+/** Begin foreground polling if it isn't already running and we're active + visible. */
+function startPoll(): void {
+  if (pollTimer !== undefined || !active()) return;
+  if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+  pollTimer = setInterval(() => void poll(), POLL_INTERVAL_MS);
+}
+
+/** Stop foreground polling — call when the tab is hidden or sync is turned off/disconnected. */
+function stopPoll(): void {
+  if (pollTimer !== undefined) {
+    clearInterval(pollTimer);
+    pollTimer = undefined;
+  }
+}
+
 function onOnline(): void {
   // Reconnected — pull others' changes; catchUp also re-pushes our own pending edits.
   if (active()) void catchUp();
@@ -254,12 +314,15 @@ function onOnline(): void {
 
 function onVisibility(): void {
   if (document.visibilityState === 'hidden') {
+    stopPoll(); // don't poll a backgrounded tab — save battery/quota (timers throttle anyway)
     // Best-effort flush when the tab is backgrounded, so a pending edit isn't stranded
     // if the user navigates away before the debounce fires.
     if (dirty && active() && isOnline()) void run();
   } else {
-    // Foregrounded — pull in whatever changed on other devices while we were away.
+    // Foregrounded — pull in whatever changed on other devices while we were away, then keep
+    // watching the remote eTag for as long as we stay in the foreground.
     void catchUp();
+    startPoll();
   }
 }
 
@@ -295,9 +358,11 @@ export function startAutoSync(): void {
       wasActive = now;
       if (now) {
         void catchUp(); // just connected/enabled — pull whatever is already in the cloud
+        startPoll(); // and keep watching for other devices' changes while we're foregrounded
         if (dirty) schedule(); // and push changes made while we were disconnected
       } else {
         cancelTimer(); // turned off or disconnected — stop automatic uploads
+        stopPoll(); // and stop watching the remote
         conflicted = false; // a fresh connection starts without a stale conflict
         autoSyncStatus.set('idle');
       }
@@ -307,8 +372,12 @@ export function startAutoSync(): void {
   window.addEventListener('online', onOnline);
   document.addEventListener('visibilitychange', onVisibility);
 
-  // On launch, catch up to anything other devices backed up while this one was closed.
-  if (active()) void catchUp();
+  // On launch, catch up to anything other devices backed up while this one was closed, then poll
+  // for further changes while this tab stays in the foreground.
+  if (active()) {
+    void catchUp();
+    startPoll();
+  }
 }
 
 /**

--- a/src/lib/storage/onedrive.ts
+++ b/src/lib/storage/onedrive.ts
@@ -330,6 +330,20 @@ export const oneDrive: SyncProvider = {
     if (!snapshot) return null;
     return { snapshot, etag: item.eTag ?? null };
   },
+  async peekEtag(opts?: PushOptions): Promise<string | null> {
+    const accessToken = await token(opts?.interactive ?? true);
+    // Metadata-only read, narrowed to just the eTag: the cheapest way to tell whether the remote
+    // moved. No download URL, no file body. cache:'no-store' so a poll always sees the latest.
+    const meta = await graph(
+      `${itemPath(activeFile())}?$select=eTag`,
+      { method: 'GET', cache: 'no-store' },
+      accessToken,
+    );
+    if (meta.status === 404) return null;
+    if (!meta.ok) throw new Error(`Version check failed (HTTP ${meta.status}).`);
+    const item = (await meta.json().catch(() => ({}))) as { eTag?: string };
+    return item.eTag ?? null;
+  },
   async listBackups(opts?: PushOptions): Promise<BackupInfo[]> {
     const accessToken = await token(opts?.interactive ?? true);
     // Trim the payload and bypass caches so the list reflects just-made changes.

--- a/src/lib/storage/sync.ts
+++ b/src/lib/storage/sync.ts
@@ -203,6 +203,13 @@ export interface SyncProvider {
    */
   pull(): Promise<PulledSnapshot | null>;
   /**
+   * Cheaply read ONLY the active backup's item eTag — a metadata request, no content download —
+   * so a foreground poll can detect a remote change before paying for a full {@link pull}. Resolves
+   * to null when no backup exists yet. Pass `{ interactive: false }` so a background poll never
+   * triggers a sign-in redirect (throws {@link InteractionRequiredError} instead).
+   */
+  peekEtag(opts?: PushOptions): Promise<string | null>;
+  /**
    * List every backup file detected in the configured folder, newest first. Resolves to an
    * empty array when the folder doesn't exist yet. Pass `{ interactive: false }` so a background /
    * on-mount refresh never triggers a sign-in redirect (throws {@link InteractionRequiredError}).

--- a/src/lib/storage/sync.ts
+++ b/src/lib/storage/sync.ts
@@ -281,6 +281,26 @@ export function mergeSnapshots(local: Snapshot, remote: Snapshot): Snapshot {
 }
 
 /**
+ * A version fingerprint of a World: each record's id paired with its effective merge stamp,
+ * order-independent. Two snapshots with the same fingerprint carry the same records at the
+ * same versions — device prefs and `exportedAt` are ignored, since they don't affect
+ * convergence of the shared data.
+ */
+function worldFingerprint(s: Snapshot): string {
+  const key = (arr: Mergeable[]) =>
+    arr
+      .map((e) => `${e.id}:${mergeStamp(e)}`)
+      .sort()
+      .join(',');
+  return `${key(s.players)}|${key(s.games)}|${key(s.rounds)}`;
+}
+
+/** Whether two Worlds hold the same records at the same versions. */
+function sameWorld(a: Snapshot, b: Snapshot): boolean {
+  return worldFingerprint(a) === worldFingerprint(b);
+}
+
+/**
  * Reconcile local and remote into one merged World and write it to both. Used when a
  * conditional push hits a {@link ConflictError}: pull the remote, merge per-entity,
  * persist the merge locally, then push it (conditional on the version we merged from).
@@ -308,6 +328,49 @@ export async function reconcile(
     }
   }
   throw lastErr instanceof Error ? lastErr : new ConflictError();
+}
+
+/** Outcome of a {@link pullMerge}: what changed locally and the eTag this device now tracks. */
+export interface PullMergeResult {
+  /** eTag of the backup this device is now aligned to (null when unknown). */
+  etag: string | null;
+  /** The local store gained records/edits from the remote — open screens should refresh. */
+  changedLocal: boolean;
+  /** This device held unique records, so the merge was written back to the cloud. */
+  pushed: boolean;
+}
+
+/**
+ * Read side of sync: pull the remote World and merge it into local WITHOUT forcing a write-back
+ * unless this device actually holds records the remote is missing. This lets a passive device
+ * (one that isn't editing) converge to other devices' changes on focus/online/connect, and it
+ * never clobbers local edits — union by id, newest-per-id wins, tombstones preserved.
+ *
+ * A pure catch-up (local carries nothing the remote lacks) adopts the remote and its eTag and
+ * does NOT push, so two idle devices don't ping-pong eTag bumps. When this device does hold
+ * unique edits, it delegates to {@link reconcile} (retry-safe) to fold both sides together.
+ *
+ * Returns `null` when no backup exists yet.
+ */
+export async function pullMerge(
+  provider: SyncProvider,
+  opts: { interactive?: boolean } = {},
+): Promise<PullMergeResult | null> {
+  const interactive = opts.interactive ?? false;
+  const pulled = await provider.pull();
+  if (!pulled) return null; // nothing backed up yet — nothing to catch up to
+  const local = await buildSnapshot();
+  const merged = mergeSnapshots(local, pulled.snapshot);
+  const changedLocal = !sameWorld(merged, local);
+  if (sameWorld(merged, pulled.snapshot)) {
+    // merged === remote ⇒ this device contributed nothing new (it was simply behind).
+    // Adopt the remote (and its version) without writing back.
+    if (changedLocal) await restoreSnapshot(merged);
+    return { etag: pulled.etag, changedLocal, pushed: false };
+  }
+  // We hold records the remote lacks — fold both sides together and push, retry-safe.
+  const res = await reconcile(provider, { interactive });
+  return { etag: res.etag, changedLocal: true, pushed: true };
 }
 
 /** Lazy-load the OneDrive provider (keeps MSAL out of the main bundle). */

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -538,7 +538,8 @@
       </label>
       <span class="muted sm">
         Backs up your edits and pulls in changes from your other devices — on open, on
-        focus, and when you reconnect. Same-record edits keep the newest; nothing is lost.
+        focus, when you reconnect, and periodically while it's open. Same-record edits keep
+        the newest; nothing is lost.
       </span>
 
       <div class="pathchip" title={locationLabel}>

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -71,14 +71,6 @@
                 : 'Not backed up yet',
   );
 
-  // Restore is paired with backup but never shows a "not yet" state: connecting
-  // already pulls the latest file down, so the local data is treated as restored.
-  const restoreText = $derived(
-    $settings.lastRestore
-      ? 'Last restored ' + relativeTime($settings.lastRestore)
-      : 'Up to date with OneDrive',
-  );
-
   let folderMode = $state($settings.oneDriveFolderMode);
   let customPath = $state($settings.oneDriveCustomPath);
 
@@ -405,7 +397,7 @@
   async function restore() {
     if (
       !confirm(
-        'Restore from OneDrive?\n\nThis overwrites the data currently on this device with the latest backup. This cannot be undone.',
+        "Replace this device with the backup?\n\nThis discards anything on this device that isn't in the backup — it does not merge. Your edits and other devices' changes normally sync automatically, so you rarely need this. Continue?",
       )
     )
       return;
@@ -430,7 +422,7 @@
       markRestored(Date.now());
       setActiveBackupEtag(pulled.etag);
       markSyncSettled();
-      showToast('Restored from OneDrive');
+      showToast('Replaced this device from the backup');
     } catch (e) {
       showToast(errMsg(e));
     } finally {
@@ -533,7 +525,7 @@
       </div>
 
       <label class="sw-row row spread">
-        <span>Automatically back up changes</span>
+        <span>Automatically sync changes</span>
         <span class="switch">
           <input
             type="checkbox"
@@ -544,6 +536,10 @@
           <span class="track"><span class="thumb"></span></span>
         </span>
       </label>
+      <span class="muted sm">
+        Backs up your edits and pulls in changes from your other devices — on open, on
+        focus, and when you reconnect. Same-record edits keep the newest; nothing is lost.
+      </span>
 
       <div class="pathchip" title={locationLabel}>
         <JsonIcon size={18} />
@@ -566,24 +562,15 @@
 
       <div class="syncrow stack" style="gap: 6px">
         <div class="row spread">
-          <span class="row" style="gap: 8px; min-width: 0">
-            <svg class="rdot" viewBox="0 0 16 16" role="img" aria-label="Restore up to date">
-              <circle cx="8" cy="8" r="8" fill="#29c785" />
-              <path
-                d="M4.5 8.3 7 10.8 11.5 5.6"
-                fill="none"
-                stroke="#04150d"
-                stroke-width="1.9"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-            <span class="sm">{restoreText}</span>
-          </span>
-          <button class="btn small ghost" onclick={restore} disabled={busy}>Restore now</button>
+          <span class="sm muted">Replace this device with a backup</span>
+          <button class="btn small ghost danger" onclick={restore} disabled={busy}>
+            Replace…
+          </button>
         </div>
         <span class="muted sm">
-          Pulls the latest backup from OneDrive and replaces the data on this device.
+          Escape hatch — a one-way overwrite that discards anything on this device that isn't
+          in the chosen backup. You rarely need this; syncing above is automatic and merges
+          both sides.
         </span>
       </div>
 


### PR DESCRIPTION
## Problem

Manual QA of the OneDrive merge (issue #21) surfaced a real architecture gap: **what shipped is push-based backup, not two-way sync.**

- `autosync.run()` only fires when this device has local edits (`dirty`). A passive device — or one you just signed in on — **never pulls**, so it never learns another device changed anything.
- The per-entity merge engine (`mergeSnapshots`/`reconcile`) is only reachable on the **push** path (a 412 conflict, or the "Merge" button). There was **no pull-side merge**.
- The only manual "get my other device's data" affordance was **"Restore now"**, a **destructive overwrite** (`replaceAll`) that silently discards un-pushed local edits.

Net: you had to manually notice you were stale and hit a button that could clobber your data.

## Fix

**`sync.ts` — `pullMerge()` (read side).** Pull remote, union-merge into local (newest-per-id wins, tombstones preserved), and **write back only when this device holds records the remote lacks**. A pure catch-up adopts the remote eTag *without* pushing, so two idle devices don't ping-pong eTag bumps. When there are unique local edits, it delegates to the existing retry-safe `reconcile()`. Adds a `sameWorld()` version fingerprint to drive that decision.

**`autosync.ts` — `catchUp()` triggers.** Runs `pullMerge` even when not `dirty`, on **focus/visibility, online, connect/enable, and app launch** (throttled to avoid focus thrash). Never starts an interactive sign-in in the background. Passive devices now converge on their own.

**`autosync.ts` + `sync.ts` — foreground eTag poll (closes the two-open-devices gap).** New `SyncProvider.peekEtag()` reads *only* the remote item eTag (a `?$select=eTag` metadata GET — no content download); OneDrive implements it cheaply. A `poll()` runs every 30s **while the tab is visible and active**, and only when the peeked eTag differs from the version this device is aligned to does it pay for a full `catchUp` (pull + merge). An unchanged eTag costs one tiny request and touches nothing (no download, no write, no ping-pong). Polling starts/stops with foreground visibility, connect/enable, and launch; a backgrounded tab doesn't poll (saves battery/quota). This is the industry-standard middle ground for sync-through-a-cloud-file — true server push isn't possible from a plain OneDrive file in a serverless PWA (Graph webhooks need a server endpoint), so an eTag-gated poll is the ceiling.

**`Settings.svelte` — de-footgun the UI.** Toggle reframed as **"Automatically sync changes"** with two-way copy (now also "periodically while it's open"); **"Restore now" demoted** to a clearly-labeled destructive escape hatch (**"Replace…"**, `ghost danger`), with reworded confirm + toast.

## Why this closes the original intent

The very first goal for this work was *"the merge should be available if someone just visited their account, as did another."* Before this PR, merge only ran on push; now a plain visit/focus pulls and merges — and two devices both left open converge within ~30s on their own.

## Verification

- `npm run check` → 0 errors / 0 warnings
- `npm run build` → clean; `onedrive` and `jsQR` stay lazy chunks, core bundle unchanged
- 25-case logic smoke-port of the merge/decision path: catch-up-no-push, in-sync idempotent, unique-local-push, concurrent two-way union, deletion tombstone propagation, same-record newest-wins, **no ping-pong on repeat catch-up**, no-backup→null, plus **poll-gate cases** proving the peek gates the pull (cheap when unchanged, pull+converge when changed, skip when no backup)

## Notes / follow-ups (not in this PR)

- Deferred "insight into what changed" (a merge diff/summary UI) is still a future item.
- Device-local settings boundary is unchanged and correct: portable prefs (theme/a11y) sync; relay URL + OneDrive/sync bookkeeping stay local.
- `files/ONEDRIVE-TEST.md` should be refreshed after this deploys to test the new behavior (passive device auto-pulls on focus; two open devices converge within ~30s; Replace is the only destructive path).