### PR TITLE
Custom game creation (data-driven, no code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ works fully offline, and can back itself up to a **JSON file in your OneDrive**.
 - **Installable PWA.** Add to home screen; launches full‑screen and works offline.
 - **Pluggable game modules.** Each game is a self‑contained module (config, round entry, scoring,
   validation). Adding a new game doesn't touch the rest of the app.
+- **Create your own game (no code).** Build a custom scorer right in the app — name, emoji, win
+  direction, a single counter or named **columns** (with per‑column penalty), plus an optional
+  target and round limit. It compiles to a real game module, so it joins the catalog and gets
+  players, history, stats, `/<id>` routing, and backup exactly like a built‑in.
 - **Players, history & stats** are shared across every game — reusable players, a full game log,
   and a win‑rate leaderboard.
 - **Optional OneDrive sync.** Automatic (and one‑click) backup to a compact `.json` file in your own
@@ -136,6 +140,35 @@ relay/                # deploy-ready Cloudflare Worker + Durable Object live rel
 
 That's it — routing (`/<id>`), players, history, stats, and persistence all work automatically.
 
+### Custom games (no code)
+
+Players can author games from the app — no build step. Tap **＋ Create a game** on the home
+catalog (or open `/create`) and fill in:
+
+- **Name, emoji, tagline** — how it shows in the catalog (a live preview updates as you type).
+- **Who wins** — highest or lowest total.
+- **Round entry** — a single number per player, or named **columns** (e.g. Bid + Tricks), each
+  column optionally flagged to **subtract** (a penalty column).
+- **Target score** and **round limit** — both optional: a target ends the game when any total
+  reaches it; a limit caps the number of rounds.
+- **Players** min/max and the **points‑per‑tap** step used during entry.
+
+Each custom game is stored as a small declarative `CustomGameDef` (in the IndexedDB `gameDefs`
+store) that the factory in [`src/lib/games/custom/`](src/lib/games/custom/) compiles into a real
+`GameModule` at runtime — **no `eval`**, just data → deterministic scoring (a round score is the
+sum of its columns, penalties subtracted). Because it resolves through the same `getModule`
+registry as the built‑ins, a custom type is first‑class: `/<def‑id>` routing, players, history,
+and stats all work with no extra wiring.
+
+**Edit · Duplicate · Delete.** A custom game's page has an **Edit**, a **Duplicate**
+(clone‑and‑tweak into a new game), and a **Delete**. Deleting a game that was never played removes
+it; deleting one that already has games **archives** it instead (hidden from the catalog but
+retained) so its history and stats keep the right name, emoji, and scoring — mirroring how players
+archive. Both actions are undoable from the toast.
+
+Custom games are part of the self‑owned **World**, so they ride along in every backup (local JSON
+export/import and OneDrive) and merge per‑entity across devices, tombstones included.
+
 ---
 
 ## ☁️ OneDrive sync setup (optional)
@@ -228,7 +261,8 @@ override with their own client ID under **Settings → Advanced**.
 A backup carries your game data **and** your portable preferences — theme, OLED, text size, high
 contrast, motion, colour‑blind palette, keep‑awake, and privacy guard — in the `settings` object, so
 restoring on a new device brings your accessibility/display setup along. The local JSON
-export/import covers the same set.
+export/import covers the same set. **Custom game definitions** ride along too (the `gameDefs`
+array), so a restored device can play, edit, and continue the history of games you invented.
 
 Deliberately **left out**, to avoid dead or conflicting state on another device: the OneDrive
 client‑ID override, the backup file's folder location, the active backup file and its ETag, the

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,6 +12,7 @@
   import GameplaySettings from './pages/GameplaySettings.svelte';
   import GameType from './pages/GameType.svelte';
   import GamePlay from './pages/GamePlay.svelte';
+  import CustomGameEdit from './pages/CustomGameEdit.svelte';
   import LiveJoin from './pages/LiveJoin.svelte';
   import NearbyJoin from './pages/NearbyJoin.svelte';
   import Recap from './pages/Recap.svelte';
@@ -70,6 +71,10 @@
     <GameplaySettings />
   {:else if route.name === 'gametype'}
     <GameType type={route.params.type} />
+  {:else if route.name === 'customedit'}
+    {#key route.params.id ?? 'new'}
+      <CustomGameEdit id={route.params.id} />
+    {/key}
   {:else if route.name === 'play'}
     {#key route.params.id}
       <GamePlay id={route.params.id} />
@@ -90,7 +95,7 @@
 </main>
 
 <nav class="tabbar">
-  <a href="/" use:link class:active={route.name === 'home' || route.name === 'gametype'}>
+  <a href="/" use:link class:active={route.name === 'home' || route.name === 'gametype' || route.name === 'customedit'}>
     <span class="ico">🏠</span>Games
   </a>
   <a href="/players" use:link class:active={route.name === 'players'}>

--- a/src/lib/games/custom/CustomRoundEditor.svelte
+++ b/src/lib/games/custom/CustomRoundEditor.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import type { CustomInput } from './types';
+  import { COUNTER_COLUMN_KEY, effectiveColumns } from './types';
+  import { getCustomDef } from './defRegistry';
+
+  let { input = $bindable(), ctx }: { input: CustomInput; ctx: RoundContext } = $props();
+
+  const def = $derived(getCustomDef(ctx.game.type));
+  const cols = $derived(def ? effectiveColumns(def) : []);
+  const columnsMode = $derived(def?.inputShape === 'columns');
+  const step = $derived(def && def.step && def.step > 0 ? def.step : 1);
+
+  // Keep the draft's shape in sync with the def and the current players. This makes the
+  // editor robust when a def gained/lost a column, or a player joined, since the round
+  // was first created — every stepper always has a real number to bind to.
+  $effect(() => {
+    if (!def) return;
+    if (!input.values) input.values = {};
+    for (const p of ctx.players) {
+      let row = input.values[p.id];
+      if (!row) {
+        row = {};
+        input.values[p.id] = row;
+      }
+      for (const c of cols) {
+        if (typeof row[c.key] !== 'number') row[c.key] = 0;
+      }
+    }
+  });
+</script>
+
+<div class="stack">
+  {#each ctx.players as p (p.id)}
+    {#if columnsMode}
+      <div class="prow cols">
+        <span class="who">
+          <Avatar name={p.name} color={p.color} />
+          <strong>{p.name}</strong>
+        </span>
+        <div class="fields">
+          {#each cols as c (c.key)}
+            <div class="field">
+              <span class="collabel">
+                {c.label}{#if c.negative}<span class="neg" aria-label="subtracts"> −</span>{/if}
+              </span>
+              {#if input.values?.[p.id]}
+                <Stepper bind:value={input.values[p.id][c.key]} {step} />
+              {/if}
+            </div>
+          {/each}
+        </div>
+      </div>
+    {:else}
+      <div class="prow spread">
+        <span class="who">
+          <Avatar name={p.name} color={p.color} />
+          <strong>{p.name}</strong>
+        </span>
+        {#if input.values?.[p.id]}
+          <Stepper bind:value={input.values[p.id][COUNTER_COLUMN_KEY]} {step} />
+        {/if}
+      </div>
+    {/if}
+  {/each}
+</div>
+
+<style>
+  .prow {
+    display: flex;
+    gap: 10px;
+  }
+  .prow.spread {
+    align-items: center;
+    justify-content: space-between;
+  }
+  .prow.cols {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .who {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .fields {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 16px;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .collabel {
+    font-size: 0.8rem;
+    color: var(--muted);
+    font-weight: 600;
+  }
+  .neg {
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/custom/defRegistry.ts
+++ b/src/lib/games/custom/defRegistry.ts
@@ -1,0 +1,23 @@
+import type { CustomGameDef } from './types';
+
+/**
+ * A tiny, dependency-free synchronous lookup of custom game definitions by id.
+ *
+ * Kept separate from the Svelte store and the module factory so leaf consumers — the
+ * generic {@link ./CustomRoundEditor round editor} — can read a def's shape synchronously
+ * without pulling in stores, IndexedDB, or the factory (and without an import cycle). The
+ * store is the single writer: it calls {@link setCustomDefsRegistry} whenever defs load or
+ * change.
+ */
+const byId = new Map<string, CustomGameDef>();
+
+/** Replace the registry contents. Called by the customGames store on load/CRUD/restore. */
+export function setCustomDefsRegistry(defs: CustomGameDef[]): void {
+  byId.clear();
+  for (const d of defs) byId.set(d.id, d);
+}
+
+/** Look up a custom definition by id (archived/retained defs included). */
+export function getCustomDef(id: string): CustomGameDef | undefined {
+  return byId.get(id);
+}

--- a/src/lib/games/custom/factory.ts
+++ b/src/lib/games/custom/factory.ts
@@ -1,0 +1,54 @@
+import type { Component } from 'svelte';
+import type { GameModule, ID, RoundContext } from '../../types';
+import type { CustomGameDef, CustomInput } from './types';
+import { effectiveColumns } from './types';
+import {
+  scoreCustomRound,
+  customMaxRounds,
+  customIsFinished,
+  describeCustomRound,
+} from './scoring';
+import CustomRoundEditor from './CustomRoundEditor.svelte';
+
+/**
+ * Compile a declarative {@link CustomGameDef} into a real, first-class `GameModule`.
+ *
+ * Scoring is pure and deterministic (see {@link ./scoring}): a round score is the sum of the
+ * def's columns per player (columns flagged `negative` subtract). There is no `eval` and no
+ * per-instance config — win direction, target, and round limit are baked into the definition,
+ * so the new-game form is just player selection.
+ */
+export function buildCustomModule(def: CustomGameDef): GameModule {
+  return {
+    id: def.id,
+    name: def.name || 'Custom game',
+    tagline: def.tagline || (def.lowerIsBetter ? 'Lowest score wins' : 'Highest score wins'),
+    emoji: def.emoji || '🎲',
+    minPlayers: def.minPlayers,
+    maxPlayers: def.maxPlayers,
+    lowerIsBetter: def.lowerIsBetter,
+
+    createRoundInput: (ctx: RoundContext): CustomInput => {
+      const cols = effectiveColumns(def);
+      return {
+        values: Object.fromEntries(
+          ctx.players.map((p) => [p.id, Object.fromEntries(cols.map((c) => [c.key, 0]))]),
+        ),
+      };
+    },
+
+    validateRound: () => null,
+
+    scoreRound: (input: CustomInput, ctx: RoundContext): Record<ID, number> =>
+      scoreCustomRound(input, ctx.players, def),
+
+    maxRounds: () => customMaxRounds(def),
+
+    isFinished: (totals) => customIsFinished(totals, def),
+
+    describeRound: (round, players) => describeCustomRound(def, round, players),
+
+    help: def.help || undefined,
+    RoundEditor: CustomRoundEditor as Component<any>,
+  };
+}

--- a/src/lib/games/custom/scoring.ts
+++ b/src/lib/games/custom/scoring.ts
@@ -1,0 +1,69 @@
+import type { ID, Player, Round } from '../../types';
+import type { CustomGameDef, CustomInput } from './types';
+import { COUNTER_COLUMN_KEY, effectiveColumns } from './types';
+
+/**
+ * The pure, deterministic scoring core for custom games — no Svelte, no IndexedDB, no `eval`.
+ * The {@link ./factory factory} wraps these into a `GameModule`; keeping them here (mirroring the
+ * top-level `src/lib/scoring.ts`) makes the engine independently testable and reusable.
+ */
+
+/** Sum one player's row across the def's columns — columns flagged `negative` subtract. */
+export function scoreCustomRow(
+  row: Record<string, number> | undefined,
+  def: CustomGameDef,
+): number {
+  let sum = 0;
+  for (const c of effectiveColumns(def)) {
+    const v = Number(row?.[c.key]) || 0;
+    sum += c.negative ? -v : v;
+  }
+  return sum;
+}
+
+/** Score a whole round: every player's total for the round, in the given order. */
+export function scoreCustomRound(
+  input: CustomInput | undefined,
+  players: Player[],
+  def: CustomGameDef,
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const p of players) out[p.id] = scoreCustomRow(input?.values?.[p.id], def);
+  return out;
+}
+
+/** The fixed round cap for a def, or null when it's open-ended. */
+export function customMaxRounds(def: CustomGameDef): number | null {
+  return def.roundLimit && def.roundLimit > 0 ? def.roundLimit : null;
+}
+
+/**
+ * Whether the game should end: only when a target is set (`> 0`) and some player's running
+ * total has reached it. Unifies "first to X" (high-wins) and a bust ceiling (low-wins), exactly
+ * like Hearts ending when someone hits 100.
+ */
+export function customIsFinished(totals: Record<ID, number>, def: CustomGameDef): boolean {
+  const target = def.target && def.target > 0 ? def.target : 0;
+  if (target <= 0) return false;
+  return Object.values(totals).some((t) => t >= target);
+}
+
+/** A concise, glanceable per-player summary of a recorded round for the history table. */
+export function describeCustomRound(def: CustomGameDef, round: Round, players: Player[]): string {
+  const input = round.input as CustomInput | undefined;
+  if (!input?.values) return '';
+  const cols = effectiveColumns(def);
+  const parts: string[] = [];
+  for (const p of players) {
+    const row = input.values[p.id];
+    if (!row) continue;
+    if (def.inputShape === 'columns') {
+      const vals = cols.map((c) => Number(row[c.key]) || 0);
+      if (vals.some((v) => v !== 0)) parts.push(`${p.name} ${vals.join('/')}`);
+    } else {
+      const v = Number(row[COUNTER_COLUMN_KEY]) || 0;
+      if (v !== 0) parts.push(`${p.name} ${v > 0 ? '+' : ''}${v}`);
+    }
+  }
+  return parts.length ? parts.join(' · ') : 'no change';
+}

--- a/src/lib/games/custom/types.ts
+++ b/src/lib/games/custom/types.ts
@@ -1,0 +1,140 @@
+import type { ID } from '../../types';
+import { uid } from '../../util';
+
+/**
+ * Custom, user-authored games.
+ * ----------------------------
+ * A {@link CustomGameDef} is a small *declarative* description of a game that the
+ * {@link ./factory factory} compiles into a real runtime `GameModule` — no code, no
+ * `eval`, just data → deterministic scoring. Defs live in their own IndexedDB store and
+ * are part of the World (backed up, merged per-entity, tombstoned), so a custom type is
+ * as first-class as a built-in: players, history, stats, `/›id‹` routing and backup all
+ * work for free.
+ */
+
+/** Every custom game id carries this prefix so it can never collide with a built-in
+ *  module id or a reserved route segment. */
+export const CUSTOM_ID_PREFIX = 'def_';
+
+/** Fallback emoji when the author hasn't picked one. */
+export const DEFAULT_EMOJI = '🎲';
+
+/** The single implicit column used by a `counter`-shaped game. */
+export const COUNTER_COLUMN_KEY = 'v';
+
+export type CustomInputShape = 'counter' | 'columns';
+
+export interface CustomColumn {
+  /** Stable id, generated — never derived from the label, so relabeling is safe. */
+  key: string;
+  label: string;
+  /** When true this column *subtracts* from the round score (a penalty column). */
+  negative?: boolean;
+}
+
+export interface CustomGameDef {
+  /** Stable id, always prefixed with {@link CUSTOM_ID_PREFIX}. */
+  id: string;
+  name: string;
+  emoji: string;
+  tagline: string;
+  minPlayers: number;
+  maxPlayers: number;
+  /** Win direction, baked into the definition (part of the game's identity). */
+  lowerIsBetter: boolean;
+  inputShape: CustomInputShape;
+  /** Columns for `columns` shape; ignored for `counter` (which uses one implicit column). */
+  columns: CustomColumn[];
+  /** Stepper increment for round entry (default 1). */
+  step: number;
+  /** End the game when any total reaches this (0 = no target). */
+  target: number;
+  /** Fixed number of rounds (0 = open-ended). */
+  roundLimit: number;
+  /** Optional rules text for the in-game help popover. */
+  help?: string;
+  createdAt: number;
+  /** Last local mutation time — drives per-entity merge (Phase 2). */
+  updatedAt?: number;
+  /**
+   * Retired but retained: hidden from the catalog and new-game list, yet still resolvable
+   * so games/history/stats of this type keep their name, emoji and correct scoring. Mirrors
+   * {@link Player.archived}. Set when the author "deletes" a type that has been played.
+   */
+  archived?: boolean;
+  archivedAt?: number;
+  /** Sync tombstone: hard-deletion time, retained so the delete propagates on merge. */
+  deleted?: number;
+}
+
+/** Per-round instance payload stored on each `Round` for a custom game. */
+export interface CustomInput {
+  /** player id → (column key → value). */
+  values: Record<ID, Record<string, number>>;
+}
+
+/** True when a game `type` refers to a custom, user-authored game. */
+export function isCustomType(type: string): boolean {
+  return typeof type === 'string' && type.startsWith(CUSTOM_ID_PREFIX);
+}
+
+/** The columns a def actually scores/renders — the single implicit one for a counter. */
+export function effectiveColumns(def: CustomGameDef): CustomColumn[] {
+  if (def.inputShape === 'columns') return def.columns;
+  return [{ key: COUNTER_COLUMN_KEY, label: '', negative: false }];
+}
+
+/** A fresh, unique column with an optional label. */
+export function newColumn(label = ''): CustomColumn {
+  return { key: 'c' + uid().replace(/-/g, '').slice(0, 8), label, negative: false };
+}
+
+/** A blank definition ready for the builder. */
+export function blankDef(): CustomGameDef {
+  const now = Date.now();
+  return {
+    id: CUSTOM_ID_PREFIX + uid(),
+    name: '',
+    emoji: DEFAULT_EMOJI,
+    tagline: '',
+    minPlayers: 2,
+    maxPlayers: 8,
+    lowerIsBetter: false,
+    inputShape: 'counter',
+    columns: [newColumn('Points')],
+    step: 1,
+    target: 0,
+    roundLimit: 0,
+    help: '',
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/** A deep copy of `src` as a brand-new (unsaved) definition, e.g. for "Duplicate". */
+export function duplicateDef(src: CustomGameDef): CustomGameDef {
+  const now = Date.now();
+  return {
+    ...src,
+    id: CUSTOM_ID_PREFIX + uid(),
+    name: `${src.name} copy`.trim(),
+    columns: src.columns.map((c) => ({ ...c })),
+    createdAt: now,
+    updatedAt: now,
+    archived: false,
+    archivedAt: undefined,
+    deleted: undefined,
+  };
+}
+
+/** Validate a def for saving. Returns a human-readable error, or null when valid. */
+export function validateDef(def: CustomGameDef): string | null {
+  if (!def.name.trim()) return 'Give your game a name.';
+  if (!Number.isFinite(def.minPlayers) || def.minPlayers < 1) return 'Minimum players must be at least 1.';
+  if (def.maxPlayers < def.minPlayers) return "Max players can't be less than min players.";
+  if (def.inputShape === 'columns') {
+    if (def.columns.length < 1) return 'Add at least one scoring column.';
+    if (def.columns.some((c) => !c.label.trim())) return 'Every column needs a label.';
+  }
+  return null;
+}

--- a/src/lib/games/registry.ts
+++ b/src/lib/games/registry.ts
@@ -3,11 +3,25 @@ import { skullking } from './skullking';
 import { hearts } from './hearts';
 import { tally } from './tally';
 
-/** All registered games. Add a new game by appending its module here. */
+/** All registered built-in games. Add a new built-in by appending its module here. */
 export const MODULES: GameModule[] = [skullking, hearts, tally];
 
 const byId = new Map(MODULES.map((m) => [m.id, m]));
 
+/**
+ * Runtime modules compiled from user-authored custom definitions, kept in sync by the
+ * customGames store. Archived types are included so historical games, history and stats
+ * still resolve; the catalog is responsible for filtering archived types out of listings.
+ */
+const customById = new Map<string, GameModule>();
+
+/** Replace the custom module set. Called by the customGames store on load/CRUD/restore. */
+export function setCustomModules(mods: GameModule[]): void {
+  customById.clear();
+  for (const m of mods) customById.set(m.id, m);
+}
+
+/** Resolve a game module by id — built-ins first, then custom (user-authored) games. */
 export function getModule(id: string): GameModule | undefined {
-  return byId.get(id);
+  return byId.get(id) ?? customById.get(id);
 }

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -82,6 +82,7 @@ export type RouteName =
   | 'nearby'
   | 'recap'
   | 'gametype'
+  | 'customedit'
   | 'notfound';
 
 export interface Route {
@@ -99,6 +100,7 @@ const RESERVED: Record<string, RouteName> = {
   gameplay: 'gameplay',
   nearby: 'nearby',
   recap: 'recap',
+  create: 'customedit',
 };
 
 export function parseRoute(path: string): Route {
@@ -110,6 +112,10 @@ export function parseRoute(path: string): Route {
     if (name) return { name, params: {} };
     // single unknown segment => a game type landing page (e.g. /skullking)
     return { name: 'gametype', params: { type: segs[0] } };
+  }
+  if (segs[0] === 'create' && segs[1]) {
+    // /create/<defId> => edit an existing custom game
+    return { name: 'customedit', params: { id: segs[1] } };
   }
   if (segs[0] === 'play' && segs[1]) {
     return { name: 'play', params: { id: segs[1] } };

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -1,5 +1,6 @@
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
 import type { Game, ID, Player, Round } from '../types';
+import type { CustomGameDef } from '../games/custom/types';
 import { uid } from '../util';
 import { markDataChanged } from './changes';
 
@@ -7,6 +8,7 @@ interface ScoreKingDB extends DBSchema {
   players: { key: string; value: Player };
   games: { key: string; value: Game; indexes: { byCreated: number } };
   rounds: { key: string; value: Round; indexes: { byGame: string } };
+  gameDefs: { key: string; value: CustomGameDef };
 }
 
 let dbp: Promise<IDBPDatabase<ScoreKingDB>> | null = null;
@@ -16,13 +18,19 @@ const raw = <T>(v: T): T => JSON.parse(JSON.stringify(v)) as T;
 
 function db(): Promise<IDBPDatabase<ScoreKingDB>> {
   if (!dbp) {
-    dbp = openDB<ScoreKingDB>('score-king', 1, {
-      upgrade(database) {
-        database.createObjectStore('players', { keyPath: 'id' });
-        const games = database.createObjectStore('games', { keyPath: 'id' });
-        games.createIndex('byCreated', 'createdAt');
-        const rounds = database.createObjectStore('rounds', { keyPath: 'id' });
-        rounds.createIndex('byGame', 'gameId');
+    dbp = openDB<ScoreKingDB>('score-king', 2, {
+      upgrade(database, oldVersion) {
+        if (oldVersion < 1) {
+          database.createObjectStore('players', { keyPath: 'id' });
+          const games = database.createObjectStore('games', { keyPath: 'id' });
+          games.createIndex('byCreated', 'createdAt');
+          const rounds = database.createObjectStore('rounds', { keyPath: 'id' });
+          rounds.createIndex('byGame', 'gameId');
+        }
+        // v2: user-authored custom game definitions (part of the World).
+        if (oldVersion < 2) {
+          database.createObjectStore('gameDefs', { keyPath: 'id' });
+        }
       },
     });
   }
@@ -126,20 +134,48 @@ export async function deleteRound(id: ID): Promise<void> {
   markDataChanged();
 }
 
+// ---- Custom game definitions ----
+/** Live custom game definitions (tombstones hidden). Includes archived defs so games,
+ *  history and stats of a retired custom type still resolve. */
+export async function getAllGameDefs(): Promise<CustomGameDef[]> {
+  const all = await (await db()).getAll('gameDefs');
+  return all.filter((d) => !d.deleted).sort((a, b) => a.createdAt - b.createdAt);
+}
+
+export async function putGameDef(def: CustomGameDef): Promise<void> {
+  await (await db()).put('gameDefs', raw({ ...def, updatedAt: Date.now() }));
+  markDataChanged();
+}
+
+/** Hard-delete a custom game definition (tombstoned so the delete propagates on merge).
+ *  Only used for a type that was never played; a played type is archived instead. */
+export async function deleteGameDef(id: ID): Promise<void> {
+  const database = await db();
+  const existing = await database.get('gameDefs', id);
+  if (existing) {
+    const now = Date.now();
+    await database.put('gameDefs', raw({ ...existing, deleted: now, updatedAt: now }));
+  }
+  markDataChanged();
+}
+
 // ---- Bulk (used by sync restore) ----
 export async function replaceAll(data: {
   players: Player[];
   games: Game[];
   rounds: Round[];
+  gameDefs?: CustomGameDef[];
 }): Promise<void> {
   const database = await db();
-  const tx = database.transaction(['players', 'games', 'rounds'], 'readwrite');
+  const tx = database.transaction(['players', 'games', 'rounds', 'gameDefs'], 'readwrite');
   await tx.objectStore('players').clear();
   await tx.objectStore('games').clear();
   await tx.objectStore('rounds').clear();
+  await tx.objectStore('gameDefs').clear();
   for (const p of data.players) await tx.objectStore('players').put(raw(p));
   for (const g of data.games) await tx.objectStore('games').put(raw(g));
   for (const r of data.rounds) await tx.objectStore('rounds').put(raw(r));
+  for (const d of data.gameDefs ?? []) await tx.objectStore('gameDefs').put(raw(d));
   await tx.done;
 }
 
@@ -157,12 +193,14 @@ export async function getAllForSync(): Promise<{
   players: Player[];
   games: Game[];
   rounds: Round[];
+  gameDefs: CustomGameDef[];
 }> {
   const database = await db();
-  const [players, games, rounds] = await Promise.all([
+  const [players, games, rounds, gameDefs] = await Promise.all([
     database.getAll('players'),
     database.getAll('games'),
     database.getAll('rounds'),
+    database.getAll('gameDefs'),
   ]);
-  return { players: players.map(normalizePlayer), games, rounds };
+  return { players: players.map(normalizePlayer), games, rounds, gameDefs };
 }

--- a/src/lib/storage/sync.ts
+++ b/src/lib/storage/sync.ts
@@ -1,5 +1,6 @@
 import * as db from './db';
 import type { Game, ID, Player, Round } from '../types';
+import type { CustomGameDef } from '../games/custom/types';
 import type { Settings } from '../stores/settings';
 import { getBackupSettings, applyBackupSettings } from '../stores/settings';
 
@@ -7,6 +8,12 @@ export interface Snapshot {
   players: Player[];
   games: Game[];
   rounds: Round[];
+  /**
+   * User-authored custom game definitions (part of the World). Optional so older backups —
+   * written before custom games existed — still restore cleanly; when absent it's treated
+   * as an empty list.
+   */
+  gameDefs?: CustomGameDef[];
   /**
    * Backed-up user preferences (the portable subset of {@link Settings}).
    * Optional so older backups — and JSON files written before settings sync —
@@ -92,6 +99,7 @@ export function serializeSnapshot(snapshot: Snapshot): string {
     players: snapshot.players,
     games: snapshot.games,
     rounds: snapshot.rounds,
+    gameDefs: snapshot.gameDefs ?? [],
     settings: snapshot.settings ?? {},
   };
   return JSON.stringify(envelope, null, 2);
@@ -121,6 +129,7 @@ export function deserializeSnapshot(text: string): Snapshot | null {
     players: obj.players as Snapshot['players'],
     games: obj.games as Snapshot['games'],
     rounds: obj.rounds as Snapshot['rounds'],
+    gameDefs: (obj.gameDefs as Snapshot['gameDefs']) ?? [],
     settings: (obj.settings as Snapshot['settings']) ?? {},
     exportedAt: typeof obj.exportedAt === 'number' ? obj.exportedAt : Date.now(),
   };
@@ -225,8 +234,8 @@ export interface SyncProvider {
 }
 
 export async function buildSnapshot(): Promise<Snapshot> {
-  const { players, games, rounds } = await db.getAllForSync();
-  return { players, games, rounds, settings: getBackupSettings(), exportedAt: Date.now() };
+  const { players, games, rounds, gameDefs } = await db.getAllForSync();
+  return { players, games, rounds, gameDefs, settings: getBackupSettings(), exportedAt: Date.now() };
 }
 
 export async function restoreSnapshot(snapshot: Snapshot): Promise<void> {
@@ -234,8 +243,13 @@ export async function restoreSnapshot(snapshot: Snapshot): Promise<void> {
     players: snapshot.players,
     games: snapshot.games,
     rounds: snapshot.rounds,
+    gameDefs: snapshot.gameDefs ?? [],
   });
   applyBackupSettings(snapshot.settings);
+  // Rebuild the in-memory custom registries so restored/merged-in custom types resolve
+  // immediately (dynamic import keeps the store out of the sync module's static graph).
+  const { refreshCustomGames } = await import('../stores/customGames');
+  await refreshCustomGames();
 }
 
 // ── Per-entity merge (Phase 2) ───────────────────────────────────────────────
@@ -282,6 +296,7 @@ export function mergeSnapshots(local: Snapshot, remote: Snapshot): Snapshot {
     players: mergeById(local.players, remote.players),
     games: mergeById(local.games, remote.games),
     rounds: mergeById(local.rounds, remote.rounds),
+    gameDefs: mergeById(local.gameDefs ?? [], remote.gameDefs ?? []),
     settings: local.settings,
     exportedAt: Date.now(),
   };
@@ -299,7 +314,7 @@ function worldFingerprint(s: Snapshot): string {
       .map((e) => `${e.id}:${mergeStamp(e)}`)
       .sort()
       .join(',');
-  return `${key(s.players)}|${key(s.games)}|${key(s.rounds)}`;
+  return `${key(s.players)}|${key(s.games)}|${key(s.rounds)}|${key(s.gameDefs ?? [])}`;
 }
 
 /** Whether two Worlds hold the same records at the same versions. */

--- a/src/lib/stores/customGames.ts
+++ b/src/lib/stores/customGames.ts
@@ -1,0 +1,68 @@
+import { writable } from 'svelte/store';
+import type { CustomGameDef } from '../games/custom/types';
+import { buildCustomModule } from '../games/custom/factory';
+import { setCustomDefsRegistry } from '../games/custom/defRegistry';
+import { setCustomModules } from '../games/registry';
+import * as db from '../storage/db';
+
+/**
+ * Custom (user-authored) games.
+ * -----------------------------
+ * The single writer that keeps the two synchronous registries — the module map used by
+ * `getModule` and the def lookup used by the round editor — in step with IndexedDB, and
+ * exposes a reactive list for the catalog/builder UI. Archived defs are kept in the list
+ * and registries (so retired types still resolve for history/stats); the catalog filters
+ * them out.
+ */
+export const customGameDefs = writable<CustomGameDef[]>([]);
+
+/** Flips to true after the first load from IndexedDB, so UI can tell "loading" from "empty". */
+export const customGamesLoaded = writable<boolean>(false);
+
+/** Rebuild the synchronous registries (def lookup + compiled module map) from a def list. */
+function syncRegistries(defs: CustomGameDef[]): void {
+  setCustomDefsRegistry(defs);
+  setCustomModules(defs.map(buildCustomModule));
+}
+
+/** Load every custom def from IndexedDB into the store and the registries. */
+export async function refreshCustomGames(): Promise<void> {
+  const defs = await db.getAllGameDefs();
+  syncRegistries(defs);
+  customGameDefs.set(defs);
+  customGamesLoaded.set(true);
+}
+
+/** Create or update a custom game definition. */
+export async function saveCustomGame(def: CustomGameDef): Promise<void> {
+  await db.putGameDef(def);
+  await refreshCustomGames();
+}
+
+/**
+ * "Delete" a custom game type. A type that has never been played is hard-deleted; a type
+ * that games/history/stats reference is **archived** instead (retained + resolvable) so
+ * those keep their name, emoji, and correct scoring. Mirrors how Players archive.
+ */
+export async function removeCustomGame(id: string, inUse: boolean): Promise<void> {
+  if (inUse) {
+    const current = (await db.getAllGameDefs()).find((d) => d.id === id);
+    if (current) await db.putGameDef({ ...current, archived: true, archivedAt: Date.now() });
+  } else {
+    await db.deleteGameDef(id);
+  }
+  await refreshCustomGames();
+}
+
+/** Return a retired (archived) custom type to the catalog. */
+export async function restoreCustomGame(id: string): Promise<void> {
+  const current = (await db.getAllGameDefs()).find((d) => d.id === id);
+  if (current) {
+    await db.putGameDef({ ...current, archived: false, archivedAt: undefined });
+    await refreshCustomGames();
+  }
+}
+
+// Populate on startup so getModule resolves custom types for deep links (e.g. /def_… or
+// /play/<id> of a custom game) as soon as IndexedDB answers.
+void refreshCustomGames();

--- a/src/pages/CustomGameEdit.svelte
+++ b/src/pages/CustomGameEdit.svelte
@@ -1,0 +1,369 @@
+<script lang="ts">
+  import Segmented from '../lib/components/Segmented.svelte';
+  import Stepper from '../lib/components/Stepper.svelte';
+  import { navigate, link } from '../lib/router';
+  import { showToast } from '../lib/stores/toast';
+  import {
+    blankDef,
+    newColumn,
+    validateDef,
+    DEFAULT_EMOJI,
+    type CustomGameDef,
+  } from '../lib/games/custom/types';
+  import { customGameDefs, customGamesLoaded, saveCustomGame } from '../lib/stores/customGames';
+
+  let { id }: { id?: string } = $props();
+
+  const editing = $derived(!!id);
+
+  // The working copy. Editing operates on a clone so the store list isn't mutated until save.
+  let def = $state<CustomGameDef>(blankDef());
+  // Local mirrors for the two Segmented controls (they need bindable string vars).
+  let dir = $state<'high' | 'low'>('high');
+  let shape = $state<'counter' | 'columns'>('counter');
+  let loadedKey = $state<string | null>(null);
+
+  // Load the def to edit (or a blank one) once it's resolvable. Depends on the store so a
+  // cold deep-link to /create/<id> fills in as soon as IndexedDB answers.
+  $effect(() => {
+    const list = $customGameDefs;
+    if (!id) {
+      if (loadedKey !== '__new__') {
+        def = blankDef();
+        dir = 'high';
+        shape = 'counter';
+        loadedKey = '__new__';
+      }
+      return;
+    }
+    const found = list.find((d) => d.id === id);
+    if (found && loadedKey !== id) {
+      def = { ...found, columns: found.columns.map((c) => ({ ...c })) };
+      dir = def.lowerIsBetter ? 'low' : 'high';
+      shape = def.inputShape;
+      loadedKey = id;
+    }
+  });
+
+  // Push the Segmented choices back into the working def (one-way).
+  $effect(() => {
+    def.lowerIsBetter = dir === 'low';
+  });
+  $effect(() => {
+    def.inputShape = shape;
+    if (shape === 'columns' && def.columns.length === 0) def.columns = [newColumn('')];
+  });
+
+  const notFound = $derived(!!id && $customGamesLoaded && !$customGameDefs.some((d) => d.id === id));
+
+  // A plain-language recap of what the author has built — reinforces meaning without color.
+  const summary = $derived.by(() => {
+    const parts: string[] = [dir === 'low' ? 'Lowest score wins' : 'Highest score wins'];
+    if (shape === 'columns') {
+      const n = def.columns.length;
+      parts.push(`${n} column${n === 1 ? '' : 's'}`);
+    }
+    if (def.target && def.target > 0) parts.push(`first to ${def.target}`);
+    if (def.roundLimit && def.roundLimit > 0) {
+      parts.push(`${def.roundLimit} round${def.roundLimit === 1 ? '' : 's'}`);
+    }
+    return parts.join(' · ');
+  });
+
+  const dirOptions = [
+    { value: 'high', label: 'Highest wins' },
+    { value: 'low', label: 'Lowest wins' },
+  ];
+  const shapeOptions = [
+    { value: 'counter', label: 'One number' },
+    { value: 'columns', label: 'Columns' },
+  ];
+
+  function addColumn() {
+    def.columns = [...def.columns, newColumn('')];
+  }
+  function removeColumn(i: number) {
+    def.columns = def.columns.filter((_, j) => j !== i);
+  }
+
+  async function save() {
+    const clean: CustomGameDef = {
+      ...def,
+      name: def.name.trim(),
+      emoji: (def.emoji || '').trim() || DEFAULT_EMOJI,
+      tagline: def.tagline.trim(),
+      help: (def.help ?? '').trim(),
+      minPlayers: Math.max(1, Math.round(def.minPlayers) || 1),
+      maxPlayers: Math.max(1, Math.round(def.maxPlayers) || 1),
+      target: Math.max(0, Math.round(def.target ?? 0) || 0),
+      roundLimit: Math.max(0, Math.round(def.roundLimit ?? 0) || 0),
+      step: Math.max(1, Math.round(def.step ?? 1) || 1),
+      columns:
+        shape === 'columns'
+          ? def.columns.map((c) => ({ ...c, label: c.label.trim() }))
+          : def.columns,
+      updatedAt: Date.now(),
+    };
+    const err = validateDef(clean);
+    if (err) {
+      showToast(err);
+      return;
+    }
+    await saveCustomGame(clean);
+    showToast(editing ? 'Game updated.' : 'Game created.');
+    navigate(`/${clean.id}`);
+  }
+
+  function cancel() {
+    navigate(editing ? `/${def.id}` : '/');
+  }
+</script>
+
+{#if notFound}
+  <div class="empty">
+    <h2>Game not found</h2>
+    <p class="muted">This custom game may have been deleted on this device.</p>
+    <a class="btn primary" href="/" use:link>Back to games</a>
+  </div>
+{:else}
+  <div class="row" style="gap: 12px; margin: 10px 4px 4px">
+    <span style="font-size: 2rem" aria-hidden="true">{def.emoji || DEFAULT_EMOJI}</span>
+    <div>
+      <h1 style="margin: 0">{editing ? 'Edit game' : 'Create a game'}</h1>
+      <div class="muted">Design your own scorer — it joins the catalog like any other.</div>
+    </div>
+  </div>
+
+  <div class="section-title">Preview</div>
+  <div class="preview gametile" aria-hidden="true">
+    <span class="emoji">{def.emoji || DEFAULT_EMOJI}</span>
+    <span class="name">{def.name.trim() || 'Untitled game'}</span>
+    <span class="tag">{def.tagline.trim() || summary}</span>
+  </div>
+  <div class="muted sm recap">{summary}</div>
+
+  <div class="section-title">Basics</div>
+  <div class="card stack">
+    <div class="row" style="align-items: flex-start; gap: 10px">
+      <div style="flex: none">
+        <div class="fieldlabel">Emoji</div>
+        <input
+          class="emoji-in"
+          type="text"
+          maxlength="8"
+          bind:value={def.emoji}
+          aria-label="Game emoji"
+        />
+      </div>
+      <div class="grow">
+        <div class="fieldlabel">Name</div>
+        <input
+          type="text"
+          bind:value={def.name}
+          placeholder="Rummy to 500"
+          aria-label="Game name"
+        />
+      </div>
+    </div>
+    <div>
+      <div class="fieldlabel">Tagline <span class="muted">(optional)</span></div>
+      <input
+        type="text"
+        bind:value={def.tagline}
+        placeholder="Low score takes it"
+        aria-label="Tagline"
+      />
+    </div>
+  </div>
+
+  <div class="section-title">Scoring</div>
+  <div class="card stack">
+    <div>
+      <div class="fieldlabel">Who wins</div>
+      <Segmented label="Who wins" bind:value={dir} options={dirOptions} />
+    </div>
+    <div>
+      <div class="fieldlabel">Round entry</div>
+      <Segmented label="Round entry" bind:value={shape} options={shapeOptions} />
+      <div class="muted sm hint">
+        {#if shape === 'counter'}
+          One number per player each round.
+        {:else}
+          A named number per player each round — add columns like Bid and Tricks.
+        {/if}
+      </div>
+    </div>
+
+    {#if shape === 'columns'}
+      <div>
+        <div class="fieldlabel">Columns</div>
+        <div class="stack cols">
+          {#each def.columns as col, i (col.key)}
+            <div class="colrow">
+              <input
+                class="collabel"
+                type="text"
+                bind:value={col.label}
+                placeholder={`Column ${i + 1}`}
+                aria-label={`Column ${i + 1} name`}
+              />
+              <label class="neg">
+                <input type="checkbox" bind:checked={col.negative} />
+                Subtracts
+              </label>
+              <button
+                type="button"
+                class="btn ghost remove"
+                onclick={() => removeColumn(i)}
+                disabled={def.columns.length <= 1}
+                aria-label={`Remove column ${i + 1}`}
+              >
+                ✕
+              </button>
+            </div>
+          {/each}
+        </div>
+        <button type="button" class="btn ghost addcol" onclick={addColumn}>＋ Add column</button>
+      </div>
+    {/if}
+  </div>
+
+  <div class="section-title">Limits &amp; players</div>
+  <div class="card stack">
+    <div class="row spread optrow">
+      <div>
+        <div class="fieldlabel">Target score</div>
+        <div class="muted sm">0 = no target</div>
+      </div>
+      <Stepper bind:value={def.target} min={0} step={def.step && def.step > 1 ? def.step : 10} />
+    </div>
+    <div class="row spread optrow">
+      <div>
+        <div class="fieldlabel">Round limit</div>
+        <div class="muted sm">0 = open-ended</div>
+      </div>
+      <Stepper bind:value={def.roundLimit} min={0} step={1} />
+    </div>
+    <div class="row spread optrow">
+      <div class="fieldlabel" style="margin: 0">Players</div>
+      <div class="row" style="gap: 10px">
+        <span class="muted sm">min</span>
+        <Stepper bind:value={def.minPlayers} min={1} max={99} step={1} />
+        <span class="muted sm">max</span>
+        <Stepper bind:value={def.maxPlayers} min={1} max={99} step={1} />
+      </div>
+    </div>
+    <div class="row spread optrow">
+      <div>
+        <div class="fieldlabel">Points per tap</div>
+        <div class="muted sm">Stepper increment during play</div>
+      </div>
+      <Stepper bind:value={def.step} min={1} max={100} step={1} />
+    </div>
+  </div>
+
+  <div class="section-title">How to play <span class="muted">(optional)</span></div>
+  <div class="card stack">
+    <textarea
+      class="help-area"
+      rows="3"
+      bind:value={def.help}
+      placeholder="A sentence or two of rules, shown in the in-game help."
+      aria-label="How to play"
+    ></textarea>
+  </div>
+
+  <div class="actions stack">
+    <button class="btn primary block" onclick={save} disabled={!def.name.trim()}>
+      {editing ? 'Save changes' : 'Create game'}
+    </button>
+    <button class="btn ghost block" onclick={cancel}>Cancel</button>
+  </div>
+{/if}
+
+<style>
+  .preview {
+    max-width: 220px;
+    cursor: default;
+  }
+  .preview:hover {
+    border-color: var(--border);
+    transform: none;
+  }
+  .recap {
+    margin: 8px 4px 0;
+  }
+  .sm {
+    font-size: 0.85rem;
+  }
+  .hint,
+  .recap {
+    margin-top: 6px;
+  }
+  .emoji-in {
+    width: 64px;
+    text-align: center;
+    font-size: 1.4rem;
+  }
+  /* Column rows are a form group on the next surface step up — not nested cards (no shadow). */
+  .colrow {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
+  .collabel {
+    flex: 1;
+    min-width: 0;
+  }
+  .neg {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+    color: var(--text);
+    font-size: 0.9rem;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+  .neg input {
+    width: 20px;
+    height: 20px;
+  }
+  .remove {
+    flex: none;
+    width: 46px;
+    padding: 0;
+  }
+  .addcol {
+    margin-top: 4px;
+  }
+  .optrow {
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .help-area {
+    width: 100%;
+    padding: 11px 12px;
+    min-height: 84px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    resize: vertical;
+  }
+  .help-area:focus {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .actions {
+    margin-top: 18px;
+  }
+  .empty {
+    text-align: center;
+    padding: 48px 16px;
+  }
+</style>

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -16,6 +16,7 @@
     restoreGame,
   } from '../lib/stores/games';
   import { getModule } from '../lib/games/registry';
+  import { customGameDefs } from '../lib/stores/customGames';
   import { computeTotals } from '../lib/scoring';
   import { navigate, link, absoluteUrl } from '../lib/router';
   import { showToast, showActionToast } from '../lib/stores/toast';
@@ -59,7 +60,10 @@
   let editDraft = $state<any>(null);
   let justSavedId = $state<string | null>(null);
 
-  const module = $derived(game ? getModule(game.type) : undefined);
+  const module = $derived.by(() => {
+    void $customGameDefs;
+    return game ? getModule(game.type) : undefined;
+  });
   const orderedPlayers = $derived(
     game
       ? (game.playerIds

--- a/src/pages/GameType.svelte
+++ b/src/pages/GameType.svelte
@@ -2,13 +2,22 @@
   import { getModule } from '../lib/games/registry';
   import { defaultConfig } from '../lib/types';
   import { games, createGame } from '../lib/stores/games';
+  import { customGameDefs, saveCustomGame, removeCustomGame, restoreCustomGame } from '../lib/stores/customGames';
+  import { isCustomType, duplicateDef } from '../lib/games/custom/types';
+  import { getCustomDef } from '../lib/games/custom/defRegistry';
   import { navigate, link } from '../lib/router';
-  import { showToast } from '../lib/stores/toast';
+  import { showToast, showActionToast } from '../lib/stores/toast';
   import PlayerSelect from '../lib/components/PlayerSelect.svelte';
   import ConfigForm from '../lib/components/ConfigForm.svelte';
 
   let { type }: { type: string } = $props();
-  const module = $derived(getModule(type));
+  // Re-resolve when custom defs load so a deep-link to /def_… lands once IndexedDB answers.
+  const module = $derived.by(() => {
+    void $customGameDefs;
+    return getModule(type);
+  });
+
+  const isCustom = $derived(isCustomType(type));
 
   let selected = $state<string[]>([]);
   let config = $state<Record<string, any>>({});
@@ -37,6 +46,35 @@
     }
     const g = await createGame(type, [...selected], { ...config });
     navigate(`/play/${g.id}`);
+  }
+
+  function editCustom() {
+    navigate(`/create/${type}`);
+  }
+
+  async function duplicateCustom() {
+    const src = getCustomDef(type);
+    if (!src) return;
+    const copy = duplicateDef(src);
+    await saveCustomGame(copy);
+    navigate(`/create/${copy.id}`);
+  }
+
+  async function deleteCustom() {
+    const src = getCustomDef(type);
+    // "In use" = any game (active or finished) of this type exists → archive, don't destroy.
+    const inUse = $games.some((g) => g.type === type);
+    await removeCustomGame(type, inUse);
+    if (inUse) {
+      showActionToast('Archived — kept for history.', 'Undo', () => {
+        void restoreCustomGame(type);
+      });
+    } else {
+      showActionToast('Game deleted.', 'Undo', () => {
+        if (src) void saveCustomGame(src);
+      });
+    }
+    navigate('/');
   }
 </script>
 
@@ -81,12 +119,27 @@
       Start game
     </button>
   </div>
+
+  {#if isCustom}
+    <div class="section-title">Manage</div>
+    <div class="card row wrap manage">
+      <button class="btn" onclick={editCustom}>✏️ Edit</button>
+      <button class="btn" onclick={duplicateCustom}>⧉ Duplicate</button>
+      <button class="btn danger del" onclick={deleteCustom}>🗑 Delete</button>
+    </div>
+  {/if}
 {/if}
 
 <style>
   .resume {
     text-decoration: none;
     color: inherit;
+  }
+  .manage {
+    gap: 10px;
+  }
+  .manage .del {
+    margin-left: auto;
   }
   hr {
     border: none;

--- a/src/pages/Home.svelte
+++ b/src/pages/Home.svelte
@@ -2,6 +2,7 @@
   import { MODULES, getModule } from '../lib/games/registry';
   import { games } from '../lib/stores/games';
   import { players } from '../lib/stores/players';
+  import { customGameDefs } from '../lib/stores/customGames';
   import { link, navigate } from '../lib/router';
   import { relativeTime, normalizeJoinCode } from '../lib/util';
   import { isLiveSupported, isNearbySupported } from '../lib/live/session';
@@ -17,6 +18,9 @@
 
   const active = $derived($games.filter((g) => g.status === 'active'));
   const recent = $derived($games.filter((g) => g.status === 'finished').slice(0, 4));
+  // Custom, user-authored games — non-archived, shown alongside the built-ins.
+  // (Seam: session 1's catalog will own ordering/favorites/hidden for these.)
+  const customTiles = $derived($customGameDefs.filter((d) => !d.archived && !d.deleted));
 
   function names(ids: string[]): string {
     return ids.map((id) => $players.find((p) => p.id === id)?.name ?? '?').join(', ');
@@ -54,6 +58,18 @@
       <span class="tag">{m.tagline}</span>
     </a>
   {/each}
+  {#each customTiles as d (d.id)}
+    <a class="gametile" href={`/${d.id}`} use:link>
+      <span class="emoji">{d.emoji}</span>
+      <span class="name">{d.name}</span>
+      <span class="tag">{d.tagline}</span>
+    </a>
+  {/each}
+  <a class="gametile create" href="/create" use:link>
+    <span class="emoji" aria-hidden="true">＋</span>
+    <span class="name">Create a game</span>
+    <span class="tag">Design your own scorer</span>
+  </a>
 </div>
 
 {#if liveSupported || nearbySupported}
@@ -109,6 +125,13 @@
   .tile {
     text-decoration: none;
     color: inherit;
+  }
+  /* "Add new" affordance — dashed outline + ＋ glyph carry the meaning, not color alone. */
+  .create {
+    border-style: dashed;
+  }
+  .create .emoji {
+    color: var(--muted);
   }
   .tile:hover {
     border-color: var(--primary);


### PR DESCRIPTION
## What & why

Today, adding a game means writing a `GameModule` in code and registering it — dev-only. This PR makes **custom games first-class**: a player can **create, edit, duplicate, and delete** their own game with **zero code**, and it behaves like any built-in.

Ambition level **(b) data-driven builder** (chosen by the product owner): a small declarative `CustomGameDef` schema is **compiled into a genuine runtime `GameModule`** — **no `eval`/`Function`**, pure data → deterministic scoring. Because it produces a real module, players/history/stats and `/<id>` routing all work automatically.

## What you can build

- **Win direction** baked into the game: high-wins ("first to X") or low-wins ("bust ceiling").
- **Round entry shape:** a *simple counter* (one number per player) **or** *named columns* (e.g. Bid + Tricks), with a per-column **"Subtracts"** toggle for penalty columns.
- Optional **target** (end when any total reaches X) and **round limit** (fixed number of rounds).
- Emoji, name, tagline, min/max players, points-per-tap step, and optional **how-to-play** text.

## How it works

- **`src/lib/games/custom/`**
  - `types.ts` — `CustomGameDef` / `CustomColumn` schema + helpers (`blankDef`, `duplicateDef`, `validateDef`, `effectiveColumns`). Ids are prefixed `def_…` so they never collide with built-ins or routes.
  - `scoring.ts` — pure, framework-free scoring core (Node-testable; mirrors the repo's `src/lib/scoring.ts` convention).
  - `factory.ts` — `buildCustomModule(def) → GameModule` (scoring, `isFinished`, `maxRounds`, `describeRound`).
  - `CustomRoundEditor.svelte` — one generic round editor that resolves its schema by `ctx.game.type`.
  - `defRegistry.ts` — leaf sync lookup (breaks the import cycle).
- **Storage / World:** `db.ts` bumps to **v2** with a `gameDefs` store; `sync.ts` threads `gameDefs` through backup/restore, **LWW merge**, and the world fingerprint. Deletes are **tombstoned** so they propagate on merge. Old backups (no `gameDefs`) restore cleanly.
- **Registry:** `getModule(id)` resolves built-ins first, then custom modules kept in sync by the `customGames` store.
- **Builder UI** (`CustomGameEdit.svelte`): reuses `Segmented` / `Stepper` / shared chrome, a **live preview tile**, and exactly **one** Royal Violet primary action. Entry points on **Home** ("＋ Create a game") and **GameType** (Edit / Duplicate / Delete).
- **CRUD = archive-when-in-use** (mirrors Players): a type with games is archived (retained + hidden) so history/stats keep the right name, emoji, and scoring; an unused type is truly deleted. Undo toasts throughout.

## Design (DESIGN.md)

One primary action per screen; no Crown Gold on controls; depth via the surface ramp (columns use `surface-2`, no nested cards); ≥46px targets; `tabular-nums` for numbers; never color-alone (dashed create tile + ＋ glyph, "Subtracts" text label); the builder is a full page, not a modal; identical shared chrome. Built with the **impeccable** skill.

## Verification

- ✅ `npm run check` — 0 errors, 0 warnings
- ✅ `npm run build` — green; bundle stays lean (main chunk +0.07 kB, no new heavy deps)
- ✅ Pure scoring engine — 11/11 Node assertions (counter sum, negative columns subtract, missing-row = 0/no NaN, `maxRounds`, `isFinished` at target, describe for both shapes)
- ✅ Live smoke test on the dev server (`/create` compiles & serves)
- Fully **offline / local-first**; nothing gates play.

The `[INEFFECTIVE_DYNAMIC_IMPORT]` build note is intentional: `sync.ts` uses a dynamic `import()` of the store to keep the storage layer free of a static dependency on the stores/UI layer.

## Coordination (flagged — not finalized unilaterally)

- **Session 1 (catalog):** custom types are referenced by stable `def_…` id; favorites/hidden/order should apply just like built-ins. My Home/GameType tiles are a **temporary seam** session 1 can own/replace. Note: `archived` (definition lifecycle) is distinct from catalog `hidden` (user view).
- **Session 4 (share):** `CustomGameDef` is a **self-contained JSON record** → directly shareable; on import, assign a fresh id (or dedupe by content) to avoid collisions.

## Out of scope / follow-ups

- Formula/expression scoring (ambition c) — only ever via a sandboxed parser.
- Live co-play of custom games by remote guests (guest lacks the def; needs the def carried in `LiveState`). Host play is first-class now.
- Per-instance overridable target/round-limit (baked into the def for v1).