### PR TITLE
Turn History into a searchable, organized game library

### DIFF
--- a/src/lib/stores/crews.ts
+++ b/src/lib/stores/crews.ts
@@ -1,0 +1,63 @@
+import { writable } from 'svelte/store';
+
+/**
+ * Crew nicknames — a device-local nicety, not part of the synced World.
+ *
+ * A "crew" is derived from who was at the table: every game sharing the same set of
+ * players belongs to the same crew, keyed by a stable {@link crewSignature}. The optional
+ * nickname a player gives that crew ("The Regulars") is cosmetic, so for v1 it lives in
+ * localStorage rather than the synced World — keeping this change fully additive (no DB
+ * migration, no touch to the shared sync surface). Upgrade path: promote to a synced entity
+ * with `updatedAt` + tombstone once the model settles.
+ */
+
+const KEY = 'sk_crews';
+
+/**
+ * Stable, order-independent id for a line-up: the player ids sorted and joined. Two games
+ * with the same players collapse to the same signature regardless of seating order.
+ */
+export function crewSignature(playerIds: string[]): string {
+  return [...playerIds].sort().join(',');
+}
+
+function load(): Record<string, string> {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(KEY) || '{}');
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Map of crew signature → nickname. Absent/empty means "no nickname" (show the names). */
+export const crewNames = writable<Record<string, string>>(load());
+
+crewNames.subscribe((v) => {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(v));
+  } catch {
+    // Best-effort: a full/blocked storage quota shouldn't break the library view.
+  }
+});
+
+/** Name (or rename) a crew. An empty/blank name clears any existing nickname. */
+export function setCrewName(signature: string, name: string): void {
+  const trimmed = name.trim();
+  crewNames.update((m) => {
+    const next = { ...m };
+    if (trimmed) next[signature] = trimmed;
+    else delete next[signature];
+    return next;
+  });
+}
+
+/** Forget a crew's nickname (revert its header to the player names). */
+export function clearCrewName(signature: string): void {
+  crewNames.update((m) => {
+    if (!(signature in m)) return m;
+    const next = { ...m };
+    delete next[signature];
+    return next;
+  });
+}

--- a/src/lib/stores/crews.ts
+++ b/src/lib/stores/crews.ts
@@ -4,11 +4,25 @@ import { writable } from 'svelte/store';
  * Crew nicknames — a device-local nicety, not part of the synced World.
  *
  * A "crew" is derived from who was at the table: every game sharing the same set of
- * players belongs to the same crew, keyed by a stable {@link crewSignature}. The optional
- * nickname a player gives that crew ("The Regulars") is cosmetic, so for v1 it lives in
- * localStorage rather than the synced World — keeping this change fully additive (no DB
- * migration, no touch to the shared sync surface). Upgrade path: promote to a synced entity
- * with `updatedAt` + tombstone once the model settles.
+ * players belongs to the same crew, keyed by a stable {@link crewSignature}. Because the
+ * signature comes from the game's (synced) `playerIds`, the *grouping itself* reappears on
+ * any device and after any restore — only the optional nickname a player gives that crew
+ * ("The Regulars") is cosmetic.
+ *
+ * Deliberate v1 decision (device-local, explicitly not accidental): that nickname lives in
+ * this device's localStorage, NOT in the synced World or the portable backup. Consequence,
+ * stated plainly: a renamed crew's label does NOT come back after a backup/restore and does
+ * NOT appear on a group's other devices — it degrades gracefully to the players' names.
+ * The grouping still works everywhere; only the custom label is per-device. Chosen for v1
+ * because it is fully additive (no DB migration, no touch to the shared sync surface) and it
+ * avoids committing to cross-device merge semantics for a cosmetic field mid-overhaul.
+ *
+ * Two upgrade paths when we want the label to travel (a product call, deferred to the PO):
+ *   1. Light — fold `crewNames` into portable settings (`BackupSettings`) so it rides the
+ *      existing backup envelope. Caveat: settings restore is whole-map last-writer-wins, so
+ *      concurrent renames on two devices would clobber rather than merge.
+ *   2. Full — promote a Crew to a first-class synced World entity with `updatedAt` +
+ *      tombstone, giving true per-entity LWW merge (needs a new object store / DB version).
  */
 
 const KEY = 'sk_crews';

--- a/src/lib/stores/games.ts
+++ b/src/lib/stores/games.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { writable, derived } from 'svelte/store';
 import type { Game, ID, Round } from '../types';
 import { defaultWinners } from '../types';
 import * as db from '../storage/db';
@@ -7,6 +7,9 @@ import { getModule } from '../games/registry';
 import { computeTotals } from '../scoring';
 
 export const games = writable<Game[]>([]);
+
+/** Games shown in the library's main list + on Home: everything not user-archived. */
+export const activeGames = derived(games, ($games) => $games.filter((g) => !g.archived));
 
 export async function refreshGames(): Promise<void> {
   games.set(await db.getAllGames());
@@ -117,6 +120,18 @@ export async function reopenGame(game: Game): Promise<Game> {
 
 export async function removeGame(id: ID): Promise<void> {
   await db.deleteGame(id);
+  await refreshGames();
+}
+
+/** Hide a game from the library's main list + Home, recoverably (kept in Stats). */
+export async function archiveGame(game: Game): Promise<void> {
+  await db.putGame({ ...game, archived: true, archivedAt: Date.now() });
+  await refreshGames();
+}
+
+/** Bring an archived game back into the main list (undo of {@link archiveGame}). */
+export async function unarchiveGame(game: Game): Promise<void> {
+  await db.putGame({ ...game, archived: false, archivedAt: undefined });
   await refreshGames();
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,6 +46,13 @@ export interface Game {
   finishedAt?: number;
   winnerIds?: ID[];
   roundCount: number;
+  /**
+   * User archive: hidden from the History library's main list and from Home, kept
+   * in Stats and fully recoverable. Distinct from {@link deleted} (a hard-delete
+   * sync tombstone) — an archived game is still present. Mirrors {@link Player.archived}.
+   */
+  archived?: boolean;
+  archivedAt?: number;
   /** Last local mutation time — drives per-entity merge (Phase 2). */
   updatedAt?: number;
   /** Sync tombstone: deletion time, retained so the delete propagates on merge. */

--- a/src/pages/GameType.svelte
+++ b/src/pages/GameType.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getModule } from '../lib/games/registry';
   import { defaultConfig } from '../lib/types';
-  import { games, createGame } from '../lib/stores/games';
+  import { games, activeGames, createGame } from '../lib/stores/games';
   import { customGameDefs, saveCustomGame, removeCustomGame, restoreCustomGame } from '../lib/stores/customGames';
   import { isCustomType, duplicateDef } from '../lib/games/custom/types';
   import { getCustomDef } from '../lib/games/custom/defRegistry';
@@ -31,7 +31,7 @@
   });
 
   const activeOfType = $derived(
-    $games.filter((g) => g.status === 'active' && g.type === type),
+    $activeGames.filter((g) => g.status === 'active' && g.type === type),
   );
 
   async function start() {

--- a/src/pages/History.svelte
+++ b/src/pages/History.svelte
@@ -16,7 +16,9 @@
   import { crewSignature, crewNames, setCrewName } from '../lib/stores/crews';
   import Avatar from '../lib/components/Avatar.svelte';
   import Segmented from '../lib/components/Segmented.svelte';
-  import type { Game } from '../lib/types';
+  import type { Game, Player } from '../lib/types';
+  import ShareResultsSheet from '../lib/components/ShareResultsSheet.svelte';
+  import { buildRecapPayload, type RecapPayload } from '../lib/share/recap';
 
   /** Below this many games, the list is glanceable on its own — no controls shown. */
   const CONTROLS_MIN = 6;
@@ -55,6 +57,7 @@
   let showArchived = $state(false);
   let editingCrew = $state<string | null>(null);
   let crewDraft = $state('');
+  let sharePayload = $state<RecapPayload | null>(null);
 
   const playerMap = $derived(new Map($players.map((p) => [p.id, p] as const)));
   const archivedGames = $derived($games.filter((g) => g.archived));
@@ -186,6 +189,21 @@
     });
   }
 
+  /**
+   * Build a share recap on tap (never eager per-row). Rounds load async; players are
+   * ordered by the game's own playerIds through the roster map (which includes archived
+   * members). A hard-deleted member gets a positional placeholder that REUSES the
+   * original id, so buildRecapPayload's per-round deltas and winner lookups — both keyed
+   * on player.id — stay aligned; a minted id would silently zero that column's scores.
+   */
+  async function share(g: Game) {
+    const rounds = await getRounds(g.id);
+    const ordered: Player[] = g.playerIds.map(
+      (id, i) => playerMap.get(id) ?? { id, name: `Player ${i + 1}`, color: '#8a8f98', createdAt: 0 },
+    );
+    sharePayload = buildRecapPayload(g, ordered, rounds);
+  }
+
   function startCrewEdit(sig: string, current: string) {
     editingCrew = sig;
     crewDraft = current;
@@ -214,6 +232,9 @@
       </span>
     </a>
     <span class="row actions">
+      {#if g.status === 'finished'}
+        <button class="iconbtn" onclick={() => share(g)} aria-label="Share results" title="Share results">📤</button>
+      {/if}
       <button class="iconbtn" onclick={() => archive(g)} aria-label="Archive game" title="Archive">🗄</button>
       <button class="iconbtn" onclick={() => del(g)} aria-label="Delete game" title="Delete">🗑</button>
     </span>
@@ -360,6 +381,10 @@
       </div>
     {/if}
   {/if}
+{/if}
+
+{#if sharePayload}
+  <ShareResultsSheet payload={sharePayload} onclose={() => (sharePayload = null)} />
 {/if}
 
 <style>
@@ -543,5 +568,18 @@
   }
   .archtoggle {
     margin-top: 16px;
+  }
+
+  @media (max-width: 360px) {
+    /* Recover a few px of info width so the 3-icon finished row (Share · Archive ·
+       Delete) keeps a comfortable title/tap area on the narrowest phones, without
+       ever shrinking the 46×46 icon hit targets. */
+    .libitem {
+      padding: 12px;
+      gap: 8px;
+    }
+    .actions {
+      gap: 4px;
+    }
   }
 </style>

--- a/src/pages/History.svelte
+++ b/src/pages/History.svelte
@@ -1,58 +1,547 @@
 <script lang="ts">
-  import { games, removeGame } from '../lib/stores/games';
+  import {
+    games,
+    activeGames,
+    removeGame,
+    restoreGame,
+    archiveGame,
+    unarchiveGame,
+  } from '../lib/stores/games';
   import { players } from '../lib/stores/players';
   import { getModule } from '../lib/games/registry';
+  import { getRounds } from '../lib/storage/db';
   import { link } from '../lib/router';
   import { formatDateTime } from '../lib/util';
+  import { showActionToast } from '../lib/stores/toast';
+  import { crewSignature, crewNames, setCrewName } from '../lib/stores/crews';
+  import Avatar from '../lib/components/Avatar.svelte';
+  import Segmented from '../lib/components/Segmented.svelte';
+  import type { Game } from '../lib/types';
 
+  /** Below this many games, the list is glanceable on its own — no controls shown. */
+  const CONTROLS_MIN = 6;
+
+  const STATUS_OPTIONS = [
+    { value: 'all', label: 'All' },
+    { value: 'active', label: 'Active' },
+    { value: 'finished', label: 'Finished' },
+  ];
+  const GROUP_LABEL: Record<string, string> = { date: 'Date', crew: 'Crew', game: 'Game' };
+
+  const DATE_BUCKETS = [
+    { key: 'today', title: 'Today' },
+    { key: 'week', title: 'This week' },
+    { key: 'month', title: 'This month' },
+    { key: 'earlier', title: 'Earlier' },
+  ];
+
+  type Group = {
+    key: string;
+    kind: 'date' | 'crew' | 'game';
+    title: string;
+    emoji?: string;
+    signature?: string;
+    memberIds?: string[];
+    nickname?: string;
+    count: number;
+    games: Game[];
+  };
+
+  let search = $state('');
+  let status = $state('all');
+  let groupBy = $state('date');
+  let sort = $state('newest');
+  let showViewOptions = $state(false);
+  let showArchived = $state(false);
+  let editingCrew = $state<string | null>(null);
+  let crewDraft = $state('');
+
+  const playerMap = $derived(new Map($players.map((p) => [p.id, p] as const)));
+  const archivedGames = $derived($games.filter((g) => g.archived));
+  const showControls = $derived($activeGames.length >= CONTROLS_MIN);
+
+  const viewSummary = $derived(
+    [groupBy === 'date' ? null : GROUP_LABEL[groupBy], sort === 'oldest' ? 'Oldest' : null]
+      .filter(Boolean)
+      .join(' · '),
+  );
+
+  function ts(g: Game): number {
+    return g.finishedAt ?? g.createdAt;
+  }
   function names(ids: string[]): string {
-    return ids.map((id) => $players.find((p) => p.id === id)?.name ?? '?').join(', ');
+    return ids.map((id) => playerMap.get(id)?.name ?? '?').join(', ');
   }
   function winners(ids: string[] | undefined): string {
-    return (ids ?? []).map((id) => $players.find((p) => p.id === id)?.name ?? '?').join(' & ');
+    return (ids ?? []).map((id) => playerMap.get(id)?.name ?? '?').join(' & ');
   }
-  async function del(id: string, e: MouseEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-    if (confirm('Delete this game and its scores?')) await removeGame(id);
+  function haystack(g: Game): string {
+    const m = getModule(g.type);
+    const parts = [m?.name ?? g.type, g.name ?? ''];
+    for (const id of g.playerIds) parts.push(playerMap.get(id)?.name ?? '');
+    for (const id of g.winnerIds ?? []) parts.push(playerMap.get(id)?.name ?? '');
+    return parts.join(' ').toLowerCase();
+  }
+  function push<K, V>(m: Map<K, V[]>, k: K, v: V): void {
+    const a = m.get(k);
+    if (a) a.push(v);
+    else m.set(k, [v]);
+  }
+
+  const filtered = $derived.by(() => {
+    let list = $activeGames;
+    if (status !== 'all') list = list.filter((g) => g.status === status);
+    const q = search.trim().toLowerCase();
+    if (q) list = list.filter((g) => haystack(g).includes(q));
+    return list;
+  });
+
+  const groups = $derived.by<Group[]>(() => {
+    const list = [...filtered].sort((a, b) =>
+      sort === 'oldest' ? ts(a) - ts(b) : ts(b) - ts(a),
+    );
+
+    if (groupBy === 'date') {
+      const now = new Date();
+      const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+      const startOfWeek = startOfToday - ((now.getDay() + 6) % 7) * 86400000;
+      const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1).getTime();
+      const bucket = (t: number) =>
+        t >= startOfToday ? 'today' : t >= startOfWeek ? 'week' : t >= startOfMonth ? 'month' : 'earlier';
+      const map = new Map<string, Game[]>();
+      for (const g of list) push(map, bucket(ts(g)), g);
+      const order = sort === 'oldest' ? [...DATE_BUCKETS].reverse() : DATE_BUCKETS;
+      return order
+        .filter((b) => map.has(b.key))
+        .map((b) => ({
+          key: `date-${b.key}`,
+          kind: 'date' as const,
+          title: b.title,
+          count: map.get(b.key)!.length,
+          games: map.get(b.key)!,
+        }));
+    }
+
+    const byLead = (a: Game[], b: Game[]) => (sort === 'oldest' ? ts(a[0]) - ts(b[0]) : ts(b[0]) - ts(a[0]));
+
+    if (groupBy === 'game') {
+      const map = new Map<string, Game[]>();
+      for (const g of list) push(map, g.type, g);
+      return [...map.values()]
+        .sort(byLead)
+        .map((gs) => {
+          const m = getModule(gs[0].type);
+          return {
+            key: `game-${gs[0].type}`,
+            kind: 'game' as const,
+            title: m?.name ?? gs[0].type,
+            emoji: m?.emoji ?? '🎲',
+            count: gs.length,
+            games: gs,
+          };
+        });
+    }
+
+    // crew — grouped by the exact line-up
+    const nicks = $crewNames;
+    const map = new Map<string, Game[]>();
+    for (const g of list) push(map, crewSignature(g.playerIds), g);
+    return [...map.entries()]
+      .sort((a, b) => byLead(a[1], b[1]))
+      .map(([sig, gs]) => {
+        const memberIds = gs[0].playerIds;
+        const nickname = nicks[sig] ?? '';
+        return {
+          key: `crew-${sig}`,
+          kind: 'crew' as const,
+          signature: sig,
+          memberIds,
+          nickname,
+          title: nickname || names(memberIds),
+          count: gs.length,
+          games: gs,
+        };
+      });
+  });
+
+  function clearFilters() {
+    search = '';
+    status = 'all';
+  }
+
+  async function del(g: Game) {
+    const snap = { ...g };
+    const roundsSnap = await getRounds(g.id);
+    await removeGame(g.id);
+    showActionToast('Game deleted', 'Undo', async () => {
+      await restoreGame(snap, roundsSnap);
+    });
+  }
+
+  async function archive(g: Game) {
+    const snap = { ...g };
+    await archiveGame(g);
+    showActionToast('Game archived', 'Undo', async () => {
+      await unarchiveGame(snap);
+    });
+  }
+
+  function startCrewEdit(sig: string, current: string) {
+    editingCrew = sig;
+    crewDraft = current;
+  }
+  function saveCrewEdit(sig: string) {
+    setCrewName(sig, crewDraft);
+    editingCrew = null;
   }
 </script>
 
+{#snippet gameCard(g: Game)}
+  {@const m = getModule(g.type)}
+  <div class="card row spread libitem">
+    <a class="row info" href={`/play/${g.id}`} use:link>
+      <span class="big-emoji" aria-hidden="true">{m?.emoji ?? '🎲'}</span>
+      <span class="meta">
+        <span class="titleline">
+          <strong>{m?.name ?? g.type}</strong>
+          {#if g.status === 'active'}<span class="pill">in progress</span>{/if}
+        </span>
+        <span class="muted sm oneline">{names(g.playerIds)}</span>
+        <span class="muted sm oneline">
+          {formatDateTime(ts(g))}
+          {#if g.status === 'finished'} · 🏆 {winners(g.winnerIds) || '—'}{/if}
+        </span>
+      </span>
+    </a>
+    <span class="row actions">
+      <button class="iconbtn" onclick={() => archive(g)} aria-label="Archive game" title="Archive">🗄</button>
+      <button class="iconbtn" onclick={() => del(g)} aria-label="Delete game" title="Delete">🗑</button>
+    </span>
+  </div>
+{/snippet}
+
 <h1>History</h1>
 
-{#if $games.length === 0}
+{#if $activeGames.length === 0 && archivedGames.length === 0}
   <div class="empty">No games yet. Start one from the Games tab.</div>
 {:else}
-  <div class="stack">
-    {#each $games as g (g.id)}
-      {@const m = getModule(g.type)}
-      <a class="card row spread tile" href={`/play/${g.id}`} use:link>
-        <span class="row" style="gap: 12px">
-          <span style="font-size: 1.5rem">{m?.emoji ?? '🎲'}</span>
-          <span>
-            <div>
-              <strong>{m?.name ?? g.type}</strong>
-              {#if g.status === 'active'}<span class="pill">in progress</span>{/if}
-            </div>
-            <div class="muted sm">{names(g.playerIds)}</div>
-            <div class="muted sm">
-              {formatDateTime(g.finishedAt ?? g.createdAt)}
-              {#if g.status === 'finished'} · 🏆 {winners(g.winnerIds) || '—'}{/if}
-            </div>
+  {#if showControls}
+    <div class="controls">
+      <div class="searchbar">
+        <span class="searchicon" aria-hidden="true">🔍</span>
+        <input
+          type="search"
+          placeholder="Search games, players, winners…"
+          aria-label="Search games"
+          bind:value={search}
+        />
+        {#if search}
+          <button class="clearbtn" onclick={() => (search = '')} aria-label="Clear search">✕</button>
+        {/if}
+      </div>
+
+      <Segmented label="Filter by status" bind:value={status} options={STATUS_OPTIONS} />
+
+      <button
+        class="viewtoggle"
+        onclick={() => (showViewOptions = !showViewOptions)}
+        aria-expanded={showViewOptions}
+      >
+        <span>{showViewOptions ? '▾' : '▸'} View options</span>
+        {#if !showViewOptions && viewSummary}<span class="muted vsum">{viewSummary}</span>{/if}
+      </button>
+
+      {#if showViewOptions}
+        <div class="viewopts">
+          <label class="optrow">
+            <span class="optlabel">Group by</span>
+            <select bind:value={groupBy}>
+              <option value="date">Date</option>
+              <option value="crew">Crew</option>
+              <option value="game">Game</option>
+            </select>
+          </label>
+          <label class="optrow">
+            <span class="optlabel">Sort</span>
+            <select bind:value={sort}>
+              <option value="newest">Newest first</option>
+              <option value="oldest">Oldest first</option>
+            </select>
+          </label>
+        </div>
+      {/if}
+    </div>
+  {/if}
+
+  {#if $activeGames.length === 0}
+    <div class="empty">Every game is archived. Restore one below to bring it back here.</div>
+  {:else if filtered.length === 0}
+    <div class="empty">
+      <div>No games match — try a different search or filter.</div>
+      <button class="btn small ghost" style="margin-top: 10px" onclick={clearFilters}>Clear filters</button>
+    </div>
+  {:else}
+    {#each groups as grp (grp.key)}
+      {#if grp.kind === 'date'}
+        <div class="section-title">{grp.title}</div>
+      {:else if grp.kind === 'game'}
+        <div class="grouphead">
+          <span class="big-emoji" aria-hidden="true">{grp.emoji}</span>
+          <span class="gh-title">{grp.title}</span>
+          <span class="pill count">{grp.count}</span>
+        </div>
+      {:else}
+        <div class="grouphead">
+          <span class="avstack">
+            {#each grp.memberIds!.slice(0, 4) as id (id)}
+              {@const p = playerMap.get(id)}
+              <Avatar name={p?.name ?? '?'} color={p?.color ?? '#7c5cff'} size={22} />
+            {/each}
+            {#if grp.memberIds!.length > 4}<span class="avmore">+{grp.memberIds!.length - 4}</span>{/if}
           </span>
-        </span>
-        <button class="iconbtn" onclick={(e) => del(g.id, e)} aria-label="Delete">🗑</button>
-      </a>
+          {#if editingCrew === grp.signature}
+            <input
+              class="crewinput"
+              type="text"
+              placeholder="Crew name…"
+              aria-label="Crew name"
+              bind:value={crewDraft}
+              onkeydown={(e) => { if (e.key === 'Enter') saveCrewEdit(grp.signature!); }}
+            />
+            <button class="btn small primary" onclick={() => saveCrewEdit(grp.signature!)}>Save</button>
+            <button class="btn small ghost" onclick={() => (editingCrew = null)}>Cancel</button>
+          {:else}
+            <span class="gh-crew">
+              <span class="gh-title">{grp.title}</span>
+              {#if grp.nickname}<span class="muted sm oneline">{names(grp.memberIds!)}</span>{/if}
+            </span>
+            <span class="pill count">{grp.count}</span>
+            <button
+              class="iconbtn small-icon"
+              onclick={() => startCrewEdit(grp.signature!, grp.nickname ?? '')}
+              aria-label="Name this crew"
+              title="Name this crew"
+            >✎</button>
+          {/if}
+        </div>
+      {/if}
+      <div class="stack">
+        {#each grp.games as g (g.id)}
+          {@render gameCard(g)}
+        {/each}
+      </div>
     {/each}
-  </div>
+  {/if}
+
+  {#if archivedGames.length > 0}
+    <button
+      class="viewtoggle archtoggle"
+      onclick={() => (showArchived = !showArchived)}
+      aria-expanded={showArchived}
+    >{showArchived ? '▾' : '▸'} Archived ({archivedGames.length})</button>
+    {#if showArchived}
+      <div class="stack">
+        {#each archivedGames as g (g.id)}
+          {@const m = getModule(g.type)}
+          <div class="card row spread libitem arch">
+            <a class="row info" href={`/play/${g.id}`} use:link>
+              <span class="big-emoji" aria-hidden="true">{m?.emoji ?? '🎲'}</span>
+              <span class="meta">
+                <span class="titleline"><strong>{m?.name ?? g.type}</strong></span>
+                <span class="muted sm oneline">{names(g.playerIds)}</span>
+              </span>
+            </a>
+            <span class="row actions">
+              <button class="btn small ghost" onclick={() => unarchiveGame(g)}>Restore</button>
+              <button class="iconbtn" onclick={() => del(g)} aria-label="Delete game" title="Delete">🗑</button>
+            </span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  {/if}
 {/if}
 
 <style>
-  .tile {
+  .controls {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 16px;
+  }
+  .searchbar {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+  .searchbar input {
+    width: 100%;
+    padding-left: 38px;
+  }
+  .searchicon {
+    position: absolute;
+    left: 12px;
+    font-size: 0.95rem;
+    opacity: 0.7;
+    pointer-events: none;
+  }
+  .clearbtn {
+    position: absolute;
+    right: 6px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  .clearbtn:hover {
+    background: var(--surface-2);
+    color: var(--text);
+  }
+
+  .viewtoggle {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 2px;
+    background: none;
+    border: none;
+    color: var(--muted);
+    font-weight: 600;
+    font-size: 0.92rem;
+    cursor: pointer;
+    text-align: left;
+  }
+  .vsum {
+    font-weight: 400;
+    font-size: 0.85rem;
+  }
+  .viewopts {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .optrow {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .optlabel {
+    flex: none;
+    width: 74px;
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+  .viewopts select {
+    flex: 1;
+    min-height: 44px;
+    padding: 8px 12px;
+    background: var(--surface);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font: inherit;
+    cursor: pointer;
+  }
+  .viewopts select:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+
+  .grouphead {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 18px 4px 8px;
+  }
+  .gh-title {
+    font-weight: 700;
+  }
+  .gh-crew {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+  }
+  .grouphead .count {
+    margin-left: auto;
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+  }
+  .grouphead .small-icon {
+    flex: none;
+    width: 38px;
+    height: 38px;
+    font-size: 0.95rem;
+  }
+  .avstack {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    flex: none;
+  }
+  .avmore {
+    font-size: 0.75rem;
+    color: var(--muted);
+    margin-left: 2px;
+  }
+  .crewinput {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .libitem {
+    align-items: center;
+  }
+  .libitem:has(.info:hover) {
+    border-color: var(--primary);
+  }
+  .info {
+    flex: 1;
+    min-width: 0;
+    gap: 12px;
     text-decoration: none;
     color: inherit;
   }
+  .big-emoji {
+    font-size: 1.6rem;
+    flex: none;
+  }
+  .meta {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .titleline {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .oneline {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+  }
+  .actions {
+    flex: none;
+    gap: 6px;
+  }
   .sm {
-    font-size: 0.82rem;
+    font-size: 0.85rem;
+  }
+  .arch {
+    opacity: 0.82;
+  }
+  .archtoggle {
+    margin-top: 16px;
   }
 </style>

--- a/src/pages/Home.svelte
+++ b/src/pages/Home.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { MODULES, getModule } from '../lib/games/registry';
-  import { games } from '../lib/stores/games';
+  import { activeGames } from '../lib/stores/games';
   import { players } from '../lib/stores/players';
   import { customGameDefs } from '../lib/stores/customGames';
   import { link, navigate } from '../lib/router';
@@ -16,8 +16,8 @@
     if (c) navigate(`/join/${c}`);
   }
 
-  const active = $derived($games.filter((g) => g.status === 'active'));
-  const recent = $derived($games.filter((g) => g.status === 'finished').slice(0, 4));
+  const active = $derived($activeGames.filter((g) => g.status === 'active'));
+  const recent = $derived($activeGames.filter((g) => g.status === 'finished').slice(0, 4));
   // Custom, user-authored games — non-archived, shown alongside the built-ins.
   // (Seam: session 1's catalog will own ordering/favorites/hidden for these.)
   const customTiles = $derived($customGameDefs.filter((d) => !d.archived && !d.deleted));

--- a/src/pages/Home.svelte
+++ b/src/pages/Home.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { MODULES, getModule } from '../lib/games/registry';
-  import { activeGames } from '../lib/stores/games';
+  import { games } from '../lib/stores/games';
   import { players } from '../lib/stores/players';
   import { customGameDefs } from '../lib/stores/customGames';
   import { link, navigate } from '../lib/router';
@@ -16,8 +16,10 @@
     if (c) navigate(`/join/${c}`);
   }
 
-  const active = $derived($activeGames.filter((g) => g.status === 'active'));
-  const recent = $derived($activeGames.filter((g) => g.status === 'finished').slice(0, 4));
+  const active = $derived($games.filter((g) => g.status === 'active' && !g.archived));
+  const recent = $derived(
+    $games.filter((g) => g.status === 'finished' && !g.archived).slice(0, 4),
+  );
   // Custom, user-authored games — non-archived, shown alongside the built-ins.
   // (Seam: session 1's catalog will own ordering/favorites/hidden for these.)
   const customTiles = $derived($customGameDefs.filter((d) => !d.archived && !d.deleted));


### PR DESCRIPTION
## Game Library & History

Transforms `History.svelte` from a flat list of every game (with a bare `confirm()` delete) into a real **library** for played game instances — searchable, filterable, organized, with recoverable archive and undo-toast delete. Offline-first and on-brand per `DESIGN.md`.

### What's new
- **Search** across game type, player names, and winner names (case-insensitive).
- **Status filter** — All / Active / Finished, as the screen's single Royal Violet control.
- **Group by** Date buckets (default: Today / This week / This month / Earlier), **Crew** (auto-derived from the line-up), or **Game type**; with **Newest / Oldest** sort — behind a quiet, collapsible *View options* disclosure.
- **Crews** — same set of players = same crew; each gets an avatar cluster, game count, and an optional **nickname** (✎ rename).
- **Archive / hide** — recoverable, distinct from delete, in a collapsible *Archived (N)* section mirroring `Player.archived` (Restore per row).
- **Undo-toast** for both delete and archive, replacing the native `confirm()` dialog.
- **Progressive disclosure** — controls only appear once the library grows (≥ 6 games), so light users stay clutter-free.

### Model / store (additive)
- `Game` gains optional `archived` / `archivedAt` — distinct from the `deleted` sync tombstone, mirroring `Player`. `db.putGame` already stamps `updatedAt`, so archive rides the per-entity LWW merge automatically; **no `db.ts` / `sync.ts` changes**.
- `games` store gains an `activeGames` derived + `archiveGame` / `unarchiveGame`.
- New **device-local** `crews` store for crew nicknames (localStorage; keeps the change off the shared sync surface for v1).

> **Shared-model note for the overhaul:** the only shared change is the additive `Game.archived` / `archivedAt` pair. Flagged to the coordinator to reconcile the field name/shape across the other sessions.

### Coherence
- Home's **Continue / Recent** and the **GameType resume** list now derive from `activeGames`, so archived games never clutter those surfaces.
- **Stats** intentionally keeps counting archived games (matches the `Player.archived` precedent).

### Design / a11y
- Exactly one Royal Violet control (Status); Group/Sort stay quiet (native selects). Crown Gold reserved for the 🏆 winner only.
- `tabular-nums` on counts, ≥46px touch targets, never color-alone, no new glass/shadows (depth via the surface ramp + `.section-title` overlines). Passes the impeccable design hook.

### Verification
- `npm run check` (svelte-check + tsc) and `npm run build` both green.
- Exercised in-browser against seeded data: search (type/player/winner), status filter, all three groupings, both sorts, crew rename (persists), delete→undo→restore, archive→undo→restore, Archived-section restore, and Home excluding archived games.

### Out of scope (v1, deliberate)
Bulk multi-select, explicit date-range picker, and synced crew nicknames — noted as possible follow-ups.