### PR TITLE
Add Stats area, The Court, and Wrapped

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "svelte-check": "^4.6.0",
         "typescript": "~6.0.2",
         "vite": "^8.1.0",
-        "vite-plugin-pwa": "^1.3.0"
+        "vite-plugin-pwa": "^1.3.0",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@apideck/better-ajv-errors": {
@@ -2529,6 +2530,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
@@ -2603,6 +2611,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2633,6 +2659,129 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/acorn": {
       "version": "8.17.0",
@@ -2720,6 +2869,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -2976,6 +3135,16 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -3369,6 +3538,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -3482,6 +3658,16 @@
       },
       "funding": {
         "url": "https://github.com/bgub/eta?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5078,6 +5264,13 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5623,6 +5816,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5702,6 +5902,20 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -5944,6 +6158,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -5959,6 +6190,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tr46": {
@@ -6346,6 +6587,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -6468,6 +6799,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wmf": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json"
+    "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -17,7 +19,8 @@
     "svelte-check": "^4.6.0",
     "typescript": "~6.0.2",
     "vite": "^8.1.0",
-    "vite-plugin-pwa": "^1.3.0"
+    "vite-plugin-pwa": "^1.3.0",
+    "vitest": "^4.1.9"
   },
   "dependencies": {
     "@azure/msal-browser": "^5.15.0",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import History from './pages/History.svelte';
   import Stats from './pages/Stats.svelte';
   import Court from './pages/Court.svelte';
+  import Wrapped from './pages/Wrapped.svelte';
   import Settings from './pages/Settings.svelte';
   import Accessibility from './pages/Accessibility.svelte';
   import GameplaySettings from './pages/GameplaySettings.svelte';
@@ -64,6 +65,8 @@
     <Stats />
   {:else if route.name === 'court'}
     <Court />
+  {:else if route.name === 'wrapped'}
+    <Wrapped />
   {:else if route.name === 'settings'}
     <Settings />
   {:else if route.name === 'accessibility'}
@@ -97,7 +100,7 @@
   <a href="/history" use:link class:active={route.name === 'history'}>
     <span class="ico">📜</span>History
   </a>
-  <a href="/stats" use:link class:active={route.name === 'stats' || route.name === 'court'}>
+  <a href="/stats" use:link class:active={route.name === 'stats' || route.name === 'court' || route.name === 'wrapped'}>
     <span class="ico">📊</span>Stats
   </a>
 </nav>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,6 +7,7 @@
   import Players from './pages/Players.svelte';
   import History from './pages/History.svelte';
   import Stats from './pages/Stats.svelte';
+  import Court from './pages/Court.svelte';
   import Settings from './pages/Settings.svelte';
   import Accessibility from './pages/Accessibility.svelte';
   import GameplaySettings from './pages/GameplaySettings.svelte';
@@ -61,6 +62,8 @@
     <History />
   {:else if route.name === 'stats'}
     <Stats />
+  {:else if route.name === 'court'}
+    <Court />
   {:else if route.name === 'settings'}
     <Settings />
   {:else if route.name === 'accessibility'}
@@ -94,7 +97,7 @@
   <a href="/history" use:link class:active={route.name === 'history'}>
     <span class="ico">📜</span>History
   </a>
-  <a href="/stats" use:link class:active={route.name === 'stats'}>
+  <a href="/stats" use:link class:active={route.name === 'stats' || route.name === 'court'}>
     <span class="ico">📊</span>Stats
   </a>
 </nav>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -70,6 +70,8 @@
     <Court />
   {:else if route.name === 'wrapped'}
     <Wrapped />
+  {:else if route.name === 'tonight'}
+    <Wrapped initialPreset="tonight" />
   {:else if route.name === 'settings'}
     <Settings />
   {:else if route.name === 'accessibility'}
@@ -113,7 +115,7 @@
   <a href="/history" use:link class:active={route.name === 'history'}>
     <span class="ico">📜</span>History
   </a>
-  <a href="/stats" use:link class:active={route.name === 'stats' || route.name === 'court' || route.name === 'wrapped'}>
+  <a href="/stats" use:link class:active={route.name === 'stats' || route.name === 'court' || route.name === 'wrapped' || route.name === 'tonight'}>
     <span class="ico">📊</span>Stats
   </a>
 </nav>

--- a/src/lib/games/hearts/index.ts
+++ b/src/lib/games/hearts/index.ts
@@ -1,5 +1,6 @@
 import type { GameModule, ID, Round, RoundContext } from '../../types';
 import Editor from './HeartsEditor.svelte';
+import { heartsStats } from './stats';
 
 export interface HeartsInput {
   hearts: Record<ID, number>;
@@ -95,6 +96,8 @@ export const hearts: GameModule = {
     if (moon) return `🌙 ${name(moon)} shot the moon`;
     return `♠Q: ${name(input.queen)}`;
   },
+
+  stats: heartsStats,
 
   RoundEditor: Editor,
 };

--- a/src/lib/games/hearts/stats.ts
+++ b/src/lib/games/hearts/stats.ts
@@ -1,0 +1,71 @@
+import type { ID } from '../../types';
+import type { HeartsInput } from './index';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtPct } from '../../stats/format';
+
+interface HeartsAgg {
+  moons: number;
+  queens: number;
+  clean: number;
+  rounds: number;
+}
+
+/** Who shot the moon this round (took all 13 hearts + the ♠Q), by original id. */
+function moonShooter(input: HeartsInput): ID | null {
+  for (const [id, h] of Object.entries(input.hearts)) {
+    if ((Number(h) || 0) === 13 && input.queen === id) return id;
+  }
+  return null;
+}
+
+/**
+ * Hearts stats from each round's recorded hearts/♠Q. Lower-is-better, so a
+ * "clean" round = took zero points. Pure; mirrors the module's own `shooter()`.
+ */
+export function heartsStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, HeartsAgg>();
+  const get = (id: ID): HeartsAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { moons: 0, queens: 0, clean: 0, rounds: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as HeartsInput | undefined;
+    if (!input?.hearts) continue;
+    const queenId = input.queen ? canonical(input.queen) : null;
+    for (const [pid, h] of Object.entries(input.hearts)) {
+      const id = canonical(pid);
+      const a = get(id);
+      a.rounds += 1;
+      const tookQueen = queenId === id;
+      if (tookQueen) a.queens += 1;
+      const points = (Number(h) || 0) + (tookQueen ? 13 : 0);
+      if (points === 0) a.clean += 1;
+    }
+    const moon = moonShooter(input);
+    if (moon) get(canonical(moon)).moons += 1;
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let totMoons = 0;
+  for (const [id, a] of per) {
+    totMoons += a.moons;
+    const metrics: Metric[] = [];
+    if (a.moons) metrics.push({ key: 'h_moon', label: 'Moons shot', value: `${a.moons}`, emoji: '🌙' });
+    if (a.queens) metrics.push({ key: 'h_queen', label: '♠Q taken', value: `${a.queens}`, emoji: '♠️' });
+    if (a.rounds) {
+      metrics.push({ key: 'h_clean', label: 'Clean rounds', value: fmtPct(a.clean / a.rounds), emoji: '😇' });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totMoons) global.push({ key: 'h_moon_all', label: 'Moons shot', value: `${totMoons}`, emoji: '🌙' });
+  return { perPlayer, global };
+}

--- a/src/lib/games/skullking/index.ts
+++ b/src/lib/games/skullking/index.ts
@@ -1,5 +1,6 @@
 import type { GameModule, ID, Round, RoundContext } from '../../types';
 import Editor from './SkullKingEditor.svelte';
+import { skullkingStats } from './stats';
 
 export interface SKRow {
   bid: number;
@@ -94,6 +95,8 @@ export const skullking: GameModule = {
     '• +50 Skull King over Mermaid',
     'Bonuses vary by edition — confirm your set.',
   ].join('\n'),
+
+  stats: skullkingStats,
 
   RoundEditor: Editor,
 };

--- a/src/lib/games/skullking/stats.ts
+++ b/src/lib/games/skullking/stats.ts
@@ -1,0 +1,74 @@
+import type { ID } from '../../types';
+import type { SKInput } from './index';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt, fmtPct } from '../../stats/format';
+
+interface SKAgg {
+  bids: number;
+  made: number;
+  zero: number;
+  zeroMade: number;
+  bonus: number;
+}
+
+/**
+ * Skull King stats, derived purely from each round's recorded bids/tricks.
+ * A bid is "made" when actual === bid; round n has n tricks. Pure — no Svelte,
+ * so it's independently unit-testable and safe for the engine to import.
+ */
+export function skullkingStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, SKAgg>();
+  const get = (id: ID): SKAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { bids: 0, made: 0, zero: 0, zeroMade: 0, bonus: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as SKInput | undefined;
+    if (!input?.rows) continue;
+    for (const [pid, row] of Object.entries(input.rows)) {
+      const a = get(canonical(pid));
+      const bid = Number(row.bid) || 0;
+      const actual = Number(row.actual) || 0;
+      const made = actual === bid;
+      a.bids += 1;
+      if (made) a.made += 1;
+      if (bid === 0) {
+        a.zero += 1;
+        if (made) a.zeroMade += 1;
+      }
+      a.bonus += Number(row.bonus) || 0;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let totBids = 0;
+  let totMade = 0;
+  for (const [id, a] of per) {
+    totBids += a.bids;
+    totMade += a.made;
+    const metrics: Metric[] = [];
+    if (a.bids) {
+      metrics.push({ key: 'sk_acc', label: 'Bid accuracy', value: fmtPct(a.made / a.bids), emoji: '🎯' });
+    }
+    if (a.zero) {
+      metrics.push({ key: 'sk_zero', label: 'Zero-bid success', value: `${a.zeroMade}/${a.zero}`, emoji: '🥚' });
+    }
+    if (a.bonus) {
+      metrics.push({ key: 'sk_bonus', label: 'Bonus hunted', value: fmtInt(a.bonus), emoji: '💰' });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totBids) {
+    global.push({ key: 'sk_acc_all', label: 'Bid accuracy', value: fmtPct(totMade / totBids), emoji: '🎯' });
+  }
+  return { perPlayer, global };
+}

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -75,6 +75,7 @@ export type RouteName =
   | 'history'
   | 'stats'
   | 'court'
+  | 'wrapped'
   | 'settings'
   | 'accessibility'
   | 'gameplay'
@@ -95,6 +96,7 @@ const RESERVED: Record<string, RouteName> = {
   history: 'history',
   stats: 'stats',
   court: 'court',
+  wrapped: 'wrapped',
   settings: 'settings',
   accessibility: 'accessibility',
   gameplay: 'gameplay',

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -76,6 +76,7 @@ export type RouteName =
   | 'stats'
   | 'court'
   | 'wrapped'
+  | 'tonight'
   | 'settings'
   | 'accessibility'
   | 'managegames'
@@ -100,6 +101,7 @@ const RESERVED: Record<string, RouteName> = {
   stats: 'stats',
   court: 'court',
   wrapped: 'wrapped',
+  tonight: 'tonight',
   settings: 'settings',
   accessibility: 'accessibility',
   'manage-games': 'managegames',

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -74,6 +74,7 @@ export type RouteName =
   | 'players'
   | 'history'
   | 'stats'
+  | 'court'
   | 'settings'
   | 'accessibility'
   | 'gameplay'
@@ -93,6 +94,7 @@ const RESERVED: Record<string, RouteName> = {
   players: 'players',
   history: 'history',
   stats: 'stats',
+  court: 'court',
   settings: 'settings',
   accessibility: 'accessibility',
   gameplay: 'gameplay',

--- a/src/lib/stats/badges.test.ts
+++ b/src/lib/stats/badges.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import type { GameRecord, MemberStats } from './types';
+import { computeBadges, newlyEarned } from './badges';
+
+function mkStats(p: Partial<MemberStats> = {}): MemberStats {
+  return {
+    playerId: 'me',
+    played: 5,
+    finished: 5,
+    wins: 0,
+    podiums: 1,
+    winRate: 0,
+    currentStreak: 0,
+    longestStreak: 0,
+    points: 50,
+    rounds: 20,
+    byGameType: {},
+    headToHead: {},
+    comebackWins: 0,
+    wireToWireWins: 0,
+    closeGames: 0,
+    closeWins: 0,
+    gameNights: 2,
+    ...p,
+  };
+}
+
+const keys = (b: { key: string }[]) => b.map((x) => x.key);
+
+describe('computeBadges', () => {
+  it('awards nothing headline-worthy to a winless newcomer', () => {
+    expect(keys(computeBadges(mkStats()))).not.toContain('first_win');
+  });
+
+  it('unlocks First Win and the right milestone tiers', () => {
+    expect(keys(computeBadges(mkStats({ wins: 1 })))).toContain('first_win');
+
+    const contender = computeBadges(mkStats({ wins: 10 })).find((b) => b.key === 'wins_tier');
+    expect(contender).toMatchObject({ name: 'Contender', rarity: 'uncommon' });
+
+    const centurion = computeBadges(mkStats({ wins: 120 })).find((b) => b.key === 'wins_tier');
+    expect(centurion).toMatchObject({ name: 'Centurion', rarity: 'epic' });
+  });
+
+  it('tiers played count and streaks', () => {
+    expect(computeBadges(mkStats({ played: 25 })).find((b) => b.key === 'played_tier')?.name).toBe('Regular');
+    expect(computeBadges(mkStats({ longestStreak: 3 })).find((b) => b.key === 'streak_tier')?.name).toBe('Hat-trick');
+    expect(computeBadges(mkStats({ longestStreak: 8 })).find((b) => b.key === 'streak_tier')?.rarity).toBe('epic');
+  });
+
+  it('awards drama badges from comeback / wire-to-wire wins', () => {
+    const b = computeBadges(mkStats({ comebackWins: 1, wireToWireWins: 1 }));
+    expect(keys(b)).toEqual(expect.arrayContaining(['comeback', 'wire']));
+  });
+
+  it('awards a record badge only to the record holder', () => {
+    const records: GameRecord[] = [
+      { key: 'blowout', label: 'Biggest blowout', value: '80', holderId: 'me' },
+      { key: 'longest', label: 'Longest game', value: '12', holderId: 'someone-else' },
+    ];
+    const b = computeBadges(mkStats({ wins: 1 }), { records });
+    expect(keys(b)).toContain('record_blowout');
+    expect(keys(b)).not.toContain('record_longest');
+  });
+
+  it('sorts rarest first', () => {
+    const b = computeBadges(mkStats({ wins: 120, played: 25, longestStreak: 8 }));
+    const rank = { legendary: 4, epic: 3, rare: 2, uncommon: 1, common: 0 } as const;
+    for (let i = 1; i < b.length; i++) {
+      expect(rank[b[i - 1].rarity]).toBeGreaterThanOrEqual(rank[b[i].rarity]);
+    }
+  });
+});
+
+describe('newlyEarned', () => {
+  it('returns only badges absent from the seen set', () => {
+    const current = computeBadges(mkStats({ wins: 1, comebackWins: 1 }));
+    const seen = new Set(['first_win']);
+    expect(keys(newlyEarned(current, seen))).toEqual(['comeback']);
+  });
+});

--- a/src/lib/stats/badges.ts
+++ b/src/lib/stats/badges.ts
@@ -1,0 +1,99 @@
+import type { GameRecord, ID, MemberStats } from './types';
+
+export type Rarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
+
+export interface Badge {
+  key: string;
+  name: string;
+  emoji: string;
+  rarity: Rarity;
+  desc: string;
+}
+
+const RARITY_ORDER: Record<Rarity, number> = {
+  legendary: 4,
+  epic: 3,
+  rare: 2,
+  uncommon: 1,
+  common: 0,
+};
+
+/** Highest tier whose threshold is met, or undefined. */
+function tier<T>(value: number, tiers: ReadonlyArray<readonly [number, T]>): T | undefined {
+  for (const [n, out] of tiers) if (value >= n) return out;
+  return undefined;
+}
+
+export interface BadgeInput {
+  /** Records the engine surfaced, used to award "record holder" badges. */
+  records?: GameRecord[];
+}
+
+/**
+ * Earned badges for a member, derived on read from their stats (and any records
+ * they currently hold). Pure — the "newly unlocked" diff against a device-local
+ * last-seen set is the caller's concern, not this catalog's.
+ */
+export function computeBadges(m: MemberStats, input: BadgeInput = {}): Badge[] {
+  const out: Badge[] = [];
+  const add = (key: string, name: string, emoji: string, rarity: Rarity, desc: string) =>
+    out.push({ key, name, emoji, rarity, desc });
+
+  // ── Milestones ────────────────────────────────────────────────────────────
+  if (m.wins >= 1) add('first_win', 'First Win', '🥇', 'common', 'Won your first game.');
+
+  const win = tier<[string, Rarity]>(m.wins, [
+    [500, ['Legend', 'legendary']],
+    [100, ['Centurion', 'epic']],
+    [50, ['Champion', 'rare']],
+    [10, ['Contender', 'uncommon']],
+  ]);
+  if (win) add('wins_tier', win[0], '💯', win[1], `Won ${m.wins} games.`);
+
+  const played = tier<[string, Rarity]>(m.played, [
+    [500, ['Grandmaster', 'epic']],
+    [100, ['Veteran', 'rare']],
+    [25, ['Regular', 'uncommon']],
+  ]);
+  if (played) add('played_tier', played[0], '🎖️', played[1], `Played ${m.played} games.`);
+
+  const nights = tier<[string, Rarity]>(m.gameNights, [
+    [50, ['Fixture', 'rare']],
+    [10, ['Anchor', 'uncommon']],
+  ]);
+  if (nights) add('nights_tier', nights[0], '🪑', nights[1], `Showed up for ${m.gameNights} game nights.`);
+
+  // ── Streaks ───────────────────────────────────────────────────────────────
+  const streak = tier<[string, Rarity]>(m.longestStreak, [
+    [8, ['Unstoppable', 'epic']],
+    [5, ['On Fire', 'rare']],
+    [3, ['Hat-trick', 'uncommon']],
+  ]);
+  if (streak) add('streak_tier', streak[0], '🔥', streak[1], `${m.longestStreak}-win streak.`);
+
+  // ── Drama ─────────────────────────────────────────────────────────────────
+  if (m.comebackWins >= 1) add('comeback', 'Comeback Kid', '🪦', 'rare', 'Won a game after trailing.');
+  if (m.wireToWireWins >= 1) add('wire', 'Wire-to-Wire', '🏁', 'uncommon', 'Led a win from start to finish.');
+
+  // ── Records held right now ────────────────────────────────────────────────
+  const RECORD_BADGE: Record<string, { name: string; emoji: string }> = {
+    blowout: { name: 'Blowout', emoji: '💥' },
+    closest: { name: 'Photo Finish', emoji: '📸' },
+    topRound: { name: 'Big Bang', emoji: '🚀' },
+    highTotal: { name: 'High Score', emoji: '📈' },
+    longest: { name: 'Marathoner', emoji: '🏃' },
+  };
+  const mine: ID = m.playerId;
+  for (const rec of input.records ?? []) {
+    if (rec.holderId !== mine) continue;
+    const meta = RECORD_BADGE[rec.key];
+    if (meta) add(`record_${rec.key}`, meta.name, meta.emoji, 'rare', `Holds the ${rec.label.toLowerCase()} record.`);
+  }
+
+  return out.sort((a, b) => RARITY_ORDER[b.rarity] - RARITY_ORDER[a.rarity]);
+}
+
+/** Badges present now but absent from a device-local last-seen key set. */
+export function newlyEarned(current: Badge[], seenKeys: ReadonlySet<string>): Badge[] {
+  return current.filter((b) => !seenKeys.has(b.key));
+}

--- a/src/lib/stats/compare.ts
+++ b/src/lib/stats/compare.ts
@@ -1,0 +1,41 @@
+import type { ID } from '../types';
+import type { MemberStats, StatsResult } from './types';
+
+export interface MetricDelta {
+  key: string;
+  label: string;
+  current: number;
+  prior: number;
+  delta: number;
+  /** Direction-aware: true when the change is an improvement. */
+  better: boolean;
+}
+
+export interface StatsDelta {
+  playerId: ID;
+  metrics: MetricDelta[];
+}
+
+const pick = (m: MemberStats | undefined, f: (m: MemberStats) => number | undefined): number =>
+  m ? f(m) ?? 0 : 0;
+
+/**
+ * Diff one member's stats between two windows (current vs prior) — powers
+ * "vs last season", "vs last year", and "this time last year" comparison cards.
+ */
+export function compareStats(current: StatsResult, prior: StatsResult, playerId: ID): StatsDelta {
+  const c = current.perPlayer[playerId];
+  const p = prior.perPlayer[playerId];
+  const metrics: MetricDelta[] = [];
+  const push = (key: string, label: string, cur: number, pri: number, higherBetter = true) => {
+    metrics.push({ key, label, current: cur, prior: pri, delta: cur - pri, better: higherBetter ? cur > pri : cur < pri });
+  };
+
+  push('wins', 'Wins', pick(c, (m) => m.wins), pick(p, (m) => m.wins));
+  push('winRate', 'Win %', pick(c, (m) => m.winRate), pick(p, (m) => m.winRate));
+  push('played', 'Games', pick(c, (m) => m.played), pick(p, (m) => m.played));
+  push('avgFinish', 'Avg finish', pick(c, (m) => m.avgFinish), pick(p, (m) => m.avgFinish), false);
+  push('longestStreak', 'Best streak', pick(c, (m) => m.longestStreak), pick(p, (m) => m.longestStreak));
+  push('points', 'Points', pick(c, (m) => m.points), pick(p, (m) => m.points));
+  return { playerId, metrics };
+}

--- a/src/lib/stats/court.test.ts
+++ b/src/lib/stats/court.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round } from '../types';
+import { computeStats } from './engine';
+import { buildCourt, reigningKings, rivalrySpotlight, parityIndex, wallOfShame } from './court';
+
+const DAY = 86_400_000;
+const BASE = 1_700_000_000_000;
+
+const player = (id: string): Player => ({ id, name: id, color: '#7c5cff', createdAt: 0 });
+
+function mkGame(p: Partial<Game> & { id: string; type: string; playerIds: ID[]; winnerIds: ID[] }): Game {
+  return {
+    config: {},
+    status: 'finished',
+    createdAt: p.finishedAt ?? BASE,
+    finishedAt: p.finishedAt ?? BASE,
+    roundCount: 1,
+    ...p,
+  } as Game;
+}
+
+function mkRound(gameId: string, deltas: Record<ID, number>): Round {
+  return { id: `${gameId}-r0`, gameId, index: 0, input: {}, deltas, createdAt: BASE };
+}
+
+/**
+ * A, B, C play five games. Skull King (higher wins): A, A, B. Hearts (lower wins): B, B.
+ * → B leads overall (3 wins) and is on a 3-game heater; A owns Skull King, B owns Hearts;
+ *   C never wins. A vs B is the close rivalry (2–3); C is everyone's victim.
+ */
+function courtFixture() {
+  const players = [player('A'), player('B'), player('C')];
+  const games = [
+    mkGame({ id: 'g1', type: 'skullking', playerIds: ['A', 'B', 'C'], winnerIds: ['A'], finishedAt: BASE }),
+    mkGame({ id: 'g2', type: 'skullking', playerIds: ['A', 'B', 'C'], winnerIds: ['A'], finishedAt: BASE + DAY }),
+    mkGame({ id: 'g3', type: 'skullking', playerIds: ['A', 'B', 'C'], winnerIds: ['B'], finishedAt: BASE + 2 * DAY }),
+    mkGame({ id: 'g4', type: 'hearts', playerIds: ['A', 'B', 'C'], winnerIds: ['B'], finishedAt: BASE + 3 * DAY }),
+    mkGame({ id: 'g5', type: 'hearts', playerIds: ['A', 'B', 'C'], winnerIds: ['B'], finishedAt: BASE + 4 * DAY }),
+  ];
+  const rounds = [
+    mkRound('g1', { A: 30, B: 20, C: 10 }),
+    mkRound('g2', { A: 30, B: 20, C: 10 }),
+    mkRound('g3', { B: 30, A: 20, C: 10 }),
+    mkRound('g4', { B: 5, A: 10, C: 15 }), // hearts: lower is better
+    mkRound('g5', { B: 5, A: 10, C: 15 }),
+  ];
+  return computeStats({ players, games, rounds });
+}
+
+describe('court — reigning kings & the belt', () => {
+  const res = courtFixture();
+  const throne = reigningKings(res);
+
+  it('crowns the overall leader', () => {
+    expect(throne.overallId).toBe('B');
+    expect(throne.overallWins).toBe(3);
+  });
+
+  it('awards the Iron Throne to the longest active streak', () => {
+    expect(throne.ironThroneId).toBe('B'); // won the last three
+    expect(throne.ironThroneStreak).toBe(3);
+  });
+
+  it('names a King per game, most-contested first', () => {
+    expect(throne.kings.map((k) => k.gameType)).toEqual(['skullking', 'hearts']);
+    const sk = throne.kings.find((k) => k.gameType === 'skullking');
+    const hearts = throne.kings.find((k) => k.gameType === 'hearts');
+    expect(sk?.holderId).toBe('A');
+    expect(sk?.wins).toBe(2);
+    expect(hearts?.holderId).toBe('B');
+  });
+
+  it('withholds a crown when nobody clears the games floor', () => {
+    const strict = reigningKings(res, { minGamesForKing: 99 });
+    expect(strict.kings).toEqual([]);
+  });
+});
+
+describe('court — rivalry spotlight', () => {
+  const res = courtFixture();
+
+  it('picks the closest well-played pair as hottest', () => {
+    const { hottest } = rivalrySpotlight(res);
+    expect(hottest).toBeDefined();
+    expect([hottest!.aId, hottest!.bId]).toEqual(['A', 'B']);
+    expect(hottest!.games).toBe(5);
+    expect(hottest!.aWins).toBe(2);
+    expect(hottest!.bWins).toBe(3);
+    expect(hottest!.closeness).toBeCloseTo(0.8, 5);
+  });
+
+  it('surfaces a one-sided pairing as the mismatch', () => {
+    const { mismatch } = rivalrySpotlight(res);
+    expect(mismatch).toBeDefined();
+    expect(mismatch!.closeness).toBe(0); // C never beats anyone
+    expect(mismatch!.games).toBe(5);
+  });
+
+  it('needs enough co-games to call a rivalry', () => {
+    expect(rivalrySpotlight(res, { minGamesForRivalry: 99 })).toEqual({});
+  });
+});
+
+describe('court — parity & shame', () => {
+  const res = courtFixture();
+
+  it('measures competitiveness as normalized win entropy', () => {
+    // wins 2 / 3 / 0 across three players -> H/ln(3)
+    expect(parityIndex(res)).toBeCloseTo(0.6126, 3);
+  });
+
+  it('reports the cold spell and the still-winless', () => {
+    const shame = wallOfShame(res);
+    expect(shame.coldestId).toBe('C');
+    expect(shame.coldestWinRate).toBe(0);
+    expect(shame.winlessIds).toEqual(['C']);
+  });
+});
+
+describe('court — buildCourt end to end', () => {
+  it('assembles the whole view-model in one pass', () => {
+    const court = buildCourt(courtFixture());
+    expect(court.throne.overallId).toBe('B');
+    expect(court.hottestRivalry?.closeness).toBeCloseTo(0.8, 5);
+    expect(court.biggestMismatch?.closeness).toBe(0);
+    expect(court.parity).toBeGreaterThan(0);
+    expect(court.shame.winlessIds).toEqual(['C']);
+  });
+
+  it('stays calm with no data', () => {
+    const empty = computeStats({ players: [], games: [], rounds: [] });
+    const court = buildCourt(empty);
+    expect(court.throne.overallId).toBeUndefined();
+    expect(court.throne.kings).toEqual([]);
+    expect(court.hottestRivalry).toBeUndefined();
+    expect(court.parity).toBe(1);
+    expect(court.shame.winlessIds).toEqual([]);
+  });
+});

--- a/src/lib/stats/court.ts
+++ b/src/lib/stats/court.ts
@@ -1,0 +1,206 @@
+import type { ID } from '../types';
+import type { StatsResult } from './types';
+
+/**
+ * Court view-model: the group-facing derivations that need real logic (reigning
+ * Kings, the Iron Throne, rivalry spotlight, parity, a light Wall of Shame). Pure
+ * and id-only — names, emoji and Crown Gold styling are the component's job. The
+ * plain leaderboard / records / totals are read straight off {@link StatsResult}.
+ */
+
+/** Who reigns over a single game right now (most wins, then win rate). */
+export interface GameKing {
+  gameType: string;
+  holderId: ID;
+  wins: number;
+  winRate: number;
+  games: number;
+}
+
+export interface Throne {
+  /** Top of the overall leaderboard — the reigning monarch. */
+  overallId?: ID;
+  overallWins: number;
+  overallWinRate: number;
+  /** Longest *active* win streak in the group (the belt), if anyone is on one. */
+  ironThroneId?: ID;
+  ironThroneStreak: number;
+  /** Reigning King of each game played, most-contested game first. */
+  kings: GameKing[];
+}
+
+export interface RivalryCard {
+  aId: ID;
+  bId: ID;
+  games: number;
+  aWins: number;
+  bWins: number;
+  ties: number;
+  /** 1 = dead even, 0 = one-sided. */
+  closeness: number;
+}
+
+export interface CourtShame {
+  /** Lowest win rate among members with enough games — the current cold spell. */
+  coldestId?: ID;
+  coldestWinRate?: number;
+  /** Members who have finished games but are still chasing a first win. */
+  winlessIds: ID[];
+}
+
+export interface CourtView {
+  throne: Throne;
+  hottestRivalry?: RivalryCard;
+  biggestMismatch?: RivalryCard;
+  /** 0..1 — normalized entropy of wins; 1 = perfectly even, →0 = one player dominates. */
+  parity: number;
+  shame: CourtShame;
+}
+
+export interface CourtOptions {
+  /** Minimum games before a member can hold a game crown. Default 2. */
+  minGamesForKing?: number;
+  /** Minimum co-games before a pair counts as a rivalry / mismatch. Default 3. */
+  minGamesForRivalry?: number;
+  /** Minimum games before a member is eligible for "coldest". Default 3. */
+  minGamesForShame?: number;
+}
+
+const pairKey = (a: ID, b: ID): string => (a < b ? `${a}\u0000${b}` : `${b}\u0000${a}`);
+
+/** Reigning King of each game + the overall monarch and the Iron Throne (belt). */
+export function reigningKings(result: StatsResult, opts: CourtOptions = {}): Throne {
+  const minGames = opts.minGamesForKing ?? 2;
+  const top = result.leaderboard[0];
+
+  // Longest active streak in the group.
+  let ironThroneId: ID | undefined;
+  let ironThroneStreak = 0;
+  for (const m of Object.values(result.perPlayer)) {
+    if (m.currentStreak > ironThroneStreak) {
+      ironThroneStreak = m.currentStreak;
+      ironThroneId = m.playerId;
+    }
+  }
+
+  // Best record per game type: a King must have won at least once and cleared the
+  // games floor, so a single lucky game doesn't crown anyone.
+  const best = new Map<string, GameKing>();
+  const contested = new Map<string, number>();
+  for (const m of Object.values(result.perPlayer)) {
+    for (const [type, bt] of Object.entries(m.byGameType)) {
+      contested.set(type, (contested.get(type) ?? 0) + bt.played);
+      if (bt.wins < 1 || bt.played < minGames) continue;
+      const cur = best.get(type);
+      if (!cur || bt.wins > cur.wins || (bt.wins === cur.wins && bt.winRate > cur.winRate)) {
+        best.set(type, {
+          gameType: type,
+          holderId: m.playerId,
+          wins: bt.wins,
+          winRate: bt.winRate,
+          games: bt.played,
+        });
+      }
+    }
+  }
+
+  const kings = [...best.values()].sort(
+    (a, b) => (contested.get(b.gameType) ?? 0) - (contested.get(a.gameType) ?? 0),
+  );
+
+  return {
+    overallId: top?.playerId,
+    overallWins: top?.wins ?? 0,
+    overallWinRate: top?.winRate ?? 0,
+    ironThroneId,
+    ironThroneStreak,
+    kings,
+  };
+}
+
+/** Every unique co-playing pair as a rivalry card (deduped, self-pairs dropped). */
+export function rivalryCards(result: StatsResult): RivalryCard[] {
+  const seen = new Map<string, RivalryCard>();
+  for (const m of Object.values(result.perPlayer)) {
+    for (const h of Object.values(m.headToHead)) {
+      if (h.opponentId === m.playerId || h.games <= 0) continue;
+      const key = pairKey(m.playerId, h.opponentId);
+      if (seen.has(key)) continue;
+      const a = m.playerId < h.opponentId ? m.playerId : h.opponentId;
+      const b = m.playerId < h.opponentId ? h.opponentId : m.playerId;
+      // Orient wins/losses from a's perspective.
+      const aWins = a === m.playerId ? h.wins : h.losses;
+      const bWins = a === m.playerId ? h.losses : h.wins;
+      const closeness = h.games > 0 ? 1 - Math.abs(aWins - bWins) / h.games : 0;
+      seen.set(key, { aId: a, bId: b, games: h.games, aWins, bWins, ties: h.ties, closeness });
+    }
+  }
+  return [...seen.values()];
+}
+
+/** Hottest rivalry (most games, then closest) and biggest mismatch (most lopsided). */
+export function rivalrySpotlight(
+  result: StatsResult,
+  opts: CourtOptions = {},
+): { hottest?: RivalryCard; mismatch?: RivalryCard } {
+  const minGames = opts.minGamesForRivalry ?? 3;
+  const cards = rivalryCards(result).filter((c) => c.games >= minGames);
+  if (cards.length === 0) return {};
+
+  const hottest = [...cards].sort(
+    (a, b) => b.games - a.games || b.closeness - a.closeness,
+  )[0];
+  const mismatch = [...cards].sort(
+    (a, b) => a.closeness - b.closeness || b.games - a.games,
+  )[0];
+  return { hottest, mismatch: mismatch.closeness < 1 ? mismatch : undefined };
+}
+
+/**
+ * Competitiveness of the group as normalized Shannon entropy of wins across
+ * everyone who has played: 1 = wins spread perfectly evenly, →0 = one player
+ * hoards them. Undefined participation collapses to 1 (nothing to see yet).
+ */
+export function parityIndex(result: StatsResult): number {
+  const players = result.leaderboard.filter((r) => r.played > 0);
+  const n = players.length;
+  if (n <= 1) return 1;
+  const totalWins = players.reduce((s, r) => s + r.wins, 0);
+  if (totalWins <= 0) return 1;
+  let h = 0;
+  for (const r of players) {
+    if (r.wins <= 0) continue;
+    const p = r.wins / totalWins;
+    h -= p * Math.log(p);
+  }
+  return h / Math.log(n);
+}
+
+/** A gentle Wall of Shame: the current cold spell and who's still hunting a first win. */
+export function wallOfShame(result: StatsResult, opts: CourtOptions = {}): CourtShame {
+  const minGames = opts.minGamesForShame ?? 3;
+  let coldestId: ID | undefined;
+  let coldestWinRate: number | undefined;
+  const winlessIds: ID[] = [];
+  for (const r of result.leaderboard) {
+    if (r.played <= 0) continue;
+    if (r.wins === 0) winlessIds.push(r.playerId);
+    if (r.played >= minGames && (coldestWinRate === undefined || r.winRate < coldestWinRate)) {
+      coldestWinRate = r.winRate;
+      coldestId = r.playerId;
+    }
+  }
+  return { coldestId, coldestWinRate, winlessIds };
+}
+
+/** One pass over an all-players {@link StatsResult} → the whole Court view-model. */
+export function buildCourt(result: StatsResult, opts: CourtOptions = {}): CourtView {
+  const { hottest, mismatch } = rivalrySpotlight(result, opts);
+  return {
+    throne: reigningKings(result, opts),
+    hottestRivalry: hottest,
+    biggestMismatch: mismatch,
+    parity: parityIndex(result),
+    shame: wallOfShame(result, opts),
+  };
+}

--- a/src/lib/stats/crown.test.ts
+++ b/src/lib/stats/crown.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import type { MemberStats } from './types';
+import { dailyCrown, nudges } from './crown';
+
+function mkStats(p: Partial<MemberStats> = {}): MemberStats {
+  return {
+    playerId: 'me',
+    played: 10,
+    finished: 10,
+    wins: 3,
+    podiums: 5,
+    winRate: 0.3,
+    currentStreak: 0,
+    longestStreak: 2,
+    points: 100,
+    rounds: 40,
+    byGameType: {},
+    headToHead: {},
+    comebackWins: 0,
+    wireToWireWins: 0,
+    closeGames: 0,
+    closeWins: 0,
+    gameNights: 4,
+    ...p,
+  };
+}
+
+const DAY = Date.UTC(2026, 5, 30, 18, 0, 0);
+
+describe('dailyCrown', () => {
+  it('welcomes a member with no games', () => {
+    const line = dailyCrown({ meId: 'me', me: mkStats({ played: 0, wins: 0 }), now: DAY });
+    expect(line.key).toBe('welcome');
+  });
+
+  it('leads with a live streak when one is running', () => {
+    const line = dailyCrown({ meId: 'me', me: mkStats({ currentStreak: 5, wins: 7 }), now: DAY });
+    expect(line.key).toBe('hot_streak');
+    expect(line.text).toContain('5');
+  });
+
+  it('is stable across the day but avoids yesterday’s pick', () => {
+    const me = mkStats({
+      currentStreak: 4,
+      wins: 6,
+      comebackWins: 2,
+      headToHead: { alex: { opponentId: 'alex', games: 6, wins: 5, losses: 1, ties: 0 } },
+    });
+    const today = dailyCrown({ meId: 'me', me, now: DAY });
+    // Same inputs, later the same day → identical pick (deterministic seed).
+    expect(dailyCrown({ meId: 'me', me, now: DAY + 3_600_000 }).key).toBe(today.key);
+    // Feeding yesterday's pick forces a different headline.
+    expect(dailyCrown({ meId: 'me', me, now: DAY, lastKey: today.key }).key).not.toBe(today.key);
+  });
+
+  it('marks a reigning leader line as gold', () => {
+    const line = dailyCrown({
+      meId: 'me',
+      me: mkStats({ wins: 9, currentStreak: 0 }),
+      leaderboard: [{ playerId: 'me', played: 10, wins: 9, winRate: 0.9, currentStreak: 0 }],
+      now: DAY,
+    });
+    expect(line.key).toBe('reigning');
+    expect(line.gold).toBe(true);
+  });
+
+  it('resolves opponent names for rivalry lines', () => {
+    const line = dailyCrown({
+      meId: 'me',
+      me: mkStats({ currentStreak: 0, wins: 4, headToHead: { p2: { opponentId: 'p2', games: 5, wins: 4, losses: 1, ties: 0 } } }),
+      nameOf: (id) => (id === 'p2' ? 'Sam' : id),
+      lastKey: 'rival_own',
+      now: DAY,
+    });
+    // The rival line, when it surfaces, uses the display name not the id.
+    const rival = nudges({ meId: 'me', me: mkStats({ wins: 4, headToHead: { p2: { opponentId: 'p2', games: 5, wins: 4, losses: 1, ties: 0 } } }), nameOf: (id) => (id === 'p2' ? 'Sam' : id) }).find((n) => n.key === 'rival_own');
+    expect(rival?.text).toContain('Sam');
+    expect(line).toBeTruthy();
+  });
+});
+
+describe('roast mode', () => {
+  const me = mkStats({ played: 6, wins: 0, winRate: 0, headToHead: { foe: { opponentId: 'foe', games: 4, wins: 1, losses: 3, ties: 0 } } });
+
+  it('includes roast lines by default', () => {
+    const tones = nudges({ meId: 'me', me }).map((n) => n.tone);
+    expect(tones).toContain('roast');
+  });
+
+  it('suppresses roast lines when roast is off', () => {
+    const tones = nudges({ meId: 'me', me, roast: false }).map((n) => n.tone);
+    expect(tones).not.toContain('roast');
+  });
+});
+
+describe('nudges', () => {
+  it('omits everyday fallbacks and the excluded hero key', () => {
+    const list = nudges({ meId: 'me', me: mkStats({ currentStreak: 4, comebackWins: 2 }) }, 'hot_streak');
+    const ks = list.map((n) => n.key);
+    expect(ks).not.toContain('hot_streak');
+    expect(ks).not.toContain('tally');
+    expect(ks).not.toContain('welcome');
+  });
+});

--- a/src/lib/stats/crown.ts
+++ b/src/lib/stats/crown.ts
@@ -1,0 +1,195 @@
+import type { GameRecord, HeadToHead, ID, LeaderRow, MemberStats } from './types';
+import type { Persona } from './personas';
+import type { Badge, Rarity } from './badges';
+import { dayKey } from './format';
+
+export type CrownTone = 'flex' | 'roast' | 'neutral';
+
+/** One candidate (and, after selection, the chosen) Daily Crown headline. */
+export interface CrownLine {
+  /** Candidate type — used for anti-repeat and daily selection. */
+  key: string;
+  emoji: string;
+  text: string;
+  tone: CrownTone;
+  /** Crown Gold styling — reserved for genuine leader/winner lines. */
+  gold: boolean;
+  /** Notability (higher = more headline-worthy). */
+  score: number;
+}
+
+export interface CrownInput {
+  meId: ID;
+  me?: MemberStats;
+  persona?: Persona;
+  /** Badges unlocked since the last visit (device-local diff). */
+  newBadges?: Badge[];
+  records?: GameRecord[];
+  leaderboard?: LeaderRow[];
+  /** Resolve a member id to a display name for rivalry lines. */
+  nameOf?: (id: ID) => string;
+  /** Include playful roast/rivalry lines. Default true. */
+  roast?: boolean;
+  now?: number;
+  /** Yesterday's chosen key, so today avoids repeating it. */
+  lastKey?: string;
+}
+
+const RARITY_SCORE: Record<Rarity, number> = {
+  legendary: 1,
+  epic: 0.9,
+  rare: 0.75,
+  uncommon: 0.6,
+  common: 0.4,
+};
+
+const WIN_MILESTONES = [10, 25, 50, 100, 250, 500];
+
+/** Unsigned djb2 string hash — small, deterministic, dependency-free. */
+function hash(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return h >>> 0;
+}
+
+function bestRival(h2h: Record<ID, HeadToHead>): HeadToHead | undefined {
+  let best: HeadToHead | undefined;
+  let bestEdge = 0;
+  for (const r of Object.values(h2h)) {
+    if (r.games < 3 || r.wins <= r.losses) continue;
+    const edge = (r.wins - r.losses) / r.games;
+    if (edge > bestEdge) {
+      best = r;
+      bestEdge = edge;
+    }
+  }
+  return best;
+}
+
+function nemesis(h2h: Record<ID, HeadToHead>): HeadToHead | undefined {
+  let worst: HeadToHead | undefined;
+  let mostLosses = 0;
+  for (const r of Object.values(h2h)) {
+    if (r.games < 3 || r.losses <= r.wins) continue;
+    if (r.losses > mostLosses) {
+      worst = r;
+      mostLosses = r.losses;
+    }
+  }
+  return worst;
+}
+
+function nextMilestone(wins: number): { next: number; gap: number } | undefined {
+  for (const n of WIN_MILESTONES) {
+    if (wins < n) {
+      const gap = n - wins;
+      return gap <= 3 ? { next: n, gap } : undefined;
+    }
+  }
+  return undefined;
+}
+
+/** Generate every applicable candidate line for the member (unranked). */
+function candidates(input: CrownInput): CrownLine[] {
+  const { me, meId, persona, records = [], leaderboard = [], newBadges = [] } = input;
+  const name = input.nameOf ?? ((id: ID) => id);
+  const roast = input.roast !== false;
+  const out: CrownLine[] = [];
+  const add = (key: string, emoji: string, text: string, tone: CrownTone, score: number, gold = false) =>
+    out.push({ key, emoji, text, tone, gold, score });
+
+  if (!me || me.played === 0) {
+    add('welcome', '👑', 'A king is born — play your first game.', 'neutral', 0.3);
+    return out;
+  }
+
+  if (me.currentStreak >= 3) {
+    add('hot_streak', '🔥', `You're on a ${me.currentStreak}-game heater.`, 'flex', 1);
+  }
+
+  const top = leaderboard[0];
+  if (top && top.playerId === meId && me.wins > 0) {
+    add('reigning', '👑', `Reigning champ — ${me.wins} wins to your name.`, 'flex', 0.85, true);
+  }
+
+  for (const rec of records) {
+    if (rec.holderId === meId) {
+      add(`record_${rec.key}`, rec.emoji ?? '📈', `You hold the ${rec.label.toLowerCase()} — ${rec.value}.`, 'flex', 0.8);
+    }
+  }
+
+  const rival = bestRival(me.headToHead);
+  if (rival) {
+    add('rival_own', '😤', `You own ${name(rival.opponentId)}, ${rival.wins}–${rival.losses}.`, 'flex', 0.8);
+  }
+
+  if (me.comebackWins >= 1) {
+    add('comeback', '🪦', `Comeback royalty — ${me.comebackWins} won from behind.`, 'flex', me.comebackWins >= 3 ? 0.8 : 0.6);
+  }
+
+  for (const b of newBadges) {
+    add(`badge_${b.key}`, b.emoji, `New badge: ${b.name}.`, 'flex', RARITY_SCORE[b.rarity]);
+  }
+
+  const near = nextMilestone(me.wins);
+  if (near) {
+    add('milestone', '🎯', `${near.gap} ${near.gap === 1 ? 'win' : 'wins'} from ${near.next}.`, 'neutral', 0.65);
+  }
+
+  if (persona && persona.key !== 'rookie' && persona.confidence >= 0.5) {
+    add('persona', persona.emoji, `Certified ${persona.name}.`, 'neutral', 0.6);
+  }
+
+  if (roast) {
+    const foe = nemesis(me.headToHead);
+    if (foe) {
+      add('nemesis', '💀', `${name(foe.opponentId)}'s got your number, ${foe.losses}–${foe.wins}.`, 'roast', 0.7);
+    }
+    if (me.wins === 0 && me.played >= 3) {
+      add('winless', '🥶', 'Still hunting that first win.', 'roast', 0.7);
+    } else if (me.played >= 5 && me.winRate < 0.2) {
+      add('rough', '🥶', `Rough patch — ${me.wins} in ${me.played}.`, 'roast', 0.6);
+    }
+  }
+
+  // Never empty: a couple of graceful low-data / everyday fallbacks.
+  if (me.played < 3) {
+    add('early', '🎲', `${me.played} games in — your legend begins.`, 'neutral', 0.35);
+  }
+  add('tally', '📊', `${me.played} games, ${me.wins} wins and counting.`, 'neutral', 0.25);
+
+  return out;
+}
+
+/**
+ * Pick the day's headline: rank candidates by notability with a deterministic
+ * per-day jitter (so it's stable all day on a device but varies day to day),
+ * and skip yesterday's pick. Fully on-device.
+ */
+export function dailyCrown(input: CrownInput): CrownLine {
+  const pool = candidates(input);
+  const day = dayKey(input.now ?? Date.now());
+  const jitter = (key: string) => (hash(`${input.meId}|${day}|${key}`) % 1000) / 1000;
+
+  const ranked = pool
+    .map((c) => ({ c, s: c.score + jitter(c.key) * 0.2 }))
+    .sort((a, b) => b.s - a.s);
+
+  if (ranked.length === 0) {
+    return { key: 'welcome', emoji: '👑', text: 'A king is born — play your first game.', tone: 'neutral', gold: false, score: 0 };
+  }
+  if (ranked.length > 1 && ranked[0].c.key === input.lastKey) return ranked[1].c;
+  return ranked[0].c;
+}
+
+/**
+ * Secondary notable lines for the "recent & nudges" strip — the top candidates
+ * minus the everyday fallbacks and an optional already-shown hero line.
+ */
+export function nudges(input: CrownInput, excludeKey?: string, limit = 3): CrownLine[] {
+  const skip = new Set(['tally', 'early', 'welcome']);
+  return candidates(input)
+    .filter((c) => c.key !== excludeKey && !skip.has(c.key))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}

--- a/src/lib/stats/engine.test.ts
+++ b/src/lib/stats/engine.test.ts
@@ -213,6 +213,36 @@ describe('computeStats — injected game-specific hook', () => {
   });
 });
 
+describe('computeStats — abandoned games', () => {
+  const players = [player('A'), player('B')];
+  const finished = mkGame({ id: 'f', playerIds: ['A', 'B'], winnerIds: ['A'], roundCount: 1, finishedAt: BASE });
+  const dead = mkGame({ id: 'x', playerIds: ['A', 'B'], status: 'abandoned', roundCount: 1, finishedAt: BASE + DAY });
+  const data = {
+    players,
+    games: [finished, dead],
+    rounds: [mkRound('f', 0, { A: 5, B: 1 }), mkRound('x', 0, { A: 9, B: 0 })],
+  };
+
+  it('excludes abandoned games from standings, wins and records by default', () => {
+    const res = computeStats(data);
+    expect(res.totals.finishedGames).toBe(1);
+    expect(res.totals.abandonedGames).toBe(1);
+    expect(res.totals.games).toBe(1); // abandoned left out of the volume count by default
+    expect(res.perPlayer['A'].played).toBe(1);
+    expect(res.perPlayer['A'].wins).toBe(1);
+    expect(res.records.find((r) => r.key === 'topRound')?.value).toBe('5'); // the abandoned 9 never counts
+  });
+
+  it('counts abandoned games in volume when includeAbandoned is set, but never as finished', () => {
+    const res = computeStats(data, { includeAbandoned: true });
+    expect(res.totals.games).toBe(2);
+    expect(res.totals.finishedGames).toBe(1);
+    expect(res.totals.abandonedGames).toBe(1);
+    expect(res.perPlayer['A'].played).toBe(1); // still excluded from standings
+    expect(res.records.find((r) => r.key === 'topRound')?.value).toBe('5');
+  });
+});
+
 describe('buildAliasMap', () => {
   it('resolves merge chains transitively', () => {
     const canonical = canonicalizer(

--- a/src/lib/stats/engine.test.ts
+++ b/src/lib/stats/engine.test.ts
@@ -131,6 +131,32 @@ describe('computeStats — head to head', () => {
   });
 });
 
+describe('computeStats — deleted (tombstoned) members are hidden everywhere', () => {
+  // C was tombstoned, so getAllPlayers() drops them: they're absent from
+  // data.players but still referenced by past games. They must vanish from the
+  // leaderboard and H2H, yet keep their seat so A/B ranks and counts stay correct.
+  const { games, rounds } = trio();
+  const res = computeStats({ players: [player('A'), player('B')], games, rounds });
+
+  it('omits the deleted member from perPlayer and the leaderboard', () => {
+    expect(res.perPlayer['C']).toBeUndefined();
+    expect(res.leaderboard.map((r) => r.playerId)).toEqual(['A', 'B']);
+  });
+
+  it('keeps surviving players’ counts and finish positions intact', () => {
+    // A still played all 3 games and won 2 — deleting C doesn’t rewrite history.
+    expect(res.perPlayer['A'].played).toBe(3);
+    expect(res.perPlayer['A'].wins).toBe(2);
+    // A finished 1st, 3rd, 1st: the deleted seat still occupied 2nd/3rd.
+    expect(res.perPlayer['A'].avgFinish).toBeCloseTo(5 / 3, 5);
+  });
+
+  it('drops head-to-head rows against the deleted member', () => {
+    expect(res.perPlayer['A'].headToHead['C']).toBeUndefined();
+    expect(res.perPlayer['A'].headToHead['B']).toMatchObject({ games: 3 });
+  });
+});
+
 describe('computeStats — lower-is-better direction inference', () => {
   it('infers from winnerIds vs totals (no game module needed)', () => {
     const players = [player('A'), player('B')];

--- a/src/lib/stats/engine.test.ts
+++ b/src/lib/stats/engine.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round } from '../types';
+import { computeStats, type ComputeOptions } from './engine';
+import { compareStats } from './compare';
+import { buildAliasMap, canonicalizer } from './identity';
+import { skullkingStats } from '../games/skullking/stats';
+import { heartsStats } from '../games/hearts/stats';
+
+const DAY = 86_400_000;
+const BASE = 1_700_000_000_000;
+
+const player = (id: string, name = id): Player => ({ id, name, color: '#7c5cff', createdAt: 0 });
+
+function mkGame(p: Partial<Game> & { id: string; playerIds: ID[] }): Game {
+  return {
+    type: 'tally',
+    config: {},
+    status: 'finished',
+    createdAt: p.finishedAt ?? BASE,
+    finishedAt: p.finishedAt ?? BASE,
+    roundCount: 0,
+    ...p,
+  } as Game;
+}
+
+function mkRound(gameId: string, index: number, deltas: Record<ID, number>, input: unknown = {}): Round {
+  return { id: `${gameId}-r${index}`, gameId, index, input, deltas, createdAt: BASE };
+}
+
+/** Three games: A wins wire-to-wire (g1), B wins from behind (g2), A wins a lower-is-better game (g3). */
+function trio() {
+  const players = [player('A'), player('B'), player('C')];
+  const g1 = mkGame({ id: 'g1', playerIds: ['A', 'B', 'C'], winnerIds: ['A'], roundCount: 3, finishedAt: BASE });
+  const g2 = mkGame({ id: 'g2', playerIds: ['A', 'B', 'C'], winnerIds: ['B'], roundCount: 3, finishedAt: BASE + 2 * DAY });
+  const g3 = mkGame({ id: 'g3', type: 'hearts', playerIds: ['A', 'B', 'C'], winnerIds: ['A'], roundCount: 1, finishedAt: BASE + 4 * DAY });
+  const games = [g1, g2, g3];
+  const rounds = [
+    mkRound('g1', 0, { A: 10, B: 5, C: 5 }),
+    mkRound('g1', 1, { A: 10, B: 10, C: 5 }),
+    mkRound('g1', 2, { A: 10, B: 5, C: 0 }),
+    mkRound('g2', 0, { A: 10, B: 0, C: 5 }),
+    mkRound('g2', 1, { A: 0, B: 15, C: 5 }),
+    mkRound('g2', 2, { A: 0, B: 10, C: 5 }),
+    mkRound('g3', 0, { A: 5, B: 20, C: 15 }),
+  ];
+  return { players, games, rounds };
+}
+
+describe('computeStats — counting & rates', () => {
+  const { players, games, rounds } = trio();
+  const res = computeStats({ players, games, rounds });
+
+  it('counts played / wins / win rate per member', () => {
+    const a = res.perPlayer['A'];
+    expect(a.played).toBe(3);
+    expect(a.wins).toBe(2);
+    expect(a.winRate).toBeCloseTo(2 / 3, 5);
+    expect(res.perPlayer['B'].wins).toBe(1);
+    expect(res.perPlayer['C'].wins).toBe(0);
+  });
+
+  it('splits wins by game type', () => {
+    expect(res.perPlayer['A'].byGameType['tally']).toMatchObject({ played: 2, wins: 1 });
+    expect(res.perPlayer['A'].byGameType['hearts']).toMatchObject({ played: 1, wins: 1 });
+  });
+
+  it('totals points across all rounds (canonical)', () => {
+    expect(res.perPlayer['A'].points).toBe(45); // 30 + 10 + 5
+    expect(res.perPlayer['B'].points).toBe(65); // 20 + 25 + 20
+  });
+
+  it('builds a leaderboard ordered by wins', () => {
+    expect(res.leaderboard.map((r) => r.playerId)).toEqual(['A', 'B', 'C']);
+    expect(res.totals).toMatchObject({ finishedGames: 3, gameNights: 3 });
+  });
+});
+
+describe('computeStats — finishing position & podium', () => {
+  const { players, games, rounds } = trio();
+  const res = computeStats({ players, games, rounds });
+
+  it('averages finishing position (1 = first)', () => {
+    // A finished 1st, 3rd, 1st
+    expect(res.perPlayer['A'].avgFinish).toBeCloseTo(5 / 3, 5);
+    expect(res.perPlayer['A'].bestFinish).toBe(1);
+  });
+
+  it('excludes last place from podium at a small table', () => {
+    // top-2 of 3 players: A is 1st,3rd,1st -> 2 podiums (the 3rd doesn't count)
+    expect(res.perPlayer['A'].podiums).toBe(2);
+  });
+});
+
+describe('computeStats — streaks', () => {
+  const { players, games, rounds } = trio();
+  const res = computeStats({ players, games, rounds });
+
+  it('tracks current and longest win streak chronologically', () => {
+    // A: win, loss, win -> current 1, longest 1
+    expect(res.perPlayer['A'].currentStreak).toBe(1);
+    expect(res.perPlayer['A'].longestStreak).toBe(1);
+    // C never wins
+    expect(res.perPlayer['C'].currentStreak).toBe(0);
+    expect(res.perPlayer['C'].longestStreak).toBe(0);
+  });
+});
+
+describe('computeStats — comeback vs wire-to-wire', () => {
+  const { players, games, rounds } = trio();
+  const res = computeStats({ players, games, rounds });
+
+  it('classifies A’s wins as wire-to-wire', () => {
+    expect(res.perPlayer['A'].wireToWireWins).toBe(2);
+    expect(res.perPlayer['A'].comebackWins).toBe(0);
+  });
+
+  it('classifies B’s win as a comeback', () => {
+    expect(res.perPlayer['B'].comebackWins).toBe(1);
+    expect(res.perPlayer['B'].wireToWireWins).toBe(0);
+  });
+});
+
+describe('computeStats — head to head', () => {
+  const { players, games, rounds } = trio();
+  const res = computeStats({ players, games, rounds });
+
+  it('records co-finished results and never self-pairs', () => {
+    expect(res.perPlayer['A'].headToHead['B']).toMatchObject({ games: 3, wins: 2, losses: 1, ties: 0 });
+    expect(res.perPlayer['A'].headToHead['C']).toMatchObject({ games: 3, wins: 2, losses: 1 });
+    expect(res.perPlayer['A'].headToHead['A']).toBeUndefined();
+  });
+});
+
+describe('computeStats — lower-is-better direction inference', () => {
+  it('infers from winnerIds vs totals (no game module needed)', () => {
+    const players = [player('A'), player('B')];
+    const games = [mkGame({ id: 'h', type: 'hearts', playerIds: ['A', 'B'], winnerIds: ['A'], roundCount: 1 })];
+    const rounds = [mkRound('h', 0, { A: 5, B: 20 })]; // A has fewer points and wins -> lower is better
+    const res = computeStats({ players, games, rounds });
+    expect(res.perPlayer['A'].wins).toBe(1);
+    expect(res.perPlayer['A'].bestFinish).toBe(1);
+    expect(res.perPlayer['B'].bestFinish).toBe(2);
+  });
+});
+
+describe('computeStats — records', () => {
+  const { players, games, rounds } = trio();
+  const res = computeStats({ players, games, rounds });
+  const rec = (k: string) => res.records.find((r) => r.key === k);
+
+  it('captures headline records with holders', () => {
+    expect(rec('topRound')).toMatchObject({ value: '20', holderId: 'B', gameId: 'g3' });
+    expect(rec('highTotal')).toMatchObject({ value: '30', holderId: 'A', gameId: 'g1' }); // A's 30 in g1
+    expect(rec('longest')).toMatchObject({ value: '3 rounds' });
+    expect(rec('blowout')).toMatchObject({ value: 'by 10' });
+    expect(rec('closest')).toMatchObject({ value: 'by 10' });
+  });
+});
+
+describe('computeStats — filters', () => {
+  const { players, games, rounds } = trio();
+
+  it('filters by date range', () => {
+    const res = computeStats({ players, games, rounds }, { range: { from: BASE + DAY } });
+    expect(res.totals.finishedGames).toBe(2); // g2, g3
+    expect(res.perPlayer['A'].played).toBe(2);
+  });
+
+  it('filters by game type', () => {
+    const res = computeStats({ players, games, rounds }, { gameType: 'hearts' });
+    expect(res.totals.finishedGames).toBe(1);
+    expect(res.perPlayer['A'].byGameType['tally']).toBeUndefined();
+  });
+
+  it('excludes non-finished games', () => {
+    const active = mkGame({ id: 'open', playerIds: ['A', 'B'], status: 'active', roundCount: 0 });
+    const res = computeStats({ players, games: [...games, active], rounds });
+    expect(res.totals.games).toBe(4);
+    expect(res.totals.finishedGames).toBe(3);
+  });
+});
+
+describe('computeStats — merge-aware identity (forward compatible)', () => {
+  it('folds a merged member into the survivor and drops self-pairs', () => {
+    const players = [
+      player('X'),
+      player('Y'),
+      { id: 'Y2', name: 'Y (old)', color: '#7c5cff', createdAt: 0, mergedInto: 'Y' } as unknown as Player,
+    ];
+    const games = [mkGame({ id: 'gm', playerIds: ['X', 'Y', 'Y2'], winnerIds: ['Y2'], roundCount: 1 })];
+    const rounds = [mkRound('gm', 0, { X: 5, Y: 3, Y2: 7 })];
+    const res = computeStats({ players, games, rounds });
+
+    expect(res.perPlayer['Y2']).toBeUndefined();
+    expect(res.perPlayer['Y']).toMatchObject({ wins: 1, played: 1, points: 10 }); // 3 + 7 merged
+    expect(res.perPlayer['Y'].headToHead['Y']).toBeUndefined();
+    expect(res.perPlayer['Y'].headToHead['X']).toMatchObject({ games: 1, wins: 1 });
+    expect(res.players.map((p) => p.id).sort()).toEqual(['X', 'Y']);
+  });
+});
+
+describe('computeStats — injected game-specific hook', () => {
+  it('routes per-type stats through the injected resolver', () => {
+    const players = [player('A'), player('B')];
+    const games = [mkGame({ id: 'g', playerIds: ['A', 'B'], winnerIds: ['A'], roundCount: 1 })];
+    const rounds = [mkRound('g', 0, { A: 5, B: 1 })];
+    const opts: ComputeOptions = {
+      gameStats: (type) =>
+        type === 'tally' ? () => ({ global: [{ key: 'k', label: 'L', value: '42' }] }) : undefined,
+    };
+    const res = computeStats({ players, games, rounds }, {}, opts);
+    expect(res.gameSpecific['tally'].global?.[0]).toMatchObject({ value: '42' });
+  });
+});
+
+describe('buildAliasMap', () => {
+  it('resolves merge chains transitively', () => {
+    const canonical = canonicalizer(
+      buildAliasMap([
+        { id: 'a', mergedInto: 'b' },
+        { id: 'b', mergedInto: 'c' },
+        { id: 'c' },
+      ]),
+    );
+    expect(canonical('a')).toBe('c');
+    expect(canonical('b')).toBe('c');
+    expect(canonical('c')).toBe('c');
+    expect(canonical('unknown')).toBe('unknown');
+  });
+
+  it('does not hang on a cycle', () => {
+    const canonical = canonicalizer(
+      buildAliasMap([
+        { id: 'a', mergedInto: 'b' },
+        { id: 'b', mergedInto: 'a' },
+      ]),
+    );
+    expect(['a', 'b']).toContain(canonical('a'));
+  });
+});
+
+describe('compareStats', () => {
+  it('diffs a member between two windows', () => {
+    const players = [player('A'), player('B')];
+    const prior = computeStats({
+      players,
+      games: [mkGame({ id: 'p1', playerIds: ['A', 'B'], winnerIds: ['A'], roundCount: 1 })],
+      rounds: [mkRound('p1', 0, { A: 5, B: 1 })],
+    });
+    const current = computeStats({
+      players,
+      games: [
+        mkGame({ id: 'c1', playerIds: ['A', 'B'], winnerIds: ['A'], roundCount: 1 }),
+        mkGame({ id: 'c2', playerIds: ['A', 'B'], winnerIds: ['A'], roundCount: 1 }),
+      ],
+      rounds: [mkRound('c1', 0, { A: 5, B: 1 }), mkRound('c2', 0, { A: 5, B: 1 })],
+    });
+    const delta = compareStats(current, prior, 'A');
+    const wins = delta.metrics.find((m) => m.key === 'wins')!;
+    expect(wins).toMatchObject({ current: 2, prior: 1, delta: 1, better: true });
+  });
+});
+
+describe('skullkingStats', () => {
+  it('computes bid accuracy, zero-bid success and bonus', () => {
+    const games = [mkGame({ id: 'sk', type: 'skullking', playerIds: ['A', 'B'], roundCount: 1 })];
+    const rounds = [
+      mkRound('sk', 0, {}, { rows: { A: { bid: 2, actual: 2, bonus: 10 }, B: { bid: 0, actual: 1, bonus: 0 } } }),
+    ];
+    const out = skullkingStats({ games, rounds, players: [], canonical: (id) => id });
+    expect(out.perPlayer?.['A'].find((m) => m.key === 'sk_acc')?.value).toBe('100%');
+    expect(out.perPlayer?.['A'].find((m) => m.key === 'sk_bonus')?.value).toBe('10');
+    expect(out.global?.[0]).toMatchObject({ key: 'sk_acc_all', value: '50%' });
+  });
+});
+
+describe('heartsStats', () => {
+  it('counts moons, ♠Q and clean rounds', () => {
+    const games = [mkGame({ id: 'h', type: 'hearts', playerIds: ['A', 'B', 'C'], roundCount: 1 })];
+    const rounds = [mkRound('h', 0, {}, { hearts: { A: 13, B: 0, C: 0 }, queen: 'A', jack: null })];
+    const out = heartsStats({ games, rounds, players: [], canonical: (id) => id });
+    expect(out.perPlayer?.['A'].find((m) => m.key === 'h_moon')?.value).toBe('1');
+    expect(out.perPlayer?.['A'].find((m) => m.key === 'h_queen')?.value).toBe('1');
+    expect(out.global?.[0]).toMatchObject({ key: 'h_moon_all', value: '1' });
+  });
+});

--- a/src/lib/stats/engine.ts
+++ b/src/lib/stats/engine.ts
@@ -166,6 +166,11 @@ export function computeStats(
     const closeGame = spread > 0 && f.margin !== undefined && f.margin <= 0.1 * spread;
 
     for (const id of f.playerIds) {
+      // Deleted (tombstoned) members are hidden everywhere: they keep their seat
+      // so surviving players' finish positions and field size stay accurate, but
+      // they never become stat subjects. Archived members remain in playerById,
+      // so they keep their full stats.
+      if (!playerById.has(id)) continue;
       const a = acc(id);
       const rank = f.rankOf[id] ?? f.playerIds.length;
       const isWin = f.winners.includes(id);
@@ -207,9 +212,9 @@ export function computeStats(
         a.run = 0;
       }
 
-      // Head-to-head vs every co-finisher.
+      // Head-to-head vs every co-finisher (skip deleted members — hidden everywhere).
       for (const opp of f.playerIds) {
-        if (opp === id) continue;
+        if (opp === id || !playerById.has(opp)) continue;
         const row = h2hRow(a, opp);
         row.games += 1;
         const oppRank = f.rankOf[opp] ?? f.playerIds.length;

--- a/src/lib/stats/engine.ts
+++ b/src/lib/stats/engine.ts
@@ -103,7 +103,15 @@ export function computeStats(
   for (const p of data.players) if (canonical(p.id) === p.id) playerById.set(p.id, p);
 
   const typeOk = (g: Game) => !query.gameType || g.type === query.gameType;
-  const inWindow = data.games.filter((g) => typeOk(g) && inRange(gameTime(g), query.range));
+  const inRangeType = (g: Game) => typeOk(g) && inRange(gameTime(g), query.range);
+  // Abandoned games (started but called off) have no winner, so they never enter
+  // standings/wins; by default they're left out of volume counts too.
+  // `includeAbandoned` keeps them in the games total as a "started but not
+  // finished" tally — they still never become `finished`.
+  const abandoned = data.games.filter((g) => inRangeType(g) && g.status === 'abandoned');
+  const inWindow = data.games.filter(
+    (g) => inRangeType(g) && (query.includeAbandoned || g.status !== 'abandoned'),
+  );
   const finished = inWindow
     .filter((g) => g.status === 'finished')
     .sort((a, b) => gameTime(a) - gameTime(b) || a.createdAt - b.createdAt);
@@ -233,6 +241,7 @@ export function computeStats(
     totals: {
       games: inWindow.length,
       finishedGames: finished.length,
+      abandonedGames: abandoned.length,
       rounds: facts.reduce((n, f) => n + f.rounds.length, 0),
       gameNights: allNights.size,
     },

--- a/src/lib/stats/engine.ts
+++ b/src/lib/stats/engine.ts
@@ -40,6 +40,7 @@ interface Acc {
   wins: number;
   podiums: number;
   rankSum: number;
+  rankSqSum: number;
   bestFinish: number;
   points: number;
   rounds: number;
@@ -47,6 +48,8 @@ interface Acc {
   h2h: Record<ID, HeadToHead>;
   comebackWins: number;
   wireToWireWins: number;
+  closeGames: number;
+  closeWins: number;
   bestWinMargin?: number;
   closestWinMargin?: number;
   nights: Set<string>;
@@ -65,6 +68,7 @@ function newAcc(id: ID): Acc {
     wins: 0,
     podiums: 0,
     rankSum: 0,
+    rankSqSum: 0,
     bestFinish: Infinity,
     points: 0,
     rounds: 0,
@@ -72,6 +76,8 @@ function newAcc(id: ID): Acc {
     h2h: {},
     comebackWins: 0,
     wireToWireWins: 0,
+    closeGames: 0,
+    closeWins: 0,
     nights: new Set(),
     firstPlayedAt: Infinity,
     lastPlayedAt: -Infinity,
@@ -152,6 +158,13 @@ export function computeStats(
     records.consider('longest', f.rounds.length, f.winners[0], f.game.id, t);
     for (const id of f.playerIds) records.consider('highTotal', f.totals[id], id, f.game.id, t);
 
+    // A "close" game: the winning margin is a small slice of the score spread —
+    // scale-free, so it reads the same for any game and either direction. Powers
+    // the clutch trait (win rate when it's tight).
+    const vals = f.playerIds.map((id) => f.totals[id] ?? 0);
+    const spread = vals.length ? Math.max(...vals) - Math.min(...vals) : 0;
+    const closeGame = spread > 0 && f.margin !== undefined && f.margin <= 0.1 * spread;
+
     for (const id of f.playerIds) {
       const a = acc(id);
       const rank = f.rankOf[id] ?? f.playerIds.length;
@@ -159,7 +172,12 @@ export function computeStats(
 
       a.played += 1;
       a.rankSum += rank;
+      a.rankSqSum += rank * rank;
       a.bestFinish = Math.min(a.bestFinish, rank);
+      if (closeGame) {
+        a.closeGames += 1;
+        if (isWin) a.closeWins += 1;
+      }
       // Top-3, but never "everyone" at a small table: caps at playerCount-1 so
       // last place is never a podium (e.g. top-2 in a 3-player game).
       if (rank <= Math.min(3, Math.max(1, f.playerIds.length - 1))) a.podiums += 1;
@@ -266,11 +284,15 @@ function finalize(a: Acc): MemberStats {
     headToHead: a.h2h,
     comebackWins: a.comebackWins,
     wireToWireWins: a.wireToWireWins,
+    closeGames: a.closeGames,
+    closeWins: a.closeWins,
     gameNights: a.nights.size,
   };
   if (a.played > 0) {
     m.avgFinish = a.rankSum / a.played;
     m.bestFinish = a.bestFinish;
+    const variance = a.rankSqSum / a.played - m.avgFinish * m.avgFinish;
+    m.finishStdev = Math.sqrt(Math.max(0, variance));
     m.firstPlayedAt = a.firstPlayedAt;
     m.lastPlayedAt = a.lastPlayedAt;
   }

--- a/src/lib/stats/engine.ts
+++ b/src/lib/stats/engine.ts
@@ -1,0 +1,354 @@
+import type { Game, ID, Player, Round } from '../types';
+import { buildAliasMap, canonicalizer } from './identity';
+import { computeGameFacts, gameTime, type GameFacts } from './facts';
+import { dayKey } from './format';
+import type {
+  ByGameType,
+  DateRange,
+  GameRecord,
+  GameSpecificStats,
+  GameStatsHook,
+  HeadToHead,
+  LeaderRow,
+  MemberStats,
+  Metric,
+  StatsData,
+  StatsQuery,
+  StatsResult,
+} from './types';
+
+export interface ComputeOptions {
+  /**
+   * Resolve a game module's stats hook by type. Injected (rather than imported)
+   * so the engine never pulls in Svelte game modules and stays unit-testable.
+   * In the app: `(type) => getModule(type)?.stats`.
+   */
+  gameStats?: (type: string) => GameStatsHook | undefined;
+}
+
+function inRange(t: number, range?: DateRange): boolean {
+  if (!range) return true;
+  if (range.from !== undefined && t < range.from) return false;
+  if (range.to !== undefined && t > range.to) return false;
+  return true;
+}
+
+/** Mutable per-member accumulator; finalized into {@link MemberStats}. */
+interface Acc {
+  playerId: ID;
+  played: number;
+  wins: number;
+  podiums: number;
+  rankSum: number;
+  bestFinish: number;
+  points: number;
+  rounds: number;
+  byGameType: Record<string, ByGameType>;
+  h2h: Record<ID, HeadToHead>;
+  comebackWins: number;
+  wireToWireWins: number;
+  bestWinMargin?: number;
+  closestWinMargin?: number;
+  nights: Set<string>;
+  firstPlayedAt: number;
+  lastPlayedAt: number;
+  lastWinAt?: number;
+  // streaks
+  run: number;
+  longest: number;
+}
+
+function newAcc(id: ID): Acc {
+  return {
+    playerId: id,
+    played: 0,
+    wins: 0,
+    podiums: 0,
+    rankSum: 0,
+    bestFinish: Infinity,
+    points: 0,
+    rounds: 0,
+    byGameType: {},
+    h2h: {},
+    comebackWins: 0,
+    wireToWireWins: 0,
+    nights: new Set(),
+    firstPlayedAt: Infinity,
+    lastPlayedAt: -Infinity,
+    run: 0,
+    longest: 0,
+  };
+}
+
+function h2hRow(acc: Acc, opp: ID): HeadToHead {
+  let row = acc.h2h[opp];
+  if (!row) {
+    row = { opponentId: opp, games: 0, wins: 0, losses: 0, ties: 0 };
+    acc.h2h[opp] = row;
+  }
+  return row;
+}
+
+export function computeStats(
+  data: StatsData,
+  query: StatsQuery = {},
+  options: ComputeOptions = {},
+): StatsResult {
+  const canonical = canonicalizer(buildAliasMap(data.players));
+
+  // Canonical player directory (skip rows that are merged away). No synthesis:
+  // the engine returns only real Member records and leaves display name/color to
+  // the UI, which resolves them from the live players store.
+  const playerById = new Map<ID, Player>();
+  for (const p of data.players) if (canonical(p.id) === p.id) playerById.set(p.id, p);
+
+  const typeOk = (g: Game) => !query.gameType || g.type === query.gameType;
+  const inWindow = data.games.filter((g) => typeOk(g) && inRange(gameTime(g), query.range));
+  const finished = inWindow
+    .filter((g) => g.status === 'finished')
+    .sort((a, b) => gameTime(a) - gameTime(b) || a.createdAt - b.createdAt);
+
+  const roundsByGame = new Map<ID, Round[]>();
+  for (const r of data.rounds) {
+    const arr = roundsByGame.get(r.gameId);
+    if (arr) arr.push(r);
+    else roundsByGame.set(r.gameId, [r]);
+  }
+
+  const facts: GameFacts[] = finished.map((g) =>
+    computeGameFacts(g, roundsByGame.get(g.id) ?? [], canonical),
+  );
+
+  const accs = new Map<ID, Acc>();
+  const acc = (id: ID): Acc => {
+    let a = accs.get(id);
+    if (!a) {
+      a = newAcc(id);
+      accs.set(id, a);
+    }
+    return a;
+  };
+
+  const records = newRecords();
+
+  for (const f of facts) {
+    const t = gameTime(f.game);
+    const night = dayKey(t);
+
+    // Records (global, per game).
+    if (f.topRound) records.consider('topRound', f.topRound.value, f.topRound.playerId, f.game.id, t);
+    if (f.margin !== undefined && f.winners.length) {
+      records.consider('blowout', f.margin, f.winners[0], f.game.id, t);
+      if (f.margin > 0) records.considerMin('closest', f.margin, f.winners[0], f.game.id, t);
+    }
+    records.consider('longest', f.rounds.length, f.winners[0], f.game.id, t);
+    for (const id of f.playerIds) records.consider('highTotal', f.totals[id], id, f.game.id, t);
+
+    for (const id of f.playerIds) {
+      const a = acc(id);
+      const rank = f.rankOf[id] ?? f.playerIds.length;
+      const isWin = f.winners.includes(id);
+
+      a.played += 1;
+      a.rankSum += rank;
+      a.bestFinish = Math.min(a.bestFinish, rank);
+      // Top-3, but never "everyone" at a small table: caps at playerCount-1 so
+      // last place is never a podium (e.g. top-2 in a 3-player game).
+      if (rank <= Math.min(3, Math.max(1, f.playerIds.length - 1))) a.podiums += 1;
+      a.points += f.totals[id] ?? 0;
+      a.rounds += f.rounds.length;
+      a.firstPlayedAt = Math.min(a.firstPlayedAt, t);
+      a.lastPlayedAt = Math.max(a.lastPlayedAt, t);
+      a.nights.add(night);
+
+      const bt = (a.byGameType[f.game.type] ??= { played: 0, wins: 0, winRate: 0 });
+      bt.played += 1;
+
+      if (isWin) {
+        a.wins += 1;
+        bt.wins += 1;
+        a.lastWinAt = a.lastWinAt === undefined ? t : Math.max(a.lastWinAt, t);
+        a.run += 1;
+        a.longest = Math.max(a.longest, a.run);
+        if (f.comeback.has(id)) a.comebackWins += 1;
+        if (f.wireToWire.has(id)) a.wireToWireWins += 1;
+        if (f.margin !== undefined) {
+          a.bestWinMargin = a.bestWinMargin === undefined ? f.margin : Math.max(a.bestWinMargin, f.margin);
+          a.closestWinMargin =
+            a.closestWinMargin === undefined ? f.margin : Math.min(a.closestWinMargin, f.margin);
+        }
+      } else {
+        a.run = 0;
+      }
+
+      // Head-to-head vs every co-finisher.
+      for (const opp of f.playerIds) {
+        if (opp === id) continue;
+        const row = h2hRow(a, opp);
+        row.games += 1;
+        const oppRank = f.rankOf[opp] ?? f.playerIds.length;
+        if (rank < oppRank) row.wins += 1;
+        else if (rank > oppRank) row.losses += 1;
+        else row.ties += 1;
+      }
+    }
+  }
+
+  // Ensure the queried member always has an entry (low-data states).
+  if (query.playerId) acc(canonical(query.playerId));
+
+  const perPlayer: Record<ID, MemberStats> = {};
+  for (const a of accs.values()) perPlayer[a.playerId] = finalize(a);
+
+  const leaderboard: LeaderRow[] = Object.values(perPlayer)
+    .filter((m) => m.played > 0)
+    .map((m) => ({
+      playerId: m.playerId,
+      played: m.played,
+      wins: m.wins,
+      winRate: m.winRate,
+      avgFinish: m.avgFinish,
+      currentStreak: m.currentStreak,
+    }))
+    .sort((a, b) => b.wins - a.wins || b.winRate - a.winRate || b.played - a.played);
+
+  const referenced = new Set<ID>();
+  for (const f of facts) for (const id of f.playerIds) referenced.add(id);
+  if (query.playerId) referenced.add(canonical(query.playerId));
+  const players = [...referenced]
+    .map((id) => playerById.get(id))
+    .filter((p): p is Player => p !== undefined);
+
+  const allNights = new Set<string>();
+  for (const f of facts) allNights.add(dayKey(gameTime(f.game)));
+
+  const result: StatsResult = {
+    range: query.range,
+    players,
+    leaderboard,
+    perPlayer,
+    records: records.list(),
+    global: globalMetrics(facts, leaderboard.length, allNights.size),
+    gameSpecific: gameSpecific(finished, roundsByGame, players, query.range, canonical, options.gameStats),
+    totals: {
+      games: inWindow.length,
+      finishedGames: finished.length,
+      rounds: facts.reduce((n, f) => n + f.rounds.length, 0),
+      gameNights: allNights.size,
+    },
+  };
+  return result;
+}
+
+function finalize(a: Acc): MemberStats {
+  for (const bt of Object.values(a.byGameType)) bt.winRate = bt.played ? bt.wins / bt.played : 0;
+  const m: MemberStats = {
+    playerId: a.playerId,
+    played: a.played,
+    finished: a.played,
+    wins: a.wins,
+    podiums: a.podiums,
+    winRate: a.played ? a.wins / a.played : 0,
+    currentStreak: a.run,
+    longestStreak: a.longest,
+    points: a.points,
+    rounds: a.rounds,
+    byGameType: a.byGameType,
+    headToHead: a.h2h,
+    comebackWins: a.comebackWins,
+    wireToWireWins: a.wireToWireWins,
+    gameNights: a.nights.size,
+  };
+  if (a.played > 0) {
+    m.avgFinish = a.rankSum / a.played;
+    m.bestFinish = a.bestFinish;
+    m.firstPlayedAt = a.firstPlayedAt;
+    m.lastPlayedAt = a.lastPlayedAt;
+  }
+  if (a.lastWinAt !== undefined) m.lastWinAt = a.lastWinAt;
+  if (a.bestWinMargin !== undefined) m.bestWinMargin = a.bestWinMargin;
+  if (a.closestWinMargin !== undefined) m.closestWinMargin = a.closestWinMargin;
+  return m;
+}
+
+// ---- Records ----
+
+interface RecordSlot {
+  value: number;
+  holderId?: ID;
+  gameId?: ID;
+  at?: number;
+}
+
+function newRecords() {
+  const slots: Record<string, RecordSlot> = {};
+  const put = (key: string, value: number, holderId?: ID, gameId?: ID, at?: number, min = false) => {
+    const cur = slots[key];
+    if (!cur || (min ? value < cur.value : value > cur.value)) {
+      slots[key] = { value, holderId, gameId, at };
+    }
+  };
+  return {
+    consider: (k: string, v: number, h?: ID, g?: ID, at?: number) => put(k, v, h, g, at, false),
+    considerMin: (k: string, v: number, h?: ID, g?: ID, at?: number) => put(k, v, h, g, at, true),
+    list(): GameRecord[] {
+      const out: GameRecord[] = [];
+      const add = (key: string, label: string, emoji: string, fmt: (v: number) => string) => {
+        const s = slots[key];
+        if (s) out.push({ key, label, emoji, value: fmt(s.value), holderId: s.holderId, gameId: s.gameId, at: s.at });
+      };
+      add('topRound', 'Highest single round', '💥', (v) => `${Math.round(v)}`);
+      add('highTotal', 'Highest game total', '📈', (v) => `${Math.round(v)}`);
+      add('blowout', 'Biggest blowout', '🚀', (v) => `by ${Math.round(v)}`);
+      add('closest', 'Closest finish', '📸', (v) => `by ${Math.round(v)}`);
+      add('longest', 'Longest game', '⏳', (v) => `${Math.round(v)} rounds`);
+      return out;
+    },
+  };
+}
+
+// ---- Global metrics ----
+
+function globalMetrics(facts: GameFacts[], playerCount: number, nights: number): Metric[] {
+  const byType = new Map<string, number>();
+  for (const f of facts) byType.set(f.game.type, (byType.get(f.game.type) ?? 0) + 1);
+  let topType: string | undefined;
+  let topCount = 0;
+  for (const [type, c] of byType) if (c > topCount) ((topType = type), (topCount = c));
+
+  const out: Metric[] = [
+    { key: 'g_games', label: 'Finished games', value: `${facts.length}`, emoji: '🎲' },
+    { key: 'g_nights', label: 'Game nights', value: `${nights}`, emoji: '🌙' },
+    { key: 'g_players', label: 'Players', value: `${playerCount}`, emoji: '👥' },
+  ];
+  if (topType) out.push({ key: 'g_toptype', label: 'Most played', value: topType, sub: `${topCount} games`, emoji: '🏆' });
+  return out;
+}
+
+// ---- Game-specific hooks ----
+
+function gameSpecific(
+  finished: Game[],
+  roundsByGame: Map<ID, Round[]>,
+  players: Player[],
+  range: DateRange | undefined,
+  canonical: (id: ID) => ID,
+  resolve?: (type: string) => GameStatsHook | undefined,
+): Record<string, GameSpecificStats> {
+  const out: Record<string, GameSpecificStats> = {};
+  if (!resolve) return out;
+  const byType = new Map<string, Game[]>();
+  for (const g of finished) {
+    const arr = byType.get(g.type);
+    if (arr) arr.push(g);
+    else byType.set(g.type, [g]);
+  }
+  for (const [type, games] of byType) {
+    const hook = resolve(type);
+    if (!hook) continue;
+    const rounds: Round[] = [];
+    for (const g of games) for (const r of roundsByGame.get(g.id) ?? []) rounds.push(r);
+    out[type] = hook({ games, rounds, players, range, canonical });
+  }
+  return out;
+}

--- a/src/lib/stats/facts.ts
+++ b/src/lib/stats/facts.ts
@@ -1,0 +1,125 @@
+import type { Game, ID, Round } from '../types';
+import { standings } from '../scoring';
+import { canonicalDeltas, canonicalIds } from './identity';
+
+/** Sorting/range anchor for a game: when it finished, falling back to creation. */
+export function gameTime(g: Game): number {
+  return g.finishedAt ?? g.createdAt;
+}
+
+/** Derived, canonicalized facts about one finished game — the unit every stat builds on. */
+export interface GameFacts {
+  game: Game;
+  rounds: Round[]; // sorted by index
+  /** Canonical, deduped participants. */
+  playerIds: ID[];
+  totals: Record<ID, number>;
+  /** Inferred from winners vs totals so the engine never needs the game module. */
+  dir: 'higher' | 'lower';
+  /** Best → worst finishing order (canonical). */
+  order: ID[];
+  /** 1-based finishing rank; ties share a rank. */
+  rankOf: Record<ID, number>;
+  /** Canonical winners (from winnerIds, falling back to rank-1 on legacy data). */
+  winners: ID[];
+  /** |winner − best non-winner|; undefined when there's no opponent. */
+  margin?: number;
+  /** Winners who trailed (rank > 1) at some round before winning. */
+  comeback: Set<ID>;
+  /** Winners who held rank 1 at every round. */
+  wireToWire: Set<ID>;
+  /** Largest single-round delta in this game (for records). */
+  topRound?: { playerId: ID; value: number; index: number };
+}
+
+/** Decide win direction from the recorded winners: do they hold the max or the min total? */
+function inferDirection(totals: Record<ID, number>, winners: ID[]): 'higher' | 'lower' {
+  const vals = Object.values(totals);
+  if (winners.length === 0 || vals.length === 0) return 'higher';
+  const max = Math.max(...vals);
+  const min = Math.min(...vals);
+  if (max === min) return 'higher';
+  const winnerVals = winners.map((w) => totals[w] ?? 0);
+  const allMax = winnerVals.every((v) => v === max);
+  const allMin = winnerVals.every((v) => v === min);
+  if (allMin && !allMax) return 'lower';
+  return 'higher';
+}
+
+function marginOf(
+  totals: Record<ID, number>,
+  winners: ID[],
+  playerIds: ID[],
+  dir: 'higher' | 'lower',
+): number | undefined {
+  const losers = playerIds.filter((id) => !winners.includes(id));
+  if (winners.length === 0 || losers.length === 0) return undefined;
+  const better = (a: number, b: number) => (dir === 'lower' ? a < b : a > b);
+  let winTotal = totals[winners[0]];
+  for (const w of winners) if (better(totals[w], winTotal)) winTotal = totals[w];
+  let bestLoser = totals[losers[0]];
+  for (const l of losers) if (better(totals[l], bestLoser)) bestLoser = totals[l];
+  return Math.abs(winTotal - bestLoser);
+}
+
+/** Replay round-by-round to classify comeback / wire-to-wire wins and find the biggest swing. */
+function replay(
+  rounds: Round[],
+  playerIds: ID[],
+  winners: ID[],
+  dir: 'higher' | 'lower',
+  canonical: (id: ID) => ID,
+): Pick<GameFacts, 'comeback' | 'wireToWire' | 'topRound'> {
+  const run: Record<ID, number> = {};
+  for (const id of playerIds) run[id] = 0;
+  const trailed = new Set<ID>();
+  const ledThroughout = new Set<ID>(winners);
+  let topRound: GameFacts['topRound'];
+
+  for (const r of rounds) {
+    const cd = canonicalDeltas(r.deltas, canonical);
+    for (const [id, v] of Object.entries(cd)) {
+      run[id] = (run[id] ?? 0) + v;
+      if (!topRound || v > topRound.value) topRound = { playerId: id, value: v, index: r.index };
+    }
+    const ranked = standings(run, dir === 'lower');
+    const rank: Record<ID, number> = {};
+    for (const s of ranked) rank[s.playerId] = s.rank;
+    for (const w of winners) {
+      if ((rank[w] ?? Infinity) > 1) {
+        trailed.add(w);
+        ledThroughout.delete(w);
+      }
+    }
+  }
+  return { comeback: trailed, wireToWire: ledThroughout, topRound };
+}
+
+export function computeGameFacts(
+  game: Game,
+  gameRounds: Round[],
+  canonical: (id: ID) => ID,
+): GameFacts {
+  const rounds = [...gameRounds].sort((a, b) => a.index - b.index);
+  const playerIds = canonicalIds(game.playerIds, canonical);
+
+  const totals: Record<ID, number> = {};
+  for (const id of playerIds) totals[id] = 0;
+  for (const r of rounds) {
+    const cd = canonicalDeltas(r.deltas, canonical);
+    for (const [id, v] of Object.entries(cd)) totals[id] = (totals[id] ?? 0) + v;
+  }
+
+  const declared = canonicalIds(game.winnerIds ?? [], canonical).filter((id) => id in totals);
+  const dir = inferDirection(totals, declared);
+  const ranked = standings(totals, dir === 'lower');
+  const rankOf: Record<ID, number> = {};
+  for (const s of ranked) rankOf[s.playerId] = s.rank;
+  const order = ranked.map((s) => s.playerId);
+  const winners = declared.length ? declared : order.filter((id) => rankOf[id] === 1);
+
+  const margin = marginOf(totals, winners, playerIds, dir);
+  const { comeback, wireToWire, topRound } = replay(rounds, playerIds, winners, dir, canonical);
+
+  return { game, rounds, playerIds, totals, dir, order, rankOf, winners, margin, comeback, wireToWire, topRound };
+}

--- a/src/lib/stats/format.ts
+++ b/src/lib/stats/format.ts
@@ -1,0 +1,66 @@
+/** Presentation helpers for stat values. Pure; safe to unit-test. */
+
+export function fmtInt(n: number): string {
+  return Math.round(n).toLocaleString();
+}
+
+export function fmtPct(ratio: number, digits = 0): string {
+  if (!isFinite(ratio)) return '—';
+  return `${(ratio * 100).toFixed(digits)}%`;
+}
+
+export function fmtSigned(n: number): string {
+  return n > 0 ? `+${fmtInt(n)}` : fmtInt(n);
+}
+
+/** Ordinal finishing position: 1 -> "1st". */
+export function ordinal(n: number): string {
+  const r = Math.round(n);
+  const mod100 = r % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${r}th`;
+  switch (r % 10) {
+    case 1:
+      return `${r}st`;
+    case 2:
+      return `${r}nd`;
+    case 3:
+      return `${r}rd`;
+    default:
+      return `${r}th`;
+  }
+}
+
+/** One-decimal average when not whole (avg finishing position etc.). */
+export function fmtAvg(n: number): string {
+  return Number.isInteger(n) ? String(n) : n.toFixed(1);
+}
+
+/** Compact human duration from ms (used for game/session length). */
+export function fmtDuration(ms: number): string {
+  if (!isFinite(ms) || ms < 0) return '—';
+  const mins = Math.round(ms / 60000);
+  if (mins < 60) return `${mins}m`;
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return m ? `${h}h ${m}m` : `${h}h`;
+}
+
+/** Approximate hours, one decimal (lifetime "hours played"). */
+export function fmtHours(ms: number): string {
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+}
+
+const WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+export function weekdayName(dow: number): string {
+  return WEEKDAYS[((dow % 7) + 7) % 7];
+}
+
+/** Local YYYY-MM-DD key for a timestamp — the unit of a "game night". */
+export function dayKey(ts: number): string {
+  const d = new Date(ts);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}

--- a/src/lib/stats/identity.ts
+++ b/src/lib/stats/identity.ts
@@ -1,0 +1,83 @@
+import type { ID } from '../types';
+
+/**
+ * Merge-aware identity resolution.
+ *
+ * Under the World's per-entity LWW model, two member records that turn out to be
+ * the same human are reconciled by tombstoning the loser with a `mergedInto`
+ * redirect rather than rewriting history. Stats therefore resolve identity **on
+ * read**: build an alias map once, then canonicalize every member reference
+ * (game.playerIds, winnerIds, round.deltas keys) before aggregating.
+ *
+ * Today's `Player` has no `mergedInto`, so this is a transparent no-op — but the
+ * code path exists, is tested, and turns on the moment the field lands.
+ */
+
+/** The (future) shape this reads — kept structural so it works before `Member` exists. */
+export interface MergeableMember {
+  id: ID;
+  mergedInto?: ID;
+}
+
+/**
+ * Resolve each member id to its surviving canonical id, following `mergedInto`
+ * chains transitively. Cycles and dangling targets resolve to the last safe id
+ * rather than looping forever.
+ */
+export function buildAliasMap(members: ReadonlyArray<MergeableMember>): Map<ID, ID> {
+  const direct = new Map<ID, ID>();
+  for (const m of members) {
+    if (m.mergedInto && m.mergedInto !== m.id) direct.set(m.id, m.mergedInto);
+  }
+
+  const resolved = new Map<ID, ID>();
+  const resolve = (start: ID): ID => {
+    const cached = resolved.get(start);
+    if (cached) return cached;
+    let current = start;
+    const seen = new Set<ID>([current]);
+    while (direct.has(current)) {
+      const next = direct.get(current)!;
+      if (seen.has(next)) break; // cycle guard
+      seen.add(next);
+      current = next;
+    }
+    for (const id of seen) resolved.set(id, current);
+    return current;
+  };
+
+  for (const m of members) resolve(m.id);
+  return resolved;
+}
+
+/** A canonicalizer closure; ids with no alias map to themselves. */
+export function canonicalizer(aliases: Map<ID, ID>): (id: ID) => ID {
+  return (id: ID) => aliases.get(id) ?? id;
+}
+
+/** Canonicalize + dedupe a list of member ids, preserving first-seen order. */
+export function canonicalIds(ids: ReadonlyArray<ID>, canonical: (id: ID) => ID): ID[] {
+  const out: ID[] = [];
+  const seen = new Set<ID>();
+  for (const id of ids) {
+    const c = canonical(id);
+    if (!seen.has(c)) {
+      seen.add(c);
+      out.push(c);
+    }
+  }
+  return out;
+}
+
+/** Sum a per-id delta map into canonical buckets. */
+export function canonicalDeltas(
+  deltas: Record<ID, number>,
+  canonical: (id: ID) => ID,
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const [id, v] of Object.entries(deltas)) {
+    const c = canonical(id);
+    out[c] = (out[c] ?? 0) + (Number(v) || 0);
+  }
+  return out;
+}

--- a/src/lib/stats/index.ts
+++ b/src/lib/stats/index.ts
@@ -1,0 +1,12 @@
+export * from './types';
+export { computeStats, type ComputeOptions } from './engine';
+export { compareStats, type StatsDelta, type MetricDelta } from './compare';
+export {
+  buildAliasMap,
+  canonicalizer,
+  canonicalIds,
+  canonicalDeltas,
+  type MergeableMember,
+} from './identity';
+export { computeGameFacts, gameTime, type GameFacts } from './facts';
+export * from './format';

--- a/src/lib/stats/index.ts
+++ b/src/lib/stats/index.ts
@@ -12,4 +12,18 @@ export { computeGameFacts, gameTime, type GameFacts } from './facts';
 export { assignPersona, personaTraits, PERSONA_MIN_GAMES, type Persona, type PersonaTraits } from './personas';
 export { computeBadges, newlyEarned, type Badge, type Rarity } from './badges';
 export { dailyCrown, nudges, type CrownLine, type CrownInput, type CrownTone } from './crown';
+export {
+  buildCourt,
+  reigningKings,
+  rivalryCards,
+  rivalrySpotlight,
+  parityIndex,
+  wallOfShame,
+  type CourtView,
+  type CourtOptions,
+  type Throne,
+  type GameKing,
+  type RivalryCard,
+  type CourtShame,
+} from './court';
 export * from './format';

--- a/src/lib/stats/index.ts
+++ b/src/lib/stats/index.ts
@@ -9,4 +9,7 @@ export {
   type MergeableMember,
 } from './identity';
 export { computeGameFacts, gameTime, type GameFacts } from './facts';
+export { assignPersona, personaTraits, PERSONA_MIN_GAMES, type Persona, type PersonaTraits } from './personas';
+export { computeBadges, newlyEarned, type Badge, type Rarity } from './badges';
+export { dailyCrown, nudges, type CrownLine, type CrownInput, type CrownTone } from './crown';
 export * from './format';

--- a/src/lib/stats/index.ts
+++ b/src/lib/stats/index.ts
@@ -26,4 +26,12 @@ export {
   type RivalryCard,
   type CourtShame,
 } from './court';
+export {
+  buildWrapped,
+  buildRecap,
+  type WrappedCard,
+  type WrappedInput,
+  type WrappedKind,
+  type WrappedStat,
+} from './wrapped';
 export * from './format';

--- a/src/lib/stats/personas.test.ts
+++ b/src/lib/stats/personas.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import type { MemberStats } from './types';
+import { assignPersona, personaTraits } from './personas';
+
+function mkStats(p: Partial<MemberStats> = {}): MemberStats {
+  return {
+    playerId: 'me',
+    played: 10,
+    finished: 10,
+    wins: 3,
+    podiums: 5,
+    winRate: 0.3,
+    currentStreak: 0,
+    longestStreak: 2,
+    points: 100,
+    rounds: 40,
+    byGameType: {},
+    headToHead: {},
+    comebackWins: 0,
+    wireToWireWins: 0,
+    closeGames: 0,
+    closeWins: 0,
+    gameNights: 4,
+    ...p,
+  };
+}
+
+describe('personaTraits', () => {
+  it('only trusts clutch once there are 3+ close games', () => {
+    expect(personaTraits(mkStats({ closeGames: 2, closeWins: 2 })).clutch).toBe(0);
+    expect(personaTraits(mkStats({ closeGames: 4, closeWins: 3 })).clutch).toBeCloseTo(0.75);
+  });
+
+  it('normalizes volatility from finish stdev and clamps to 1', () => {
+    expect(personaTraits(mkStats({ finishStdev: 0 })).volatility).toBe(0);
+    expect(personaTraits(mkStats({ finishStdev: 2 })).volatility).toBe(1);
+  });
+
+  it('front-running and comeback are shares of wins', () => {
+    const t = personaTraits(mkStats({ wins: 4, wireToWireWins: 2, comebackWins: 1 }));
+    expect(t.frontRunning).toBeCloseTo(0.5);
+    expect(t.comeback).toBeCloseTo(0.25);
+  });
+});
+
+describe('assignPersona', () => {
+  it('is a Rookie under the minimum game count', () => {
+    const p = assignPersona(mkStats({ played: 5 }));
+    expect(p.key).toBe('rookie');
+    expect(p.confidence).toBeCloseTo(5 / 8);
+  });
+
+  it('reads high close-game win rate as The Closer', () => {
+    const p = assignPersona(mkStats({ played: 10, wins: 5, closeGames: 4, closeWins: 4, finishStdev: 0, podiums: 0 }));
+    expect(p.key).toBe('closer');
+  });
+
+  it('reads high finish variance as a Wildcard', () => {
+    const p = assignPersona(mkStats({ played: 10, wins: 2, finishStdev: 1.25, podiums: 0 }));
+    expect(p.key).toBe('wildcard');
+  });
+
+  it('reads wins-from-behind as the Comeback Kid', () => {
+    const p = assignPersona(mkStats({ played: 10, wins: 4, comebackWins: 4, finishStdev: 0, podiums: 0 }));
+    expect(p.key).toBe('comeback');
+  });
+
+  it('reads wire-to-wire wins as the Front-Runner', () => {
+    const p = assignPersona(mkStats({ played: 10, wins: 4, wireToWireWins: 4, comebackWins: 0, finishStdev: 0, podiums: 0 }));
+    expect(p.key).toBe('frontrunner');
+  });
+
+  it('reads high podium + low volatility as Consistent', () => {
+    const p = assignPersona(mkStats({ played: 10, wins: 2, podiums: 8, finishStdev: 0, wireToWireWins: 0 }));
+    expect(p.key).toBe('consistent');
+  });
+
+  it('falls back to All-Rounder when nothing stands out', () => {
+    const p = assignPersona(mkStats({ played: 10, wins: 1, podiums: 0, finishStdev: 0, closeGames: 0, comebackWins: 0, wireToWireWins: 0 }));
+    expect(p.key).toBe('allrounder');
+  });
+});

--- a/src/lib/stats/personas.ts
+++ b/src/lib/stats/personas.ts
@@ -1,0 +1,113 @@
+import type { MemberStats } from './types';
+
+/** Normalized playstyle axes (0..1), derived from a member's window of stats. */
+export interface PersonaTraits {
+  winRate: number;
+  /** Win rate when the game was decided by a small margin. */
+  clutch: number;
+  /** Spread of finishing positions — high = boom-or-bust. */
+  volatility: number;
+  /** Share of wins led wire-to-wire. */
+  frontRunning: number;
+  /** Share of wins clawed back from behind. */
+  comeback: number;
+  /** Podium reliability tempered by low volatility. */
+  consistency: number;
+}
+
+export interface Persona {
+  key: string;
+  name: string;
+  emoji: string;
+  voice: string;
+  /** 0..1 strength of the match; low = "still figuring you out". */
+  confidence: number;
+  traits: PersonaTraits;
+}
+
+const clamp01 = (n: number): number => (n < 0 ? 0 : n > 1 ? 1 : n);
+
+/** ~8 finished games before a real archetype is assigned (else "Rookie"). */
+export const PERSONA_MIN_GAMES = 8;
+
+/** Derive the normalized trait vector from a member's stats. */
+export function personaTraits(m: MemberStats): PersonaTraits {
+  const podiumRate = m.played ? m.podiums / m.played : 0;
+  const volatility = clamp01((m.finishStdev ?? 0) / 1.25);
+  return {
+    winRate: clamp01(m.winRate),
+    // Only trust clutch once there's a few close games on record.
+    clutch: m.closeGames >= 3 ? clamp01(m.closeWins / m.closeGames) : 0,
+    volatility,
+    frontRunning: m.wins > 0 ? clamp01(m.wireToWireWins / m.wins) : 0,
+    comeback: m.wins > 0 ? clamp01(m.comebackWins / m.wins) : 0,
+    consistency: clamp01(podiumRate * (1 - volatility)),
+  };
+}
+
+interface Archetype {
+  key: string;
+  name: string;
+  emoji: string;
+  voice: string;
+  /** Trait emphasis; the dot product with the trait vector is the match score. */
+  w: Partial<Record<keyof PersonaTraits, number>>;
+}
+
+// Ordered rarest → most common so ties break toward the more distinctive persona.
+const ARCHETYPES: Archetype[] = [
+  { key: 'closer', name: 'The Closer', emoji: '🧊', voice: 'Ice in your veins when it’s tight.', w: { clutch: 1 } },
+  { key: 'wildcard', name: 'Wildcard', emoji: '🎲', voice: 'Boom or bust, never boring.', w: { volatility: 1 } },
+  { key: 'comeback', name: 'Comeback Kid', emoji: '🪦', voice: 'Down? Never out.', w: { comeback: 1 } },
+  { key: 'frontrunner', name: 'Front-Runner', emoji: '🐎', voice: 'Grab the lead, never give it back.', w: { frontRunning: 1, comeback: -0.4 } },
+  { key: 'consistent', name: 'Mr./Ms. Consistent', emoji: '📏', voice: 'Always there or thereabouts.', w: { consistency: 1, volatility: -0.4 } },
+];
+
+const score = (t: PersonaTraits, a: Archetype): number => {
+  let s = 0;
+  for (const [k, w] of Object.entries(a.w)) s += (w ?? 0) * t[k as keyof PersonaTraits];
+  return s;
+};
+
+/**
+ * Assign a playstyle persona from a member's stats. Under {@link PERSONA_MIN_GAMES}
+ * finished games it's "The Rookie"; otherwise the best-matching archetype, or a
+ * neutral "All-Rounder" when nothing stands out. The caller chooses the window
+ * (e.g. a trailing ~20 games) by passing the matching {@link MemberStats}.
+ */
+export function assignPersona(m: MemberStats): Persona {
+  const traits = personaTraits(m);
+  if (m.played < PERSONA_MIN_GAMES) {
+    return {
+      key: 'rookie',
+      name: 'The Rookie',
+      emoji: '🌱',
+      voice: 'Your style is still being written…',
+      confidence: clamp01(m.played / PERSONA_MIN_GAMES),
+      traits,
+    };
+  }
+
+  let best = ARCHETYPES[0];
+  let bestScore = score(traits, best);
+  for (const a of ARCHETYPES.slice(1)) {
+    const s = score(traits, a);
+    if (s > bestScore) {
+      best = a;
+      bestScore = s;
+    }
+  }
+
+  if (bestScore < 0.34) {
+    return {
+      key: 'allrounder',
+      name: 'The All-Rounder',
+      emoji: '⚖️',
+      voice: 'No single tell — you play it all.',
+      confidence: clamp01(bestScore + 0.34),
+      traits,
+    };
+  }
+
+  return { key: best.key, name: best.name, emoji: best.emoji, voice: best.voice, confidence: clamp01(bestScore), traits };
+}

--- a/src/lib/stats/types.ts
+++ b/src/lib/stats/types.ts
@@ -127,6 +127,7 @@ export interface StatsResult {
   totals: {
     games: number;
     finishedGames: number;
+    abandonedGames: number;
     rounds: number;
     gameNights: number;
   };

--- a/src/lib/stats/types.ts
+++ b/src/lib/stats/types.ts
@@ -1,0 +1,145 @@
+import type { ID, Game, Player, Round } from '../types';
+
+export type { ID };
+
+/**
+ * The minimal slice of the World the stats engine reads. Deliberately NOT the
+ * full {@link import('../storage/sync').Snapshot} so the engine never pulls in
+ * the backup/transport layer (xlsx, MSAL) — it stays a pure, testable function
+ * of members + games + rounds.
+ */
+export interface StatsData {
+  players: Player[];
+  games: Game[];
+  rounds: Round[];
+}
+
+/** Half-open-ish time window in ms epoch. Omit a bound to leave it open. */
+export interface DateRange {
+  from?: number;
+  to?: number;
+}
+
+export interface StatsQuery {
+  /** Any window; surfaces pick presets (year / YTD / rolling-12mo / season / tonight). */
+  range?: DateRange;
+  /** Personal lens — already a canonical member id ("your" stats / Wrapped). */
+  playerId?: ID;
+  /** Restrict to a single game module id. */
+  gameType?: string;
+  /** Include abandoned games in counts/records. Defaults to false. */
+  includeAbandoned?: boolean;
+}
+
+/** A single presentational stat line, ready to render with `tabular-nums`. */
+export interface Metric {
+  key: string;
+  label: string;
+  value: string;
+  sub?: string;
+  emoji?: string;
+}
+
+export interface HeadToHead {
+  opponentId: ID;
+  /** Games both members co-finished. */
+  games: number;
+  /** You finished strictly ahead. */
+  wins: number;
+  /** Opponent finished strictly ahead. */
+  losses: number;
+  /** Same finishing rank. */
+  ties: number;
+}
+
+export interface ByGameType {
+  played: number;
+  wins: number;
+  winRate: number;
+}
+
+/** Everything the engine derives for one member over the queried window. */
+export interface MemberStats {
+  playerId: ID;
+  played: number;
+  finished: number;
+  wins: number;
+  /** Top-3 finishes (or top-half in small games). */
+  podiums: number;
+  winRate: number; // 0..1
+  /** Mean finishing position (1 = first); undefined with no finished games. */
+  avgFinish?: number;
+  bestFinish?: number;
+  /** Consecutive wins ending at the most recent finished game. */
+  currentStreak: number;
+  longestStreak: number;
+  /** Total points (Σ deltas) and rounds the member appears in. */
+  points: number;
+  rounds: number;
+  byGameType: Record<string, ByGameType>;
+  headToHead: Record<ID, HeadToHead>;
+  // Drama
+  comebackWins: number;
+  wireToWireWins: number;
+  bestWinMargin?: number;
+  closestWinMargin?: number;
+  // Cadence
+  gameNights: number; // distinct local calendar days with a finished game
+  firstPlayedAt?: number;
+  lastPlayedAt?: number;
+  lastWinAt?: number;
+}
+
+export interface LeaderRow {
+  playerId: ID;
+  played: number;
+  wins: number;
+  winRate: number;
+  avgFinish?: number;
+  currentStreak: number;
+}
+
+export interface GameRecord {
+  key: string;
+  label: string;
+  value: string;
+  emoji?: string;
+  holderId?: ID;
+  gameId?: ID;
+  at?: number;
+}
+
+export interface GameSpecificStats {
+  perPlayer?: Record<ID, Metric[]>;
+  global?: Metric[];
+}
+
+export interface StatsResult {
+  range?: DateRange;
+  /** Canonical members referenced by the queried games. */
+  players: Player[];
+  leaderboard: LeaderRow[];
+  perPlayer: Record<ID, MemberStats>;
+  records: GameRecord[];
+  global: Metric[];
+  /** Keyed by game module id, fed by each module's `stats` hook. */
+  gameSpecific: Record<string, GameSpecificStats>;
+  totals: {
+    games: number;
+    finishedGames: number;
+    rounds: number;
+    gameNights: number;
+  };
+}
+
+/** Input handed to a game module's `stats` hook (already range/type-filtered & canonicalized). */
+export interface GameStatsInput {
+  games: Game[];
+  rounds: Round[];
+  players: Player[];
+  range?: DateRange;
+  /** Map any (possibly merged/legacy) member id to its surviving canonical id. */
+  canonical: (id: ID) => ID;
+}
+
+export type GameStatsHook = (input: GameStatsInput) => GameSpecificStats;

--- a/src/lib/stats/types.ts
+++ b/src/lib/stats/types.ts
@@ -70,6 +70,8 @@ export interface MemberStats {
   /** Mean finishing position (1 = first); undefined with no finished games. */
   avgFinish?: number;
   bestFinish?: number;
+  /** Population stdev of finishing positions — volatility; undefined with no games. */
+  finishStdev?: number;
   /** Consecutive wins ending at the most recent finished game. */
   currentStreak: number;
   longestStreak: number;
@@ -81,6 +83,9 @@ export interface MemberStats {
   // Drama
   comebackWins: number;
   wireToWireWins: number;
+  /** Games decided by a small margin, and how many the member won (clutch). */
+  closeGames: number;
+  closeWins: number;
   bestWinMargin?: number;
   closestWinMargin?: number;
   // Cadence

--- a/src/lib/stats/wrapped.test.ts
+++ b/src/lib/stats/wrapped.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round } from '../types';
+import { computeStats } from './engine';
+import { compareStats } from './compare';
+import { assignPersona } from './personas';
+import { buildWrapped, buildRecap, type WrappedInput } from './wrapped';
+
+const DAY = 86_400_000;
+const BASE = 1_700_000_000_000;
+const player = (id: string): Player => ({ id, name: id, color: '#7c5cff', createdAt: 0 });
+
+function mkGame(p: Partial<Game> & { id: string; type: string; playerIds: ID[]; winnerIds: ID[] }): Game {
+  return { config: {}, status: 'finished', createdAt: p.finishedAt ?? BASE, finishedAt: p.finishedAt ?? BASE, roundCount: 1, ...p } as Game;
+}
+function mkRound(gameId: string, deltas: Record<ID, number>): Round {
+  return { id: `${gameId}-r0`, gameId, index: 0, input: {}, deltas, createdAt: BASE };
+}
+
+/** A pumps out a strong personal season: 6 games, wins 4, incl. comebacks. */
+function season() {
+  const players = [player('A'), player('B'), player('C')];
+  const games: Game[] = [];
+  const rounds: Round[] = [];
+  const winByType: [string, ID][] = [
+    ['skullking', 'A'],
+    ['skullking', 'A'],
+    ['skullking', 'B'],
+    ['hearts', 'A'],
+    ['hearts', 'A'],
+    ['hearts', 'C'],
+  ];
+  winByType.forEach(([type, w], i) => {
+    const id = `g${i}`;
+    games.push(mkGame({ id, type, playerIds: ['A', 'B', 'C'], winnerIds: [w], finishedAt: BASE + i * DAY }));
+    // Winner gets the best score in the game's direction (Hearts = lower is better).
+    const others = ['A', 'B', 'C'].filter((p) => p !== w);
+    const deltas: Record<ID, number> = {};
+    if (type === 'hearts') {
+      deltas[w] = 5;
+      others.forEach((p, k) => (deltas[p] = 10 + k * 10));
+    } else {
+      deltas[w] = 40;
+      others.forEach((p, k) => (deltas[p] = 10 + k * 10));
+    }
+    rounds.push(mkRound(id, deltas));
+  });
+  return { players, games, rounds };
+}
+
+function inputFor(range?: { from?: number; to?: number }): WrappedInput {
+  const { players, games, rounds } = season();
+  const result = computeStats({ players, games, rounds }, { playerId: 'A', range });
+  const me = result.perPlayer['A'];
+  const persona = assignPersona(me);
+  return {
+    meId: 'A',
+    me,
+    result,
+    persona,
+    label: '2026',
+    nameOf: (id) => id,
+    gameName: (t) => t,
+    gameEmoji: () => '🎲',
+    roast: true,
+  };
+}
+
+describe('wrapped — year arc', () => {
+  const cards = buildWrapped(inputFor());
+
+  it('opens on a cover and ends on a group toast', () => {
+    expect(cards[0].kind).toBe('cover');
+    expect(cards[cards.length - 1].kind).toBe('toast');
+  });
+
+  it('includes the marquee moments', () => {
+    const kinds = cards.map((c) => c.kind);
+    expect(kinds).toContain('numbers');
+    expect(kinds).toContain('record');
+    expect(kinds).toContain('persona');
+    expect(kinds).toContain('crown');
+    expect(kinds).toContain('title');
+  });
+
+  it('reserves gold for the crowned and title cards only', () => {
+    for (const c of cards) {
+      if (c.kind === 'crown' || c.kind === 'title') expect(c.gold).toBe(true);
+      else expect(c.gold).toBeFalsy();
+    }
+  });
+
+  it('reports the real record on the record card', () => {
+    const rec = cards.find((c) => c.kind === 'record');
+    expect(rec?.headline).toBe('4–2'); // A won 4 of 6
+  });
+
+  it('surfaces vs-prior deltas when a comparison is supplied', () => {
+    const cur = inputFor();
+    // Prior window with zero games -> +4 wins improvement.
+    const priorResult = computeStats({ players: [player('A')], games: [], rounds: [] }, { playerId: 'A' });
+    cur.prior = compareStats(cur.result, priorResult, 'A');
+    const rec = buildWrapped(cur).find((c) => c.kind === 'record');
+    expect(rec?.lines?.some((l) => l.includes('▲'))).toBe(true);
+  });
+});
+
+describe('wrapped — recap arc', () => {
+  it('is short, MVP-led and toast-tailed', () => {
+    const cards = buildRecap({ ...inputFor(), label: 'tonight' });
+    expect(cards.length).toBeLessThanOrEqual(6);
+    expect(cards.some((c) => c.kind === 'crown')).toBe(true); // MVP card
+    expect(cards[cards.length - 1].kind).toBe('toast');
+  });
+});
+
+describe('wrapped — low data', () => {
+  it('gives a single welcome card when nothing was finished', () => {
+    const empty = computeStats({ players: [player('A')], games: [], rounds: [] }, { playerId: 'A' });
+    const cards = buildWrapped({
+      meId: 'A',
+      me: empty.perPlayer['A'],
+      result: empty,
+      label: '2026',
+      nameOf: (id) => id,
+      gameName: (t) => t,
+      gameEmoji: () => '🎲',
+    });
+    expect(cards).toHaveLength(1);
+    expect(cards[0].kind).toBe('lowdata');
+  });
+});

--- a/src/lib/stats/wrapped.ts
+++ b/src/lib/stats/wrapped.ts
@@ -1,0 +1,342 @@
+import type { ID } from '../types';
+import type { MemberStats, StatsResult } from './types';
+import type { StatsDelta } from './compare';
+import type { Persona } from './personas';
+import type { Badge } from './badges';
+import { fmtInt, fmtPct, fmtSigned } from './format';
+
+/**
+ * Wrapped: the same engine + a date range, shaped into an ordered, swipeable
+ * card story. Pure — takes a personal-lensed {@link StatsResult} and returns
+ * ready-to-render cards. The page owns range math, theming and motion.
+ */
+
+export type WrappedKind =
+  | 'cover'
+  | 'numbers'
+  | 'game'
+  | 'record'
+  | 'streak'
+  | 'moment'
+  | 'persona'
+  | 'rivalry'
+  | 'badges'
+  | 'crown'
+  | 'title'
+  | 'toast'
+  | 'lowdata';
+
+export interface WrappedStat {
+  label: string;
+  value: string;
+}
+
+export interface WrappedCard {
+  key: string;
+  kind: WrappedKind;
+  emoji: string;
+  headline: string;
+  lines?: string[];
+  stats?: WrappedStat[];
+  /** Crown Gold treatment — reserved for the crowned / title moments. */
+  gold?: boolean;
+}
+
+export interface WrappedInput {
+  meId: ID;
+  me: MemberStats;
+  /** Personal-lensed result for the window (records, totals, per-game highlights). */
+  result: StatsResult;
+  persona?: Persona;
+  newBadges?: Badge[];
+  earnedBadges?: Badge[];
+  /** compareStats(current, prior, meId) — powers "vs last time" deltas. */
+  prior?: StatsDelta;
+  /** Human label for the window: "2026", "the last 12 months", "tonight". */
+  label: string;
+  nameOf: (id: ID) => string;
+  gameName: (type: string) => string;
+  gameEmoji: (type: string) => string;
+  roast?: boolean;
+}
+
+const RARITY_RANK: Record<string, number> = { legendary: 4, epic: 3, rare: 2, common: 1 };
+
+function favoriteGame(me: MemberStats): { type: string; played: number; wins: number } | undefined {
+  let best: { type: string; played: number; wins: number } | undefined;
+  for (const [type, bt] of Object.entries(me.byGameType)) {
+    if (!best || bt.played > best.played) best = { type, played: bt.played, wins: bt.wins };
+  }
+  return best;
+}
+
+function favoriteRival(me: MemberStats): { id: ID; games: number; wins: number; losses: number } | undefined {
+  let best: { id: ID; games: number; wins: number; losses: number } | undefined;
+  for (const h of Object.values(me.headToHead)) {
+    if (!best || h.games > best.games) best = { id: h.opponentId, games: h.games, wins: h.wins, losses: h.losses };
+  }
+  return best;
+}
+
+function nemesis(me: MemberStats, minGames = 3): { id: ID; wins: number; losses: number } | undefined {
+  let worst: { id: ID; wins: number; losses: number; diff: number } | undefined;
+  for (const h of Object.values(me.headToHead)) {
+    if (h.games < minGames) continue;
+    const diff = h.wins - h.losses;
+    if (h.losses > h.wins && (!worst || diff < worst.diff)) {
+      worst = { id: h.opponentId, wins: h.wins, losses: h.losses, diff };
+    }
+  }
+  return worst;
+}
+
+function priorDelta(prior: StatsDelta | undefined, key: string): number | undefined {
+  return prior?.metrics.find((m) => m.key === key)?.delta;
+}
+
+function coverCard(input: WrappedInput): WrappedCard {
+  const { me, label } = input;
+  return {
+    key: 'cover',
+    kind: 'cover',
+    emoji: '👑',
+    headline: `Your ${label}`,
+    lines: [`${fmtInt(me.finished)} games · ${fmtInt(me.gameNights)} nights — let’s relive it.`],
+  };
+}
+
+function numbersCard(input: WrappedInput): WrappedCard {
+  const { me } = input;
+  const opponents = Object.keys(me.headToHead).length;
+  return {
+    key: 'numbers',
+    kind: 'numbers',
+    emoji: '🧮',
+    headline: 'By the numbers',
+    stats: [
+      { label: 'Games', value: fmtInt(me.finished) },
+      { label: 'Rounds', value: fmtInt(me.rounds) },
+      { label: 'Nights', value: fmtInt(me.gameNights) },
+      { label: 'Points', value: fmtInt(me.points) },
+      { label: 'Rivals', value: fmtInt(opponents) },
+    ],
+  };
+}
+
+function gameCard(input: WrappedInput): WrappedCard | undefined {
+  const fav = favoriteGame(input.me);
+  if (!fav) return undefined;
+  const losses = fav.played - fav.wins;
+  return {
+    key: 'game',
+    kind: 'game',
+    emoji: input.gameEmoji(fav.type),
+    headline: `Your game: ${input.gameName(fav.type)}`,
+    lines: [`${fmtInt(fav.played)} games · ${fav.wins}–${losses} record`],
+  };
+}
+
+function recordCard(input: WrappedInput): WrappedCard {
+  const { me, prior } = input;
+  const losses = me.finished - me.wins;
+  const lines = [`${fmtPct(me.winRate)} win rate`];
+  const dWins = priorDelta(prior, 'wins');
+  if (dWins !== undefined && dWins !== 0) {
+    lines.push(`${fmtSigned(dWins)} wins ${dWins > 0 ? '▲' : '▼'} vs last time`);
+  }
+  return {
+    key: 'record',
+    kind: 'record',
+    emoji: '📊',
+    headline: `${me.wins}–${losses}`,
+    lines,
+  };
+}
+
+function streakCard(input: WrappedInput): WrappedCard | undefined {
+  if (input.me.longestStreak < 2) return undefined;
+  return {
+    key: 'streak',
+    kind: 'streak',
+    emoji: '🔥',
+    headline: `${input.me.longestStreak}-game win streak`,
+    lines: ['Your hottest run of the stretch.'],
+  };
+}
+
+function momentCard(input: WrappedInput): WrappedCard | undefined {
+  const { me } = input;
+  if (me.comebackWins > 0) {
+    return {
+      key: 'moment',
+      kind: 'moment',
+      emoji: '🪦',
+      headline: 'Signature moment',
+      lines: [`${fmtInt(me.comebackWins)} comeback ${me.comebackWins === 1 ? 'win' : 'wins'} from behind.`],
+    };
+  }
+  if (me.wireToWireWins > 0) {
+    return {
+      key: 'moment',
+      kind: 'moment',
+      emoji: '🐎',
+      headline: 'Wire to wire',
+      lines: [`${fmtInt(me.wireToWireWins)} ${me.wireToWireWins === 1 ? 'game' : 'games'} led start to finish.`],
+    };
+  }
+  if (me.closeWins > 0) {
+    return {
+      key: 'moment',
+      kind: 'moment',
+      emoji: '⏱️',
+      headline: 'Ice in the veins',
+      lines: [`${fmtInt(me.closeWins)} nail-biter ${me.closeWins === 1 ? 'win' : 'wins'}.`],
+    };
+  }
+  return undefined;
+}
+
+function personaCard(input: WrappedInput): WrappedCard | undefined {
+  if (!input.persona) return undefined;
+  return {
+    key: 'persona',
+    kind: 'persona',
+    emoji: input.persona.emoji,
+    headline: input.persona.name,
+    lines: [input.persona.voice],
+  };
+}
+
+function rivalryCard(input: WrappedInput): WrappedCard | undefined {
+  const { me, nameOf, roast } = input;
+  const fav = favoriteRival(me);
+  if (!fav) return undefined;
+  const lines = [`Most-played rival — ${fav.wins}–${fav.losses} against ${nameOf(fav.id)}.`];
+  const nem = nemesis(me);
+  if (nem && roast && nem.id !== fav.id) {
+    lines.push(`😤 ${nameOf(nem.id)} has your number (${nem.losses}–${nem.wins}).`);
+  }
+  return {
+    key: 'rivalry',
+    kind: 'rivalry',
+    emoji: '⚔️',
+    headline: 'Rivalries',
+    lines,
+  };
+}
+
+function badgesCard(input: WrappedInput): WrappedCard | undefined {
+  const badges = input.earnedBadges ?? [];
+  if (badges.length === 0) return undefined;
+  const rarest = [...badges].sort((a, b) => (RARITY_RANK[b.rarity] ?? 0) - (RARITY_RANK[a.rarity] ?? 0))[0];
+  const fresh = input.newBadges?.length ?? 0;
+  const lines = [`${fmtInt(badges.length)} earned${fresh ? ` · ${fmtInt(fresh)} new` : ''}.`];
+  if (rarest) lines.push(`Rarest: ${rarest.emoji} ${rarest.name}.`);
+  return {
+    key: 'badges',
+    kind: 'badges',
+    emoji: '🏅',
+    headline: 'Badge cabinet',
+    lines,
+  };
+}
+
+function crownCard(input: WrappedInput): WrappedCard | undefined {
+  if (input.me.wins < 1) return undefined;
+  return {
+    key: 'crown',
+    kind: 'crown',
+    emoji: '👑',
+    headline: `Crowned ${fmtInt(input.me.wins)}×`,
+    lines: [`${fmtPct(input.me.winRate)} of your games ended in a win.`],
+    gold: true,
+  };
+}
+
+function titleCard(input: WrappedInput): WrappedCard {
+  const { persona, label } = input;
+  return {
+    key: 'title',
+    kind: 'title',
+    emoji: '🏆',
+    headline: persona ? persona.name : 'Contender',
+    lines: [`Your title for ${label}.`],
+    gold: true,
+  };
+}
+
+function toastCard(input: WrappedInput): WrappedCard {
+  const t = input.result.totals;
+  return {
+    key: 'toast',
+    kind: 'toast',
+    emoji: '🥂',
+    headline: 'Group toast',
+    lines: [`The crew logged ${fmtInt(t.finishedGames)} games across ${fmtInt(t.gameNights)} nights.`],
+  };
+}
+
+function mvpCard(input: WrappedInput): WrappedCard | undefined {
+  const top = input.result.leaderboard[0];
+  if (!top || top.wins < 1) return undefined;
+  const you = top.playerId === input.meId;
+  return {
+    key: 'mvp',
+    kind: 'crown',
+    emoji: '👑',
+    headline: you ? 'Tonight’s MVP: you' : `Tonight’s MVP: ${input.nameOf(top.playerId)}`,
+    lines: [`${top.wins} ${top.wins === 1 ? 'win' : 'wins'} · ${fmtPct(top.winRate)}.`],
+    gold: true,
+  };
+}
+
+function lowDataCards(input: WrappedInput): WrappedCard[] {
+  const n = input.me.finished;
+  if (n === 0) {
+    return [
+      {
+        key: 'lowdata',
+        kind: 'lowdata',
+        emoji: '🎲',
+        headline: 'Your legend begins',
+        lines: [`No finished games ${input.label === 'tonight' ? 'tonight' : `in ${input.label}`} yet — play one and come back.`],
+      },
+    ];
+  }
+  // 1–2 games: a tiny, honest arc rather than a padded one.
+  return [coverCard(input), numbersCard(input), recordCard(input), toastCard(input)];
+}
+
+/** The full year-in-review arc (or a graceful short arc when data is thin). */
+export function buildWrapped(input: WrappedInput): WrappedCard[] {
+  if (input.me.finished < 3) return lowDataCards(input);
+  const cards: (WrappedCard | undefined)[] = [
+    coverCard(input),
+    numbersCard(input),
+    gameCard(input),
+    recordCard(input),
+    streakCard(input),
+    momentCard(input),
+    personaCard(input),
+    rivalryCard(input),
+    badgesCard(input),
+    crownCard(input),
+    titleCard(input),
+    toastCard(input),
+  ];
+  return cards.filter((c): c is WrappedCard => c !== undefined);
+}
+
+/** The tonight-only Game Night Recap — a short, punchy mini-Wrapped. */
+export function buildRecap(input: WrappedInput): WrappedCard[] {
+  if (input.me.finished === 0) return lowDataCards(input);
+  const cards: (WrappedCard | undefined)[] = [
+    { ...coverCard(input), emoji: '🌙', headline: 'Tonight at the table' },
+    mvpCard(input),
+    recordCard(input),
+    momentCard(input),
+    input.roast ? rivalryCard(input) : undefined,
+    toastCard(input),
+  ];
+  return cards.filter((c): c is WrappedCard => c !== undefined);
+}

--- a/src/lib/stores/games.ts
+++ b/src/lib/stores/games.ts
@@ -115,6 +115,25 @@ export async function reopenGame(game: Game): Promise<Game> {
   return updated;
 }
 
+/**
+ * Mark an unfinished game as abandoned — it was started but called off, so it
+ * has no winner and is excluded from win%/standings. Distinct from an open
+ * (active) game and from a finished one; reopen to resume it.
+ */
+export async function abandonGame(game: Game): Promise<Game> {
+  const rounds = await db.getRounds(game.id);
+  const updated: Game = {
+    ...game,
+    status: 'abandoned',
+    finishedAt: Date.now(),
+    winnerIds: undefined,
+    roundCount: rounds.length,
+  };
+  await db.putGame(updated);
+  await refreshGames();
+  return updated;
+}
+
 export async function removeGame(id: ID): Promise<void> {
   await db.deleteGame(id);
   await refreshGames();

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -33,6 +33,8 @@ export interface Settings {
   keepAwake: boolean;
   /** Blur scores with a tap-to-reveal veil after the phone is set down. */
   privacyGuard: boolean;
+  /** Let the Daily Crown & Court surface playful roasts/rivalries, not just flexes. */
+  roastMode: boolean;
 
   // ── Device-local sync state ───────────────────────────────────────────────
   // OneDrive connection, the backup file's own location, and per-device sync
@@ -47,6 +49,12 @@ export interface Settings {
   oneDriveConnected: boolean;
   lastSync: number | null;
   lastRestore: number | null;
+  /**
+   * Which member this device treats as "you" — the personal lens for Stats,
+   * Daily Crown and Wrapped. Device-local: the member record lives in the World,
+   * but which one is *you* is per-device, so it never rides a backup.
+   */
+  mePlayerId: string | null;
 }
 
 /**
@@ -68,6 +76,7 @@ export const PORTABLE_SETTING_KEYS = [
   'colorBlind',
   'keepAwake',
   'privacyGuard',
+  'roastMode',
 ] as const;
 
 /**
@@ -86,6 +95,7 @@ export const LOCAL_SETTING_KEYS = [
   'oneDriveConnected',
   'lastSync',
   'lastRestore',
+  'mePlayerId',
 ] as const;
 
 export type PortableSettingKey = (typeof PORTABLE_SETTING_KEYS)[number];
@@ -116,6 +126,7 @@ const defaults: Settings = {
   colorBlind: false,
   keepAwake: false,
   privacyGuard: false,
+  roastMode: true,
   oneDriveClientId: '',
   oneDriveFolderMode: 'app',
   oneDriveCustomPath: '',
@@ -124,6 +135,7 @@ const defaults: Settings = {
   oneDriveConnected: false,
   lastSync: null,
   lastRestore: null,
+  mePlayerId: null,
 };
 
 function load(): Settings {
@@ -157,6 +169,11 @@ export function applySettings() {
 
 export function toggleTheme() {
   settings.update((s) => ({ ...s, theme: s.theme === 'dark' ? 'light' : 'dark' }));
+}
+
+/** Point this device's personal lens at a member (or clear it). */
+export function setMePlayer(id: string | null) {
+  settings.update((s) => ({ ...s, mePlayerId: id }));
 }
 
 export function markSynced(ts: number) {

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -81,6 +81,7 @@ export const LOCAL_SETTING_KEYS = [
   'oneDriveClientId',
   'oneDriveFolderMode',
   'oneDriveCustomPath',
+  'oneDriveBackupFile',
   'autoSync',
   'oneDriveConnected',
   'lastSync',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 import type { Component } from 'svelte';
+import type { GameStatsHook } from './stats/types';
 
 export type ID = string;
 
@@ -112,6 +113,13 @@ export interface GameModule {
   help?: string;
   /** Short summary of a recorded round for the history table. */
   describeRound?(round: Round, players: Player[]): string;
+  /**
+   * Optional game-specific stats over this game's finished games. Pure, no I/O —
+   * mirrors {@link describeRound}: a new game contributes stats the same way it
+   * contributes scoring. The stats engine injects this via the registry so it
+   * never imports Svelte components.
+   */
+  stats?: GameStatsHook;
 }
 
 export function defaultConfig(fields: ConfigField[] | undefined): Record<string, unknown> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,7 +10,7 @@ export interface Player {
   createdAt: number;
 }
 
-export type GameStatus = 'active' | 'finished';
+export type GameStatus = 'active' | 'finished' | 'abandoned';
 
 export interface Game {
   id: ID;

--- a/src/pages/Court.svelte
+++ b/src/pages/Court.svelte
@@ -1,0 +1,509 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { games } from '../lib/stores/games';
+  import { players } from '../lib/stores/players';
+  import { settings } from '../lib/stores/settings';
+  import { getModule } from '../lib/games/registry';
+  import { link } from '../lib/router';
+  import * as db from '../lib/storage/db';
+  import Avatar from '../lib/components/Avatar.svelte';
+  import type { Player, Round } from '../lib/types';
+  import { computeStats, buildCourt, fmtPct, fmtAvg, type LeaderRow } from '../lib/stats';
+
+  let rounds = $state<Round[]>([]);
+  let loaded = $state(false);
+  onMount(async () => {
+    rounds = await db.getAllRounds();
+    loaded = true;
+  });
+
+  type SortKey = 'wins' | 'winRate' | 'played' | 'streak' | 'avgFinish';
+  let sortKey = $state<SortKey>('wins');
+  let filterType = $state<string>('all');
+
+  const meId = $derived($settings.leadMemberId);
+  const roast = $derived($settings.roastMode);
+  const playerById = $derived(new Map<string, Player>($players.map((p) => [p.id, p])));
+  const nameOf = (id: string | undefined): string => (id ? playerById.get(id)?.name ?? 'Someone' : '—');
+  const gameLabel = (type: string): string => getModule(type)?.name ?? type;
+  const gameEmoji = (type: string): string => getModule(type)?.emoji ?? '🎲';
+
+  // Distinct finished-game types drive the lens chips (stable regardless of filter).
+  const gameTypes = $derived(
+    [...new Set($games.filter((g) => g.status === 'finished').map((g) => g.type))].sort(),
+  );
+
+  // One engine pass, optionally lensed to a single game — the whole Court follows it.
+  const result = $derived(
+    loaded
+      ? computeStats(
+          { players: $players, games: $games, rounds },
+          filterType === 'all' ? {} : { gameType: filterType },
+          { gameStats: (type) => getModule(type)?.stats },
+        )
+      : undefined,
+  );
+  const court = $derived(result ? buildCourt(result) : undefined);
+  const hasData = $derived((result?.totals.finishedGames ?? 0) > 0);
+
+  const sorters: Record<SortKey, (a: LeaderRow, b: LeaderRow) => number> = {
+    wins: (a, b) => b.wins - a.wins || b.winRate - a.winRate,
+    winRate: (a, b) => b.winRate - a.winRate || b.wins - a.wins,
+    played: (a, b) => b.played - a.played || b.wins - a.wins,
+    streak: (a, b) => b.currentStreak - a.currentStreak || b.wins - a.wins,
+    avgFinish: (a, b) => (a.avgFinish ?? 99) - (b.avgFinish ?? 99) || b.wins - a.wins,
+  };
+  const standings = $derived([...(result?.leaderboard ?? [])].sort(sorters[sortKey]));
+
+  // Matrix / rivalry read off the same members, ranked by the live standings.
+  const courtMembers = $derived(
+    standings.map((r) => playerById.get(r.playerId)).filter((p): p is Player => !!p),
+  );
+  const h2h = (aId: string, bId: string) => result?.perPlayer[aId]?.headToHead[bId];
+
+  const sortOptions: { key: SortKey; label: string }[] = [
+    { key: 'wins', label: 'Wins' },
+    { key: 'winRate', label: 'Win %' },
+    { key: 'played', label: 'Games' },
+    { key: 'streak', label: 'Streak' },
+    { key: 'avgFinish', label: 'Avg' },
+  ];
+
+  const parityText = (p: number): string =>
+    p >= 0.66 ? 'Anyone’s crown' : p >= 0.33 ? 'A clear favourite' : 'One-horse race';
+</script>
+
+<div class="row spread" style="margin: 2px 4px 6px">
+  <h1 style="margin: 0">👑 The Court</h1>
+  <a class="linkbtn" href="/stats" use:link>← Your stats</a>
+</div>
+
+{#if !loaded}
+  <div class="empty">Gathering the court…</div>
+{:else if !hasData}
+  <div class="empty">Finish a game and the court will assemble — Kings, rivalries and all.</div>
+{:else if result && court}
+  <!-- Lens chips: whole Court can focus on one game -->
+  {#if gameTypes.length > 1}
+    <div class="row wrap seg" role="group" aria-label="Filter by game">
+      <button class="chip" class:on={filterType === 'all'} onclick={() => (filterType = 'all')}>All games</button>
+      {#each gameTypes as t (t)}
+        <button class="chip" class:on={filterType === t} onclick={() => (filterType = t)}>
+          {gameEmoji(t)} {gameLabel(t)}
+        </button>
+      {/each}
+    </div>
+  {/if}
+
+  <!-- 1 ─ The Throne -->
+  <div class="section-title">The Throne</div>
+  <section class="card throne" aria-label="Who reigns">
+    {#if court.throne.overallId}
+      {@const k = playerById.get(court.throne.overallId)}
+      <div class="row" style="gap: 12px">
+        <span class="crown" aria-hidden="true">👑</span>
+        {#if k}<Avatar name={k.name} color={k.color} size={40} />{/if}
+        <div class="grow">
+          <div class="lead" style="font-size: 1.15rem">{nameOf(court.throne.overallId)}</div>
+          <div class="muted sm">
+            reigns with <b class="tnum">{court.throne.overallWins}</b> wins ·
+            <b class="tnum">{fmtPct(court.throne.overallWinRate)}</b>
+          </div>
+        </div>
+        {#if court.throne.overallId === meId}<span class="you">You</span>{/if}
+      </div>
+    {/if}
+
+    {#if court.throne.ironThroneId && court.throne.ironThroneStreak > 1}
+      <div class="row belt" style="gap: 10px">
+        <span aria-hidden="true">🔥</span>
+        <span class="grow">
+          <b>{nameOf(court.throne.ironThroneId)}</b> holds the Iron Throne —
+          <b class="tnum">{court.throne.ironThroneStreak}</b> straight
+        </span>
+      </div>
+    {/if}
+  </section>
+
+  {#if court.throne.kings.length > 0}
+    <div class="section-title">Reigning kings</div>
+    <div class="stack">
+      {#each court.throne.kings as king (king.gameType)}
+        {@const k = playerById.get(king.holderId)}
+        <div class="card row spread tile">
+          <span class="row" style="gap: 10px">
+            <span style="font-size: 1.3rem" aria-hidden="true">{gameEmoji(king.gameType)}</span>
+            <span>
+              <div class="muted sm">{gameLabel(king.gameType)}</div>
+              <div class="row" style="gap: 8px">
+                {#if k}<Avatar name={k.name} color={k.color} size={20} />{/if}
+                <strong>{nameOf(king.holderId)}</strong>
+                {#if king.holderId === meId}<span class="you">You</span>{/if}
+              </div>
+            </span>
+          </span>
+          <span class="row" style="gap: 10px">
+            <span class="muted sm"><b class="tnum">{fmtPct(king.winRate)}</b></span>
+            <b class="tnum lead">{king.wins}W</b>
+          </span>
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  <!-- 2 ─ Standings -->
+  <div class="section-title">Standings</div>
+  <div class="row wrap seg" role="group" aria-label="Sort standings">
+    {#each sortOptions as o (o.key)}
+      <button class="chip" class:on={sortKey === o.key} onclick={() => (sortKey = o.key)}>{o.label}</button>
+    {/each}
+  </div>
+  <div class="card stack">
+    {#each standings as row, i (row.playerId)}
+      {@const p = playerById.get(row.playerId)}
+      <div class="row spread" class:me={row.playerId === meId}>
+        <span class="row" style="gap: 8px">
+          <span class="rank tnum" class:lead={i === 0}>{i + 1}</span>
+          {#if p}<Avatar name={p.name} color={p.color} size={22} />{/if}
+          <span>{p?.name ?? '—'}</span>
+          {#if row.playerId === meId}<span class="you">You</span>{/if}
+        </span>
+        <span class="row figures">
+          <span class="fig"><b class="tnum" class:lead={i === 0}>{row.wins}</b><span class="lbl">W</span></span>
+          <span class="fig"><b class="tnum">{fmtPct(row.winRate)}</b><span class="lbl">win</span></span>
+          <span class="fig"><b class="tnum">{row.avgFinish ? fmtAvg(row.avgFinish) : '—'}</b><span class="lbl">avg</span></span>
+          <span class="fig">
+            <b class="tnum">{row.currentStreak > 0 ? `🔥${row.currentStreak}` : '—'}</b><span class="lbl">run</span>
+          </span>
+        </span>
+      </div>
+    {/each}
+  </div>
+
+  <!-- 3 ─ Rivalries -->
+  {#if court.hottestRivalry || court.biggestMismatch}
+    <div class="section-title">Rivalries</div>
+    <div class="stack">
+      {#if court.hottestRivalry}
+        {@const r = court.hottestRivalry}
+        <div class="card stack" style="gap: 8px">
+          <div class="row spread">
+            <span class="row" style="gap: 8px"><span aria-hidden="true">⚔️</span><strong>Hottest rivalry</strong></span>
+            <span class="pill sm"><b class="tnum">{r.games}</b> games</span>
+          </div>
+          <div class="row spread vs">
+            <span class="side">{nameOf(r.aId)}</span>
+            <span class="score tnum">{r.aWins}–{r.bWins}</span>
+            <span class="side end">{nameOf(r.bId)}</span>
+          </div>
+        </div>
+      {/if}
+      {#if court.biggestMismatch}
+        {@const r = court.biggestMismatch}
+        {@const lead = r.aWins >= r.bWins ? r.aId : r.bId}
+        {@const trail = r.aWins >= r.bWins ? r.bId : r.aId}
+        {@const hi = Math.max(r.aWins, r.bWins)}
+        {@const lo = Math.min(r.aWins, r.bWins)}
+        <div class="card row spread tile">
+          <span class="row" style="gap: 8px"><span aria-hidden="true">🎯</span><strong>Biggest mismatch</strong></span>
+          <span class="muted sm">
+            <b>{nameOf(lead)}</b> owns <b>{nameOf(trail)}</b> <b class="tnum">{hi}–{lo}</b>
+          </span>
+        </div>
+      {/if}
+    </div>
+  {/if}
+
+  <!-- 4 ─ Head-to-head matrix -->
+  {#if courtMembers.length > 1}
+    <div class="section-title">Head to head</div>
+    <div class="card matrix-wrap">
+      <table class="matrix">
+        <thead>
+          <tr>
+            <th class="corner" scope="col"><span class="vh">Row beats column</span></th>
+            {#each courtMembers as c (c.id)}
+              <th scope="col" title={c.name}><Avatar name={c.name} color={c.color} size={22} /></th>
+            {/each}
+          </tr>
+        </thead>
+        <tbody>
+          {#each courtMembers as rowM (rowM.id)}
+            <tr>
+              <th scope="row" class="rowhead">
+                <Avatar name={rowM.name} color={rowM.color} size={22} />
+                <span class="nm">{rowM.name}</span>
+              </th>
+              {#each courtMembers as colM (colM.id)}
+                {#if colM.id === rowM.id}
+                  <td class="diag">—</td>
+                {:else}
+                  {@const rec = h2h(rowM.id, colM.id)}
+                  <td
+                    class:win={rec && rec.wins > rec.losses}
+                    class:loss={rec && rec.wins < rec.losses}
+                    title={`${rowM.name} vs ${colM.name}`}
+                  >
+                    {#if rec}<span class="tnum">{rec.wins}–{rec.losses}</span>{:else}<span class="muted">·</span>{/if}
+                  </td>
+                {/if}
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+
+  <!-- 5 ─ Wall of Fame -->
+  {#if result.records.length > 0}
+    <div class="section-title">Wall of fame</div>
+    <div class="card stack">
+      {#each result.records as rec (rec.key)}
+        <div class="row spread">
+          <span class="row" style="gap: 8px"><span aria-hidden="true">{rec.emoji}</span>{rec.label}</span>
+          <span class="row" style="gap: 8px">
+            <b class="tnum">{rec.value}</b>
+            {#if rec.holderId}
+              {@const h = playerById.get(rec.holderId)}
+              {#if h}<Avatar name={h.name} color={h.color} size={20} />{/if}
+              {#if rec.holderId === meId}<span class="you">You</span>{/if}
+            {/if}
+          </span>
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  <!-- 6 ─ Group pulse -->
+  <div class="section-title">Group pulse</div>
+  <div class="card stack">
+    <div class="stack" style="gap: 6px">
+      <div class="row spread">
+        <span class="row" style="gap: 8px"><span aria-hidden="true">⚖️</span>Parity</span>
+        <span class="muted sm">{parityText(court.parity)}</span>
+      </div>
+      <div class="parity" role="img" aria-label={`Parity ${parityText(court.parity)}`}>
+        <span class="parity-fill" style={`transform:scaleX(${court.parity})`}></span>
+      </div>
+    </div>
+    <div class="row wrap" style="gap: 8px">
+      <span class="pill">🌙 <b class="tnum">{result.totals.gameNights}</b> game nights</span>
+      <span class="pill">🎲 <b class="tnum">{result.totals.finishedGames}</b> games</span>
+      <span class="pill">👥 <b class="tnum">{standings.length}</b> players</span>
+    </div>
+  </div>
+
+  <!-- 7 ─ Wall of Shame (lighthearted, opt-out via roastMode) -->
+  {#if roast && (court.shame.coldestId || court.shame.winlessIds.length > 0)}
+    <div class="section-title">Wall of shame 😅</div>
+    <div class="card stack">
+      {#if court.shame.coldestId}
+        <div class="row spread">
+          <span class="row" style="gap: 8px"><span aria-hidden="true">🥶</span>Coldest spell</span>
+          <span class="muted sm">
+            <b>{nameOf(court.shame.coldestId)}</b> · <b class="tnum">{fmtPct(court.shame.coldestWinRate ?? 0)}</b>
+          </span>
+        </div>
+      {/if}
+      {#if court.shame.winlessIds.length > 0}
+        <div class="row spread">
+          <span class="row" style="gap: 8px"><span aria-hidden="true">🫥</span>Still hunting a first win</span>
+          <span class="muted sm">{court.shame.winlessIds.map(nameOf).join(', ')}</span>
+        </div>
+      {/if}
+    </div>
+  {/if}
+{/if}
+
+<style>
+  .tnum {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+  }
+  .sm {
+    font-size: 0.82rem;
+  }
+  .linkbtn {
+    background: none;
+    border: none;
+    color: var(--muted);
+    text-decoration: underline;
+    cursor: pointer;
+    padding: 8px 4px;
+    min-height: 44px;
+    font: inherit;
+  }
+
+  /* Lens + sort chips — a quiet segmented control on the surface ramp. */
+  .seg {
+    gap: 6px;
+    margin: 0 2px 8px;
+  }
+  .chip {
+    min-height: 40px;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--muted);
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+  .chip.on {
+    background: var(--surface-3);
+    color: var(--text);
+    border-color: color-mix(in srgb, var(--text) 30%, var(--border));
+  }
+
+  .throne {
+    background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 10%, var(--surface)), var(--surface));
+    border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  }
+  .crown {
+    font-size: 1.7rem;
+    line-height: 1;
+  }
+  .belt {
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border);
+  }
+
+  .tile {
+    min-height: 46px;
+  }
+
+  .rank {
+    display: inline-block;
+    min-width: 1.4em;
+    text-align: center;
+    color: var(--muted);
+  }
+  .you {
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    padding: 1px 6px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+  }
+  .row.me {
+    margin: 0 -8px;
+    padding: 4px 8px;
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+  }
+  .pill.sm {
+    font-size: 0.7rem;
+    padding: 1px 7px;
+  }
+
+  /* Standings figures — compact, right-aligned, tabular. */
+  .figures {
+    gap: 12px;
+  }
+  .fig {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-end;
+    line-height: 1.05;
+    min-width: 2.4em;
+  }
+  .fig .lbl {
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--muted);
+    font-weight: 600;
+  }
+
+  /* Rivalry vs bar */
+  .vs .side {
+    flex: 1;
+    font-weight: 700;
+  }
+  .vs .side.end {
+    text-align: right;
+  }
+  .vs .score {
+    padding: 2px 12px;
+    border-radius: 999px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+  }
+
+  /* Head-to-head matrix */
+  .matrix-wrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .matrix {
+    border-collapse: collapse;
+    min-width: max-content;
+  }
+  .matrix th,
+  .matrix td {
+    padding: 6px 8px;
+    text-align: center;
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+  }
+  .matrix thead th {
+    position: sticky;
+    top: 0;
+  }
+  .matrix .corner {
+    text-align: left;
+  }
+  .matrix .rowhead {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    text-align: left;
+    font-weight: 600;
+  }
+  .matrix .rowhead .nm {
+    max-width: 6.5em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .matrix .diag {
+    color: var(--muted);
+  }
+  .matrix td.win {
+    color: var(--accent-ink);
+    font-weight: 700;
+  }
+  .matrix td.loss {
+    color: var(--muted);
+  }
+  .vh {
+    font-size: 0.7rem;
+    color: var(--muted);
+    font-weight: 600;
+  }
+
+  /* Parity meter — neutral (never gold/violet), state also carried by the label. */
+  .parity {
+    height: 10px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    overflow: hidden;
+  }
+  .parity-fill {
+    display: block;
+    height: 100%;
+    width: 100%;
+    transform-origin: left center;
+    background: color-mix(in srgb, var(--text) 45%, var(--surface-3));
+    transition: transform 0.4s ease;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .parity-fill {
+      transition: none;
+    }
+  }
+</style>

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -469,13 +469,15 @@
     <button class="btn block" style="margin-top: 12px" onclick={() => (shareOpen = true)}>
       📤 Share results
     </button>
+    <a class="btn block" style="margin-top: 10px" href="/tonight" use:link>🎁 Tonight’s Recap</a>
     <div class="row" style="gap: 10px; margin-top: 10px">
       <button class="btn" onclick={doReopen} title="Reopen to add more rounds">Reopen</button>
       <button class="btn primary grow" onclick={playAgain}>Play again</button>
     </div>
   {:else if game.status === 'abandoned'}
     <div class="card center banner">🪦 Game abandoned — no winner recorded.</div>
-    <div class="row" style="gap: 10px; margin-top: 12px">
+    <a class="btn block" style="margin-top: 12px" href="/tonight" use:link>🎁 Tonight’s Recap</a>
+    <div class="row" style="gap: 10px; margin-top: 10px">
       <button class="btn" onclick={doReopen} title="Reopen to keep playing">Reopen</button>
       <button class="btn primary grow" onclick={playAgain}>Play again</button>
     </div>

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -11,6 +11,7 @@
     restoreRound,
     finishGame,
     reopenGame,
+    abandonGame,
     createGame,
     removeGame,
     restoreGame,
@@ -184,6 +185,10 @@
     game = await reopenGame(game);
     resetDraft();
   }
+  async function doAbandon() {
+    if (!game) return;
+    game = await abandonGame(game);
+  }
   async function playAgain() {
     if (!game) return;
     const g = await createGame(game.type, [...game.playerIds], { ...game.config });
@@ -228,7 +233,11 @@
       <span>
         <div><strong>{module.name}</strong></div>
         <div class="muted" style="font-size: 0.8rem">
-          {game.status === 'finished' ? 'Finished' : 'Started'} · {relativeTime(
+          {game.status === 'finished'
+            ? 'Finished'
+            : game.status === 'abandoned'
+              ? 'Abandoned'
+              : 'Started'} · {relativeTime(
             game.finishedAt ?? game.createdAt,
           )}
         </div>
@@ -243,6 +252,12 @@
     <div class="card center banner">🏆 {winnerNames || 'Nobody'} {(game.winnerIds?.length ?? 0) > 1 ? 'tie!' : 'wins!'}</div>
     <div class="row" style="gap: 10px; margin-top: 12px">
       <button class="btn" onclick={doReopen} title="Reopen to add more rounds">Reopen</button>
+      <button class="btn primary grow" onclick={playAgain}>Play again</button>
+    </div>
+  {:else if game.status === 'abandoned'}
+    <div class="card center banner">🪦 Game abandoned — no winner recorded.</div>
+    <div class="row" style="gap: 10px; margin-top: 12px">
+      <button class="btn" onclick={doReopen} title="Reopen to keep playing">Reopen</button>
       <button class="btn primary grow" onclick={playAgain}>Play again</button>
     </div>
   {:else if editing}
@@ -282,6 +297,12 @@
     {:else}
       <button class="btn ghost block" style="margin-top: 12px" onclick={doFinish}>Finish game now</button>
     {/if}
+    <button
+      class="btn ghost block"
+      style="margin-top: 8px; color: var(--muted)"
+      onclick={doAbandon}
+      title="Stop this game without recording a winner"
+    >🪦 Abandon game</button>
   {/if}
 
   {#if rounds.length}
@@ -305,7 +326,7 @@
                 <td class="num">{fmt(r.deltas[p.id])}</td>
               {/each}
               <td class="acts">
-                {#if game.status !== 'finished'}
+                {#if game.status === 'active'}
                   <button
                     class="rowbtn"
                     onclick={() => startEdit(r)}

--- a/src/pages/History.svelte
+++ b/src/pages/History.svelte
@@ -32,12 +32,13 @@
           <span>
             <div>
               <strong>{m?.name ?? g.type}</strong>
-              {#if g.status === 'active'}<span class="pill">in progress</span>{/if}
+              {#if g.status === 'active'}<span class="pill">in progress</span>{:else if g.status === 'abandoned'}<span class="pill">🪦 abandoned</span>{/if}
             </div>
             <div class="muted sm">{names(g.playerIds)}</div>
             <div class="muted sm">
               {formatDateTime(g.finishedAt ?? g.createdAt)}
               {#if g.status === 'finished'} · 👑 {winners(g.winnerIds) || '—'}{/if}
+              {#if g.status === 'abandoned'} · no winner{/if}
             </div>
           </span>
         </span>

--- a/src/pages/Stats.svelte
+++ b/src/pages/Stats.svelte
@@ -181,6 +181,18 @@
     </section>
   {/if}
 
+  <!-- Gateway to the Wrapped story -->
+  <a class="wrapped-cta row spread" href="/wrapped" use:link>
+    <span class="row" style="gap: 12px">
+      <span class="wrapped-emoji" aria-hidden="true">🎁</span>
+      <span>
+        <div><strong>Your Wrapped</strong></div>
+        <div class="muted sm">A swipeable year in review</div>
+      </span>
+    </span>
+    <span aria-hidden="true">→</span>
+  </a>
+
   <!-- 2 ─ Persona + badges -->
   {#if persona}
     <div class="section-title">Your style</div>
@@ -425,5 +437,23 @@
   }
   .picker:hover {
     background: var(--surface-3);
+  }
+
+  .wrapped-cta {
+    margin-top: 10px;
+    padding: 14px 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface-2);
+    color: inherit;
+    text-decoration: none;
+    min-height: 46px;
+  }
+  .wrapped-cta:hover {
+    background: var(--surface-3);
+  }
+  .wrapped-emoji {
+    font-size: 1.6rem;
+    line-height: 1;
   }
 </style>

--- a/src/pages/Stats.svelte
+++ b/src/pages/Stats.svelte
@@ -1,92 +1,425 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { games } from '../lib/stores/games';
   import { players } from '../lib/stores/players';
+  import { settings, setMePlayer } from '../lib/stores/settings';
   import { getModule } from '../lib/games/registry';
+  import { link } from '../lib/router';
+  import * as db from '../lib/storage/db';
   import Avatar from '../lib/components/Avatar.svelte';
+  import type { Player, Round } from '../lib/types';
+  import {
+    computeStats,
+    assignPersona,
+    computeBadges,
+    newlyEarned,
+    dailyCrown,
+    nudges,
+    dayKey,
+    fmtPct,
+    fmtAvg,
+  } from '../lib/stats';
 
-  interface Row {
-    id: string;
-    name: string;
-    color: string;
-    played: number;
-    wins: number;
-  }
+  let rounds = $state<Round[]>([]);
+  let loaded = $state(false);
+  const today = dayKey(Date.now());
 
-  const finished = $derived($games.filter((g) => g.status === 'finished'));
-
-  const rows = $derived.by<Row[]>(() => {
-    const map = new Map<string, Row>();
-    for (const p of $players) {
-      map.set(p.id, { id: p.id, name: p.name, color: p.color, played: 0, wins: 0 });
-    }
-    for (const g of finished) {
-      for (const pid of g.playerIds) {
-        const r = map.get(pid);
-        if (r) r.played++;
-      }
-      for (const wid of g.winnerIds ?? []) {
-        const r = map.get(wid);
-        if (r) r.wins++;
-      }
-    }
-    return [...map.values()]
-      .filter((r) => r.played > 0)
-      .sort((a, b) => b.wins - a.wins || b.played - a.played);
+  onMount(async () => {
+    rounds = await db.getAllRounds();
+    loaded = true;
   });
 
-  const byType = $derived.by(() => {
-    const m = new Map<string, number>();
-    for (const g of $games) m.set(g.type, (m.get(g.type) ?? 0) + 1);
-    return [...m.entries()].sort((a, b) => b[1] - a[1]);
+  const meId = $derived($settings.mePlayerId);
+  const playerById = $derived(new Map<string, Player>($players.map((p) => [p.id, p])));
+  const nameOf = (id: string): string => playerById.get(id)?.name ?? 'Someone';
+
+  const result = $derived(
+    loaded
+      ? computeStats(
+          { players: $players, games: $games, rounds },
+          meId ? { playerId: meId } : {},
+          { gameStats: (type) => getModule(type)?.stats },
+        )
+      : undefined,
+  );
+
+  const me = $derived(meId && result ? result.perPlayer[meId] : undefined);
+  const persona = $derived(me ? assignPersona(me) : undefined);
+  const records = $derived(result?.records ?? []);
+  const badges = $derived(me ? computeBadges(me, { records }) : []);
+
+  // "New since last visit" — a tiny device-local diff, never backed up. On the
+  // very first visit there's no baseline, so nothing is flagged (we just seed it).
+  const seenKey = $derived(`sk_seen_badges_${meId}`);
+  const hadSeen = $derived(!!meId && localStorage.getItem(seenKey) !== null);
+  const seenBadges = $derived(loadSet(seenKey));
+  const freshBadges = $derived(me && hadSeen ? newlyEarned(badges, seenBadges) : []);
+  const freshKeys = $derived(new Set(freshBadges.map((b) => b.key)));
+
+  const crownMem = $derived(loadCrown(meId));
+  const hero = $derived(
+    me
+      ? dailyCrown({
+          meId: meId as string,
+          me,
+          persona,
+          newBadges: freshBadges,
+          records,
+          leaderboard: result?.leaderboard,
+          nameOf,
+          roast: $settings.roastMode,
+          lastKey: crownMem.day !== today ? crownMem.key : undefined,
+        })
+      : undefined,
+  );
+
+  const sideNudges = $derived(
+    me
+      ? nudges(
+          {
+            meId: meId as string,
+            me,
+            persona,
+            newBadges: freshBadges,
+            records,
+            leaderboard: result?.leaderboard,
+            nameOf,
+            roast: $settings.roastMode,
+          },
+          hero?.key,
+          3,
+        )
+      : [],
+  );
+
+  const board = $derived((result?.leaderboard ?? []).slice(0, 5));
+  const recent = $derived(
+    [...$games]
+      .filter((g) => g.status !== 'active')
+      .sort((a, b) => (b.finishedAt ?? b.createdAt) - (a.finishedAt ?? a.createdAt))
+      .slice(0, 5),
+  );
+
+  // Persist "seen" badges and today's crown pick so tomorrow can vary.
+  $effect(() => {
+    if (!meId || !me) return;
+    localStorage.setItem(seenKey, JSON.stringify(badges.map((b) => b.key)));
+  });
+  $effect(() => {
+    if (!meId || !hero || crownMem.day === today) return;
+    localStorage.setItem(`sk_crown_${meId}`, JSON.stringify({ day: today, key: hero.key }));
   });
 
-  function pct(r: Row): string {
-    return r.played ? `${Math.round((r.wins / r.played) * 100)}%` : '—';
+  function loadSet(key: string): Set<string> {
+    try {
+      return new Set(JSON.parse(localStorage.getItem(key) || '[]') as string[]);
+    } catch {
+      return new Set();
+    }
   }
+  function loadCrown(id: string | null): { day?: string; key?: string } {
+    if (!id) return {};
+    try {
+      return JSON.parse(localStorage.getItem(`sk_crown_${id}`) || '{}');
+    } catch {
+      return {};
+    }
+  }
+
+  const chooserPlayers = $derived([...$players].sort((a, b) => a.name.localeCompare(b.name)));
+  const recordLosses = $derived(me ? me.played - me.wins : 0);
+  const winnerNames = (ids: string[] | undefined) => (ids ?? []).map(nameOf).join(' & ');
 </script>
 
 <h1>Stats</h1>
 
-<div class="row wrap" style="gap: 10px; margin-bottom: 6px">
-  <span class="pill">{$games.length} games</span>
-  <span class="pill">{finished.length} finished</span>
-  <span class="pill">{$players.length} players</span>
-</div>
-
-{#if rows.length === 0}
-  <div class="empty">Finish a game to start building stats.</div>
-{:else}
-  <div class="section-title">Leaderboard</div>
-  <div class="card">
-    <table>
-      <thead>
-        <tr><th>Player</th><th>Played</th><th>Wins</th><th>Win %</th></tr>
-      </thead>
-      <tbody>
-        {#each rows as r (r.id)}
-          <tr>
-            <td>
-              <span class="row" style="gap: 8px">
-                <Avatar name={r.name} color={r.color} size={24} />{r.name}
-              </span>
-            </td>
-            <td>{r.played}</td>
-            <td class="lead">{r.wins}</td>
-            <td>{pct(r)}</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
-  </div>
-
-  <div class="section-title">Games played by type</div>
+{#if !loaded}
+  <div class="empty">Loading your stats…</div>
+{:else if !meId}
+  <!-- Personal-first: without a "you" anchor the whole screen is a lens with no focus. -->
   <div class="card stack">
-    {#each byType as [type, count] (type)}
-      {@const m = getModule(type)}
-      <div class="row spread">
-        <span class="row" style="gap: 8px">{m?.emoji ?? '🎲'} {m?.name ?? type}</span>
-        <span class="pill">{count}</span>
+    <div class="section-title" style="margin: 0">Who are you?</div>
+    <p class="muted" style="margin: 0">
+      Pick your player to unlock your Daily Crown, persona, records and rivalries. This lives only on
+      this device.
+    </p>
+    {#if chooserPlayers.length === 0}
+      <div class="empty">Add a player first, then come back to claim your crown.</div>
+    {:else}
+      <div class="stack" style="gap: 8px">
+        {#each chooserPlayers as p (p.id)}
+          <button class="picker row" onclick={() => setMePlayer(p.id)}>
+            <Avatar name={p.name} color={p.color} size={32} />
+            <span class="grow" style="text-align: left">{p.name}</span>
+            <span aria-hidden="true">👑</span>
+          </button>
+        {/each}
       </div>
-    {/each}
+    {/if}
   </div>
+{:else}
+  <!-- 1 ─ Daily Crown hero -->
+  {#if hero}
+    <section class="hero" class:gold={hero.gold} aria-label="Today's headline">
+      <span class="hero-emoji" aria-hidden="true">{hero.emoji}</span>
+      <p class="hero-text">{hero.text}</p>
+      <div class="row wrap hero-stats">
+        <span class="pill"><b class="tnum">{me?.wins}</b>–<b class="tnum">{recordLosses}</b> record</span>
+        <span class="pill"><b class="tnum">{fmtPct(me?.winRate ?? 0)}</b> win rate</span>
+        {#if me?.avgFinish !== undefined}
+          <span class="pill">avg <b class="tnum">{fmtAvg(me.avgFinish)}</b></span>
+        {/if}
+        {#if (me?.currentStreak ?? 0) > 0}
+          <span class="pill">🔥 <b class="tnum">{me?.currentStreak}</b> streak</span>
+        {/if}
+      </div>
+      <div class="row spread hero-foot">
+        <span class="muted sm">as {nameOf(meId)}</span>
+        <button class="linkbtn" onclick={() => setMePlayer(null)}>Not you?</button>
+      </div>
+    </section>
+  {/if}
+
+  <!-- 2 ─ Persona + badges -->
+  {#if persona}
+    <div class="section-title">Your style</div>
+    <div class="card stack">
+      <div class="row" style="gap: 12px">
+        <span class="persona-emoji" aria-hidden="true">{persona.emoji}</span>
+        <div class="grow">
+          <div><strong>{persona.name}</strong></div>
+          <div class="muted sm">{persona.voice}</div>
+        </div>
+      </div>
+      {#if badges.length > 0}
+        <div class="row wrap" style="gap: 6px">
+          {#each badges as b (b.key)}
+            <span class="badge" data-rarity={b.rarity} title={b.desc}>
+              <span aria-hidden="true">{b.emoji}</span>
+              {b.name}
+              {#if freshKeys.has(b.key)}<span class="new">NEW</span>{/if}
+            </span>
+          {/each}
+        </div>
+      {:else}
+        <p class="muted sm" style="margin: 0">Win a game to start earning badges.</p>
+      {/if}
+    </div>
+  {/if}
+
+  <!-- 3 ─ Records + brief leaderboard -->
+  {#if records.length > 0}
+    <div class="section-title">Record book</div>
+    <div class="card stack">
+      {#each records as r (r.key)}
+        <div class="row spread">
+          <span class="row" style="gap: 8px">
+            <span aria-hidden="true">{r.emoji}</span>{r.label}
+          </span>
+          <span class="row" style="gap: 8px">
+            <b class="tnum">{r.value}</b>
+            {#if r.holderId}
+              {@const h = playerById.get(r.holderId)}
+              {#if h}<Avatar name={h.name} color={h.color} size={20} />{/if}
+              {#if r.holderId === meId}<span class="you">You</span>{/if}
+            {/if}
+          </span>
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  {#if board.length > 0}
+    <div class="section-title">Standings</div>
+    <div class="card stack">
+      {#each board as row, i (row.playerId)}
+        {@const p = playerById.get(row.playerId)}
+        <div class="row spread" class:me={row.playerId === meId}>
+          <span class="row" style="gap: 8px">
+            <span class="rank tnum" class:lead={i === 0}>{i + 1}</span>
+            {#if p}<Avatar name={p.name} color={p.color} size={22} />{/if}
+            <span>{p?.name ?? '—'}</span>
+            {#if row.playerId === meId}<span class="you">You</span>{/if}
+          </span>
+          <span class="row" style="gap: 10px">
+            <span class="sm muted"><b class="tnum">{fmtPct(row.winRate)}</b></span>
+            <b class="tnum" class:lead={i === 0}>{row.wins}W</b>
+          </span>
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  <!-- 4 ─ Recent activity + nudges -->
+  {#if sideNudges.length > 0}
+    <div class="section-title">On your radar</div>
+    <div class="card stack">
+      {#each sideNudges as n (n.key)}
+        <div class="row" style="gap: 10px">
+          <span aria-hidden="true">{n.emoji}</span>
+          <span class="grow">{n.text}</span>
+          {#if n.tone === 'roast'}<span class="pill sm">roast</span>{/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  {#if recent.length > 0}
+    <div class="section-title">Recent games</div>
+    <div class="stack">
+      {#each recent as g (g.id)}
+        {@const m = getModule(g.type)}
+        <a class="card row spread tile" href={`/play/${g.id}`} use:link>
+          <span class="row" style="gap: 10px">
+            <span style="font-size: 1.3rem" aria-hidden="true">{m?.emoji ?? '🎲'}</span>
+            <span>
+              <div><strong>{m?.name ?? g.type}</strong></div>
+              <div class="muted sm">
+                {#if g.status === 'abandoned'}🪦 abandoned{:else}👑 {winnerNames(g.winnerIds) || '—'}{/if}
+              </div>
+            </span>
+          </span>
+          <span class="muted sm">{new Date(g.finishedAt ?? g.createdAt).toLocaleDateString()}</span>
+        </a>
+      {/each}
+    </div>
+  {:else}
+    <div class="empty">Finish a game to start building your legend.</div>
+  {/if}
 {/if}
+
+<style>
+  .tnum {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+  }
+  .sm {
+    font-size: 0.82rem;
+  }
+
+  /* Hero — depth from the surface ramp, one accent, no shadow stacking. */
+  .hero {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 18px 16px 12px;
+    margin-bottom: 6px;
+  }
+  .hero.gold {
+    border-color: var(--accent);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 12%, var(--surface-2)), var(--surface-2));
+  }
+  .hero-emoji {
+    font-size: 2rem;
+    line-height: 1;
+  }
+  .hero-text {
+    margin: 8px 0 12px;
+    font-size: 1.25rem;
+    font-weight: 700;
+    line-height: 1.25;
+  }
+  .hero.gold .hero-text {
+    color: var(--accent-ink);
+  }
+  .hero-stats {
+    gap: 6px;
+  }
+  .hero-foot {
+    margin-top: 12px;
+  }
+
+  .linkbtn {
+    background: none;
+    border: none;
+    color: var(--muted);
+    text-decoration: underline;
+    cursor: pointer;
+    padding: 8px 4px;
+    min-height: 44px;
+    font: inherit;
+  }
+
+  .persona-emoji {
+    font-size: 1.9rem;
+    line-height: 1;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 5px 10px;
+    border-radius: 999px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    font-size: 0.82rem;
+    font-weight: 600;
+  }
+  .badge[data-rarity='rare'] {
+    border-color: color-mix(in srgb, var(--text) 35%, var(--border));
+  }
+  .badge[data-rarity='epic'],
+  .badge[data-rarity='legendary'] {
+    border-color: color-mix(in srgb, var(--text) 55%, var(--border));
+    background: var(--surface-3);
+  }
+  .badge .new {
+    font-size: 0.62rem;
+    letter-spacing: 0.06em;
+    font-weight: 800;
+    padding: 1px 5px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+  }
+
+  .rank {
+    display: inline-block;
+    min-width: 1.4em;
+    text-align: center;
+    color: var(--muted);
+  }
+  .you {
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    padding: 1px 6px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+  }
+  .row.me {
+    margin: 0 -8px;
+    padding: 4px 8px;
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+  }
+
+  .pill.sm {
+    font-size: 0.7rem;
+    padding: 1px 7px;
+  }
+
+  .tile {
+    text-decoration: none;
+    color: inherit;
+    min-height: 46px;
+  }
+
+  .picker {
+    gap: 10px;
+    width: 100%;
+    min-height: 46px;
+    padding: 8px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font: inherit;
+  }
+  .picker:hover {
+    background: var(--surface-3);
+  }
+</style>

--- a/src/pages/Stats.svelte
+++ b/src/pages/Stats.svelte
@@ -231,7 +231,10 @@
   {/if}
 
   {#if board.length > 0}
-    <div class="section-title">Standings</div>
+    <div class="row spread" style="margin: 18px 4px 8px">
+      <span class="section-title" style="margin: 0">Standings</span>
+      <a class="linkbtn" href="/court" use:link>Full Court 👑 →</a>
+    </div>
     <div class="card stack">
       {#each board as row, i (row.playerId)}
         {@const p = playerById.get(row.playerId)}

--- a/src/pages/Wrapped.svelte
+++ b/src/pages/Wrapped.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import { games } from '../lib/stores/games';
   import { players, activePlayers } from '../lib/stores/players';
   import { settings } from '../lib/stores/settings';
@@ -30,7 +30,8 @@
   });
 
   type Preset = 'year' | 'rolling' | 'tonight';
-  let preset = $state<Preset>('year');
+  let { initialPreset = 'year' }: { initialPreset?: Preset } = $props();
+  let preset = $state<Preset>(untrack(() => initialPreset));
   let index = $state(0);
 
   const meId = $derived($settings.leadMemberId);

--- a/src/pages/Wrapped.svelte
+++ b/src/pages/Wrapped.svelte
@@ -1,0 +1,445 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { games } from '../lib/stores/games';
+  import { players, activePlayers } from '../lib/stores/players';
+  import { settings } from '../lib/stores/settings';
+  import { setLeadMember } from '../lib/stores/identity';
+  import { getModule } from '../lib/games/registry';
+  import { link } from '../lib/router';
+  import * as db from '../lib/storage/db';
+  import Avatar from '../lib/components/Avatar.svelte';
+  import type { Player, Round } from '../lib/types';
+  import {
+    computeStats,
+    compareStats,
+    assignPersona,
+    computeBadges,
+    newlyEarned,
+    buildWrapped,
+    buildRecap,
+    type WrappedInput,
+  } from '../lib/stats';
+
+  const DAY = 86_400_000;
+
+  let rounds = $state<Round[]>([]);
+  let loaded = $state(false);
+  onMount(async () => {
+    rounds = await db.getAllRounds();
+    loaded = true;
+  });
+
+  type Preset = 'year' | 'rolling' | 'tonight';
+  let preset = $state<Preset>('year');
+  let index = $state(0);
+
+  const meId = $derived($settings.leadMemberId);
+  const roast = $derived($settings.roastMode);
+  const playerById = $derived(new Map<string, Player>($players.map((p) => [p.id, p])));
+  const nameOf = (id: string): string => playerById.get(id)?.name ?? 'Someone';
+  const gameName = (type: string): string => getModule(type)?.name ?? type;
+  const gameEmoji = (type: string): string => getModule(type)?.emoji ?? '🎲';
+  const gameStats = (type: string) => getModule(type)?.stats;
+
+  /** Preset → window (+ comparison window for "vs last time" and card mode). */
+  const cfg = $derived.by(() => {
+    const now = Date.now();
+    const d = new Date(now);
+    if (preset === 'tonight') {
+      const from = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+      return { range: { from, to: now }, prior: undefined, label: 'tonight', mode: 'recap' as const };
+    }
+    if (preset === 'rolling') {
+      const from = now - 365 * DAY;
+      return {
+        range: { from, to: now },
+        prior: { from: from - 365 * DAY, to: from },
+        label: 'the last 12 months',
+        mode: 'year' as const,
+      };
+    }
+    const from = new Date(d.getFullYear(), 0, 1).getTime();
+    const priorFrom = new Date(d.getFullYear() - 1, 0, 1).getTime();
+    const priorTo = new Date(
+      d.getFullYear() - 1,
+      d.getMonth(),
+      d.getDate(),
+      d.getHours(),
+      d.getMinutes(),
+      d.getSeconds(),
+    ).getTime();
+    return {
+      range: { from, to: now },
+      prior: { from: priorFrom, to: priorTo },
+      label: String(d.getFullYear()),
+      mode: 'year' as const,
+    };
+  });
+
+  const result = $derived(
+    loaded && meId
+      ? computeStats({ players: $players, games: $games, rounds }, { playerId: meId, range: cfg.range }, { gameStats })
+      : undefined,
+  );
+  const me = $derived(meId && result ? result.perPlayer[meId] : undefined);
+  const persona = $derived(me ? assignPersona(me) : undefined);
+  const records = $derived(result?.records ?? []);
+  const badges = $derived(me ? computeBadges(me, { records }) : []);
+
+  // "New this window" = badges held now minus badges already held before it started.
+  const beforeResult = $derived(
+    loaded && meId && cfg.range.from !== undefined
+      ? computeStats(
+          { players: $players, games: $games, rounds },
+          { playerId: meId, range: { to: cfg.range.from } },
+          { gameStats },
+        )
+      : undefined,
+  );
+  const newBadges = $derived.by(() => {
+    if (!me) return [];
+    const before = beforeResult?.perPlayer[meId as string];
+    const beforeBadges = before ? computeBadges(before, { records: beforeResult?.records ?? [] }) : [];
+    return newlyEarned(badges, new Set(beforeBadges.map((b) => b.key)));
+  });
+
+  const priorResult = $derived(
+    loaded && meId && cfg.prior
+      ? computeStats({ players: $players, games: $games, rounds }, { playerId: meId, range: cfg.prior }, { gameStats })
+      : undefined,
+  );
+  const prior = $derived(result && priorResult && meId ? compareStats(result, priorResult, meId) : undefined);
+
+  const cards = $derived.by(() => {
+    if (!me || !meId || !result) return [];
+    const input: WrappedInput = {
+      meId,
+      me,
+      result,
+      persona,
+      earnedBadges: badges,
+      newBadges,
+      prior,
+      label: cfg.label,
+      nameOf,
+      gameName,
+      gameEmoji,
+      roast,
+    };
+    return cfg.mode === 'recap' ? buildRecap(input) : buildWrapped(input);
+  });
+
+  const clamped = $derived(Math.min(index, Math.max(0, cards.length - 1)));
+  const card = $derived(cards[clamped]);
+
+  const presetOptions: { key: Preset; label: string }[] = [
+    { key: 'year', label: 'This year' },
+    { key: 'rolling', label: 'Last 12 months' },
+    { key: 'tonight', label: 'Tonight' },
+  ];
+
+  function choose(p: Preset) {
+    preset = p;
+    index = 0;
+  }
+  function prev() {
+    if (clamped > 0) index = clamped - 1;
+  }
+  function next() {
+    if (clamped < cards.length - 1) index = clamped + 1;
+  }
+  function onKey(e: KeyboardEvent) {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (e.key === 'ArrowLeft') prev();
+    else if (e.key === 'ArrowRight') next();
+  }
+
+  const chooserPlayers = $derived([...$activePlayers].sort((a, b) => a.name.localeCompare(b.name)));
+</script>
+
+<svelte:window onkeydown={onKey} />
+
+<div class="row spread" style="margin: 2px 4px 8px">
+  <h1 style="margin: 0">🎁 Wrapped</h1>
+  <a class="linkbtn" href="/stats" use:link>← Your stats</a>
+</div>
+
+{#if !loaded}
+  <div class="empty">Wrapping up your year…</div>
+{:else if !meId}
+  <!-- Personal-first: Wrapped is a portrait of you — pick who "you" are. -->
+  <div class="card stack">
+    <div class="section-title" style="margin: 0">Whose Wrapped?</div>
+    <p class="muted" style="margin: 0">Pick your player to see your year in Score King. Stays on this device.</p>
+    {#if chooserPlayers.length === 0}
+      <div class="empty">Add a player first, then come back for your Wrapped.</div>
+    {:else}
+      <div class="stack" style="gap: 8px">
+        {#each chooserPlayers as p (p.id)}
+          <button class="picker row" onclick={() => setLeadMember(p.id)}>
+            <Avatar name={p.name} color={p.color} size={32} />
+            <span class="grow" style="text-align: left">{p.name}</span>
+            <span aria-hidden="true">🎁</span>
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{:else}
+  <!-- Range presets -->
+  <div class="row wrap seg" role="group" aria-label="Wrapped range">
+    {#each presetOptions as o (o.key)}
+      <button class="chip" class:on={preset === o.key} onclick={() => choose(o.key)}>{o.label}</button>
+    {/each}
+  </div>
+
+  {#if cards.length === 0}
+    <div class="empty">
+      No finished games {preset === 'tonight' ? 'tonight' : `in ${cfg.label}`} yet — try another range or play a game.
+    </div>
+  {:else if card}
+    <!-- Swipeable card story: manual advance (reduced-motion safe by default). -->
+    <section class="stage" role="group" aria-roledescription="carousel" aria-label="Your Wrapped cards">
+      {#key clamped}
+        <article class="wcard" class:gold={card.gold} aria-live="polite">
+          <span class="wc-emoji" aria-hidden="true">{card.emoji}</span>
+          <h2 class="wc-head">{card.headline}</h2>
+          {#if card.stats && card.stats.length > 0}
+            <div class="wc-grid">
+              {#each card.stats as s (s.label)}
+                <div class="wc-cell">
+                  <div class="wc-val tnum">{s.value}</div>
+                  <div class="wc-lbl">{s.label}</div>
+                </div>
+              {/each}
+            </div>
+          {/if}
+          {#if card.lines}
+            <div class="wc-lines">
+              {#each card.lines as line, i (i)}
+                <p class="wc-line">{line}</p>
+              {/each}
+            </div>
+          {/if}
+        </article>
+      {/key}
+    </section>
+
+    <!-- Progress + controls -->
+    <div class="row spread controls">
+      <button class="nav" onclick={prev} disabled={clamped === 0} aria-label="Previous card">←</button>
+      <div class="dots" role="tablist" aria-label="Wrapped progress">
+        {#each cards as c, i (c.key)}
+          <button
+            class="dot"
+            class:on={i === clamped}
+            role="tab"
+            aria-selected={i === clamped}
+            aria-label={`Card ${i + 1} of ${cards.length}`}
+            onclick={() => (index = i)}
+          >
+            <span class="dot-mark" aria-hidden="true"></span>
+          </button>
+        {/each}
+      </div>
+      <button class="nav" onclick={next} disabled={clamped >= cards.length - 1} aria-label="Next card">→</button>
+    </div>
+    <p class="center muted sm counter">
+      <span class="tnum">{clamped + 1}</span> / <span class="tnum">{cards.length}</span> · as {nameOf(meId)}
+    </p>
+  {/if}
+{/if}
+
+<style>
+  .tnum {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+  }
+  .sm {
+    font-size: 0.82rem;
+  }
+
+  .linkbtn {
+    background: none;
+    border: none;
+    color: var(--muted);
+    text-decoration: underline;
+    cursor: pointer;
+    padding: 8px 4px;
+    min-height: 44px;
+    font: inherit;
+  }
+
+  .seg {
+    gap: 6px;
+    margin: 0 2px 10px;
+  }
+  .chip {
+    min-height: 40px;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--muted);
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+  .chip.on {
+    background: var(--surface-3);
+    color: var(--text);
+    border-color: color-mix(in srgb, var(--text) 30%, var(--border));
+  }
+
+  /* The card stage — depth from the surface ramp, single soft lift. */
+  .stage {
+    outline: none;
+  }
+  .wcard {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 14px;
+    min-height: 340px;
+    padding: 40px 24px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface-2);
+    box-shadow: var(--shadow);
+  }
+  .wcard.gold {
+    border-color: var(--accent);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 14%, var(--surface-2)), var(--surface-2));
+  }
+  .wc-emoji {
+    font-size: 3.4rem;
+    line-height: 1;
+  }
+  .wc-head {
+    margin: 0;
+    font-size: 1.9rem;
+    font-weight: 800;
+    line-height: 1.15;
+  }
+  .wcard.gold .wc-head {
+    color: var(--accent-ink);
+  }
+  .wc-lines {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .wc-line {
+    margin: 0;
+    font-size: 1.05rem;
+    color: var(--muted);
+    line-height: 1.4;
+  }
+  .wc-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 14px 10px;
+    width: 100%;
+    max-width: 340px;
+    margin-top: 4px;
+  }
+  .wc-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .wc-val {
+    font-size: 1.6rem;
+  }
+  .wc-lbl {
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+
+  .controls {
+    margin: 12px 2px 4px;
+    gap: 10px;
+  }
+  .nav {
+    min-width: 46px;
+    min-height: 46px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    color: var(--text);
+    font-size: 1.2rem;
+    cursor: pointer;
+  }
+  .nav:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .dots {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 2px;
+  }
+  .dot {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 32px;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+  }
+  .dot-mark {
+    width: 7px;
+    height: 7px;
+    border-radius: 999px;
+    background: var(--border);
+    transition: transform 0.15s ease, background 0.15s ease;
+  }
+  .dot.on .dot-mark {
+    background: var(--text);
+    transform: scale(1.5);
+  }
+  .counter {
+    margin: 4px 0 0;
+  }
+
+  /* Whimsical entrance — transform/opacity only, disabled under reduced motion. */
+  @media (prefers-reduced-motion: no-preference) {
+    .wcard {
+      animation: wc-in 0.28s ease-out;
+    }
+  }
+  @keyframes wc-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px) scale(0.99);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  .picker {
+    gap: 10px;
+    width: 100%;
+    min-height: 46px;
+    padding: 8px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font: inherit;
+  }
+  .picker:hover {
+    background: var(--surface-3);
+  }
+</style>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+// Isolated from vite.config.ts on purpose: the stats engine is pure TypeScript,
+// so tests need neither the Svelte plugin nor the PWA service-worker build.
+export default defineConfig({
+  test: {
+    include: ['src/**/*.{test,spec}.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Overview

Introduces a **personal Stats area**, a group **Court** leaderboard, and a **Wrapped** year-in-review (plus a tonight-only **Game Night Recap**) for Score King. Everything is derived on-read from the user's own local data — no new storage, no backend, nothing leaves the device. "Me" is a device-local pointer (`leadMemberId`), never backed up.

## What's included

- **Pure stats engine** (`src/lib/stats/engine.ts`) + per-game hooks and tests. One `computeStats(data, query, options)` pass powers every surface; supports a personal lens, date ranges, and per-game-type filtering.
- **Abandoned game status** — games can be explicitly abandoned (host-authoritative, via `hostSerial` + `publish`), denoted throughout History/Stats (🪦, "no winner"). Distinct from open/active games.
- **Personal Stats screen** — Daily Crown hero, personas, badges (with "new since last visit"), record book, rivalries, and nudges.
- **Member-model adoption** — merges `main`'s Member identity model; the engine soft-keeps **archived** members in stats and hides **deleted (tombstoned)** members as stat subjects while preserving seat/rank integrity for everyone else.
- **The Court** (`src/pages/Court.svelte`) — group leaderboard: Throne, per-game Kings, sortable standings with a per-game lens, head-to-head matrix, Wall of Fame, group parity/pulse, and a roast-gated Wall of Shame.
- **Wrapped** (`src/pages/Wrapped.svelte` + `src/lib/stats/wrapped.ts`) — a swipeable card story: 12-card year arc and a short tonight Recap arc. Range presets (This year / Last 12 months / Tonight), "vs last time" deltas, low-data-graceful, reduced-motion-safe.

## Design

Follows the committed design system: Royal Violet for the single primary action, **Crown Gold reserved for leader/winner** (Wrapped's crowned/title cards only), depth via the surface ramp + one soft shadow, `tabular-nums` on changing numbers, ≥46px touch targets, no color-only signals, and `prefers-reduced-motion` honored (animations use transform/opacity only).

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm test` — **70 tests pass** (6 files)
- `npm run build` — clean

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>