### PR TITLE
Add Mario Kart Grand Prix tracker game

### DIFF
--- a/src/lib/games/mariokart/MarioKartEditor.svelte
+++ b/src/lib/games/mariokart/MarioKartEditor.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { ordinal } from '../../stats/format';
+  import {
+    pointsForPosition,
+    normalizeRacers,
+    normalizeTable,
+    tableMeta,
+    type MarioKartInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: MarioKartInput; ctx: RoundContext } = $props();
+
+  const table = $derived(normalizeTable(ctx.config.pointsTable));
+  const racers = $derived(normalizeRacers(ctx.config.racers));
+  const meta = $derived(tableMeta(table));
+
+  let showPoints = $state(false);
+
+  function pos(id: string): number {
+    return Math.floor(Number(input.positions[id]) || 0);
+  }
+  function pts(id: string): number {
+    return pointsForPosition(table, pos(id), racers);
+  }
+
+  // Two racers can't share a spot — flag any clash so it's fixable at a glance.
+  const clashes = $derived.by(() => {
+    const seen = new Map<number, number>();
+    for (const p of ctx.players) {
+      const v = pos(p.id);
+      if (v > 0) seen.set(v, (seen.get(v) ?? 0) + 1);
+    }
+    return seen;
+  });
+  function isClash(id: string): boolean {
+    const v = pos(id);
+    return v > 0 && (clashes.get(v) ?? 0) > 1;
+  }
+
+  function medal(p: number): string {
+    return p === 1 ? '🥇' : p === 2 ? '🥈' : p === 3 ? '🥉' : '';
+  }
+  function rankLabel(p: number): string {
+    return p >= 1 ? ordinal(p) : '—';
+  }
+
+  // Active table payout, for the "Points" reference: 1st → field-back.
+  const payout = $derived.by(() => {
+    const depth = table === 'party' ? racers : Math.min(racers, 24);
+    const rows: { pos: number; pts: number }[] = [];
+    for (let i = 1; i <= depth; i++) {
+      const value = pointsForPosition(table, i, racers);
+      if (table !== 'party' && value === 0) break;
+      rows.push({ pos: i, pts: value });
+    }
+    return rows;
+  });
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="pill">{meta.emoji} {meta.label}</span>
+    <button type="button" class="btn small ghost" onclick={() => (showPoints = !showPoints)}>
+      {showPoints ? 'Hide points' : 'Points'}
+    </button>
+  </div>
+
+  {#if showPoints}
+    <div class="points" role="note">
+      <p class="blurb">{meta.blurb}</p>
+      <div class="chips">
+        {#each payout as row (row.pos)}
+          <span class="chip">
+            <span class="p">{medal(row.pos)}{ordinal(row.pos)}</span>
+            <span class="v tnum">{row.pts}</span>
+          </span>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  {#each ctx.players as p (p.id)}
+    {@const finish = pos(p.id)}
+    {@const clash = isClash(p.id)}
+    <div class="prow" class:clash>
+      <div class="row spread head">
+        <span class="who">
+          <Avatar name={p.name} color={p.color} />
+          <strong>{p.name}</strong>
+        </span>
+        <span class="pts tnum" class:score-good={pts(p.id) > 0} class:zero={pts(p.id) === 0}>
+          {pts(p.id) > 0 ? '+' : ''}{pts(p.id)}
+        </span>
+      </div>
+      <div class="entry">
+        <span class="rank tnum" aria-label={`Finished ${rankLabel(finish)}`}>
+          {#if medal(finish)}<span class="badge" aria-hidden="true">{medal(finish)}</span>{/if}
+          {rankLabel(finish)}
+        </span>
+        <Stepper bind:value={input.positions[p.id]} min={1} max={racers} />
+        {#if clash}
+          <span class="clash-tag" role="status">⚠ ties {ordinal(finish)}</span>
+        {/if}
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+  }
+  .prow.clash {
+    border-color: color-mix(in srgb, var(--bad) 60%, var(--border));
+  }
+  .head {
+    margin-bottom: 10px;
+  }
+  .who {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .who strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .pts {
+    font-weight: 800;
+    font-size: 1.05rem;
+  }
+  .pts.zero {
+    color: var(--muted);
+  }
+  .entry {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .rank {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 52px;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .badge {
+    font-size: 1.1rem;
+  }
+  .clash-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--bad);
+  }
+  .points {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+  }
+  .blurb {
+    margin: 0 0 10px;
+    font-size: 0.85rem;
+    color: var(--muted);
+    line-height: 1.45;
+  }
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 9px;
+    border-radius: 999px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    font-size: 0.82rem;
+  }
+  .chip .v {
+    font-weight: 800;
+  }
+  .tnum {
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/src/lib/games/mariokart/index.ts
+++ b/src/lib/games/mariokart/index.ts
@@ -1,0 +1,116 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { ordinal } from '../../stats/format';
+import Editor from './MarioKartEditor.svelte';
+import { mariokartStats } from './stats';
+import {
+  TABLE_META,
+  freshPositions,
+  normalizeRaces,
+  normalizeTable,
+  scoreRace,
+  validateRace,
+  type MarioKartInput,
+} from './logic';
+
+export type { MarioKartInput };
+export { scoreRace, pointsForPosition } from './logic';
+
+/** Medal for the podium, otherwise the ordinal — used in one-line round summaries. */
+function place(pos: number): string {
+  if (pos === 1) return '🥇';
+  if (pos === 2) return '🥈';
+  if (pos === 3) return '🥉';
+  return `${ordinal(pos)} `;
+}
+
+export const mariokart: GameModule = {
+  id: 'mariokart',
+  name: 'Mario Kart',
+  tagline: 'Grand Prix points across the cup 🏎️',
+  emoji: '🏎️',
+  keywords: ['grand prix', 'racing', 'kart', 'nintendo', 'cup', 'party', 'couch'],
+  minPlayers: 2,
+  maxPlayers: 12,
+  configFields: [
+    {
+      key: 'pointsTable',
+      label: 'Points table',
+      type: 'select',
+      default: 'modern12',
+      options: [
+        { value: 'modern12', label: `Modern · 12 racers (${TABLE_META.modern12.curve})` },
+        { value: 'classic8', label: `Classic · 8 racers (${TABLE_META.classic8.curve})` },
+        { value: 'retro4', label: `Retro · top 4 (${TABLE_META.retro4.curve})` },
+        { value: 'party', label: 'Party · everyone scores (rank countdown)' },
+      ],
+      help: 'How each finishing spot pays out. Modern is Mario Kart 8 / Wii; Retro is the MK64 top-4.',
+    },
+    {
+      key: 'racers',
+      label: 'Racers on the track',
+      type: 'number',
+      default: 12,
+      min: 2,
+      max: 24,
+      help: 'Total karts including CPUs — the furthest-back spot you can enter. Modern races run 12.',
+    },
+    {
+      key: 'racesPerCup',
+      label: 'Races per cup',
+      type: 'number',
+      default: 4,
+      min: 0,
+      max: 64,
+      help: 'A cup is 4 races. Set 0 for an endless, play-all-night cup.',
+    },
+  ],
+
+  maxRounds: (config) => {
+    const n = normalizeRaces(config.racesPerCup);
+    return n > 0 ? n : null;
+  },
+
+  createRoundInput: (ctx: RoundContext): MarioKartInput => freshPositions(ctx.players, ctx.config),
+
+  validateRound: (input: MarioKartInput, ctx: RoundContext): string | null =>
+    validateRace(input, ctx.players, ctx.config),
+
+  scoreRound: (input: MarioKartInput, ctx: RoundContext): Record<ID, number> =>
+    scoreRace(input, ctx.config),
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as MarioKartInput;
+    const ranked = players
+      .map((p) => ({ name: p.name, pos: Number(input?.positions?.[p.id]) || 0 }))
+      .filter((r) => r.pos > 0)
+      .sort((a, b) => a.pos - b.pos);
+    if (!ranked.length) return 'no results yet';
+    const head = ranked
+      .slice(0, 3)
+      .map((r) => `${place(r.pos)}${r.name}`)
+      .join(' · ');
+    return ranked.length > 3 ? `${head} · +${ranked.length - 3}` : head;
+  },
+
+  help: [
+    '🏎️ Mario Kart Grand Prix — chase the cup! 🏆',
+    '',
+    'A cup is 4 races. After each race, enter where every racer finished; points are',
+    'awarded by position and pile up across the cup. Most points at the end wins.',
+    '',
+    'Points tables (choose one when you start):',
+    `• Modern · 12 — ${TABLE_META.modern12.curve}`,
+    `• Classic · 8 — ${TABLE_META.classic8.curve}`,
+    `• Retro · top 4 — ${TABLE_META.retro4.curve} (5th and back score nothing)`,
+    '• Party — everyone scores: 1st gets one point per racer, last still gets 1',
+    '',
+    'Good to know:',
+    '• Finishing spots count the CPUs — 3rd against a full grid still pays 3rd.',
+    '• No two racers can share a spot.',
+    '• 🍄 Tied on points at the finish? Share the crown.',
+  ].join('\n'),
+
+  stats: mariokartStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/mariokart/logic.ts
+++ b/src/lib/games/mariokart/logic.ts
@@ -1,0 +1,174 @@
+import type { ID, Player } from '../../types';
+import { ordinal } from '../../stats/format';
+
+/**
+ * Mario Kart Grand Prix — pure scoring. A cup is a set of races; each race awards
+ * points by finishing position, and points pile up across the cup (highest total
+ * wins). This module is Svelte-free on purpose so the round editor, the module, and
+ * the tests all share one source of truth for position → points.
+ */
+
+export type PointsTableId = 'modern12' | 'classic8' | 'retro4' | 'party';
+
+/** A single race: each player's finishing position (1 = first). 0 = not entered yet. */
+export interface MarioKartInput {
+  positions: Record<ID, number>;
+}
+
+export interface MarioKartConfig {
+  pointsTable: PointsTableId;
+  /** Total karts on the track including CPUs — the highest finishing spot enterable. */
+  racers: number;
+  /** Races in a cup. 0 = endless (open-ended) cup. */
+  racesPerCup: number;
+}
+
+/**
+ * Authentic Grand Prix points tables, indexed by finishing position (index 0 = 1st).
+ * A position past the end of a table scores 0 — faithful to the retro games, where
+ * only the front of the pack scored. `party` is not a fixed array: it scales to the
+ * field so everyone always scores (see {@link pointsForPosition}).
+ */
+export const POINTS_TABLES: Record<Exclude<PointsTableId, 'party'>, readonly number[]> = {
+  // Mario Kart 8 Deluxe / Mario Kart Wii (12-racer grid).
+  modern12: [15, 12, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+  // Mario Kart Wii Grand Prix, trimmed to an 8-racer grid.
+  classic8: [15, 12, 10, 9, 8, 7, 6, 5],
+  // Mario Kart 64 & Super Mario Kart — only the top four scored.
+  retro4: [9, 6, 3, 1],
+};
+
+export interface TableMeta {
+  id: PointsTableId;
+  /** Short label for pills/among UI, e.g. "Modern · 12". */
+  label: string;
+  emoji: string;
+  /** Human curve string, e.g. "15·12·10·9·8·7·6·5·4·3·2·1" (party scales, so undefined). */
+  curve?: string;
+  /** One-line describing how the table pays out. */
+  blurb: string;
+}
+
+export const TABLE_META: Record<PointsTableId, TableMeta> = {
+  modern12: {
+    id: 'modern12',
+    label: 'Modern · 12',
+    emoji: '🏁',
+    curve: POINTS_TABLES.modern12.join('·'),
+    blurb: 'Mario Kart 8 / Wii — a full 12-kart grid, everyone in the field scores.',
+  },
+  classic8: {
+    id: 'classic8',
+    label: 'Classic · 8',
+    emoji: '🏎️',
+    curve: POINTS_TABLES.classic8.join('·'),
+    blurb: 'Mario Kart Wii — an 8-kart grid, 1st down to 8th on the board.',
+  },
+  retro4: {
+    id: 'retro4',
+    label: 'Retro · top 4',
+    emoji: '👾',
+    curve: POINTS_TABLES.retro4.join('·'),
+    blurb: 'Mario Kart 64 & Super Mario Kart — only the top four score, 5th+ get nothing.',
+  },
+  party: {
+    id: 'party',
+    label: 'Party · all score',
+    emoji: '🍄',
+    blurb: 'House rule — everyone scores: 1st takes one point per racer, last still gets 1.',
+  },
+};
+
+const DEFAULTS: MarioKartConfig = { pointsTable: 'modern12', racers: 12, racesPerCup: 4 };
+
+/** Coerce an unknown config value into a known table id (defaults to modern12). */
+export function normalizeTable(value: unknown): PointsTableId {
+  return value === 'classic8' || value === 'retro4' || value === 'party' || value === 'modern12'
+    ? value
+    : DEFAULTS.pointsTable;
+}
+
+/** Coerce the racer count into a sane field size (2–24, defaults to 12). */
+export function normalizeRacers(value: unknown): number {
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n)) return DEFAULTS.racers;
+  return Math.min(24, Math.max(2, n));
+}
+
+/** Coerce races-per-cup (>= 0; 0 means an open-ended cup). */
+export function normalizeRaces(value: unknown): number {
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n) || n < 0) return DEFAULTS.racesPerCup;
+  return Math.min(64, n);
+}
+
+export function tableMeta(table: PointsTableId): TableMeta {
+  return TABLE_META[table];
+}
+
+/**
+ * Points a finishing position earns under a table. `racers` only matters for the
+ * `party` table, which scales to the field. Positions ≤ 0 or past the field score 0.
+ */
+export function pointsForPosition(table: PointsTableId, position: number, racers: number): number {
+  const pos = Math.floor(Number(position));
+  if (!Number.isFinite(pos) || pos < 1) return 0;
+  if (table === 'party') {
+    const field = normalizeRacers(racers);
+    return pos > field ? 0 : field - pos + 1;
+  }
+  const arr = POINTS_TABLES[table];
+  return pos <= arr.length ? arr[pos - 1] : 0;
+}
+
+/** Score one race: every player's position mapped to points for the given config. */
+export function scoreRace(
+  input: MarioKartInput,
+  config: Partial<MarioKartConfig> | Record<string, unknown> = {},
+): Record<ID, number> {
+  const table = normalizeTable((config as Record<string, unknown>).pointsTable);
+  const racers = normalizeRacers((config as Record<string, unknown>).racers);
+  const positions = input?.positions ?? {};
+  const out: Record<ID, number> = {};
+  for (const [id, pos] of Object.entries(positions)) {
+    out[id] = pointsForPosition(table, Number(pos) || 0, racers);
+  }
+  return out;
+}
+
+/**
+ * Validate a race entry: every racer needs a distinct finishing spot within the field.
+ * Pure so both the module and its tests can share it; returns null when valid.
+ */
+export function validateRace(
+  input: MarioKartInput,
+  players: Pick<Player, 'id' | 'name'>[],
+  config: Partial<MarioKartConfig> | Record<string, unknown> = {},
+): string | null {
+  const racers = normalizeRacers((config as Record<string, unknown>).racers);
+  if (players.length > racers) {
+    return `Only ${racers} karts on the track — raise "Racers" to seat all ${players.length} players.`;
+  }
+  const positions = input?.positions ?? {};
+  const takenBy = new Map<number, string>();
+  for (const p of players) {
+    const pos = Math.floor(Number(positions[p.id]) || 0);
+    if (pos < 1) return `Where did ${p.name} finish? 🏁`;
+    if (pos > racers) return `${p.name}: there are only ${racers} karts, so ${ordinal(pos)} isn't on the track.`;
+    const clash = takenBy.get(pos);
+    if (clash) return `${clash} and ${p.name} can't both finish ${ordinal(pos)}.`;
+    takenBy.set(pos, p.name);
+  }
+  return null;
+}
+
+/** Fresh race draft: seed each player into a distinct spot so entry is one-tap-to-fix. */
+export function freshPositions(
+  players: Pick<Player, 'id'>[],
+  config: Partial<MarioKartConfig> | Record<string, unknown> = {},
+): MarioKartInput {
+  const racers = normalizeRacers((config as Record<string, unknown>).racers);
+  return {
+    positions: Object.fromEntries(players.map((p, i) => [p.id, Math.min(i + 1, racers)])),
+  };
+}

--- a/src/lib/games/mariokart/mariokart.test.ts
+++ b/src/lib/games/mariokart/mariokart.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, Player, Round, RoundContext } from '../../types';
+import type { GameStatsInput } from '../../stats/types';
+import { mariokart } from './index';
+import { mariokartStats } from './stats';
+import {
+  POINTS_TABLES,
+  freshPositions,
+  normalizeRaces,
+  normalizeRacers,
+  normalizeTable,
+  pointsForPosition,
+  scoreRace,
+  validateRace,
+  type MarioKartInput,
+  type PointsTableId,
+} from './logic';
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+function player(id: string, name = id): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+function ctxOf(players: Player[], config: Record<string, unknown>): RoundContext {
+  return {
+    game: { id: 'g', config } as unknown as Game,
+    players,
+    config,
+    roundIndex: 0,
+    totals: {},
+    rounds: [],
+  };
+}
+const P = [player('a', 'Alice'), player('b', 'Bob'), player('c', 'Carol'), player('d', 'Dan')];
+
+describe('mario kart points tables', () => {
+  it('modern12 is the Mario Kart 8 / Wii 12-racer curve', () => {
+    expect(POINTS_TABLES.modern12).toEqual([15, 12, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+  });
+
+  it('classic8 is the Mario Kart Wii 8-racer curve', () => {
+    expect(POINTS_TABLES.classic8).toEqual([15, 12, 10, 9, 8, 7, 6, 5]);
+  });
+
+  it('retro4 is the MK64 / Super Mario Kart top-4 curve', () => {
+    expect(POINTS_TABLES.retro4).toEqual([9, 6, 3, 1]);
+  });
+
+  it('maps every modern12 position to its exact points', () => {
+    const expected = [15, 12, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+    expected.forEach((v, i) => expect(pointsForPosition('modern12', i + 1, 12)).toBe(v));
+  });
+
+  it('maps every classic8 position to its exact points', () => {
+    const expected = [15, 12, 10, 9, 8, 7, 6, 5];
+    expected.forEach((v, i) => expect(pointsForPosition('classic8', i + 1, 8)).toBe(v));
+  });
+
+  it('maps every retro4 position and scores 0 from 5th back', () => {
+    expect([1, 2, 3, 4].map((p) => pointsForPosition('retro4', p, 8))).toEqual([9, 6, 3, 1]);
+    for (const p of [5, 6, 7, 8]) expect(pointsForPosition('retro4', p, 8)).toBe(0);
+  });
+
+  it('party scales to the field so everyone scores (1st = racers, last = 1)', () => {
+    expect(pointsForPosition('party', 1, 12)).toBe(12);
+    expect(pointsForPosition('party', 12, 12)).toBe(1);
+    expect(pointsForPosition('party', 1, 8)).toBe(8);
+    expect(pointsForPosition('party', 8, 8)).toBe(1);
+    // Past the field, even party scores nothing.
+    expect(pointsForPosition('party', 13, 12)).toBe(0);
+  });
+
+  it('scores 0 past the end of a fixed table', () => {
+    expect(pointsForPosition('modern12', 13, 24)).toBe(0);
+    expect(pointsForPosition('classic8', 9, 12)).toBe(0);
+  });
+
+  it('scores 0 for invalid positions (0, negative, NaN)', () => {
+    for (const table of ['modern12', 'classic8', 'retro4', 'party'] as PointsTableId[]) {
+      expect(pointsForPosition(table, 0, 12)).toBe(0);
+      expect(pointsForPosition(table, -3, 12)).toBe(0);
+      expect(pointsForPosition(table, Number.NaN, 12)).toBe(0);
+    }
+  });
+});
+
+describe('scoreRace', () => {
+  it('maps a full race under modern12', () => {
+    const input: MarioKartInput = { positions: { a: 1, b: 3, c: 12, d: 6 } };
+    expect(scoreRace(input, { pointsTable: 'modern12', racers: 12 })).toEqual({
+      a: 15,
+      b: 10,
+      c: 1,
+      d: 7,
+    });
+  });
+
+  it('honours the chosen table', () => {
+    const input: MarioKartInput = { positions: { a: 1, b: 2, c: 3, d: 4 } };
+    expect(scoreRace(input, { pointsTable: 'retro4', racers: 8 })).toEqual({
+      a: 9,
+      b: 6,
+      c: 3,
+      d: 1,
+    });
+  });
+
+  it('defaults to modern12 when the table is missing/unknown', () => {
+    const input: MarioKartInput = { positions: { a: 1 } };
+    expect(scoreRace(input, {})).toEqual({ a: 15 });
+    expect(scoreRace(input, { pointsTable: 'nonsense' })).toEqual({ a: 15 });
+  });
+
+  it('accumulates across a 4-race cup (highest total wins)', () => {
+    const cfg = { pointsTable: 'modern12', racers: 12 };
+    const races: MarioKartInput[] = [
+      { positions: { a: 1, b: 2 } },
+      { positions: { a: 2, b: 1 } },
+      { positions: { a: 1, b: 3 } },
+      { positions: { a: 3, b: 1 } },
+    ];
+    const totals: Record<string, number> = { a: 0, b: 0 };
+    for (const r of races) {
+      const d = scoreRace(r, cfg);
+      for (const id of Object.keys(d)) totals[id] += d[id];
+    }
+    // a: 15+12+15+10 = 52 ; b: 12+15+10+15 = 52 — a genuine tie.
+    expect(totals).toEqual({ a: 52, b: 52 });
+  });
+});
+
+describe('validateRace', () => {
+  const cfg = { pointsTable: 'modern12', racers: 12 };
+
+  it('passes when every racer has a distinct spot', () => {
+    expect(validateRace({ positions: { a: 1, b: 2, c: 3, d: 4 } }, P, cfg)).toBeNull();
+  });
+
+  it('flags a racer with no finishing spot', () => {
+    const err = validateRace({ positions: { a: 1, b: 0, c: 3, d: 4 } }, P, cfg);
+    expect(err).toMatch(/Bob/);
+  });
+
+  it('flags two racers sharing a spot', () => {
+    const err = validateRace({ positions: { a: 1, b: 1, c: 3, d: 4 } }, P, cfg);
+    expect(err).toMatch(/both finish 1st/);
+  });
+
+  it('flags a spot beyond the field', () => {
+    const err = validateRace({ positions: { a: 5, b: 2, c: 3, d: 4 } }, P, { racers: 4 });
+    expect(err).toMatch(/5th/);
+  });
+
+  it('flags more players than karts', () => {
+    const err = validateRace({ positions: { a: 1, b: 2, c: 3, d: 4 } }, P, { racers: 3 });
+    expect(err).toMatch(/Only 3 karts/);
+  });
+});
+
+describe('freshPositions', () => {
+  it('seeds every player into a distinct, valid spot', () => {
+    const input = freshPositions(P, { racers: 12 });
+    expect(input.positions).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+    expect(validateRace(input, P, { racers: 12 })).toBeNull();
+  });
+});
+
+describe('config normalizers', () => {
+  it('normalizeTable falls back to modern12', () => {
+    expect(normalizeTable('classic8')).toBe('classic8');
+    expect(normalizeTable('party')).toBe('party');
+    expect(normalizeTable(undefined)).toBe('modern12');
+    expect(normalizeTable('???')).toBe('modern12');
+  });
+
+  it('normalizeRacers clamps to 2–24 and defaults to 12', () => {
+    expect(normalizeRacers(8)).toBe(8);
+    expect(normalizeRacers(1)).toBe(2);
+    expect(normalizeRacers(99)).toBe(24);
+    expect(normalizeRacers(undefined)).toBe(12);
+  });
+
+  it('normalizeRaces keeps >= 0 and defaults invalid to 4', () => {
+    expect(normalizeRaces(4)).toBe(4);
+    expect(normalizeRaces(0)).toBe(0);
+    expect(normalizeRaces(-2)).toBe(4);
+    expect(normalizeRaces(undefined)).toBe(4);
+  });
+});
+
+describe('mariokart game module', () => {
+  it('exposes the folder id and sane bounds', () => {
+    expect(mariokart.id).toBe('mariokart');
+    expect(mariokart.minPlayers).toBeLessThanOrEqual(mariokart.maxPlayers);
+    expect(mariokart.emoji).toBeTruthy();
+    expect(mariokart.tagline).toBeTruthy();
+    expect(mariokart.lowerIsBetter).toBeFalsy(); // highest total wins
+  });
+
+  it('maxRounds is the cup length, or open-ended at 0', () => {
+    expect(mariokart.maxRounds?.({ racesPerCup: 4 }, 4)).toBe(4);
+    expect(mariokart.maxRounds?.({ racesPerCup: 8 }, 4)).toBe(8);
+    expect(mariokart.maxRounds?.({ racesPerCup: 0 }, 4)).toBeNull();
+    expect(mariokart.maxRounds?.({}, 4)).toBe(4); // default cup
+  });
+
+  it('createRoundInput seeds distinct spots that validate', () => {
+    const ctx = ctxOf(P, { pointsTable: 'modern12', racers: 12 });
+    const input = mariokart.createRoundInput(ctx) as MarioKartInput;
+    expect(mariokart.validateRound(input, ctx)).toBeNull();
+  });
+
+  it('scoreRound routes through the configured table', () => {
+    const ctx = ctxOf(P, { pointsTable: 'classic8', racers: 8 });
+    const input: MarioKartInput = { positions: { a: 1, b: 2, c: 3, d: 8 } };
+    expect(mariokart.scoreRound(input, ctx)).toEqual({ a: 15, b: 12, c: 10, d: 5 });
+  });
+
+  it('validateRound surfaces entry problems', () => {
+    const ctx = ctxOf(P, { pointsTable: 'modern12', racers: 12 });
+    expect(mariokart.validateRound({ positions: { a: 1, b: 1, c: 3, d: 4 } }, ctx)).toMatch(/1st/);
+  });
+
+  it('describeRound lists the podium in finishing order', () => {
+    const input: MarioKartInput = { positions: { a: 2, b: 1, c: 3, d: 4 } };
+    const round = { input } as unknown as Round;
+    const desc = mariokart.describeRound?.(round, P) ?? '';
+    expect(desc).toMatch(/🥇Bob/);
+    expect(desc.indexOf('Bob')).toBeLessThan(desc.indexOf('Alice'));
+    expect(desc).toContain('+1'); // Dan (4th) rolled into the tail
+  });
+
+  it('help mentions the cup and the authentic tables', () => {
+    expect(mariokart.help).toMatch(/cup/i);
+    expect(mariokart.help).toContain('15·12·10·9·8·7·6·5·4·3·2·1');
+  });
+});
+
+describe('mariokart stats', () => {
+  function statsInput(rounds: MarioKartInput[]): GameStatsInput {
+    const games = [{ id: 'g1' } as unknown as Game];
+    const roundRecords = rounds.map(
+      (input, i) => ({ id: `r${i}`, gameId: 'g1', index: i, input } as unknown as Round),
+    );
+    return { games, rounds: roundRecords, players: P, canonical: (id) => id };
+  }
+
+  it('derives wins, podium rate and average finish per player', () => {
+    // Alice: 1st, 1st, 2nd → 2 wins, 3 podiums, avg (1+1+2)/3 = 1.3
+    // Bob:   2nd, 3rd, 1st → 1 win, 3 podiums, avg 2.0
+    const res = mariokartStats(
+      statsInput([
+        { positions: { a: 1, b: 2 } },
+        { positions: { a: 1, b: 3 } },
+        { positions: { a: 2, b: 1 } },
+      ]),
+    );
+    const alice = res.perPlayer?.a ?? [];
+    const wins = alice.find((m) => m.key === 'mk_wins');
+    const avg = alice.find((m) => m.key === 'mk_avg');
+    expect(wins?.value).toBe('2');
+    expect(avg?.value).toBe('1.3');
+    const bob = res.perPlayer?.b ?? [];
+    expect(bob.find((m) => m.key === 'mk_avg')?.value).toBe('2');
+    expect(res.global?.find((m) => m.key === 'mk_races')?.value).toBe('3');
+  });
+
+  it('ignores rounds from other games', () => {
+    const input = statsInput([{ positions: { a: 1, b: 2 } }]);
+    input.rounds = input.rounds.map((r) => ({ ...r, gameId: 'other' }) as Round);
+    const res = mariokartStats(input);
+    expect(res.perPlayer?.a).toBeUndefined();
+    expect(res.global?.length ?? 0).toBe(0);
+  });
+});

--- a/src/lib/games/mariokart/stats.ts
+++ b/src/lib/games/mariokart/stats.ts
@@ -1,0 +1,69 @@
+import type { ID } from '../../types';
+import type { MarioKartInput } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg, fmtInt, fmtPct } from '../../stats/format';
+
+interface MKAgg {
+  races: number;
+  finishSum: number;
+  wins: number;
+  podiums: number;
+  best: number;
+}
+
+/**
+ * Mario Kart stats, derived purely from each race's recorded finishing positions.
+ * Position 1 is a race win; positions 1–3 are podiums; average finish is the mean
+ * spot across every race a racer entered. Pure — no Svelte — so it's unit-testable
+ * and safe for the stats engine to import.
+ */
+export function mariokartStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, MKAgg>();
+  const get = (id: ID): MKAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { races: 0, finishSum: 0, wins: 0, podiums: 0, best: Infinity };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let races = 0;
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as MarioKartInput | undefined;
+    if (!input?.positions) continue;
+    races += 1;
+    for (const [pid, raw] of Object.entries(input.positions)) {
+      const pos = Math.floor(Number(raw) || 0);
+      if (pos < 1) continue;
+      const a = get(canonical(pid));
+      a.races += 1;
+      a.finishSum += pos;
+      if (pos === 1) a.wins += 1;
+      if (pos <= 3) a.podiums += 1;
+      if (pos < a.best) a.best = pos;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let totWins = 0;
+  for (const [id, a] of per) {
+    totWins += a.wins;
+    if (!a.races) continue;
+    const metrics: Metric[] = [
+      { key: 'mk_avg', label: 'Avg finish', value: fmtAvg(a.finishSum / a.races), emoji: '🏎️' },
+    ];
+    if (a.wins) {
+      metrics.push({ key: 'mk_wins', label: 'Race wins', value: fmtInt(a.wins), emoji: '🥇' });
+    }
+    metrics.push({ key: 'mk_pod', label: 'Podium rate', value: fmtPct(a.podiums / a.races), emoji: '🏅' });
+    perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (races) global.push({ key: 'mk_races', label: 'Races run', value: fmtInt(races), emoji: '🏁' });
+  if (totWins) global.push({ key: 'mk_wins_all', label: 'Race wins', value: fmtInt(totWins), emoji: '🥇' });
+  return { perPlayer, global };
+}


### PR DESCRIPTION
﻿## 🏎️ Mario Kart — Grand Prix tracker

A couch-multiplayer **Grand Prix points tracker** for friends racing Mario Kart. A **cup** is a set of races; each race awards points by finishing position, and points pile up across the cup. **Highest total wins.** 🏆

Purely additive — everything lives in `src/lib/games/mariokart/` and is picked up by the auto-discovery registry (no `registry.ts` edit).

### 🏁 Scoring
Enter each racer''s finishing position after a race; positions auto-map to points via the chosen table. Finishing spots count the CPUs, so 3rd against a full 12-kart grid still pays 3rd even with 4 friends. Positions past a table score 0 (faithful to the retro games).

| Table | Curve | Source |
|---|---|---|
| **Modern · 12** | 15·12·10·9·8·7·6·5·4·3·2·1 | Mario Kart 8 Deluxe / Wii |
| **Classic · 8** | 15·12·10·9·8·7·6·5 | Mario Kart Wii (8-kart) |
| **Retro · top 4** | 9·6·3·1 (5th+ = 0) | Mario Kart 64 / Super Mario Kart |
| **Party** | everyone scores — 1st = racers, last = 1 | house rule, scales to the field |

### ⚙️ Config
- **Points table** — modern12 / classic8 / retro4 / party
- **Racers on the track** (default 12) — total karts incl. CPUs; the furthest-back spot you can enter
- **Races per cup** (default 4, `0` = endless cup → open-ended `maxRounds`)

> Note: the shared `ConfigField` contract (which this PR does not touch) supports number / boolean / select only, so a truly freeform custom table isn''t exposed; the scaling **Party** table + configurable **Racers** cover custom needs without editing shared code.

### 🎮 Round entry (`MarioKartEditor.svelte`)
One-handed and glanceable: the shared **Stepper** sets each racer''s spot, seeded distinct so it''s one-tap-to-fix. Each row shows a medal/ordinal rank, a live points preview, and a duplicate-spot warning. A **Points** toggle reveals the active table''s payout.

### 📊 Stats (`stats.ts`)
Per player: avg finish 🏎️, race wins 🥇, podium rate 🏅. Global: races run 🏁, race wins 🥇.

### 🎨 Design
Chrome unchanged — personality via emoji + copy only. No Crown Gold in the editor (leader/winner only). Depth via the surface ramp; `tabular-nums` on changing numbers; ≥46px targets; state never carried by color alone (medal + ordinal + text co-signal); no new animation.

### ✅ Verification
- `npm run check` — 0 errors, 0 warnings
- `npm test` — 106 passed (incl. new `mariokart.test.ts` + shared registry auto-discovery)
- `npm run build` — clean

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
