### PR TITLE
Share a game's results — backendless recap (link · QR · text · image)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -14,6 +14,7 @@
   import GamePlay from './pages/GamePlay.svelte';
   import LiveJoin from './pages/LiveJoin.svelte';
   import NearbyJoin from './pages/NearbyJoin.svelte';
+  import Recap from './pages/Recap.svelte';
   import NotFound from './pages/NotFound.svelte';
   import SyncBubble from './lib/components/SyncBubble.svelte';
 
@@ -79,6 +80,10 @@
     {/key}
   {:else if route.name === 'nearby'}
     <NearbyJoin />
+  {:else if route.name === 'recap'}
+    {#key current}
+      <Recap />
+    {/key}
   {:else}
     <NotFound />
   {/if}

--- a/src/lib/components/ShareResultsSheet.svelte
+++ b/src/lib/components/ShareResultsSheet.svelte
@@ -1,0 +1,317 @@
+<script lang="ts">
+  /**
+   * The "Share results" sheet for a finished game. One read-only recap, four ways to hand it
+   * off: a scannable QR, a copyable link, copyable text, and a rendered image card for group
+   * chats. Everything is encoded in the link's fragment, so nothing about the game is ever sent
+   * to a server. Reuses the live "Play together" sheet chrome so sharing feels native to the app.
+   */
+  import { onMount } from 'svelte';
+  import type { Player } from '../types';
+  import { showToast } from '../stores/toast';
+  import {
+    recapView,
+    encodeRecap,
+    recapShareUrl,
+    recapText,
+    type RecapPayload,
+    type RecapView,
+  } from '../share/recap';
+  import Scoreboard from './Scoreboard.svelte';
+
+  let { payload, onclose }: { payload: RecapPayload; onclose: () => void } = $props();
+
+  const view: RecapView = $derived(recapView(payload));
+  const previewPlayers: Player[] = $derived(
+    view.players.map((p) => ({ id: p.id, name: p.name, color: p.color, createdAt: 0 })),
+  );
+  const winnerNames = $derived(
+    view.winners
+      .map((id) => view.players.find((p) => p.id === id)?.name ?? '?')
+      .join(' & '),
+  );
+
+  const canNativeShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
+
+  let url = $state('');
+  let qr = $state('');
+  let building = $state(true);
+  let imageBusy = $state(false);
+
+  // Encode the recap into a shareable URL (async: deflate + base64url), then render its QR.
+  $effect(() => {
+    const p = payload;
+    let alive = true;
+    building = true;
+    url = '';
+    qr = '';
+    (async () => {
+      try {
+        const wire = await encodeRecap(p);
+        const link = recapShareUrl(wire);
+        if (!alive) return;
+        url = link;
+        building = false;
+        const { default: QRCode } = await import('qrcode');
+        const dataUrl = await QRCode.toDataURL(link, {
+          margin: 1,
+          width: 260,
+          errorCorrectionLevel: 'L',
+        });
+        if (alive) qr = dataUrl;
+      } catch {
+        if (alive) {
+          building = false;
+          showToast('Couldn’t prepare the share link on this device.');
+        }
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  });
+
+  async function copyLink() {
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      showToast('Link copied');
+    } catch {
+      showToast('Couldn’t copy the link');
+    }
+  }
+
+  async function copyText() {
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(recapText(view, url));
+      showToast('Results copied');
+    } catch {
+      showToast('Couldn’t copy the results');
+    }
+  }
+
+  async function shareLink() {
+    if (!url) return;
+    try {
+      await navigator.share({
+        title: 'Game results',
+        text: recapText(view, url),
+        url,
+      });
+    } catch {
+      /* user dismissed the share sheet — nothing to do */
+    }
+  }
+
+  async function shareImage() {
+    if (imageBusy) return;
+    imageBusy = true;
+    try {
+      const { renderRecapCard, recapCardFileName } = await import('../share/card');
+      const blob = await renderRecapCard(view);
+      const file = new File([blob], recapCardFileName(view), { type: 'image/png' });
+      const canShareFiles =
+        typeof navigator !== 'undefined' &&
+        typeof navigator.canShare === 'function' &&
+        navigator.canShare({ files: [file] });
+      if (canShareFiles) {
+        try {
+          await navigator.share({ files: [file], text: winnerNames ? `🏆 ${winnerNames}` : undefined });
+        } catch {
+          /* dismissed */
+        }
+      } else {
+        const href = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = href;
+        a.download = file.name;
+        a.click();
+        URL.revokeObjectURL(href);
+        showToast('Image saved');
+      }
+    } catch {
+      showToast('Couldn’t create the image on this device.');
+    } finally {
+      imageBusy = false;
+    }
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onclose();
+  }
+
+  let sheet = $state<HTMLDivElement | null>(null);
+  onMount(() => sheet?.focus());
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+<div
+  class="backdrop"
+  role="button"
+  tabindex="-1"
+  aria-label="Close"
+  onclick={onclose}
+  onkeydown={(e) => e.key === 'Enter' && onclose()}
+></div>
+
+<div class="sheet" role="dialog" aria-modal="true" aria-label="Share results" tabindex="-1" bind:this={sheet}>
+  <div class="grabber" aria-hidden="true"></div>
+
+  <div class="row spread">
+    <strong style="font-size: 1.05rem">Share results</strong>
+    <span class="pill">{view.emoji} {view.title}</span>
+  </div>
+
+  {#if winnerNames}
+    <div class="hero">🏆 {winnerNames} {view.winners.length > 1 ? 'tie!' : 'wins!'}</div>
+  {/if}
+
+  <div class="board">
+    <Scoreboard players={previewPlayers} totals={view.totals} lowerIsBetter={view.lowerIsBetter} winners={view.winners} />
+  </div>
+
+  <div class="qrwrap">
+    {#if qr}
+      <div class="qr"><img src={qr} alt="QR code linking to these results" width="200" height="200" /></div>
+      <span class="qrhint">Scan to view these results</span>
+    {:else}
+      <div class="qr placeholder" aria-hidden="true"></div>
+      <span class="qrhint">{building ? 'Preparing a shareable link…' : 'Link ready below'}</span>
+    {/if}
+  </div>
+
+  <button class="btn primary block" onclick={shareImage} disabled={imageBusy}>
+    {imageBusy ? 'Making image…' : '🖼️ Share image'}
+  </button>
+
+  <div class="row" style="gap: 10px">
+    <button class="btn grow" onclick={copyLink} disabled={!url}>🔗 Copy link</button>
+    <button class="btn grow" onclick={copyText} disabled={!url}>📋 Copy text</button>
+  </div>
+
+  {#if canNativeShare}
+    <button class="btn block" onclick={shareLink} disabled={!url}>Share link…</button>
+  {/if}
+
+  <p class="note">Read-only — this shares just this game's final scores, nothing else from your device.</p>
+
+  <button class="btn ghost block" onclick={onclose}>Done</button>
+</div>
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    border: 0;
+    width: 100%;
+    cursor: pointer;
+    background: color-mix(in srgb, var(--bg) 55%, transparent);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    animation: fade 0.16s ease-out;
+  }
+  .sheet {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 61;
+    margin: 0 auto;
+    max-width: var(--maxw);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 12px 16px calc(20px + env(safe-area-inset-bottom));
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-bottom: 0;
+    border-radius: var(--radius) var(--radius) 0 0;
+    box-shadow: var(--shadow);
+    animation: rise 0.2s ease-out;
+    max-height: 88vh;
+    overflow-y: auto;
+  }
+  .sheet:focus {
+    outline: none;
+  }
+  .grabber {
+    align-self: center;
+    width: 40px;
+    height: 4px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    margin-bottom: 2px;
+  }
+  .hero {
+    text-align: center;
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: var(--accent-ink);
+  }
+  .board {
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    padding: 6px 12px;
+  }
+  .qrwrap {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+  }
+  .qr img {
+    /* A white quiet zone is required for reliable scanning, so the QR keeps a light card in
+       both themes — the same deliberate, function-first exception the live share sheet uses. */
+    width: 200px;
+    height: 200px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    background: #fff;
+    box-shadow: var(--shadow);
+  }
+  .qr.placeholder {
+    width: 220px;
+    height: 220px;
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+  }
+  .qrhint {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .note {
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--muted);
+    line-height: 1.45;
+    text-align: center;
+  }
+  @keyframes rise {
+    from {
+      transform: translateY(12px);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+  @keyframes fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .sheet,
+    .backdrop {
+      animation: none;
+    }
+  }
+</style>

--- a/src/lib/live/signal.ts
+++ b/src/lib/live/signal.ts
@@ -14,6 +14,8 @@
  * Wire form: `sk1.<z|r>.<base64url>` — `z` = deflate-raw, `r` = uncompressed.
  */
 
+import { bytesToBase64url, base64urlToBytes, deflate, inflate } from '../share/codec';
+
 export type SignalKind = 'offer' | 'answer';
 
 /** Bumped on any breaking change to the {@link Signal} shape or framing below. */
@@ -32,51 +34,6 @@ export interface Signal {
   i: string;
   /** The SDP blob. */
   s: string;
-}
-
-// ── base64url over raw bytes (works in the browser and in Node) ──────────────────────────
-
-function bytesToBase64url(bytes: Uint8Array): string {
-  let bin = '';
-  const CHUNK = 0x8000; // chunk the spread so a big SDP can't blow the call stack
-  for (let i = 0; i < bytes.length; i += CHUNK) {
-    bin += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
-  }
-  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-function base64urlToBytes(text: string): Uint8Array {
-  const b64 = text.replace(/-/g, '+').replace(/_/g, '/');
-  const pad = b64.length % 4 === 0 ? '' : '='.repeat(4 - (b64.length % 4));
-  const bin = atob(b64 + pad);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
-}
-
-// ── deflate-raw via the Streams API, with graceful absence ───────────────────────────────
-
-async function pipeThrough(bytes: Uint8Array, stream: 'CompressionStream' | 'DecompressionStream'): Promise<Uint8Array> {
-  const Ctor = (globalThis as Record<string, unknown>)[stream] as
-    | (new (format: string) => ReadableWritablePair<Uint8Array, Uint8Array>)
-    | undefined;
-  if (!Ctor) throw new Error('no-stream');
-  const transform = new Ctor('deflate-raw');
-  const piped = new Blob([bytes as BlobPart]).stream().pipeThrough(transform as unknown as ReadableWritablePair);
-  const buf = await new Response(piped as unknown as BodyInit).arrayBuffer();
-  return new Uint8Array(buf);
-}
-
-async function deflate(bytes: Uint8Array): Promise<Uint8Array | null> {
-  try {
-    return await pipeThrough(bytes, 'CompressionStream');
-  } catch {
-    return null; // CompressionStream unavailable → caller falls back to raw
-  }
-}
-
-async function inflate(bytes: Uint8Array): Promise<Uint8Array> {
-  return pipeThrough(bytes, 'DecompressionStream');
 }
 
 // ── public codec ─────────────────────────────────────────────────────────────────────────

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -80,6 +80,7 @@ export type RouteName =
   | 'play'
   | 'join'
   | 'nearby'
+  | 'recap'
   | 'gametype'
   | 'notfound';
 
@@ -97,6 +98,7 @@ const RESERVED: Record<string, RouteName> = {
   accessibility: 'accessibility',
   gameplay: 'gameplay',
   nearby: 'nearby',
+  recap: 'recap',
 };
 
 export function parseRoute(path: string): Route {

--- a/src/lib/share/card.ts
+++ b/src/lib/share/card.ts
@@ -1,0 +1,258 @@
+/**
+ * Renders a finished game's standings to a shareable **image card** (PNG) — the "bragging
+ * rights" artifact you drop into a group chat. Standings-only on purpose: a dense
+ * round-by-round matrix doesn't read as an image, so the card stays glanceable.
+ *
+ * Drawn on an offscreen canvas with a fixed, canonical **dark-violet** palette (DESIGN.md) so
+ * the artifact looks the same regardless of the sharer's current theme, using only the system
+ * font (no web-font load). Crown Gold marks the winner and their score — nothing else. This
+ * module is imported lazily so its canvas work never touches the core bundle.
+ */
+
+import type { RecapView } from './recap';
+import { initials, textOn } from '../util';
+
+// Canonical dark palette (DESIGN.md frontmatter) — a consistent artifact, theme-independent.
+const C = {
+  bg: '#0f1020',
+  glow: '#1c1d3a',
+  surface2: '#24263f',
+  border: '#313357',
+  text: '#e9e9f4',
+  muted: '#a3a6cb',
+  accent: '#ffd166',
+  accentInk: '#ffd166',
+} as const;
+
+const FONT = "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif";
+const W = 1080;
+const PAD = 72;
+const ROW_H = 104;
+
+/** Render the recap view to a PNG blob. */
+export async function renderRecapCard(view: RecapView): Promise<Blob> {
+  const rows = view.standings;
+  // Lay out vertically, accumulating a running Y so the card height fits the content exactly.
+  let y = PAD;
+  const headerTop = y;
+  const H =
+    PAD + // top pad
+    120 + // brand + emoji block
+    100 + // title
+    50 + // date
+    96 + // winner hero
+    28 + // gap
+    rows.length * ROW_H +
+    40 + // gap
+    64 + // footer
+    PAD;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = W;
+  canvas.height = H;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Couldn’t prepare the image on this device.');
+
+  // Background: deep field with a soft violet glow toward the top (matches the app body).
+  ctx.fillStyle = C.bg;
+  ctx.fillRect(0, 0, W, H);
+  const glow = ctx.createRadialGradient(W / 2, -H * 0.08, 80, W / 2, -H * 0.08, W * 1.1);
+  glow.addColorStop(0, C.glow);
+  glow.addColorStop(1, C.bg);
+  ctx.fillStyle = glow;
+  ctx.fillRect(0, 0, W, H);
+
+  y = headerTop;
+
+  // Brand overline.
+  ctx.textBaseline = 'alphabetic';
+  ctx.textAlign = 'left';
+  ctx.fillStyle = C.muted;
+  ctx.font = `600 30px ${FONT}`;
+  ctx.fillText('👑 SCORE KING', PAD, y + 30);
+  y += 84;
+
+  // Game emoji + title + date, centered.
+  ctx.textAlign = 'center';
+  ctx.font = `88px ${FONT}`;
+  ctx.fillText(view.emoji, W / 2, y + 78);
+  y += 116;
+
+  ctx.fillStyle = C.text;
+  ctx.font = `700 62px ${FONT}`;
+  fillCentered(ctx, view.title, W / 2, y + 40, W - PAD * 2);
+  y += 82;
+
+  ctx.fillStyle = C.muted;
+  ctx.font = `400 32px ${FONT}`;
+  const date = new Date(view.finishedAt).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  ctx.fillText(date, W / 2, y + 24);
+  y += 74;
+
+  // Winner hero.
+  const byId = new Map(view.players.map((p) => [p.id, p]));
+  const winnerNames = view.winners.map((id) => byId.get(id)?.name ?? '?').join(' & ');
+  const heroText = winnerNames
+    ? `🏆 ${winnerNames} ${view.winners.length > 1 ? 'tie!' : 'wins!'}`
+    : '🏁 Final standings';
+  ctx.fillStyle = winnerNames ? C.accentInk : C.text;
+  ctx.font = `700 56px ${FONT}`;
+  fillCentered(ctx, heroText, W / 2, y + 44, W - PAD * 2);
+  y += 96 + 28;
+
+  // Standings rows.
+  ctx.textAlign = 'left';
+  for (const s of rows) {
+    const p = byId.get(s.playerId);
+    const isWinner = view.winners.includes(s.playerId);
+    const rowY = y;
+
+    if (isWinner) {
+      // Restrained Crown Gold wash + underline — the same "gold is a hint" treatment as the app.
+      ctx.fillStyle = 'rgba(255, 209, 102, 0.13)';
+      roundRect(ctx, PAD - 20, rowY, W - (PAD - 20) * 2, ROW_H - 16, 18);
+      ctx.fill();
+    }
+
+    const midY = rowY + (ROW_H - 16) / 2;
+
+    // Rank.
+    ctx.fillStyle = C.muted;
+    ctx.font = `700 34px ${FONT}`;
+    ctx.textAlign = 'center';
+    ctx.fillText(String(s.rank), PAD + 6, midY + 12);
+
+    // Avatar chip.
+    const avX = PAD + 62;
+    const avR = 32;
+    if (p) {
+      ctx.beginPath();
+      ctx.arc(avX + avR, midY, avR, 0, Math.PI * 2);
+      ctx.fillStyle = p.color;
+      ctx.fill();
+      ctx.fillStyle = textOn(p.color);
+      ctx.font = `700 30px ${FONT}`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(initials(p.name), avX + avR, midY + 1);
+      ctx.textBaseline = 'alphabetic';
+    }
+
+    // Name (+ trophy for the winner).
+    const nameX = avX + avR * 2 + 24;
+    const scoreX = W - PAD;
+    ctx.textAlign = 'left';
+    ctx.fillStyle = C.text;
+    ctx.font = `600 40px ${FONT}`;
+    const label = isWinner ? `${p?.name ?? '?'}  🏆` : (p?.name ?? '?');
+    const scoreStr = String(s.total);
+    ctx.font = `700 46px ${FONT}`;
+    const scoreW = ctx.measureText(scoreStr).width;
+    ctx.font = `600 40px ${FONT}`;
+    const maxNameW = scoreX - nameX - scoreW - 32;
+    fillTruncated(ctx, label, nameX, midY + 14, maxNameW);
+
+    // Score (Crown Gold for the winner, per the Crown Gold rule).
+    ctx.textAlign = 'right';
+    ctx.fillStyle = isWinner ? C.accentInk : C.text;
+    ctx.font = `700 46px ${FONT}`;
+    ctx.fillText(scoreStr, scoreX, midY + 16);
+
+    y += ROW_H;
+  }
+
+  y += 40;
+
+  // Footer.
+  ctx.textAlign = 'center';
+  ctx.fillStyle = C.muted;
+  ctx.font = `500 30px ${FONT}`;
+  ctx.fillText('score.jrmoulckers.com', W / 2, y + 24);
+
+  return await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error('Couldn’t create the image on this device.'))),
+      'image/png',
+    );
+  });
+}
+
+/** A short, safe file name for the shared card. */
+export function recapCardFileName(view: RecapView): string {
+  const slug = view.title.replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '').toLowerCase();
+  return `score-king-${slug || 'results'}.png`;
+}
+
+// ── canvas helpers ───────────────────────────────────────────────────────────────────────
+
+/** Draw text centered at x, shrinking the font until it fits `maxW`. */
+function fillCentered(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  baselineY: number,
+  maxW: number,
+): void {
+  const base = parseFontSize(ctx.font);
+  let size = base;
+  while (size > 24 && measure(ctx, text, size) > maxW) size -= 2;
+  const family = ctx.font.replace(/^[^ ]* \d+px /, '');
+  const weight = ctx.font.split(' ')[0];
+  ctx.font = `${weight} ${size}px ${family}`;
+  ctx.fillText(text, x, baselineY);
+  ctx.font = `${weight} ${base}px ${family}`;
+}
+
+/** Draw left-aligned text, truncating with an ellipsis so it never exceeds `maxW`. */
+function fillTruncated(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  baselineY: number,
+  maxW: number,
+): void {
+  if (ctx.measureText(text).width <= maxW) {
+    ctx.fillText(text, x, baselineY);
+    return;
+  }
+  let t = text;
+  while (t.length > 1 && ctx.measureText(t + '…').width > maxW) t = t.slice(0, -1);
+  ctx.fillText(t + '…', x, baselineY);
+}
+
+function measure(ctx: CanvasRenderingContext2D, text: string, size: number): number {
+  const family = ctx.font.replace(/^[^ ]* \d+px /, '');
+  const weight = ctx.font.split(' ')[0];
+  const prev = ctx.font;
+  ctx.font = `${weight} ${size}px ${family}`;
+  const w = ctx.measureText(text).width;
+  ctx.font = prev;
+  return w;
+}
+
+function parseFontSize(font: string): number {
+  const m = font.match(/(\d+)px/);
+  return m ? Number(m[1]) : 40;
+}
+
+function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): void {
+  const rr = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + rr, y);
+  ctx.arcTo(x + w, y, x + w, y + h, rr);
+  ctx.arcTo(x + w, y + h, x, y + h, rr);
+  ctx.arcTo(x, y + h, x, y, rr);
+  ctx.arcTo(x, y, x + w, y, rr);
+  ctx.closePath();
+}

--- a/src/lib/share/codec.ts
+++ b/src/lib/share/codec.ts
@@ -1,0 +1,61 @@
+/**
+ * Framework-free primitives for turning a small JSON blob into a compact, paste- and
+ * QR-safe string: **base64url** over raw bytes, plus optional **deflate-raw** compression
+ * via the Streams API (with graceful absence on browsers that lack `CompressionStream`).
+ *
+ * Extracted from the nearby-play handshake codec ({@link ../live/signal}) so the live
+ * handshake and the game-recap share codec ({@link ./recap}) share one battle-tested
+ * implementation. This module is pure and side-effect free.
+ */
+
+// ── base64url over raw bytes (works in the browser and in Node) ──────────────────────────
+
+export function bytesToBase64url(bytes: Uint8Array): string {
+  let bin = '';
+  const CHUNK = 0x8000; // chunk the spread so a big payload can't blow the call stack
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function base64urlToBytes(text: string): Uint8Array {
+  const b64 = text.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = b64.length % 4 === 0 ? '' : '='.repeat(4 - (b64.length % 4));
+  const bin = atob(b64 + pad);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+// ── deflate-raw via the Streams API, with graceful absence ───────────────────────────────
+
+async function pipeThrough(
+  bytes: Uint8Array,
+  stream: 'CompressionStream' | 'DecompressionStream',
+): Promise<Uint8Array> {
+  const Ctor = (globalThis as Record<string, unknown>)[stream] as
+    | (new (format: string) => ReadableWritablePair<Uint8Array, Uint8Array>)
+    | undefined;
+  if (!Ctor) throw new Error('no-stream');
+  const transform = new Ctor('deflate-raw');
+  const piped = new Blob([bytes as BlobPart])
+    .stream()
+    .pipeThrough(transform as unknown as ReadableWritablePair);
+  const buf = await new Response(piped as unknown as BodyInit).arrayBuffer();
+  return new Uint8Array(buf);
+}
+
+/** Deflate-raw the bytes, or return null when `CompressionStream` is unavailable. */
+export async function deflate(bytes: Uint8Array): Promise<Uint8Array | null> {
+  try {
+    return await pipeThrough(bytes, 'CompressionStream');
+  } catch {
+    return null; // CompressionStream unavailable → caller falls back to raw
+  }
+}
+
+/** Inverse of {@link deflate}. Throws when the bytes aren't valid deflate-raw. */
+export async function inflate(bytes: Uint8Array): Promise<Uint8Array> {
+  return pipeThrough(bytes, 'DecompressionStream');
+}

--- a/src/lib/share/recap.ts
+++ b/src/lib/share/recap.ts
@@ -1,0 +1,213 @@
+/**
+ * Codec + view model for **sharing one game's results** — a read-only recap of final
+ * standings and the round-by-round scorecard. The whole snapshot is self-contained and
+ * carried in a URL **fragment** (never sent to the server), so a friend can open the link,
+ * scan the QR, or read the copied text and see the outcome without any backend, account, or
+ * access to the sharer's wider World.
+ *
+ * The payload is JSON, `deflate`-compressed then base64url-encoded (reusing the same
+ * primitives as the nearby-play handshake, see {@link ./codec}). It is deliberately compact
+ * and **index-based**: players are a positional list and rounds/winners reference them by
+ * index, so no stable member ids ever leave the device. Totals are derived from the rounds.
+ *
+ * Wire form: `skr1.<z|r>.<base64url>` — `z` = deflate-raw, `r` = uncompressed.
+ */
+
+import type { Game, ID, Player } from '../types';
+import { resolveLower } from '../types';
+import { getModule } from '../games/registry';
+import { standings, type Standing } from '../scoring';
+import { absoluteUrl } from '../router';
+import { bytesToBase64url, base64urlToBytes, deflate, inflate } from './codec';
+
+/** Bumped on any breaking change to {@link RecapPayload} or the framing below. */
+export const RECAP_VERSION = 1;
+
+const HEADER = `skr${RECAP_VERSION}`;
+
+/** The app-relative route that renders a shared recap. */
+export const RECAP_PATH = '/recap';
+
+/**
+ * The compact, self-contained snapshot of a finished game's results. Keys are terse to keep
+ * the encoded string short; everything is positional so no member ids are shared.
+ */
+export interface RecapPayload {
+  /** Format version — must equal {@link RECAP_VERSION}. */
+  v: number;
+  /** Game module id (e.g. 'skullking'), used to resolve emoji / name / win direction. */
+  t: string;
+  /** Optional custom game label. */
+  n?: string;
+  /** Game config — drives lower-is-better resolution (and any future display). */
+  cfg?: Record<string, unknown>;
+  /** Finished-at time (ms epoch). */
+  f: number;
+  /** Players as `[name, color]`, index-aligned with {@link r} columns and {@link w}. */
+  p: [name: string, color: string][];
+  /** Winner indices into {@link p} (the exact recorded outcome). */
+  w: number[];
+  /** Rounds: each is per-player deltas aligned to {@link p} (missing entries default to 0). */
+  r: number[][];
+}
+
+/** Build a shareable payload from a finished game and its ordered players + rounds. */
+export function buildRecapPayload(
+  game: Game,
+  orderedPlayers: Player[],
+  rounds: { index: number; deltas: Record<ID, number> }[],
+  opts: { name?: string } = {},
+): RecapPayload {
+  const idIndex = new Map(orderedPlayers.map((p, i) => [p.id, i]));
+  const ordered = [...rounds].sort((a, b) => a.index - b.index);
+  return {
+    v: RECAP_VERSION,
+    t: game.type,
+    n: opts.name ?? game.name,
+    cfg: game.config,
+    f: game.finishedAt ?? Date.now(),
+    p: orderedPlayers.map((p) => [p.name, p.color] as [string, string]),
+    w: (game.winnerIds ?? [])
+      .map((id) => idIndex.get(id))
+      .filter((i): i is number => i != null),
+    r: ordered.map((round) => orderedPlayers.map((p) => round.deltas[p.id] ?? 0)),
+  };
+}
+
+/** Encode a payload to its compact wire string (`skr1.z.…` deflated, or `skr1.r.…` raw). */
+export async function encodeRecap(payload: RecapPayload): Promise<string> {
+  const json = JSON.stringify({ ...payload, v: RECAP_VERSION } satisfies RecapPayload);
+  const raw = new TextEncoder().encode(json);
+  const packed = await deflate(raw);
+  if (packed && packed.length < raw.length) {
+    return `${HEADER}.z.${bytesToBase64url(packed)}`;
+  }
+  return `${HEADER}.r.${bytesToBase64url(raw)}`;
+}
+
+/** Decode a wire string back to a {@link RecapPayload}. Throws a friendly Error on bad input. */
+export async function decodeRecap(text: string): Promise<RecapPayload> {
+  const trimmed = (text ?? '').trim().replace(/^#/, '');
+  const parts = trimmed.split('.');
+  if (parts.length !== 3 || parts[0] !== HEADER || (parts[1] !== 'z' && parts[1] !== 'r')) {
+    throw new Error('That doesn’t look like a Score King results link.');
+  }
+  let bytes: Uint8Array;
+  try {
+    bytes = base64urlToBytes(parts[2]);
+    if (parts[1] === 'z') bytes = await inflate(bytes);
+  } catch {
+    throw new Error('This results link looks corrupted — ask for a fresh one.');
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    throw new Error('This results link looks corrupted — ask for a fresh one.');
+  }
+  if (!isRecapPayload(parsed)) {
+    throw new Error('This results link is from a different app version — ask for a fresh one.');
+  }
+  return parsed;
+}
+
+function isRecapPayload(x: unknown): x is RecapPayload {
+  if (!x || typeof x !== 'object') return false;
+  const o = x as Record<string, unknown>;
+  return (
+    o.v === RECAP_VERSION &&
+    typeof o.t === 'string' &&
+    typeof o.f === 'number' &&
+    Array.isArray(o.p) &&
+    o.p.every((e) => Array.isArray(e) && typeof e[0] === 'string' && typeof e[1] === 'string') &&
+    Array.isArray(o.w) &&
+    o.w.every((i) => typeof i === 'number') &&
+    Array.isArray(o.r) &&
+    o.r.every((row) => Array.isArray(row) && (row as unknown[]).every((n) => typeof n === 'number'))
+  );
+}
+
+/** Build an absolute, shareable URL that carries the recap in its fragment. */
+export function recapShareUrl(wire: string): string {
+  return `${absoluteUrl(RECAP_PATH)}#${wire}`;
+}
+
+// ── Derived view model (shared by the recap page and the image card) ─────────────────────
+
+export interface RecapView {
+  type: string;
+  name?: string;
+  /** Module emoji, or a die fallback for an unknown/removed game type. */
+  emoji: string;
+  /** Module display name, or the raw type id as a fallback. */
+  title: string;
+  finishedAt: number;
+  /** Synthesized players — `id` is the positional index as a string (read-only artifact). */
+  players: { id: string; name: string; color: string }[];
+  totals: Record<string, number>;
+  winners: string[];
+  lowerIsBetter: boolean;
+  standings: Standing[];
+  /** Round-by-round per-player deltas, aligned to {@link players} order. */
+  rounds: number[][];
+}
+
+/**
+ * Expand a payload into a ready-to-render view: synthesized players (positional ids),
+ * derived totals + standings, resolved win direction, and winner ids. Falls back to the
+ * rank-1 finishers when a payload carries no explicit winners.
+ */
+export function recapView(payload: RecapPayload): RecapView {
+  const module = getModule(payload.t);
+  const players = payload.p.map(([name, color], i) => ({ id: String(i), name, color }));
+  const totals: Record<string, number> = {};
+  players.forEach((p) => (totals[p.id] = 0));
+  for (const row of payload.r) {
+    row.forEach((delta, i) => {
+      const id = String(i);
+      if (id in totals) totals[id] += delta || 0;
+    });
+  }
+  const lowerIsBetter = module ? resolveLower(module, payload.cfg ?? {}) : false;
+  const ranked = standings(totals, lowerIsBetter);
+  const explicit = payload.w.map((i) => String(i)).filter((id) => id in totals);
+  const winners = explicit.length
+    ? explicit
+    : ranked.filter((s) => s.rank === 1).map((s) => s.playerId);
+  return {
+    type: payload.t,
+    name: payload.n,
+    emoji: module?.emoji ?? '🎲',
+    title: payload.n || module?.name || payload.t,
+    finishedAt: payload.f,
+    players,
+    totals,
+    winners,
+    lowerIsBetter,
+    standings: ranked,
+    rounds: payload.r,
+  };
+}
+
+/** A plain-text recap suitable for pasting into a chat, ending with the share link. */
+export function recapText(view: RecapView, url: string): string {
+  const date = new Date(view.finishedAt).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  const byId = new Map(view.players.map((p) => [p.id, p]));
+  const lines = view.standings.map((s) => {
+    const name = byId.get(s.playerId)?.name ?? '?';
+    const crown = view.winners.includes(s.playerId) ? ' 🏆' : '';
+    return `${s.rank}. ${name} — ${s.total}${crown}`;
+  });
+  const winnerNames = view.winners.map((id) => byId.get(id)?.name ?? '?').join(' & ');
+  const header = `${view.emoji} ${view.title} — ${date}`;
+  const crownLine = winnerNames
+    ? `🏆 ${winnerNames} ${view.winners.length > 1 ? 'tie!' : 'wins!'}`
+    : '';
+  return [header, crownLine, '', ...lines, '', `Scored with Score King 👑 ${url}`]
+    .filter((l) => l !== null)
+    .join('\n');
+}

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -26,6 +26,8 @@
   import Scoreboard from '../lib/components/Scoreboard.svelte';
   import Avatar from '../lib/components/Avatar.svelte';
   import PlaySheet from '../lib/components/PlaySheet.svelte';
+  import ShareResultsSheet from '../lib/components/ShareResultsSheet.svelte';
+  import { buildRecapPayload } from '../lib/share/recap';
   import { get } from 'svelte/store';
   import {
     startHosting,
@@ -259,6 +261,12 @@
     (game?.winnerIds ?? []).map((wid) => plist.find((p) => p.id === wid)?.name ?? '?').join(' & '),
   );
 
+  // ── Share results (read-only recap) ────────────────────────────────────
+  let shareOpen = $state(false);
+  const sharePayload = $derived(
+    game && game.status === 'finished' ? buildRecapPayload(game, orderedPlayers, rounds) : null,
+  );
+
   // ── Live co-play (host-authoritative) ──────────────────────────────────
   // The leader keeps using this very screen; the engine just mirrors the game
   // to guests and feeds their round proposals back through the same store flow.
@@ -441,7 +449,10 @@
 
   {#if game.status === 'finished'}
     <div class="card center banner">🏆 {winnerNames || 'Nobody'} {(game.winnerIds?.length ?? 0) > 1 ? 'tie!' : 'wins!'}</div>
-    <div class="row" style="gap: 10px; margin-top: 12px">
+    <button class="btn block" style="margin-top: 12px" onclick={() => (shareOpen = true)}>
+      📤 Share results
+    </button>
+    <div class="row" style="gap: 10px; margin-top: 10px">
       <button class="btn" onclick={doReopen} title="Reopen to add more rounds">Reopen</button>
       <button class="btn primary grow" onclick={playAgain}>Play again</button>
     </div>
@@ -546,6 +557,10 @@
       onswitch={switchMode}
     />
   {/key}
+{/if}
+
+{#if shareOpen && sharePayload}
+  <ShareResultsSheet payload={sharePayload} onclose={() => (shareOpen = false)} />
 {/if}
 
 <style>

--- a/src/pages/Recap.svelte
+++ b/src/pages/Recap.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+  /**
+   * Read-only recap of a shared game's results at /recap. The whole game is carried in the URL
+   * fragment (never sent to a server), decoded fully on-device, and rendered as final standings
+   * plus the round-by-round scorecard. Nothing is written to this device's World — it only shows
+   * the outcome, then invites the viewer to keep score of their own.
+   */
+  import { onMount } from 'svelte';
+  import { link } from '../lib/router';
+  import { formatDate } from '../lib/util';
+  import { decodeRecap, recapView, type RecapView } from '../lib/share/recap';
+  import Scoreboard from '../lib/components/Scoreboard.svelte';
+  import Avatar from '../lib/components/Avatar.svelte';
+  import type { Player } from '../lib/types';
+
+  let status = $state<'loading' | 'ok' | 'error'>('loading');
+  let errorMsg = $state('');
+  let view = $state<RecapView | null>(null);
+
+  const players = $derived<Player[]>(
+    view ? view.players.map((p) => ({ id: p.id, name: p.name, color: p.color, createdAt: 0 })) : [],
+  );
+  const winnerNames = $derived(
+    view
+      ? view.winners.map((id) => view!.players.find((p) => p.id === id)?.name ?? '?').join(' & ')
+      : '',
+  );
+
+  async function decodeFromHash() {
+    status = 'loading';
+    const wire = window.location.hash.replace(/^#/, '').trim();
+    if (!wire) {
+      status = 'error';
+      errorMsg = 'This link doesn’t have any results in it.';
+      return;
+    }
+    try {
+      const payload = await decodeRecap(wire);
+      view = recapView(payload);
+      status = 'ok';
+    } catch (e) {
+      status = 'error';
+      errorMsg = e instanceof Error ? e.message : 'This results link couldn’t be read.';
+    }
+  }
+
+  function fmt(d: number): string {
+    return d > 0 ? `+${d}` : `${d}`;
+  }
+
+  onMount(() => {
+    decodeFromHash();
+    const onHash = () => decodeFromHash();
+    window.addEventListener('hashchange', onHash);
+    return () => window.removeEventListener('hashchange', onHash);
+  });
+</script>
+
+{#if status === 'loading'}
+  <div class="skeleton" aria-busy="true" aria-label="Loading results">
+    <div class="sk" style="height: 56px"></div>
+    <div class="sk" style="height: 184px"></div>
+    <div class="sk" style="height: 150px"></div>
+  </div>
+{:else if status === 'error' || !view}
+  <div class="empty">
+    <h2>Nothing to show</h2>
+    <p class="muted">{errorMsg}</p>
+    <a class="btn primary" href="/" use:link>Go to Score King</a>
+  </div>
+{:else}
+  <div class="row" style="gap: 10px; margin: 10px 4px 6px">
+    <span style="font-size: 1.7rem">{view.emoji}</span>
+    <span>
+      <div><strong>{view.title}</strong></div>
+      <div class="muted" style="font-size: 0.8rem">Final results · {formatDate(view.finishedAt)}</div>
+    </span>
+  </div>
+
+  {#if winnerNames}
+    <div class="card center banner">🏆 {winnerNames} {view.winners.length > 1 ? 'tie!' : 'wins!'}</div>
+  {/if}
+
+  <Scoreboard {players} totals={view.totals} lowerIsBetter={view.lowerIsBetter} winners={view.winners} />
+
+  {#if view.rounds.length}
+    <div class="section-title">Scorecard</div>
+    <div class="scroll">
+      <table class="matrix">
+        <thead>
+          <tr>
+            <th scope="col">Rd</th>
+            {#each view.players as p (p.id)}
+              <th scope="col"><Avatar name={p.name} color={p.color} size={22} /></th>
+            {/each}
+          </tr>
+        </thead>
+        <tbody>
+          {#each view.rounds as row, i (i)}
+            <tr>
+              <td>{i + 1}</td>
+              {#each view.players as _p, j (j)}
+                <td class="num">{fmt(row[j] ?? 0)}</td>
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td>Σ</td>
+            {#each view.players as p (p.id)}
+              <td class="num tot">{view.totals[p.id] ?? 0}</td>
+            {/each}
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  {/if}
+
+  <div class="cta card center stack">
+    <span class="muted">Made with Score King 👑</span>
+    <a class="btn primary block" href="/" use:link>Keep score of your own game</a>
+  </div>
+{/if}
+
+<style>
+  .banner {
+    font-weight: 700;
+    color: var(--accent-ink);
+    background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+    border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+    margin-top: 10px;
+  }
+  .scroll {
+    overflow-x: auto;
+  }
+  .matrix {
+    width: 100%;
+    border-collapse: collapse;
+    font-variant-numeric: tabular-nums;
+  }
+  .matrix th,
+  .matrix td {
+    padding: 8px 10px;
+    text-align: center;
+    border-bottom: 1px solid var(--border);
+  }
+  .matrix .num {
+    font-weight: 700;
+  }
+  .matrix tfoot .tot {
+    font-weight: 800;
+  }
+  .cta {
+    margin-top: 16px;
+    gap: 10px;
+  }
+</style>


### PR DESCRIPTION
## What & why

Adds the first way to share **one** game in Score King. Until now "sharing" was only live co-play or a whole-World backup (everything at once). This adds a polished, **backendless** way to share **a finished game's results** — a read-only recap of final standings + the round-by-round scorecard — as a **link, QR, copyable text, or image card**, with a working read-only **view** side. Fully offline-capable and on-brand.

Scope of this slice (session 4 of the game-management overhaul): **results recap only**. Sharing a game *setup/preset* is deferred — it needs the encoded format co-designed with the custom-game-types and catalog sessions, so it shouldn't be finalized here.

## Privacy & hosting (the important part)

The entire game snapshot is encoded in the URL **fragment** (`/recap#skr1.…`). A fragment is **never sent to GitHub Pages, any server, or logs** — the cleanest fit for the privacy contract. The recap carries only *this* game's names + colors + scores: **no member ids, no other games, no World data**. It's read-only — opening a recap **writes nothing** to the viewer's device.

Because the `spa404` copy serves `/recap` **without a redirect** and the PWA `navigateFallback` serves the shell offline, the `#fragment` survives both online and offline.

## How it's built (reuses existing seams)

- **`src/lib/share/codec.ts`** — extracted the base64url + `deflate`/`inflate` primitives out of `live/signal.ts` so the live handshake and the recap share one implementation. **`signal.ts`'s public API and wire format are unchanged** (only `session.ts`/`webrtc.ts` import it).
- **`src/lib/share/recap.ts`** — versioned, index-based `RecapPayload`, `encodeRecap`/`decodeRecap` (wire `skr1.<z|r>.<base64url>`, mirroring `signal.ts`), and a derived view model shared by the page and the card. Totals derive from rounds; win direction resolves from the game module + config.
- **`src/lib/share/card.ts`** — lazy-loaded offscreen-canvas → PNG on a fixed canonical **dark-violet** palette (a consistent bragging artifact regardless of the sharer's theme), standings-only, system font only. `navigator.share({files})` with a download fallback.
- **`src/lib/components/ShareResultsSheet.svelte`** — bottom sheet reusing the live "Play together" sheet chrome (grabber, backdrop, rise, reduced-motion). Mini Scoreboard preview, lazy QR of the share URL at EC `'L'`, and **Copy link · Copy text · Share… (native) · Share image**.
- **`src/pages/Recap.svelte`** at `/recap` — decodes the hash fully on-device; renders the winner hero, the reused `Scoreboard`, the round-by-round matrix, and a quiet "keep score" CTA. Handles loading / error / ok and `hashchange`.
- Route wiring in `router.ts` (`RouteName` + `RESERVED`) and `App.svelte`.

**Entry point:** a full-width `📤 Share results` **default** button in `GamePlay`'s finished state — **Play again stays the sole Royal Violet primary**.

## Design (DESIGN.md)

- Exactly **one Royal Violet primary** per surface (sheet → *Share image*; recap → *Keep score*; GamePlay unchanged).
- **Crown Gold = winner only**, in the view and the card.
- `tabular-nums` on every changing number; touch targets ≥46px; never color-alone (rank #, 🏆, initials all co-signal); honors `prefers-reduced-motion`; identical chrome reused, not restyled. QR keeps a white quiet-zone card — the same deliberate, function-first exception the live share sheet already uses.

## Validation

- `npm run check` (svelte-check + tsc): **0 errors, 0 warnings**.
- `npm run build`: **green**; the image card lands in its own lazy `card-*.js` chunk (≈3.5 kB).
- Codec round-trip verified out-of-band: a dense 4-player / 10-round game compresses to a **~370-char URL** — very comfortable for a dim-light QR at EC `'L'` — round-trips identically, derives correct totals, and rejects malformed links.

## Coordination

The recap format is **self-contained and read-only**, so it touches **no shared model** and needs no alignment with the catalog / custom-game sessions (flagged to the coordinator separately). A per-game share action in **History** is intentionally **deferred to the History-owning session** to avoid conflicting edits — the reusable `ShareResultsSheet` drops straight in once placement is confirmed there.

## Try it

Finish a game → **📤 Share results** → Copy link / show QR / copy text / share image → open the link (works offline) to see the read-only recap.