### PR TITLE
Add Golf card game (9-hole, lowest total wins)

### DIFF
--- a/src/lib/games/golf/GolfEditor.svelte
+++ b/src/lib/games/golf/GolfEditor.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { holeCeiling, holeFloor, holeTag, readConfig, rulesetLines, type GolfInput } from './logic';
+
+  let { input = $bindable(), ctx }: { input: GolfInput; ctx: RoundContext } = $props();
+
+  const cfg = $derived(readConfig(ctx.config));
+  const n = $derived(ctx.roundIndex + 1);
+  const floor = $derived(holeFloor(cfg));
+  const ceil = $derived(holeCeiling(cfg));
+  let showRules = $state(false);
+
+  function projected(id: string): number {
+    return (ctx.totals[id] ?? 0) + (Math.trunc(Number(input.scores[id]) || 0));
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="pill">⛳ Hole {n} / {cfg.holes}</span>
+    <button type="button" class="btn small ghost" onclick={() => (showRules = !showRules)}>
+      Card values
+    </button>
+  </div>
+
+  {#if showRules}
+    <div class="help">
+      {#each rulesetLines(cfg) as line}<div>{line}</div>{/each}
+    </div>
+  {/if}
+
+  {#each ctx.players as p (p.id)}
+    {@const tag = holeTag(Math.trunc(Number(input.scores[p.id]) || 0))}
+    <div class="prow">
+      <div class="row spread">
+        <span class="row" style="gap: 8px">
+          <Avatar name={p.name} color={p.color} />
+          <strong>{p.name}</strong>
+        </span>
+        <Stepper bind:value={input.scores[p.id]} min={floor} max={ceil} />
+      </div>
+      <div class="row spread foot">
+        <span class="tag" class:under={tag === 'under'}>
+          {#if tag === 'under'}🐦 under par{:else if tag === 'clean'}⛳ clean sheet{:else}&nbsp;{/if}
+        </span>
+        <span class="running">
+          <span class="lbl">total</span>
+          <span class="num">{projected(p.id)}</span>
+        </span>
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+  }
+  .foot {
+    margin-top: 8px;
+  }
+  .tag {
+    font-size: 0.82rem;
+    font-weight: 700;
+    color: var(--muted);
+  }
+  .tag.under {
+    color: var(--good);
+  }
+  .running {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+  .lbl {
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .num {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .help {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/golf/golf.test.ts
+++ b/src/lib/games/golf/golf.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round, RoundContext } from '../../types';
+import { defaultWinners } from '../../types';
+import type { GameStatsInput, Metric } from '../../stats/types';
+import { golf } from './index';
+import { golfStats } from './stats';
+import {
+  createGolfInput,
+  gridCount,
+  holeCeiling,
+  holeFloor,
+  holeTag,
+  minCardValue,
+  readConfig,
+  rulesetLines,
+  scoreGolf,
+  validateGolf,
+  type GolfConfig,
+  type GolfInput,
+} from './logic';
+
+const player = (id: string, name = id): Player => ({ id, name, color: '#7c5cff', createdAt: 0 });
+
+function mkCtx(
+  players: Player[],
+  config: Record<string, unknown> = {},
+  extra: Partial<RoundContext> = {},
+): RoundContext {
+  return {
+    game: { id: 'g', type: 'golf', config, playerIds: players.map((p) => p.id), status: 'active', createdAt: 0, roundCount: 0 },
+    players,
+    config,
+    roundIndex: 0,
+    totals: {},
+    rounds: [],
+    ...extra,
+  };
+}
+
+const cfg = (over: Partial<GolfConfig> = {}): GolfConfig => ({
+  holes: 9,
+  grid: '6',
+  kingValue: 0,
+  jokers: false,
+  ...over,
+});
+
+describe('golf ruleset helpers', () => {
+  it('maps grid size to card count with a 6-card default', () => {
+    expect(gridCount('4')).toBe(4);
+    expect(gridCount('6')).toBe(6);
+    expect(gridCount('9')).toBe(9);
+    expect(gridCount('nonsense')).toBe(6);
+  });
+
+  it('reads + normalises config with sane defaults', () => {
+    expect(readConfig({})).toEqual(cfg());
+    expect(readConfig({ holes: 18, grid: '9', kingValue: '-2', jokers: true })).toEqual(
+      cfg({ holes: 18, grid: '9', kingValue: -2, jokers: true }),
+    );
+  });
+
+  it('clamps holes into 1..18 and falls back on garbage', () => {
+    expect(readConfig({ holes: 0 }).holes).toBe(1);
+    expect(readConfig({ holes: 99 }).holes).toBe(18);
+    expect(readConfig({ holes: 'x' }).holes).toBe(9);
+    expect(readConfig({ holes: 12.7 }).holes).toBe(12);
+  });
+
+  it('rejects unknown grid values back to 6-card', () => {
+    expect(readConfig({ grid: '5' }).grid).toBe('6');
+    expect(readConfig({ grid: '4' }).grid).toBe('4');
+  });
+
+  it('derives the min card value only from negative kings / jokers', () => {
+    expect(minCardValue(cfg())).toBe(0);
+    expect(minCardValue(cfg({ kingValue: -2 }))).toBe(-2);
+    expect(minCardValue(cfg({ jokers: true }))).toBe(-2);
+    expect(minCardValue(cfg({ kingValue: -2, jokers: true }))).toBe(-2);
+  });
+
+  it('computes hole floor and ceiling from the grid + ruleset', () => {
+    expect(holeFloor(cfg())).toBe(0);
+    expect(holeFloor(cfg({ jokers: true }))).toBe(-12);
+    expect(holeFloor(cfg({ grid: '4', kingValue: -2 }))).toBe(-8);
+    expect(holeCeiling(cfg())).toBe(72);
+    expect(holeCeiling(cfg({ grid: '9' }))).toBe(108);
+  });
+
+  it('tags a hole score below / at / above zero', () => {
+    expect(holeTag(-3)).toBe('under');
+    expect(holeTag(0)).toBe('clean');
+    expect(holeTag(7)).toBeNull();
+  });
+
+  it('renders a live, config-aware card reference', () => {
+    const base = rulesetLines(cfg());
+    expect(base[0]).toContain('K 0');
+    expect(base[0]).not.toContain('Joker');
+    expect(base[2]).toContain('6-card grid');
+    expect(base[2]).toContain('9 holes wins');
+
+    const spicy = rulesetLines(cfg({ kingValue: -2, jokers: true, holes: 1 }));
+    expect(spicy[0]).toContain('K -2');
+    expect(spicy[0]).toContain('Joker −2');
+    expect(spicy[2]).toContain('1 hole wins');
+  });
+});
+
+describe('golf round entry', () => {
+  it('creates a zeroed hole for every player', () => {
+    expect(createGolfInput([player('a'), player('b')])).toEqual({ scores: { a: 0, b: 0 } });
+  });
+
+  it('accepts whole-number hole scores within range', () => {
+    const ctx = mkCtx([player('a'), player('b')]);
+    expect(validateGolf({ scores: { a: 5, b: 0 } }, ctx)).toBeNull();
+  });
+
+  it('rejects non-integer scores', () => {
+    const ctx = mkCtx([player('a', 'Ana')]);
+    expect(validateGolf({ scores: { a: 2.5 } }, ctx)).toMatch(/whole-number/);
+  });
+
+  it('rejects scores below the ruleset floor', () => {
+    const ctx = mkCtx([player('a', 'Ana')]);
+    expect(validateGolf({ scores: { a: -1 } }, ctx)).toMatch(/below the lowest/);
+  });
+
+  it('rejects absurdly high scores', () => {
+    const ctx = mkCtx([player('a', 'Ana')]);
+    expect(validateGolf({ scores: { a: 500 } }, ctx)).toMatch(/too high/);
+  });
+
+  it('allows negative holes once jokers or a −2 king are in play', () => {
+    expect(validateGolf({ scores: { a: -4 } }, mkCtx([player('a')], { jokers: true }))).toBeNull();
+    expect(validateGolf({ scores: { a: -3 } }, mkCtx([player('a')], { kingValue: '-2' }))).toBeNull();
+  });
+
+  it('scores the called-out totals, truncating and filling gaps with 0', () => {
+    const ctx = mkCtx([player('a'), player('b'), player('c')]);
+    expect(scoreGolf({ scores: { a: 7, b: 3.9 } as Record<ID, number>, }, ctx)).toEqual({ a: 7, b: 3, c: 0 });
+  });
+});
+
+describe('golf module contract', () => {
+  it('is a lower-is-better cards module keyed by its folder', () => {
+    expect(golf.id).toBe('golf');
+    expect(golf.name).toBe('Golf');
+    expect(golf.emoji).toBe('⛳');
+    expect(golf.lowerIsBetter).toBe(true);
+    expect(golf.minPlayers).toBeLessThanOrEqual(golf.maxPlayers);
+  });
+
+  it('ends after the configured number of holes', () => {
+    expect(golf.maxRounds?.({}, 4)).toBe(9);
+    expect(golf.maxRounds?.({ holes: 18 }, 4)).toBe(18);
+    expect(golf.maxRounds?.({ holes: 99 }, 4)).toBe(18);
+  });
+
+  it('builds a fresh input through the module entrypoint', () => {
+    expect(golf.createRoundInput(mkCtx([player('a'), player('b')]))).toEqual({ scores: { a: 0, b: 0 } });
+  });
+
+  it('awards the win to the lowest total', () => {
+    expect(defaultWinners(golf, { a: 20, b: 8, c: 15 })).toEqual(['b']);
+  });
+
+  it('summarises a hole for the history table', () => {
+    const round: Round = {
+      id: 'r0',
+      gameId: 'g',
+      index: 0,
+      input: { scores: { a: 3, b: -1 } } satisfies GolfInput,
+      deltas: { a: 3, b: -1 },
+      createdAt: 0,
+    };
+    const text = golf.describeRound!(round, [player('a', 'Ana'), player('b', 'Bo')]);
+    expect(text).toBe('Hole 1 · Ana 3 · Bo -1');
+  });
+});
+
+const identity = (id: ID): ID => id;
+
+function mkGame(id: string): Game {
+  return { id, type: 'golf', config: {}, playerIds: [], status: 'finished', createdAt: 0, roundCount: 0 };
+}
+function mkRound(gameId: string, index: number, scores: Record<ID, number>): Round {
+  return { id: `${gameId}-r${index}`, gameId, index, input: { scores }, deltas: scores, createdAt: 0 };
+}
+const metric = (list: Metric[] | undefined, key: string): Metric | undefined =>
+  list?.find((m) => m.key === key);
+
+describe('golf stats', () => {
+  const input: GameStatsInput = {
+    games: [mkGame('g1')],
+    rounds: [
+      mkRound('g1', 0, { A: 5, B: 0 }),
+      mkRound('g1', 1, { A: -2, B: 3 }),
+      mkRound('g1', 2, { A: 4, B: 1 }),
+      mkRound('other', 0, { A: -99, B: -99 }),
+    ],
+    players: [player('A'), player('B')],
+    canonical: identity,
+  };
+  const res = golfStats(input);
+
+  it('reports best hole, average per hole and birdies per player', () => {
+    const a = res.perPlayer!['A'];
+    expect(metric(a, 'golf_best')?.value).toBe('-2');
+    expect(metric(a, 'golf_avg')?.value).toBe('2.3');
+    expect(metric(a, 'golf_birdie')?.value).toBe('1');
+
+    const b = res.perPlayer!['B'];
+    expect(metric(b, 'golf_best')?.value).toBe('0');
+    expect(metric(b, 'golf_birdie')).toBeUndefined();
+  });
+
+  it('ignores rounds from other games', () => {
+    // The −99 round belongs to a game not in `games`, so it never lands.
+    expect(metric(res.perPlayer!['A'], 'golf_best')?.value).toBe('-2');
+  });
+
+  it('surfaces the lowest hole as a global record', () => {
+    expect(metric(res.global, 'golf_record')?.value).toBe('-2');
+  });
+
+  it('folds merged member ids through the canonicalizer', () => {
+    const merged = golfStats({
+      ...input,
+      rounds: [mkRound('g1', 0, { A: 5 }), mkRound('g1', 1, { A2: -6 })],
+      canonical: (id) => (id === 'A2' ? 'A' : id),
+    });
+    expect(metric(merged.perPlayer!['A'], 'golf_best')?.value).toBe('-6');
+    expect(merged.perPlayer!['A2']).toBeUndefined();
+  });
+});

--- a/src/lib/games/golf/index.ts
+++ b/src/lib/games/golf/index.ts
@@ -1,0 +1,88 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './GolfEditor.svelte';
+import { golfStats } from './stats';
+import { createGolfInput, readConfig, scoreGolf, validateGolf, type GolfInput } from './logic';
+
+export type { GolfInput, GolfConfig, GridSize } from './logic';
+
+export const golf: GameModule = {
+  id: 'golf',
+  name: 'Golf',
+  tagline: 'Fewest points over 9 holes wins',
+  emoji: '⛳',
+  keywords: ['cards', 'six card golf', 'polka', 'lowest', 'grid', 'holes', 'par'],
+  minPlayers: 2,
+  maxPlayers: 8,
+  lowerIsBetter: true,
+  configFields: [
+    { key: 'holes', label: 'Number of holes', type: 'number', default: 9, min: 1, max: 18 },
+    {
+      key: 'grid',
+      label: 'Grid size',
+      type: 'select',
+      default: '6',
+      options: [
+        { value: '6', label: '6 cards (3×2)' },
+        { value: '4', label: '4 cards (2×2)' },
+        { value: '9', label: '9 cards (3×3)' },
+      ],
+      help: 'How many cards each player lays out per hole.',
+    },
+    {
+      key: 'kingValue',
+      label: 'King value',
+      type: 'select',
+      default: '0',
+      options: [
+        { value: '0', label: 'King = 0' },
+        { value: '-2', label: 'King = −2' },
+      ],
+      help: 'Kings are free in the common ruleset; −2 is a popular variant.',
+    },
+    {
+      key: 'jokers',
+      label: 'Jokers count −2',
+      type: 'boolean',
+      default: false,
+      help: 'Add two −2 Jokers to the deck for deeper red numbers.',
+    },
+  ],
+
+  maxRounds: (config) => readConfig(config).holes,
+
+  createRoundInput: (ctx: RoundContext): GolfInput => createGolfInput(ctx.players),
+  validateRound: validateGolf,
+  scoreRound: scoreGolf,
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as GolfInput;
+    const scores = input?.scores ?? {};
+    const parts = players
+      .filter((p) => p.id in scores)
+      .map((p) => `${p.name} ${Math.trunc(Number(scores[p.id]) || 0)}`);
+    return parts.length ? `Hole ${round.index + 1} · ${parts.join(' · ')}` : `Hole ${round.index + 1}`;
+  },
+
+  help: [
+    'Golf — play 9 holes and finish with the FEWEST points.',
+    '',
+    'Each hole, everyone lays out a face-down grid (6 cards by default) and',
+    'flips them as play goes. Add up your grid and call out the hole score.',
+    '',
+    'Card values (common ruleset):',
+    '• Ace = 1',
+    '• 2–10 = face value',
+    '• Jack / Queen = 10',
+    '• King = 0  (some groups play −2)',
+    '• Joker = −2  (optional)',
+    '',
+    'Two equal cards in the SAME COLUMN cancel each other to 0 — the heart of',
+    'Golf, and how a clean grid reaches 0 or dips into the red.',
+    '',
+    'Lowest running total after the last hole wins the round of Golf.',
+  ].join('\n'),
+
+  stats: golfStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/golf/logic.ts
+++ b/src/lib/games/golf/logic.ts
@@ -1,0 +1,132 @@
+import type { ID, RoundContext } from '../../types';
+
+/**
+ * Pure Golf scoring + validation — no Svelte imports, so `golf.test.ts` can
+ * exercise the real rules and the editor/stats can share one source of truth.
+ *
+ * Golf (a.k.a. Six-card Golf / Polka): each hole every player lays out a grid of
+ * cards and tries to MINIMISE its value. Card values (the common ruleset):
+ *   Ace = 1 · 2–10 = face value · J/Q = 10 · King = 0 (configurable).
+ * Two equal cards in the same column cancel to 0, so a tidy grid can reach 0 (or
+ * go negative with King = −2 or −2 Jokers). Lowest total after the last hole wins.
+ *
+ * The table does the grid math and calls out a hole score; this module records
+ * that number per player, keeps the ruleset as reference, and bounds obvious typos.
+ */
+
+export type GridSize = '4' | '6' | '9';
+
+export interface GolfConfig {
+  /** Number of holes (rounds) in the game. */
+  holes: number;
+  /** Grid size / ruleset variant. */
+  grid: GridSize;
+  /** Points a King is worth (0 in the common ruleset; −2 in a popular variant). */
+  kingValue: number;
+  /** Whether Jokers are in play, each worth −2. */
+  jokers: boolean;
+}
+
+/** One hole's raw entry: each player's called-out grid total. */
+export interface GolfInput {
+  scores: Record<ID, number>;
+}
+
+export const DEFAULT_HOLES = 9;
+/** Highest a single card can score (J/Q/10 = 10); padded for house rules. */
+export const MAX_CARD = 12;
+
+/** Cards in the grid for a given ruleset. */
+export function gridCount(grid: string): number {
+  switch (grid) {
+    case '4':
+      return 4;
+    case '9':
+      return 9;
+    default:
+      return 6;
+  }
+}
+
+function clampInt(n: number, min: number, max: number, fallback: number): number {
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(n)));
+}
+
+/** Normalise a stored config bag into a fully-resolved, typed GolfConfig. */
+export function readConfig(config: Record<string, unknown>): GolfConfig {
+  const holes = clampInt(Number(config.holes), 1, 18, DEFAULT_HOLES);
+  const gridRaw = String(config.grid);
+  const grid: GridSize = gridRaw === '4' || gridRaw === '9' ? gridRaw : '6';
+  const kingRaw = Number(config.kingValue);
+  const kingValue = Number.isFinite(kingRaw) ? Math.trunc(kingRaw) : 0;
+  return { holes, grid, kingValue, jokers: !!config.jokers };
+}
+
+/**
+ * Most-negative value a single card can contribute. Pairs only cancel *to 0*, so
+ * the floor is driven entirely by negative Kings / Jokers when those are enabled.
+ */
+export function minCardValue(cfg: GolfConfig): number {
+  let m = 0;
+  if (cfg.kingValue < 0) m = Math.min(m, cfg.kingValue);
+  if (cfg.jokers) m = Math.min(m, -2);
+  return m;
+}
+
+/** Lowest hole score that is possible under the ruleset (a whole grid of the min card). */
+export function holeFloor(cfg: GolfConfig): number {
+  return gridCount(cfg.grid) * minCardValue(cfg);
+}
+
+/** Generous upper bound on a hole score, used only to catch fat-fingered entries. */
+export function holeCeiling(cfg: GolfConfig): number {
+  return gridCount(cfg.grid) * MAX_CARD;
+}
+
+/** Fresh, all-zero entry for the next hole. */
+export function createGolfInput(players: { id: ID }[]): GolfInput {
+  return { scores: Object.fromEntries(players.map((p) => [p.id, 0])) };
+}
+
+/** null when the hole is enterable, otherwise a friendly, table-side message. */
+export function validateGolf(input: GolfInput, ctx: RoundContext): string | null {
+  const cfg = readConfig(ctx.config);
+  const floor = holeFloor(cfg);
+  const ceil = holeCeiling(cfg);
+  const cards = gridCount(cfg.grid);
+  for (const p of ctx.players) {
+    const v = Number(input.scores?.[p.id]);
+    if (!Number.isFinite(v) || !Number.isInteger(v)) {
+      return `${p.name}: enter a whole-number hole score.`;
+    }
+    if (v < floor) return `${p.name}: ${v} is below the lowest possible ${cards}-card hole (${floor}).`;
+    if (v > ceil) return `${p.name}: ${v} looks too high for a ${cards}-card hole.`;
+  }
+  return null;
+}
+
+/** Per-player points for the hole — the called-out grid totals, as integers. */
+export function scoreGolf(input: GolfInput, ctx: RoundContext): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const p of ctx.players) out[p.id] = Math.trunc(Number(input.scores?.[p.id]) || 0);
+  return out;
+}
+
+/** A tiny golf-flavoured tag for a hole score: below zero, exactly zero, or nothing. */
+export function holeTag(score: number): 'under' | 'clean' | null {
+  if (score < 0) return 'under';
+  if (score === 0) return 'clean';
+  return null;
+}
+
+/** Live, config-aware card-value reference shown in the round editor + help. */
+export function rulesetLines(cfg: GolfConfig): string[] {
+  const king = cfg.kingValue === 0 ? 'K 0' : `K ${cfg.kingValue}`;
+  const joker = cfg.jokers ? ' · Joker −2' : '';
+  return [
+    `A 1 · 2–10 face value · J/Q 10 · ${king}${joker}`,
+    'Two equal cards in the same column cancel to 0.',
+    `${gridCount(cfg.grid)}-card grid — lowest total after ${cfg.holes} ${cfg.holes === 1 ? 'hole' : 'holes'} wins.`,
+  ];
+}

--- a/src/lib/games/golf/stats.ts
+++ b/src/lib/games/golf/stats.ts
@@ -1,0 +1,72 @@
+import type { ID } from '../../types';
+import type { GolfInput } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg, fmtInt } from '../../stats/format';
+
+interface GolfAgg {
+  holes: number;
+  sum: number;
+  best: number;
+  birdies: number;
+}
+
+/**
+ * Golf stats, derived purely from each recorded hole. A "birdie" here is a hole
+ * scored below zero (all pairs cancelled with red cards to spare); "best hole" is
+ * a player's single lowest hole. Pure — no Svelte — so it is unit-testable and
+ * safe for the stats engine to import.
+ */
+export function golfStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, GolfAgg>();
+  const get = (id: ID): GolfAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { holes: 0, sum: 0, best: Infinity, birdies: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as GolfInput | undefined;
+    if (!input?.scores) continue;
+    for (const [pid, raw] of Object.entries(input.scores)) {
+      const v = Math.trunc(Number(raw) || 0);
+      const a = get(canonical(pid));
+      a.holes += 1;
+      a.sum += v;
+      if (v < a.best) a.best = v;
+      if (v < 0) a.birdies += 1;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let courseRecord = Infinity;
+  for (const [id, a] of per) {
+    if (!a.holes) continue;
+    if (a.best < courseRecord) courseRecord = a.best;
+    const metrics: Metric[] = [
+      { key: 'golf_best', label: 'Best hole', value: fmtInt(a.best), emoji: '🏌️' },
+      { key: 'golf_avg', label: 'Avg per hole', value: fmtAvg(a.sum / a.holes), emoji: '⛳' },
+    ];
+    if (a.birdies) {
+      metrics.push({
+        key: 'golf_birdie',
+        label: 'Birdies',
+        value: fmtInt(a.birdies),
+        sub: 'holes under par (0)',
+        emoji: '🐦',
+      });
+    }
+    perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (Number.isFinite(courseRecord)) {
+    global.push({ key: 'golf_record', label: 'Lowest hole', value: fmtInt(courseRecord), emoji: '🏌️' });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## ⛳ Golf

Adds **Golf** (a.k.a. Six-card Golf / Polka) — a lower-is-better cards game. Play **9 holes** and finish with the **fewest** points. Purely additive: everything lives in `src/lib/games/golf/` and is picked up by the auto-discovery registry (no `registry.ts` edit).

### How it plays & scores
Each hole every player lays out a face-down grid, flips as play goes, cancels **matched pairs in a column to 0**, tallies the grid and calls out a hole score. The module records that per-player number — which can go **negative** with the right ruleset. Lowest running total after the last hole wins.

Card values (common ruleset): **A = 1 · 2–10 = face · J/Q = 10 · K = 0** (matched column pairs → 0). The table does the grid math; the app keeps the running story and the reference.

### Config
| Option | Default | Notes |
|---|---|---|
| Number of holes | 9 | 1–18 (front/back nine, or a quick round) |
| Grid size | 6 cards (3×2) | also 4-card (2×2) and 9-card (3×3) |
| King value | 0 | or −2 (popular variant) |
| Jokers count −2 | off | adds red numbers |

The ruleset drives the entry **floor/ceiling** (so a −2-King/Joker game unlocks negative holes, while the standard ruleset floors at 0) and a **live card-value reference** in the editor.

### Structure
- **`logic.ts`** — pure scoring, validation, ruleset math (no Svelte), the single source of truth.
- **`index.ts`** — `GameModule` (`id: 'golf'`, `lowerIsBetter`, `maxRounds` = holes, config, help).
- **`GolfEditor.svelte`** — reuses `Avatar` + `Stepper`; hole counter, a **Card values** popover, per-player **running totals** in `tabular-nums`, and calm 🐦 _under par_ / ⛳ _clean sheet_ tags.
- **`stats.ts`** — best hole, average per hole, birdies (holes under par), and a global lowest-hole record.
- **`golf.test.ts`** — 24 tests over the rules, module contract, and stats.

### Design
Chrome stays identical; personality is emoji + copy only (⛳/🏌️/🐦). No new violet fill, no Crown Gold (leader/winner stays the shell's job), depth via the surface ramp, changing numbers use `tabular-nums`, ≥46px touch targets, state co-signalled by text + emoji (never colour alone), no motion added.

### Verification
- `npm run check` — 0 errors, 0 warnings
- `npm test` — 99 passing (24 new)
- `npm run build` — succeeds

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
