### PR TITLE
Add Rummikub game module

### DIFF
--- a/src/lib/games/rummikub/RummikubEditor.svelte
+++ b/src/lib/games/rummikub/RummikubEditor.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { handPenalty, type RummikubInput } from './logic';
+  import { rummikub } from './index';
+
+  let { input = $bindable(), ctx }: { input: RummikubInput; ctx: RoundContext } = $props();
+
+  const jokerValue = $derived(Math.max(0, Number(ctx.config.jokerValue) || 30));
+  const fixedRounds = $derived(
+    ctx.config.endMode === 'target' ? null : Number(ctx.config.rounds) || 4,
+  );
+
+  /** The winner's derived score: the sum of every opponent's leftover tiles. */
+  const pot = $derived(
+    ctx.players.reduce(
+      (sum, p) => (p.id === input.winner ? sum : sum + handPenalty(input.hands[p.id], jokerValue)),
+      0,
+    ),
+  );
+
+  let showHelp = $state(false);
+
+  function setWinner(id: string) {
+    input.winner = input.winner === id ? null : id;
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="pill">Round {ctx.roundIndex + 1}{fixedRounds ? ` of ${fixedRounds}` : ''}</span>
+    <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+      How to score
+    </button>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{rummikub.help}</pre>
+  {/if}
+
+  <p class="muted hint">
+    {input.winner
+      ? 'Now enter everyone else’s leftover tiles.'
+      : 'Tap whoever went out — emptied their rack.'}
+  </p>
+
+  {#each ctx.players as p (p.id)}
+    {@const isWinner = input.winner === p.id}
+    {@const penalty = handPenalty(input.hands[p.id], jokerValue)}
+    <div class="prow" class:winner={isWinner}>
+      <div class="row spread">
+        <span class="row" style="gap: 8px">
+          <Avatar name={p.name} color={p.color} />
+          <strong>{p.name}</strong>
+        </span>
+        {#if isWinner}
+          <span class="preview score-good">+{pot}</span>
+        {:else}
+          <span class="preview" class:score-bad={penalty > 0}>{penalty > 0 ? `−${penalty}` : '0'}</span>
+        {/if}
+      </div>
+
+      <div class="controls">
+        <button
+          type="button"
+          class="toggle"
+          class:on={isWinner}
+          aria-pressed={isWinner}
+          onclick={() => setWinner(p.id)}
+        >
+          {isWinner ? '🏆 Rummikub!' : 'Went out'}
+        </button>
+
+        {#if !isWinner}
+          <div class="fields">
+            <label class="f">
+              Tiles
+              <Stepper bind:value={input.hands[p.id].tiles} min={0} />
+            </label>
+            <label class="f">
+              Jokers
+              <Stepper bind:value={input.hands[p.id].jokers} min={0} max={2} />
+            </label>
+          </div>
+        {/if}
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .prow.winner {
+    border-color: var(--primary);
+  }
+  .controls {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .toggle {
+    min-height: 46px;
+    padding: 9px 12px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+  }
+  .toggle.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .fields {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  .f {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+  .preview {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .hint {
+    margin: 0;
+    font-size: 0.9rem;
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/rummikub/index.ts
+++ b/src/lib/games/rummikub/index.ts
@@ -1,0 +1,110 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './RummikubEditor.svelte';
+import {
+  DEFAULT_JOKER_VALUE,
+  scoreRummikub,
+  validateRummikub,
+  type RummikubInput,
+} from './logic';
+import { rummikubStats } from './stats';
+
+export type { RummikubHand, RummikubInput } from './logic';
+export { handPenalty } from './logic';
+
+const jokerValueOf = (config: Record<string, unknown>): number =>
+  Math.max(0, Number(config.jokerValue) || DEFAULT_JOKER_VALUE);
+
+export const rummikub: GameModule = {
+  id: 'rummikub',
+  name: 'Rummikub',
+  tagline: 'Empty your rack. Strand their tiles.',
+  emoji: '🔢',
+  keywords: ['tiles', 'runs', 'groups', 'joker', 'rummy', 'rack', 'numbers'],
+  minPlayers: 2,
+  maxPlayers: 4,
+  configFields: [
+    {
+      key: 'jokerValue',
+      label: 'Joker penalty',
+      type: 'number',
+      default: DEFAULT_JOKER_VALUE,
+      min: 0,
+      max: 60,
+      step: 5,
+      help: 'Points a leftover joker costs its holder — and adds to the winner. Official rules: 30.',
+    },
+    {
+      key: 'endMode',
+      label: 'Game length',
+      type: 'select',
+      default: 'rounds',
+      options: [
+        { value: 'rounds', label: 'Set number of rounds' },
+        { value: 'target', label: 'Play to a target score' },
+      ],
+    },
+    {
+      key: 'rounds',
+      label: 'Number of rounds',
+      type: 'number',
+      default: 4,
+      min: 1,
+      max: 20,
+      help: 'Used when playing a set number of rounds.',
+    },
+    {
+      key: 'target',
+      label: 'Target score',
+      type: 'number',
+      default: 100,
+      min: 10,
+      help: 'Used when playing to a target — the game ends once someone reaches it.',
+    },
+  ],
+
+  maxRounds: (config) => (config.endMode === 'target' ? null : Number(config.rounds) || 4),
+
+  isFinished: (totals, { config }) => {
+    if (config.endMode !== 'target') return false;
+    const target = Number(config.target) || 100;
+    return Object.values(totals).some((t) => t >= target);
+  },
+
+  createRoundInput: (ctx: RoundContext): RummikubInput => ({
+    winner: null,
+    hands: Object.fromEntries(ctx.players.map((p) => [p.id, { tiles: 0, jokers: 0 }])),
+  }),
+
+  validateRound: (input: RummikubInput, ctx: RoundContext): string | null =>
+    validateRummikub(input, ctx.players.map((p) => p.id)),
+
+  scoreRound: (input: RummikubInput, ctx: RoundContext): Record<ID, number> =>
+    scoreRummikub(input, ctx.players.map((p) => p.id), jokerValueOf(ctx.config)),
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as RummikubInput;
+    if (!input?.winner) return 'No winner recorded';
+    const name = players.find((p) => p.id === input.winner)?.name ?? '?';
+    const pot = Number(round.deltas?.[input.winner]) || 0;
+    return `🏆 ${name} went out · +${pot}`;
+  },
+
+  help: [
+    'Meld runs (consecutive numbers in one color) and groups (same number, different',
+    'colors). Your first meld must total at least 30 points. Jokers stand in for any tile.',
+    'Go out — "Rummikub!" — by playing every tile on your rack to end the round.',
+    '',
+    'Each round scores zero-sum:',
+    '• Winner (went out): + the total value of every opponent’s leftover tiles.',
+    '• Everyone else: − the value of the tiles left on their own rack.',
+    '',
+    'Tiles count their face value (1–13); a stranded joker costs 30 (house-configurable).',
+    'The winner gains exactly what the rest of the table loses.',
+    '',
+    'Highest total after the last round — or first to the target score — wins. 👑',
+  ].join('\n'),
+
+  stats: rummikubStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/rummikub/logic.ts
+++ b/src/lib/games/rummikub/logic.ts
@@ -1,0 +1,96 @@
+import type { ID } from '../../types';
+
+/**
+ * Pure Rummikub scoring — no Svelte, no I/O — so `index.ts` and `rummikub.test.ts`
+ * both import the *real* scoring functions. Rummikub is scored per round: when a
+ * player goes out ("Rummikub!") the round ends and
+ *
+ *   • the winner scores the **sum of every opponent's leftover tile value** (positive), and
+ *   • every other player scores the **negative of the tiles left on their own rack**.
+ *
+ * A numbered tile is worth its face value; a stranded joker is worth `jokerValue`
+ * (30 by the official rules, house-configurable). The round is zero-sum by
+ * construction: the winner's gain equals exactly what the table loses.
+ */
+
+/** The tiles a single player is caught holding when the round ends. */
+export interface RummikubHand {
+  /** Sum of the face values (1–13) of the numbered tiles left on the rack. */
+  tiles: number;
+  /** Number of jokers stranded on the rack — each worth `jokerValue`. */
+  jokers: number;
+}
+
+export interface RummikubInput {
+  /** The player who went out and emptied their rack. `null` until one is marked. */
+  winner: ID | null;
+  /** Leftover hands keyed by player id. The winner's own hand is ignored (empty). */
+  hands: Record<ID, RummikubHand>;
+}
+
+/** Official joker penalty: a joker left on your rack costs 30 points. */
+export const DEFAULT_JOKER_VALUE = 30;
+
+/** A safe, non-negative integer from possibly-dirty draft input. */
+function clampCount(n: unknown): number {
+  const v = Math.round(Number(n) || 0);
+  return v > 0 ? v : 0;
+}
+
+/**
+ * Points a leftover hand is worth: face-value tiles + jokers × `jokerValue`.
+ * Undefined/empty hands (e.g. the winner's) are worth 0. Never negative.
+ */
+export function handPenalty(
+  hand: RummikubHand | undefined,
+  jokerValue: number = DEFAULT_JOKER_VALUE,
+): number {
+  if (!hand) return 0;
+  const perJoker = Math.max(0, Number(jokerValue) || 0);
+  return clampCount(hand.tiles) + clampCount(hand.jokers) * perJoker;
+}
+
+/**
+ * Score one Rummikub round. Returns a delta for *every* player id (the winner and
+ * each opponent). Winner-positive is **derived** from the opponents' leftovers, so
+ * the caller only records what everyone was left holding.
+ *
+ * Guards against a missing/invalid winner by returning an all-zero no-op round —
+ * `validateRummikub` blocks that case before a round is ever saved.
+ */
+export function scoreRummikub(
+  input: RummikubInput,
+  playerIds: ID[],
+  jokerValue: number = DEFAULT_JOKER_VALUE,
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) out[id] = 0;
+
+  const winner = input.winner;
+  if (!winner || !playerIds.includes(winner)) return out;
+
+  let pot = 0;
+  for (const id of playerIds) {
+    if (id === winner) continue;
+    const penalty = handPenalty(input.hands?.[id], jokerValue);
+    out[id] = penalty === 0 ? 0 : -penalty; // avoid a stored/displayed "-0"
+    pot += penalty;
+  }
+  out[winner] = pot;
+  return out;
+}
+
+/** Return `null` when the round is valid, otherwise a human-readable reason. */
+export function validateRummikub(input: RummikubInput, playerIds: ID[]): string | null {
+  if (!input.winner) return 'Tap the player who went out (emptied their rack).';
+  if (!playerIds.includes(input.winner)) {
+    return 'The player who went out is no longer in this game.';
+  }
+  for (const id of playerIds) {
+    if (id === input.winner) continue;
+    const hand = input.hands?.[id];
+    if ((Number(hand?.tiles) || 0) < 0) return 'Leftover tile totals can’t be negative.';
+    if ((Number(hand?.jokers) || 0) < 0) return 'Joker counts can’t be negative.';
+  }
+  return null;
+}

--- a/src/lib/games/rummikub/rummikub.test.ts
+++ b/src/lib/games/rummikub/rummikub.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import type { Player, Round } from '../../types';
+import {
+  DEFAULT_JOKER_VALUE,
+  handPenalty,
+  scoreRummikub,
+  validateRummikub,
+  type RummikubInput,
+} from './logic';
+import { rummikub } from './index';
+
+const P = ['a', 'b', 'c', 'd'];
+
+function hand(tiles: number, jokers = 0) {
+  return { tiles, jokers };
+}
+
+function input(winner: string | null, hands: Record<string, { tiles: number; jokers: number }>): RummikubInput {
+  return { winner, hands };
+}
+
+const sum = (deltas: Record<string, number>) => Object.values(deltas).reduce((a, b) => a + b, 0);
+
+describe('handPenalty', () => {
+  it('counts numbered tiles at face value', () => {
+    expect(handPenalty(hand(24))).toBe(24);
+  });
+
+  it('adds the joker penalty per stranded joker', () => {
+    expect(handPenalty(hand(10, 1))).toBe(10 + 30);
+    expect(handPenalty(hand(0, 2))).toBe(60);
+  });
+
+  it('honours a custom joker value', () => {
+    expect(handPenalty(hand(5, 2), 25)).toBe(5 + 50);
+    expect(handPenalty(hand(5, 2), 0)).toBe(5);
+  });
+
+  it('treats an empty/undefined hand as zero and never goes negative', () => {
+    expect(handPenalty(undefined)).toBe(0);
+    expect(handPenalty(hand(-9, -3))).toBe(0);
+  });
+
+  it('rounds dirty draft numbers', () => {
+    expect(handPenalty(hand(12.6 as number, 1))).toBe(13 + 30);
+  });
+
+  it('defaults the joker to the official 30', () => {
+    expect(DEFAULT_JOKER_VALUE).toBe(30);
+    expect(handPenalty(hand(0, 1))).toBe(30);
+  });
+});
+
+describe('scoreRummikub', () => {
+  it('gives the winner the sum of opponents’ leftovers and others their negative', () => {
+    const deltas = scoreRummikub(input('a', { a: hand(0), b: hand(15), c: hand(8) }), ['a', 'b', 'c']);
+    expect(deltas).toEqual({ a: 23, b: -15, c: -8 });
+  });
+
+  it('folds stranded jokers into the penalty and the winner’s haul', () => {
+    const deltas = scoreRummikub(input('b', { a: hand(12, 1), b: hand(0), c: hand(3) }), ['a', 'b', 'c']);
+    // a: 12 + 30 = 42, c: 3  → winner b: 45
+    expect(deltas).toEqual({ a: -42, b: 45, c: -3 });
+  });
+
+  it('applies a house joker value', () => {
+    const deltas = scoreRummikub(input('a', { a: hand(0), b: hand(4, 1) }), ['a', 'b'], 15);
+    expect(deltas).toEqual({ a: 19, b: -19 });
+  });
+
+  it('returns a delta for every player, including zero-leftover opponents', () => {
+    const deltas = scoreRummikub(input('a', { a: hand(0), b: hand(0), c: hand(9) }), ['a', 'b', 'c']);
+    expect(Object.keys(deltas).sort()).toEqual(['a', 'b', 'c']);
+    expect(deltas).toEqual({ a: 9, b: 0, c: -9 });
+  });
+
+  it('works head-to-head (two players)', () => {
+    expect(scoreRummikub(input('b', { a: hand(17), b: hand(0) }), ['a', 'b'])).toEqual({ a: -17, b: 17 });
+  });
+
+  describe('is zero-sum for every valid winner', () => {
+    const scenarios: Array<Record<string, { tiles: number; jokers: number }>> = [
+      { a: hand(0), b: hand(15), c: hand(8), d: hand(0) },
+      { a: hand(31, 1), b: hand(0), c: hand(2, 2), d: hand(7) },
+      { a: hand(0), b: hand(0), c: hand(0), d: hand(0) },
+      { a: hand(13, 2), b: hand(9), c: hand(40), d: hand(1, 1) },
+    ];
+    for (const [i, hands] of scenarios.entries()) {
+      for (const winner of P) {
+        it(`scenario ${i} won by ${winner}`, () => {
+          const deltas = scoreRummikub(input(winner, hands), P, 30);
+          expect(sum(deltas)).toBe(0);
+          // The winner's positive equals the opponents' combined penalties.
+          const owed = P.filter((id) => id !== winner).reduce(
+            (t, id) => t + handPenalty(hands[id], 30),
+            0,
+          );
+          expect(deltas[winner]).toBe(owed);
+        });
+      }
+    }
+  });
+
+  it('is a zero no-op when no winner is marked', () => {
+    const deltas = scoreRummikub(input(null, { a: hand(5), b: hand(9) }), ['a', 'b']);
+    expect(deltas).toEqual({ a: 0, b: 0 });
+    expect(sum(deltas)).toBe(0);
+  });
+
+  it('is a zero no-op when the winner is not among the players', () => {
+    const deltas = scoreRummikub(input('z', { a: hand(5), b: hand(9) }), ['a', 'b']);
+    expect(deltas).toEqual({ a: 0, b: 0 });
+  });
+});
+
+describe('validateRummikub', () => {
+  it('requires someone to be marked as gone out', () => {
+    expect(validateRummikub(input(null, { a: hand(0), b: hand(5) }), ['a', 'b'])).toMatch(/went out/i);
+  });
+
+  it('rejects a winner who left the game', () => {
+    expect(validateRummikub(input('z', { a: hand(0), b: hand(5) }), ['a', 'b'])).toMatch(/no longer/i);
+  });
+
+  it('rejects negative leftovers', () => {
+    expect(validateRummikub(input('a', { a: hand(0), b: hand(-1) }), ['a', 'b'])).toMatch(/negative/i);
+  });
+
+  it('accepts a well-formed round', () => {
+    expect(validateRummikub(input('a', { a: hand(0), b: hand(5), c: hand(12, 1) }), ['a', 'b', 'c'])).toBeNull();
+  });
+});
+
+describe('rummikub module', () => {
+  const players: Player[] = [
+    { id: 'a', name: 'Ada', color: '#7c5cff', createdAt: 0 },
+    { id: 'b', name: 'Bo', color: '#34d399', createdAt: 0 },
+    { id: 'c', name: 'Cy', color: '#f87171', createdAt: 0 },
+  ];
+  const ctx = (config: Record<string, unknown>) => ({
+    game: {} as never,
+    players,
+    config,
+    roundIndex: 0,
+    totals: {},
+    rounds: [],
+  });
+
+  it('is highest-wins with a 2–4 player range', () => {
+    expect(rummikub.id).toBe('rummikub');
+    expect(rummikub.lowerIsBetter).toBeFalsy();
+    expect(rummikub.minPlayers).toBe(2);
+    expect(rummikub.maxPlayers).toBe(4);
+  });
+
+  it('seeds a fresh round input for every player', () => {
+    const fresh = rummikub.createRoundInput(ctx({})) as RummikubInput;
+    expect(fresh.winner).toBeNull();
+    expect(Object.keys(fresh.hands).sort()).toEqual(['a', 'b', 'c']);
+    expect(fresh.hands.a).toEqual({ tiles: 0, jokers: 0 });
+  });
+
+  it('scores a round through the module with the configured joker value', () => {
+    const round = input('a', { a: hand(0), b: hand(4, 1), c: hand(2) });
+    expect(rummikub.scoreRound(round, ctx({ jokerValue: 50 }))).toEqual({ a: 56, b: -54, c: -2 });
+  });
+
+  it('validates through the module', () => {
+    expect(rummikub.validateRound(input(null, {}), ctx({}))).toMatch(/went out/i);
+  });
+
+  it('caps rounds only when playing a fixed number of rounds', () => {
+    expect(rummikub.maxRounds!({ endMode: 'rounds', rounds: 6 }, 3)).toBe(6);
+    expect(rummikub.maxRounds!({ endMode: 'target', target: 100 }, 3)).toBeNull();
+  });
+
+  it('finishes on the target only in target mode', () => {
+    const totals = { a: 104, b: 40, c: -10 };
+    expect(rummikub.isFinished!(totals, { config: { endMode: 'target', target: 100 }, roundCount: 5, playerCount: 3 })).toBe(true);
+    expect(rummikub.isFinished!(totals, { config: { endMode: 'target', target: 120 }, roundCount: 5, playerCount: 3 })).toBe(false);
+    expect(rummikub.isFinished!(totals, { config: { endMode: 'rounds', rounds: 4 }, roundCount: 5, playerCount: 3 })).toBe(false);
+  });
+
+  it('describes a recorded round with the winner and their haul', () => {
+    const round: Round = {
+      id: 'r1',
+      gameId: 'g1',
+      index: 0,
+      input: input('a', { a: hand(0), b: hand(15), c: hand(8) }),
+      deltas: rummikub.scoreRound(input('a', { a: hand(0), b: hand(15), c: hand(8) }), ctx({})),
+      createdAt: 0,
+    };
+    expect(rummikub.describeRound!(round, players)).toBe('🏆 Ada went out · +23');
+  });
+});

--- a/src/lib/games/rummikub/stats.ts
+++ b/src/lib/games/rummikub/stats.ts
@@ -1,0 +1,75 @@
+import type { ID } from '../../types';
+import type { RummikubInput } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt } from '../../stats/format';
+
+interface RKAgg {
+  /** Rounds this member went out ("Rummikub!"). */
+  wentOut: number;
+  /** Biggest single-round pot this member collected. */
+  bestHaul: number;
+  /** Jokers this member was caught holding when a round ended. */
+  jokersStranded: number;
+}
+
+/**
+ * Rummikub stats derived purely from each round's recorded winner + leftover hands
+ * (and the winner's recorded delta = the pot they collected). Pure — no Svelte —
+ * so it's independently unit-testable and safe for the stats engine to import.
+ */
+export function rummikubStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, RKAgg>();
+  const get = (id: ID): RKAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { wentOut: 0, bestHaul: 0, jokersStranded: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as RummikubInput | undefined;
+    if (!input?.winner) continue;
+
+    const winner = get(canonical(input.winner));
+    winner.wentOut += 1;
+    const haul = Number(r.deltas?.[input.winner]) || 0;
+    if (haul > winner.bestHaul) winner.bestHaul = haul;
+
+    for (const [pid, hand] of Object.entries(input.hands ?? {})) {
+      if (pid === input.winner) continue;
+      get(canonical(pid)).jokersStranded += Math.max(0, Math.round(Number(hand?.jokers) || 0));
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let totalJokers = 0;
+  let biggestHaul = 0;
+  for (const [id, a] of per) {
+    totalJokers += a.jokersStranded;
+    if (a.bestHaul > biggestHaul) biggestHaul = a.bestHaul;
+    const metrics: Metric[] = [];
+    if (a.wentOut) {
+      metrics.push({ key: 'rk_out', label: 'Went out', value: fmtInt(a.wentOut), emoji: '🏆' });
+    }
+    if (a.bestHaul) {
+      metrics.push({ key: 'rk_haul', label: 'Best haul', value: `+${fmtInt(a.bestHaul)}`, emoji: '💰' });
+    }
+    if (a.jokersStranded) {
+      metrics.push({ key: 'rk_joker', label: 'Jokers stranded', value: fmtInt(a.jokersStranded), emoji: '🃏' });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (biggestHaul) {
+    global.push({ key: 'rk_haul_all', label: 'Biggest haul', value: `+${fmtInt(biggestHaul)}`, emoji: '💰' });
+  }
+  if (totalJokers) {
+    global.push({ key: 'rk_joker_all', label: 'Jokers stranded', value: fmtInt(totalJokers), emoji: '🃏' });
+  }
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## 🔢 Rummikub

Adds **Rummikub** as a first-class, auto-discovered game module. Purely additive — only `src/lib/games/rummikub/`; no shared files, registry, or dependencies touched.

### How it scores
Rummikub is scored per round, and each round is **zero-sum**. When a player goes out (**"Rummikub!"**, emptying their rack) the round ends and:

- **Winner** scores a **positive** amount equal to the **sum of every opponent's leftover tile value**.
- **Everyone else** scores the **negative** of the tiles left on their own rack.

A numbered tile is worth its face value (1–13); a **stranded joker costs 30** (house-configurable). The winner's positive is **derived** from opponents' leftovers, so you only record what each player was caught holding — the winner's haul falls out automatically, and the winner's gain always equals exactly what the table loses.

### Config
- **Joker penalty** — points a leftover joker costs its holder (default **30**, the official value).
- **Game length** — either a **set number of rounds** or **play to a target score**.
- **Number of rounds** / **Target score** for those two modes.
- **Highest cumulative total wins.**

### Round entry (design)
- Tap **who went out** (a single Royal-Violet selection, mirroring Hearts' toggle vocabulary), then enter everyone else's leftover **Tiles** and **Jokers** with the shared `Stepper`.
- Live previews: the winner's **+haul** in Win Green, each opponent's **−leftover** in Loss Coral — all `tabular-nums`, co-signalled by sign + emoji + text so nothing rides on colour alone.
- Reuses `Avatar` + `Stepper`; ≥46px touch targets; no Crown Gold and no shell restyling (personality via 🔢 / 🏆 / 🃏 emoji + copy). Honors `prefers-reduced-motion` (no added motion).
- A **How to score** popover carries the full rules + zero-sum explanation.

### Stats
Per-player **Went out** (🏆), **Best haul** (💰), and **Jokers stranded** (🃏), plus global **Biggest haul** / **Jokers stranded** — derived purely from recorded rounds.

### Verification
- `npm run check` — 0 errors, 0 warnings
- `npm test` — **115 passed** (new suite covers `handPenalty`, `scoreRummikub`, the **zero-sum invariant** across every winner/scenario, joker handling, validation, and the module's `maxRounds`/`isFinished`/`describeRound` wiring)
- `npm run build` — succeeds; module confirmed auto-discovered and bundled
