### PR TITLE
Game catalog & discovery: search, sections, favorite, hide, manage page

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ works fully offline, and can back itself up to a **JSON file in your OneDrive**.
   direction, a single counter or named **columns** (with per‑column penalty), plus an optional
   target and round limit. It compiles to a real game module, so it joins the catalog and gets
   players, history, stats, `/<id>` routing, and backup exactly like a built‑in.
+- **Your game catalog.** As your list of games grows, **search** it, **favorite** the ones your
+  group plays (they pin to the top, with your recently‑played games right below), and **hide** the
+  ones you never use from **Manage games**. Hiding is recoverable, and your favorites/hidden choices
+  travel with your backup.
 - **Players, history & stats** are shared across every game — reusable players, a full game log,
   and a win‑rate leaderboard.
 - **Optional OneDrive sync.** Automatic (and one‑click) backup to a compact `.json` file in your own

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,6 +10,7 @@
   import Settings from './pages/Settings.svelte';
   import Accessibility from './pages/Accessibility.svelte';
   import GameplaySettings from './pages/GameplaySettings.svelte';
+  import ManageGames from './pages/ManageGames.svelte';
   import GameType from './pages/GameType.svelte';
   import GamePlay from './pages/GamePlay.svelte';
   import CustomGameEdit from './pages/CustomGameEdit.svelte';
@@ -69,6 +70,8 @@
     <Accessibility />
   {:else if route.name === 'gameplay'}
     <GameplaySettings />
+  {:else if route.name === 'managegames'}
+    <ManageGames />
   {:else if route.name === 'gametype'}
     <GameType type={route.params.type} />
   {:else if route.name === 'customedit'}
@@ -95,7 +98,7 @@
 </main>
 
 <nav class="tabbar">
-  <a href="/" use:link class:active={route.name === 'home' || route.name === 'gametype' || route.name === 'customedit'}>
+  <a href="/" use:link class:active={route.name === 'home' || route.name === 'gametype' || route.name === 'customedit' || route.name === 'managegames'}>
     <span class="ico">🏠</span>Games
   </a>
   <a href="/players" use:link class:active={route.name === 'players'}>

--- a/src/lib/games/hearts/index.ts
+++ b/src/lib/games/hearts/index.ts
@@ -19,6 +19,7 @@ export const hearts: GameModule = {
   name: 'Hearts',
   tagline: 'Avoid hearts & the Queen of Spades',
   emoji: '♥️',
+  keywords: ['trick taking', 'shooting the moon', 'queen of spades', 'cards'],
   minPlayers: 3,
   maxPlayers: 6,
   lowerIsBetter: true,

--- a/src/lib/games/skullking/index.ts
+++ b/src/lib/games/skullking/index.ts
@@ -31,6 +31,7 @@ export const skullking: GameModule = {
   name: 'Skull King',
   tagline: 'Bid your tricks. Hunt the bonuses.',
   emoji: '🏴‍☠️',
+  keywords: ['trick taking', 'pirate', 'bidding', 'cards'],
   minPlayers: 2,
   maxPlayers: 8,
   configFields: [

--- a/src/lib/games/tally/index.ts
+++ b/src/lib/games/tally/index.ts
@@ -10,6 +10,7 @@ export const tally: GameModule = {
   name: 'Tally',
   tagline: 'Universal point counter for any game',
   emoji: '🎯',
+  keywords: ['counter', 'points', 'generic', 'any game', 'score'],
   minPlayers: 1,
   maxPlayers: 12,
   configFields: [

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -76,6 +76,7 @@ export type RouteName =
   | 'stats'
   | 'settings'
   | 'accessibility'
+  | 'managegames'
   | 'gameplay'
   | 'play'
   | 'join'
@@ -97,6 +98,7 @@ const RESERVED: Record<string, RouteName> = {
   stats: 'stats',
   settings: 'settings',
   accessibility: 'accessibility',
+  'manage-games': 'managegames',
   gameplay: 'gameplay',
   nearby: 'nearby',
   recap: 'recap',

--- a/src/lib/stores/catalog.ts
+++ b/src/lib/stores/catalog.ts
@@ -1,0 +1,197 @@
+import { derived, get, type Readable } from 'svelte/store';
+import type { Game } from '../types';
+import { MODULES } from '../games/registry';
+import { customGameDefs } from './customGames';
+import { settings } from './settings';
+import { showActionToast } from './toast';
+
+/**
+ * The shared game-*type* catalog model: favorites + hidden metadata (keyed by type id),
+ * plus the sectioning/search helpers Home and Manage games render, and the seam that lets
+ * built-in AND user-created (session 2) types flow through one uniform catalog.
+ *
+ * A "type id" is a built-in slug (`skullking`) or a custom def id (`def_…`). Favorites and
+ * hidden are persisted as portable settings keys, so a group's chosen games travel with a
+ * backup/restore.
+ */
+
+/**
+ * Whether user-created game types (session 2) are wired up. Now that this branch sits on the
+ * custom-game-creation work, the catalog includes non-archived custom defs and the
+ * "＋ Create a game" affordance (→ {@link CREATE_ROUTE}) is shown.
+ */
+export const CUSTOM_GAMES_ENABLED = true;
+
+/**
+ * The minimal projection every catalog surface needs. Both a built-in `GameModule` and a
+ * session-2 `CustomGameDef` structurally satisfy it (they each expose `id`/`name`/`emoji`/
+ * `tagline`), so built-in and custom types flow through one uniform catalog. `keywords` is
+ * optional (built-ins may add search aliases; custom defs simply omit it).
+ */
+export interface CatalogType {
+  id: string;
+  name: string;
+  emoji: string;
+  tagline: string;
+  keywords?: string[];
+}
+
+/**
+ * Reactive list of the startable game *types* the catalog offers — the single source every
+ * catalog surface reads: the built-in {@link MODULES} plus session 2's reactive `customGameDefs`
+ * store (PR #32), so newly-created types appear live. Retired (`archived`) and tombstoned
+ * (`deleted`) defs are filtered out here — that's the catalog's job per session 2, and is
+ * DISTINCT from the user's own `catalogHidden` (layered on later in {@link sectionize}).
+ * `getModule(id)` (registry) still resolves either kind when a full module is needed.
+ */
+export const startableTypes: Readable<CatalogType[]> = derived(
+  customGameDefs,
+  ($defs): CatalogType[] => [...MODULES, ...$defs.filter((d) => !d.archived && !d.deleted)],
+);
+
+/**
+ * A custom (user-authored, session 2) game type — its id is prefixed `def_`; built-ins have no
+ * editable def, so custom-only affordances (Edit) gate on this. Re-exported from the canonical
+ * source (`CUSTOM_ID_PREFIX = 'def_'`) so there's a single definition.
+ */
+export { isCustomType } from '../games/custom/types';
+
+/**
+ * The custom-game builder route (session 2). `/create` opens a fresh builder; `/create/<defId>`
+ * edits an existing custom type (route `customedit` → `CustomGameEdit.svelte`). Centralized here
+ * so both catalog surfaces link through one place. Route shape confirmed with session 2.
+ */
+export const CREATE_ROUTE = '/create';
+export function editCustomHref(defId: string): string {
+  return `${CREATE_ROUTE}/${defId}`;
+}
+
+/** Home reveals the search field once the catalog holds at least this many types. */
+export const SEARCH_THRESHOLD = 6;
+
+/** How many recently-played types to surface before they fold into the remainder. */
+export const RECENT_LIMIT = 4;
+
+// ── Metadata: favorites + hidden, backed by portable settings ────────────────────
+
+/** Pinned type ids, in display order (reactive). */
+export const favoriteIds: Readable<string[]> = derived(settings, ($s) => $s.catalogFavorites);
+/** Hidden type ids (reactive). */
+export const hiddenIds: Readable<string[]> = derived(settings, ($s) => $s.catalogHidden);
+
+export function isFavorite(id: string): boolean {
+  return get(settings).catalogFavorites.includes(id);
+}
+export function isHidden(id: string): boolean {
+  return get(settings).catalogHidden.includes(id);
+}
+
+/** Pin/unpin a type. Newly favorited types append, so the pin order stays stable. */
+export function toggleFavorite(id: string): void {
+  settings.update((s) => {
+    const has = s.catalogFavorites.includes(id);
+    return {
+      ...s,
+      catalogFavorites: has
+        ? s.catalogFavorites.filter((x) => x !== id)
+        : [...s.catalogFavorites, id],
+    };
+  });
+}
+
+/**
+ * Hide or show a type in the catalog. Independent of favorites: a hidden favorite keeps its
+ * pin and simply isn't shown until it's shown again.
+ */
+export function setHidden(id: string, hidden: boolean): void {
+  settings.update((s) => {
+    const has = s.catalogHidden.includes(id);
+    if (hidden === has) return s;
+    return {
+      ...s,
+      catalogHidden: hidden ? [...s.catalogHidden, id] : s.catalogHidden.filter((x) => x !== id),
+    };
+  });
+}
+
+/** Hide a type with an Undo toast — the app's standard recoverable-destructive pattern. */
+export function hideWithUndo(id: string, name: string): void {
+  setHidden(id, true);
+  showActionToast(`${name} hidden`, 'Undo', () => setHidden(id, false));
+}
+
+// ── View model + sectioning + search ─────────────────────────────────────────────
+
+export interface CatalogEntry {
+  type: CatalogType;
+  favorite: boolean;
+  hidden: boolean;
+}
+
+/** Every startable type paired with its catalog metadata — the unified list siblings consume. */
+export function catalogEntries(
+  types: CatalogType[] = get(startableTypes),
+  favs: string[] = get(settings).catalogFavorites,
+  hidden: string[] = get(settings).catalogHidden,
+): CatalogEntry[] {
+  const favSet = new Set(favs);
+  const hiddenSet = new Set(hidden);
+  return types.map((t) => ({
+    type: t,
+    favorite: favSet.has(t.id),
+    hidden: hiddenSet.has(t.id),
+  }));
+}
+
+/** Distinct game-type ids ordered by most recently played (active or finished). */
+export function recentTypeIds(games: Game[]): string[] {
+  const lastPlayed = new Map<string, number>();
+  for (const g of games) {
+    const t = g.finishedAt ?? g.createdAt;
+    if (t > (lastPlayed.get(g.type) ?? 0)) lastPlayed.set(g.type, t);
+  }
+  return [...lastPlayed.entries()].sort((a, b) => b[1] - a[1]).map(([id]) => id);
+}
+
+export interface CatalogSections {
+  favorites: CatalogType[];
+  recent: CatalogType[];
+  remainder: CatalogType[];
+}
+
+/**
+ * Split the visible catalog into mutually-exclusive sections so a tile never repeats:
+ * Favorites (stored order) → Recently played (most-recent-first, capped) → the remainder
+ * (registry order). Hidden types are excluded from all three.
+ */
+export function sectionize(
+  types: CatalogType[],
+  games: Game[],
+  favs: string[],
+  hidden: string[],
+): CatalogSections {
+  const hiddenSet = new Set(hidden);
+  const visible = types.filter((t) => !hiddenSet.has(t.id));
+  const byId = new Map(visible.map((t) => [t.id, t]));
+
+  const favorites = favs.map((id) => byId.get(id)).filter((t): t is CatalogType => !!t);
+  const favSet = new Set(favorites.map((t) => t.id));
+
+  const recent = recentTypeIds(games)
+    .map((id) => byId.get(id))
+    .filter((t): t is CatalogType => !!t && !favSet.has(t.id))
+    .slice(0, RECENT_LIMIT);
+  const recentSet = new Set(recent.map((t) => t.id));
+
+  const remainder = visible.filter((t) => !favSet.has(t.id) && !recentSet.has(t.id));
+
+  return { favorites, recent, remainder };
+}
+
+/** Case-insensitive match over name + tagline + optional keyword aliases. */
+export function matchModule(t: CatalogType, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const hay = [t.name, t.tagline, ...(t.keywords ?? [])].join(' ').toLowerCase();
+  return hay.includes(q);
+}

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -33,6 +33,17 @@ export interface Settings {
   keepAwake: boolean;
   /** Blur scores with a tap-to-reveal veil after the phone is set down. */
   privacyGuard: boolean;
+  /**
+   * Game *type* ids pinned to the top of the catalog, in display order. A "type id"
+   * is a built-in slug (`skullking`) or a custom def id (`def_…`). Portable so a
+   * group's chosen games travel with a restore.
+   */
+  catalogFavorites: string[];
+  /**
+   * Game *type* ids hidden from the catalog view — recoverable from Manage games.
+   * Orthogonal to a custom type being retired or a played game being archived.
+   */
+  catalogHidden: string[];
 
   // ── Device-local sync state ───────────────────────────────────────────────
   // OneDrive connection, the backup file's own location, and per-device sync
@@ -89,6 +100,8 @@ export const PORTABLE_SETTING_KEYS = [
   'colorBlind',
   'keepAwake',
   'privacyGuard',
+  'catalogFavorites',
+  'catalogHidden',
 ] as const;
 
 /**
@@ -141,6 +154,8 @@ const defaults: Settings = {
   colorBlind: false,
   keepAwake: false,
   privacyGuard: false,
+  catalogFavorites: [],
+  catalogHidden: [],
   oneDriveClientId: '',
   oneDriveFolderMode: 'app',
   oneDriveCustomPath: '',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -118,6 +118,8 @@ export interface GameModule {
   name: string;
   tagline: string;
   emoji: string;
+  /** Optional search aliases/keywords for catalog discovery (matched alongside name + tagline). */
+  keywords?: string[];
   minPlayers: number;
   maxPlayers: number;
   /** true when the lowest total wins (e.g. Hearts). */

--- a/src/pages/GameType.svelte
+++ b/src/pages/GameType.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
   import { getModule } from '../lib/games/registry';
   import { defaultConfig } from '../lib/types';
-  import { games, activeGames, createGame } from '../lib/stores/games';
-  import { customGameDefs, saveCustomGame, removeCustomGame, restoreCustomGame } from '../lib/stores/customGames';
-  import { isCustomType, duplicateDef } from '../lib/games/custom/types';
-  import { getCustomDef } from '../lib/games/custom/defRegistry';
+  import { activeGames, createGame } from '../lib/stores/games';
+  import { customGameDefs } from '../lib/stores/customGames';
   import { navigate, link } from '../lib/router';
-  import { showToast, showActionToast } from '../lib/stores/toast';
+  import { showToast } from '../lib/stores/toast';
   import PlayerSelect from '../lib/components/PlayerSelect.svelte';
   import ConfigForm from '../lib/components/ConfigForm.svelte';
 
@@ -16,8 +14,6 @@
     void $customGameDefs;
     return getModule(type);
   });
-
-  const isCustom = $derived(isCustomType(type));
 
   let selected = $state<string[]>([]);
   let config = $state<Record<string, any>>({});
@@ -46,35 +42,6 @@
     }
     const g = await createGame(type, [...selected], { ...config });
     navigate(`/play/${g.id}`);
-  }
-
-  function editCustom() {
-    navigate(`/create/${type}`);
-  }
-
-  async function duplicateCustom() {
-    const src = getCustomDef(type);
-    if (!src) return;
-    const copy = duplicateDef(src);
-    await saveCustomGame(copy);
-    navigate(`/create/${copy.id}`);
-  }
-
-  async function deleteCustom() {
-    const src = getCustomDef(type);
-    // "In use" = any game (active or finished) of this type exists → archive, don't destroy.
-    const inUse = $games.some((g) => g.type === type);
-    await removeCustomGame(type, inUse);
-    if (inUse) {
-      showActionToast('Archived — kept for history.', 'Undo', () => {
-        void restoreCustomGame(type);
-      });
-    } else {
-      showActionToast('Game deleted.', 'Undo', () => {
-        if (src) void saveCustomGame(src);
-      });
-    }
-    navigate('/');
   }
 </script>
 
@@ -119,27 +86,12 @@
       Start game
     </button>
   </div>
-
-  {#if isCustom}
-    <div class="section-title">Manage</div>
-    <div class="card row wrap manage">
-      <button class="btn" onclick={editCustom}>✏️ Edit</button>
-      <button class="btn" onclick={duplicateCustom}>⧉ Duplicate</button>
-      <button class="btn danger del" onclick={deleteCustom}>🗑 Delete</button>
-    </div>
-  {/if}
 {/if}
 
 <style>
   .resume {
     text-decoration: none;
     color: inherit;
-  }
-  .manage {
-    gap: 10px;
-  }
-  .manage .del {
-    margin-left: auto;
   }
   hr {
     border: none;

--- a/src/pages/Home.svelte
+++ b/src/pages/Home.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
-  import { MODULES, getModule } from '../lib/games/registry';
+  import { getModule } from '../lib/games/registry';
   import { games } from '../lib/stores/games';
   import { players } from '../lib/stores/players';
-  import { customGameDefs } from '../lib/stores/customGames';
+  import { settings } from '../lib/stores/settings';
   import { link, navigate } from '../lib/router';
   import { relativeTime, normalizeJoinCode } from '../lib/util';
   import { isLiveSupported, isNearbySupported } from '../lib/live/session';
+  import {
+    startableTypes,
+    sectionize,
+    matchModule,
+    SEARCH_THRESHOLD,
+    CUSTOM_GAMES_ENABLED,
+    CREATE_ROUTE,
+    type CatalogType,
+  } from '../lib/stores/catalog';
 
   const liveSupported = isLiveSupported();
   const nearbySupported = isNearbySupported();
@@ -20,9 +29,27 @@
   const recent = $derived(
     $games.filter((g) => g.status === 'finished' && !g.archived).slice(0, 4),
   );
-  // Custom, user-authored games — non-archived, shown alongside the built-ins.
-  // (Seam: session 1's catalog will own ordering/favorites/hidden for these.)
-  const customTiles = $derived($customGameDefs.filter((d) => !d.archived && !d.deleted));
+
+  // ── Catalog: search + mutually-exclusive sections over the startable game types ──
+  let search = $state('');
+  const mods = $derived($startableTypes);
+  const showSearch = $derived(mods.length >= SEARCH_THRESHOLD);
+  const searching = $derived(search.trim().length > 0);
+  const sections = $derived(
+    sectionize(mods, $games, $settings.catalogFavorites, $settings.catalogHidden),
+  );
+  const searchResults = $derived(
+    searching
+      ? mods.filter((m) => !$settings.catalogHidden.includes(m.id) && matchModule(m, search))
+      : [],
+  );
+  const firstSection = $derived(
+    sections.favorites.length ? 'fav' : sections.recent.length ? 'recent' : 'rem',
+  );
+  const remainderTitle = $derived(
+    sections.favorites.length || sections.recent.length ? 'All games' : 'Start a game',
+  );
+  const showRemainder = $derived(sections.remainder.length > 0 || CUSTOM_GAMES_ENABLED);
 
   function names(ids: string[]): string {
     return ids.map((id) => $players.find((p) => p.id === id)?.name ?? '?').join(', ');
@@ -51,28 +78,74 @@
   </div>
 {/if}
 
-<div class="section-title">Start a game</div>
-<div class="grid">
-  {#each MODULES as m (m.id)}
-    <a class="gametile" href={`/${m.id}`} use:link>
-      <span class="emoji">{m.emoji}</span>
-      <span class="name">{m.name}</span>
-      <span class="tag">{m.tagline}</span>
-    </a>
-  {/each}
-  {#each customTiles as d (d.id)}
-    <a class="gametile" href={`/${d.id}`} use:link>
-      <span class="emoji">{d.emoji}</span>
-      <span class="name">{d.name}</span>
-      <span class="tag">{d.tagline}</span>
-    </a>
-  {/each}
-  <a class="gametile create" href="/create" use:link>
-    <span class="emoji" aria-hidden="true">＋</span>
-    <span class="name">Create a game</span>
-    <span class="tag">Design your own scorer</span>
+{#snippet tile(m: CatalogType)}
+  <a class="gametile" href={`/${m.id}`} use:link>
+    <span class="emoji">{m.emoji}</span>
+    <span class="name">{m.name}</span>
+    <span class="tag">{m.tagline}</span>
   </a>
-</div>
+{/snippet}
+
+{#snippet head(label: string, withManage: boolean)}
+  <div class="section-title cathead">
+    <span>{label}</span>
+    {#if withManage}
+      <a class="manage-link" href="/manage-games" use:link>Manage</a>
+    {/if}
+  </div>
+{/snippet}
+
+{#if showSearch}
+  <div class="catalog-bar">
+    <input
+      class="catalog-search"
+      type="text"
+      placeholder="Search games…"
+      aria-label="Search games"
+      autocapitalize="off"
+      autocorrect="off"
+      spellcheck="false"
+      bind:value={search}
+    />
+    <a class="manage-link inbar" href="/manage-games" use:link>Manage</a>
+  </div>
+{/if}
+
+{#if searching}
+  {#if searchResults.length}
+    <div class="grid">
+      {#each searchResults as m (m.id)}{@render tile(m)}{/each}
+    </div>
+  {:else}
+    <div class="empty">No games match “{search.trim()}”.</div>
+  {/if}
+{:else}
+  {#if sections.favorites.length}
+    {@render head('Favorites', !showSearch && firstSection === 'fav')}
+    <div class="grid">
+      {#each sections.favorites as m (m.id)}{@render tile(m)}{/each}
+    </div>
+  {/if}
+  {#if sections.recent.length}
+    {@render head('Recently played', !showSearch && firstSection === 'recent')}
+    <div class="grid">
+      {#each sections.recent as m (m.id)}{@render tile(m)}{/each}
+    </div>
+  {/if}
+  {#if showRemainder}
+    {@render head(remainderTitle, !showSearch && firstSection === 'rem')}
+    <div class="grid">
+      {#each sections.remainder as m (m.id)}{@render tile(m)}{/each}
+      {#if CUSTOM_GAMES_ENABLED}
+        <a class="gametile createtile" href={CREATE_ROUTE} use:link>
+          <span class="emoji" aria-hidden="true">＋</span>
+          <span class="name">Create a game</span>
+          <span class="tag">Build your own scorer</span>
+        </a>
+      {/if}
+    </div>
+  {/if}
+{/if}
 
 {#if liveSupported || nearbySupported}
   <div class="section-title">Join a game</div>
@@ -128,18 +201,47 @@
     text-decoration: none;
     color: inherit;
   }
-  /* "Add new" affordance — dashed outline + ＋ glyph carry the meaning, not color alone. */
-  .create {
-    border-style: dashed;
-  }
-  .create .emoji {
-    color: var(--muted);
-  }
   .tile:hover {
     border-color: var(--primary);
   }
   .big-emoji {
     font-size: 1.6rem;
+  }
+  .catalog-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 18px 4px 4px;
+  }
+  .catalog-search {
+    flex: 1;
+  }
+  .cathead {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  /* A quiet violet text link (allowed) — not a second violet fill. Opts out of the
+     section-title's uppercase/tracked treatment. */
+  .manage-link {
+    text-transform: none;
+    letter-spacing: normal;
+    font-size: 0.85rem;
+    font-weight: 600;
+    white-space: nowrap;
+    padding: 6px 4px;
+  }
+  .manage-link.inbar {
+    padding: 8px;
+  }
+  /* The single "add" accent on Home: a dashed tile with a violet ＋ — never a solid fill. */
+  .createtile {
+    border-style: dashed;
+  }
+  .createtile .emoji {
+    color: var(--primary);
+    font-weight: 700;
   }
   .sm {
     font-size: 0.85rem;

--- a/src/pages/ManageGames.svelte
+++ b/src/pages/ManageGames.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+  import { settings } from '../lib/stores/settings';
+  import { link } from '../lib/router';
+  import {
+    startableTypes,
+    toggleFavorite,
+    setHidden,
+    matchModule,
+    isCustomType,
+    editCustomHref,
+    CREATE_ROUTE,
+    CUSTOM_GAMES_ENABLED,
+  } from '../lib/stores/catalog';
+
+  let query = $state('');
+
+  const mods = $derived($startableTypes);
+  const favs = $derived($settings.catalogFavorites);
+  const hidden = $derived($settings.catalogHidden);
+
+  // Stable registry order here (favoriting reorders the *catalog*, not this list) so rows
+  // don't jump under your thumb while you curate.
+  const visible = $derived(
+    mods.filter((m) => !hidden.includes(m.id) && matchModule(m, query)),
+  );
+  const hiddenModules = $derived(
+    mods.filter((m) => hidden.includes(m.id) && matchModule(m, query)),
+  );
+
+  const searching = $derived(query.trim().length > 0);
+  const nothing = $derived(visible.length === 0 && hiddenModules.length === 0);
+</script>
+
+<h1>Manage games</h1>
+<p class="lede muted">
+  Favorite the games your group plays and hide the ones you don’t. Favorites pin to the top of
+  the catalog; hidden games leave it — both are easy to undo here.
+</p>
+
+<input
+  class="search"
+  type="text"
+  placeholder="Search games…"
+  aria-label="Search games"
+  autocapitalize="off"
+  autocorrect="off"
+  spellcheck="false"
+  bind:value={query}
+/>
+
+{#if nothing}
+  <div class="empty">
+    {#if searching}No games match “{query}”.{:else}No games yet.{/if}
+  </div>
+{:else}
+  {#if visible.length}
+    <div class="section-title">Games</div>
+    <div class="card list">
+      {#each visible as m (m.id)}
+        {@const fav = favs.includes(m.id)}
+        <div class="mrow">
+          <span class="info">
+            <span class="emoji" aria-hidden="true">{m.emoji}</span>
+            <span class="meta">
+              <span class="name">{m.name}</span>
+              <span class="muted sm">{m.tagline}</span>
+            </span>
+          </span>
+          <span class="actions">
+            {#if CUSTOM_GAMES_ENABLED && isCustomType(m.id)}
+              <a class="btn small ghost" href={editCustomHref(m.id)} use:link>Edit</a>
+            {/if}
+            <button
+              class="starbtn"
+              type="button"
+              aria-pressed={fav}
+              title={fav ? `Unfavorite ${m.name}` : `Favorite ${m.name}`}
+              onclick={() => toggleFavorite(m.id)}
+            >
+              <span aria-hidden="true">{fav ? '★' : '☆'}</span>
+              <span class="sr-only">{fav ? `Unfavorite ${m.name}` : `Favorite ${m.name}`}</span>
+            </button>
+            <button class="btn small ghost" type="button" onclick={() => setHidden(m.id, true)}>
+              Hide
+            </button>
+          </span>
+        </div>
+      {/each}
+    </div>
+  {:else if !searching}
+    <div class="empty">Every game is hidden — show one below to bring it back to the catalog.</div>
+  {/if}
+
+  {#if hiddenModules.length}
+    <div class="section-title">Hidden</div>
+    <div class="card list">
+      {#each hiddenModules as m (m.id)}
+        <div class="mrow">
+          <span class="info dim">
+            <span class="emoji" aria-hidden="true">{m.emoji}</span>
+            <span class="meta">
+              <span class="name">{m.name}</span>
+              <span class="muted sm">{m.tagline}</span>
+            </span>
+          </span>
+          <span class="actions">
+            <button class="btn small" type="button" onclick={() => setHidden(m.id, false)}>
+              Show
+            </button>
+          </span>
+        </div>
+      {/each}
+    </div>
+  {/if}
+{/if}
+
+{#if CUSTOM_GAMES_ENABLED}
+  <a class="btn primary block createbtn" href={CREATE_ROUTE} use:link>＋ Create a game</a>
+{/if}
+
+<style>
+  .lede {
+    margin: -2px 4px 16px;
+    max-width: 60ch;
+  }
+  .search {
+    margin: 0 0 6px;
+  }
+  .list {
+    padding: 0;
+    overflow: hidden;
+  }
+  .mrow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 11px 16px;
+    min-height: 46px;
+  }
+  .mrow + .mrow {
+    border-top: 1px solid var(--border);
+  }
+  .info {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+  }
+  .info.dim {
+    opacity: 0.6;
+  }
+  .emoji {
+    font-size: 1.6rem;
+    line-height: 1;
+    flex: none;
+  }
+  .meta {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+  .name {
+    font-weight: 700;
+  }
+  .sm {
+    font-size: 0.85rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: none;
+  }
+  /* A neutral star: filled ★ vs outline ☆ + aria-pressed carry the state — never gold
+     (reserved for the leader/winner) and never a second violet fill. */
+  .starbtn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 46px;
+    height: 46px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    color: var(--muted);
+    font-size: 1.3rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: transform 0.05s ease, background 0.15s ease, color 0.15s ease;
+  }
+  .starbtn[aria-pressed='true'] {
+    color: var(--text);
+    background: var(--surface-3);
+  }
+  .starbtn:active {
+    transform: translateY(1px);
+  }
+  .starbtn:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .createbtn {
+    margin-top: var(--card-gap);
+    text-decoration: none;
+  }
+</style>

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -501,6 +501,18 @@
   <span class="chev" aria-hidden="true">›</span>
 </a>
 
+<div class="section-title">Games</div>
+<a class="card navrow row spread" href="/manage-games" use:link>
+  <span class="row" style="gap: 12px">
+    <span class="navico" aria-hidden="true">🎴</span>
+    <span class="navmeta">
+      <span class="navname">Manage games</span>
+      <span class="muted sm">Favorite, hide, and organize your game catalog</span>
+    </span>
+  </span>
+  <span class="chev" aria-hidden="true">›</span>
+</a>
+
 <div class="section-title">Display & accessibility</div>
 <a class="card navrow row spread" href="/accessibility" use:link>
   <span class="row" style="gap: 12px">


### PR DESCRIPTION
## Game catalog & discovery

Reworks Home's **"Start a game"** region into a game-*type* catalog that scales as the catalog grows (session 2 adds unlimited user-created types), and introduces the **shared catalog metadata model** that built-in and custom types both consume.

> **Rebased & integrated** on top of #30 → #32 (custom types) → #31 (library) — the last PR in the stack. The seam is now live: `CUSTOM_GAMES_ENABLED = true` and `startableTypes` is a reactive `derived` over session 2's `customGameDefs` store, so the catalog live-updates as custom types are created / archived / restored.

### What's new
- **Search** over game types — progressive: appears on Home only once the catalog is large enough (`SEARCH_THRESHOLD`), always present on the Manage page. Matches name / tagline / optional `keywords` aliases.
- **Organization** — mutually-exclusive sections so a tile never repeats: **Favorites** → **Recently played** (derived from game history) → remainder (`All games` / `Start a game`).
- **Favorite / pin** — pins a type to the top of the catalog.
- **Hide** (recoverable) — removes a type from the Home catalog; restored from the Manage page.
- **Manage games** page (`/manage-games`) — dedicated curation surface (search + favorite/hide/restore + gated Edit deep-link on custom rows), linked from Home and Settings.

### Shared catalog metadata model (owned here; siblings build on it)
- Two **portable** settings keys — `catalogFavorites: string[]`, `catalogHidden: string[]` — keyed by **type id** (built-in slug `skullking`/`hearts`/`tally` **or** a `def_…` custom id). They travel in the backup for free and satisfy the compile-time settings guard.
- New store `src/lib/stores/catalog.ts` is the API siblings consume: `startableTypes` (reactive `Readable<CatalogType[]>`), `CatalogType`, `favoriteIds`/`hiddenIds`, `isFavorite`/`isHidden`, `toggleFavorite`, `setHidden`, `hideWithUndo`, `sectionize`, `matchModule`, `recentTypeIds`, `catalogEntries`, plus the custom-type entry points `isCustomType`/`CREATE_ROUTE`/`editCustomHref`.
- Keeps the three concepts distinct: my **`hidden`** (user hides any type from their catalog) is orthogonal to session 2's `CustomGameDef.archived` (retired custom type) and session 3's `Game.archived` (hidden played instance).

### Session-2 integration seam (live)
- `catalog.ts` exposes a **reactive** `startableTypes: Readable<CatalogType[]>`, now a `derived` over session 2's reactive `customGameDefs` store so the catalog live-updates when a custom type is created / archived / restored:
  ```ts
  export const startableTypes: Readable<CatalogType[]> = derived(
    customGameDefs,
    ($defs): CatalogType[] => [...MODULES, ...$defs.filter((d) => !d.archived && !d.deleted)],
  );
  ```
  Both `GameModule` and `CustomGameDef` satisfy the `CatalogType` projection (`{ id, name, emoji, tagline, keywords? }`). There is **no `getStartableModules()` helper** — session 2 deliberately keeps custom defs in the reactive store (a plain-array helper wouldn't live-update). `registry.ts` and `customGames.ts` stay import-and-read only — untouched here. The `!archived && !deleted` filter (session 2's) lives at that source and is **distinct** from my `catalogHidden`, which is layered on top in `sectionize`/Manage.
- `isCustomType` re-exports session 2's canonical `src/lib/games/custom/types.ts` (`CUSTOM_ID_PREFIX = 'def_'`) — one definition, no divergence.
- `CUSTOM_GAMES_ENABLED = true` — the **＋ Create a game** tile (→ `CREATE_ROUTE` = `/create`) and the neutral ghost **Edit** deep-link on custom (`def_…`) Manage rows (→ `editCustomHref(defId)` = `/create/<defId>`, route `customedit`) are live. Built-in tiles never show custom-only affordances (gated by `isCustomType`).
- `Home.svelte` supersedes session 2's temporary appended custom/Create tiles, while session 3's `!g.archived` filters on the Continue / Recent-results derives are preserved. `GameType.svelte` consolidates management into `/manage-games`: session 2's temporary per-type Edit/Duplicate/Delete buttons are removed, while session 3's active-games resume list and the custom-def deep-link re-resolve are kept. **Merge order:** #30 → #32 → #31 → **#33 (this PR — last)**.

### Boundary (coordinator "Option A", Edit-only)
Curation (favorite/hide/appear) + both entry points (create + edit) live here; the custom-type **rules/fields/duplicate/delete/archive** editor stays session 2's. Manage surfaces **only** an **Edit** deep-link into that editor — never reimplements it, and never shows Duplicate/Delete (destructive controls kept in one place).

### Brand / DESIGN.md
- Favorite affordance is **shape-based** (★ filled vs ☆ outline) in neutral ink with `aria-pressed` — **not** Crown Gold (reserved for leader/winner) and not a second violet fill.
- One violet accent per screen: the dashed **＋ Create** tile; "Manage" is a violet text link. Shared chrome unchanged; touch targets ≥46px; reduced-motion honored.

### Verification
- `npm run check` → 0 errors / 0 warnings (post-rebase).
- `npm run build` → success (post-rebase).
- Fully offline; no new dependencies; nothing gates play.

Closes the catalog slice of the game-management overhaul (offered · organized · searched · hidden, for game types).