### PR TITLE
Make cloud sync converge on mobile + show a visible poll heartbeat

### DIFF
--- a/src/lib/storage/autosync.ts
+++ b/src/lib/storage/autosync.ts
@@ -1,5 +1,5 @@
 import { get, writable } from 'svelte/store';
-import { settings, markSynced, getBackupSettings, setActiveBackupEtag } from '../stores/settings';
+import { settings, markSynced, markChecked, getBackupSettings, setActiveBackupEtag } from '../stores/settings';
 import { dataVersion } from './changes';
 import { buildSnapshot, getOneDrive, reconcile, pullMerge, ConflictError, InteractionRequiredError } from './sync';
 import type { SyncProvider } from './sync';
@@ -40,6 +40,7 @@ let lastVersion = 0;
 let wasActive = false;
 let lastPortableSig: string | undefined; // JSON of the last-seen portable settings
 let lastCatchUp = 0; // last foreground pull time, to throttle focus/online bursts
+let lastRemoteCheck = 0; // last successful remote confirmation (peek or pull), for interaction-gated freshness
 let pollTimer: ReturnType<typeof setInterval> | undefined; // foreground eTag poll, when visible
 
 function enabled(): boolean {
@@ -227,6 +228,8 @@ async function catchUp(): Promise<void> {
   autoSyncStatus.set('syncing');
   try {
     const res = await pullMerge(od, { interactive: false });
+    lastRemoteCheck = Date.now();
+    markChecked(lastRemoteCheck); // heartbeat: a successful pull also confirms the remote
     if (res) {
       setActiveBackupEtag(res.etag); // track the version we're now aligned to
       if (res.changedLocal) await Promise.all([refreshPlayers(), refreshGames()]);
@@ -286,6 +289,8 @@ async function poll(): Promise<void> {
   } catch {
     return; // silent-auth or transient network failure — retry next tick
   }
+  lastRemoteCheck = Date.now();
+  markChecked(lastRemoteCheck); // heartbeat: we reached the remote, even if nothing changed
   if (remoteEtag === null) return; // nothing backed up yet — nothing to catch up to
   if (remoteEtag === get(settings).oneDriveBackupEtag) return; // already aligned — skip the pull
 
@@ -324,6 +329,30 @@ function onVisibility(): void {
     void catchUp();
     startPoll();
   }
+}
+
+/**
+ * The window regained focus or was restored from the back/forward cache (`focus`/`pageshow`).
+ * On mobile these fire when you switch back to the app even when `visibilitychange` doesn't, so we
+ * treat them like a foreground: catch up on other devices' changes and (re)arm the poll.
+ */
+function onForeground(): void {
+  if (!active()) return;
+  void catchUp();
+  startPoll();
+}
+
+/**
+ * A user interaction (tap/click/keypress) is the reliable convergence moment on mobile, where a
+ * foreground-but-idle tab's `setInterval` gets throttled or suspended. If our last remote
+ * confirmation has gone stale, cheaply re-check the eTag now — {@link poll} still gates on
+ * visibility/active and only pays for a full pull on a real change — so glancing at a device
+ * converges it without hunting for "Sync now".
+ */
+function onInteract(): void {
+  if (!active() || !isOnline()) return;
+  if (Date.now() - lastRemoteCheck < POLL_INTERVAL_MS) return; // still fresh — do nothing
+  void poll();
 }
 
 /** Wire the auto-sync controller once, at app start. Safe to call repeatedly. */
@@ -370,7 +399,11 @@ export function startAutoSync(): void {
   });
 
   window.addEventListener('online', onOnline);
+  window.addEventListener('focus', onForeground);
+  window.addEventListener('pageshow', onForeground);
   document.addEventListener('visibilitychange', onVisibility);
+  // Passive: we never preventDefault. `pointerdown` covers touch, mouse and pen in one listener.
+  document.addEventListener('pointerdown', onInteract, { passive: true });
 
   // On launch, catch up to anything other devices backed up while this one was closed, then poll
   // for further changes while this tab stays in the foreground.

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -49,6 +49,12 @@ export interface Settings {
   oneDriveConnected: boolean;
   lastSync: number | null;
   lastRestore: number | null;
+  /**
+   * When this device last successfully confirmed the remote backup's state — either a
+   * cheap eTag peek from the foreground poll or a full pull. Device-local bookkeeping (a
+   * heartbeat for the "Last checked …" indicator), never backed up.
+   */
+  lastCheck: number | null;
 
   /**
    * Per-device override for the live-play relay URL (a `wss://` origin). Empty uses the
@@ -102,6 +108,7 @@ export const LOCAL_SETTING_KEYS = [
   'oneDriveConnected',
   'lastSync',
   'lastRestore',
+  'lastCheck',
   'relayUrl',
   'leadMemberId',
 ] as const;
@@ -143,6 +150,7 @@ const defaults: Settings = {
   oneDriveConnected: false,
   lastSync: null,
   lastRestore: null,
+  lastCheck: null,
   relayUrl: '',
   leadMemberId: null,
 };
@@ -189,6 +197,14 @@ export function toggleTheme() {
 
 export function markSynced(ts: number) {
   settings.update((s) => ({ ...s, lastSync: ts }));
+}
+
+/**
+ * Record that we just confirmed the remote's state (a poll eTag peek or a pull), even when
+ * nothing changed. Drives the "Last checked …" heartbeat so the background poll is visible.
+ */
+export function markChecked(ts: number) {
+  settings.update((s) => ({ ...s, lastCheck: ts }));
 }
 
 export function markRestored(ts: number) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -85,6 +85,18 @@ export function relativeTime(ts: number): string {
   return formatDate(ts);
 }
 
+/**
+ * Like {@link relativeTime} but with seconds granularity, for fast-moving heartbeats such as the
+ * sync poll's "Last checked …" label. Pass `now` (e.g. a 1s ticker) so callers can force the label
+ * to recompute each second. Falls back to {@link relativeTime} once past a minute.
+ */
+export function relativeTimeSec(ts: number, now: number = Date.now()): string {
+  const sec = Math.max(0, Math.round((now - ts) / 1000));
+  if (sec < 3) return 'just now';
+  if (sec < 60) return `${sec}s ago`;
+  return relativeTime(ts);
+}
+
 const HANDLE_ADJECTIVES = [
   'Royal', 'Crowned', 'Sneaky', 'Lucky', 'Mighty', 'Jolly', 'Dapper', 'Cosmic',
   'Turbo', 'Wily', 'Brave', 'Cheeky', 'Noble', 'Zany', 'Swift', 'Grand',

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -20,7 +20,7 @@
   import { refreshGames } from '../lib/stores/games';
   import { refreshPlayers } from '../lib/stores/players';
   import { showToast } from '../lib/stores/toast';
-  import { relativeTime } from '../lib/util';
+  import { relativeTime, relativeTimeSec } from '../lib/util';
   import JsonIcon from '../lib/components/JsonIcon.svelte';
 
   let override = $state($settings.oneDriveClientId);
@@ -69,6 +69,18 @@
               : $settings.lastSync
                 ? 'Synced · Backed up ' + relativeTime($settings.lastSync)
                 : 'Not backed up yet',
+  );
+
+  // A 1s ticker so the "Last checked" heartbeat visibly counts up between polls (which land
+  // ~every 30s while the app is open). Cheap; runs only while this page is mounted.
+  let nowTick = $state(Date.now());
+  $effect(() => {
+    const id = setInterval(() => (nowTick = Date.now()), 1000);
+    return () => clearInterval(id);
+  });
+
+  const checkedText = $derived(
+    $settings.lastCheck ? 'Last checked ' + relativeTimeSec($settings.lastCheck, nowTick) : '',
   );
 
   let folderMode = $state($settings.oneDriveFolderMode);
@@ -560,6 +572,10 @@
           <button class="btn small primary" onclick={backup} disabled={busy}>Sync now</button>
         {/if}
       </div>
+
+      {#if $settings.autoSync && checkedText}
+        <span class="muted" style="font-size: 0.72rem; margin-top: -4px">{checkedText}</span>
+      {/if}
 
       <div class="syncrow stack" style="gap: 6px">
         <div class="row spread">


### PR DESCRIPTION
## Why

Follow-up to the two-way sync work (#28). Manual QA on a phone surfaced two real gaps:

1. **The 30s foreground eTag poll didn't converge an idle phone.** It fires reliably on desktop, but iOS/WebKit throttles or suspends `setInterval` on a foreground-but-idle tab, so two devices left open didn't catch up — only "Sync now" did.
2. **The poll was invisible.** When the eTag was unchanged (the common case) it touched nothing, so there was no way to tell whether sync was even alive — it *looked* broken even when working.

## What

- **Visible heartbeat.** Stamp a device-local `lastCheck` on every successful remote read (eTag peek *or* pull), even when nothing changed, and surface it in Settings as a live **"Last checked *N*s ago"** line (1s ticker). Now the poll is observable on any device — no DevTools. On desktop you can watch it reset every ~30s = proof it fires.
- **Reliable mobile convergence.** Add `focus` + `pageshow` triggers (these fire on mobile app-switch-back even when `visibilitychange` doesn't), plus an **interaction-gated freshness check**: a tap re-peeks the eTag when the last check has gone stale (>30s), so *glancing at* a device converges it without reaching for "Sync now". 
- All new paths stay **eTag-cheap and non-interactive** — an unchanged eTag is one small metadata request, no download, no write, no ping-pong. `poll()`'s existing guards (active/online/visible) still apply.

## Boundary (honest)

A phone left *completely untouched* in the foreground may still not tick on iOS (the OS suspends idle timers — unbeatable from a PWA). But **any** return-to-app or tap now converges it cheaply, which is the realistic flow.

## Verification

- `npm run check` → 0 errors / 0 warnings
- `npm run build` → clean; `onedrive`/`jsQR` stay lazy, core entry unchanged
- pull-merge / poll-gate smoke → **25/25**

Files: `autosync.ts` (triggers + heartbeat), `settings.ts` (`lastCheck` + `markChecked`), `util.ts` (`relativeTimeSec`), `Settings.svelte` (live line).