### PR TITLE
Add Euchre game

### DIFF
--- a/src/lib/games/euchre/EuchreEditor.svelte
+++ b/src/lib/games/euchre/EuchreEditor.svelte
@@ -1,0 +1,323 @@
+<script lang="ts">
+  import type { Player, RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import { euchre } from './index';
+  import { handPoints, optionsFromConfig, type EuchreInput, type HandResult, type TeamIndex } from './logic';
+
+  let { input = $bindable(), ctx }: { input: EuchreInput; ctx: RoundContext } = $props();
+
+  let showRules = $state(false);
+
+  const byId = $derived(new Map(ctx.players.map((p) => [p.id, p])));
+  const opts = $derived(optionsFromConfig(ctx.config));
+
+  function members(idx: TeamIndex): Player[] {
+    return (input.teams[idx] ?? [])
+      .map((id) => byId.get(id))
+      .filter((p): p is Player => !!p);
+  }
+  function teamLabel(idx: TeamIndex): string {
+    const names = members(idx).map((p) => p.name);
+    return names.length ? names.join(' & ') : `Team ${idx + 1}`;
+  }
+
+  const makerMembers = $derived(input.maker == null ? [] : members(input.maker));
+
+  const results: { value: HandResult; emoji: string; label: string; hint: string }[] = [
+    { value: 'made', emoji: '✋', label: 'Made', hint: '3–4' },
+    { value: 'march', emoji: '🧹', label: 'March', hint: 'all 5' },
+    { value: 'euchred', emoji: '🚫', label: 'Euchred', hint: 'set' },
+  ];
+
+  const preview = $derived.by(() => {
+    if (input.maker == null || input.result == null) return null;
+    const makerIdx = input.maker;
+    const defIdx = (makerIdx === 0 ? 1 : 0) as TeamIndex;
+    const p = handPoints(input.result, input.alone, opts);
+    const lone = input.alone ? ' alone' : '';
+    if (input.result === 'euchred') {
+      return { text: `${teamLabel(defIdx)} euchre ${teamLabel(makerIdx)}`, pts: p.defenders };
+    }
+    if (input.result === 'march') {
+      return { text: `${teamLabel(makerIdx)}${lone} march`, pts: p.maker };
+    }
+    return { text: `${teamLabel(makerIdx)}${lone} make it`, pts: p.maker };
+  });
+
+  function setMaker(idx: TeamIndex) {
+    input.maker = idx;
+    const makers = input.teams[idx] ?? [];
+    if (input.alonePlayer && !makers.includes(input.alonePlayer)) input.alonePlayer = null;
+  }
+  function toggleAlone() {
+    input.alone = !input.alone;
+    if (!input.alone) input.alonePlayer = null;
+  }
+  function setAlonePlayer(id: string) {
+    input.alonePlayer = input.alonePlayer === id ? null : id;
+  }
+  function setResult(res: HandResult) {
+    input.result = res;
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="muted hint">Name trump, then how the hand went.</span>
+    <button type="button" class="btn small ghost" onclick={() => (showRules = !showRules)}>
+      Rules
+    </button>
+  </div>
+
+  {#if showRules}
+    <pre class="help">{euchre.help}</pre>
+  {/if}
+
+  <div class="field">
+    <div class="qlabel">Who called it up?</div>
+    <div class="teams">
+      {#each [0, 1] as idx (idx)}
+        {@const ti = idx as TeamIndex}
+        <button
+          type="button"
+          class="teambtn"
+          class:on={input.maker === ti}
+          aria-pressed={input.maker === ti}
+          onclick={() => setMaker(ti)}
+        >
+          <span class="teamtag">Team {idx + 1}</span>
+          <span class="avatars">
+            {#each members(ti) as p (p.id)}
+              <Avatar name={p.name} color={p.color} size={26} />
+            {/each}
+          </span>
+          <span class="names">{teamLabel(ti)}</span>
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <div class="field">
+    <button
+      type="button"
+      class="alonebtn"
+      class:on={input.alone}
+      aria-pressed={input.alone}
+      onclick={toggleAlone}
+    >
+      🐺 Going alone
+    </button>
+    {#if input.alone}
+      {#if input.maker == null}
+        <div class="muted hint" style="margin-top: 8px">Pick the calling team first.</div>
+      {:else}
+        <div class="qlabel" style="margin-top: 10px">Who went alone?</div>
+        <div class="who">
+          {#each makerMembers as p (p.id)}
+            <button
+              type="button"
+              class="whobtn"
+              class:on={input.alonePlayer === p.id}
+              aria-pressed={input.alonePlayer === p.id}
+              onclick={() => setAlonePlayer(p.id)}
+            >
+              <Avatar name={p.name} color={p.color} size={24} />
+              {p.name}
+            </button>
+          {/each}
+        </div>
+      {/if}
+    {/if}
+  </div>
+
+  <div class="field">
+    <div class="qlabel">How did the hand go?</div>
+    <div class="results">
+      {#each results as r (r.value)}
+        <button
+          type="button"
+          class="resbtn"
+          class:on={input.result === r.value}
+          aria-pressed={input.result === r.value}
+          onclick={() => setResult(r.value)}
+        >
+          <span class="remoji" aria-hidden="true">{r.emoji}</span>
+          <span class="rlabel">{r.label}</span>
+          <span class="rhint">{r.hint}</span>
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <div class="preview" class:ready={!!preview}>
+    {#if preview}
+      <span class="ptext">{preview.text}</span>
+      <strong class="pts score-good">+{preview.pts}</strong>
+    {:else}
+      <span class="muted">Pick the calling team and the result.</span>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .hint {
+    font-size: 0.85rem;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+  }
+  .qlabel {
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin-bottom: 8px;
+  }
+  .teams {
+    display: flex;
+    gap: 10px;
+  }
+  .teambtn {
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    min-height: 46px;
+    padding: 12px 10px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+  }
+  .teambtn.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .teamtag {
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    opacity: 0.75;
+  }
+  .avatars {
+    display: flex;
+  }
+  .avatars :global(.avatar:not(:first-child)) {
+    margin-left: -8px;
+  }
+  .names {
+    font-weight: 700;
+    text-align: center;
+    line-height: 1.2;
+  }
+  .alonebtn {
+    align-self: flex-start;
+    min-height: 46px;
+    padding: 10px 16px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+  }
+  .alonebtn.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .who {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .whobtn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 8px 14px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 600;
+  }
+  .whobtn.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .results {
+    display: flex;
+    gap: 8px;
+  }
+  .resbtn {
+    flex: 1 1 0;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    min-height: 46px;
+    padding: 10px 6px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+  }
+  .resbtn.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .remoji {
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+  .rlabel {
+    font-weight: 700;
+  }
+  .rhint {
+    font-size: 0.72rem;
+    opacity: 0.7;
+  }
+  .preview {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    min-height: 46px;
+    padding: 10px 14px;
+    border: 1px dashed var(--border);
+    border-radius: 12px;
+    background: var(--surface-2);
+  }
+  .preview.ready {
+    border-style: solid;
+  }
+  .ptext {
+    font-weight: 600;
+  }
+  .pts {
+    font-size: 1.2rem;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/euchre/euchre.test.ts
+++ b/src/lib/games/euchre/euchre.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from 'vitest';
+import type { ID, RoundContext, Round } from '../../types';
+import { euchre } from './index';
+import {
+  DEFAULT_OPTIONS,
+  describeHand,
+  handPoints,
+  optionsFromConfig,
+  pairingFromConfig,
+  resolveTeams,
+  scoreEuchre,
+  targetFromConfig,
+  validateEuchre,
+  type EuchreInput,
+} from './logic';
+
+const players = [
+  { id: 'a', name: 'Ann', color: '#111', createdAt: 0 },
+  { id: 'b', name: 'Bo', color: '#222', createdAt: 0 },
+  { id: 'c', name: 'Cy', color: '#333', createdAt: 0 },
+  { id: 'd', name: 'Di', color: '#444', createdAt: 0 },
+];
+
+const ADJACENT: [ID[], ID[]] = [
+  ['a', 'b'],
+  ['c', 'd'],
+];
+
+function mk(partial: Partial<EuchreInput> = {}): EuchreInput {
+  return {
+    teams: ADJACENT,
+    maker: 0,
+    alone: false,
+    alonePlayer: null,
+    result: 'made',
+    ...partial,
+  };
+}
+
+function ctx(config: Record<string, unknown> = {}): RoundContext {
+  return { players, config } as unknown as RoundContext;
+}
+
+function sum(deltas: Record<ID, number>): number {
+  return Object.values(deltas).reduce((a, b) => a + b, 0);
+}
+
+describe('resolveTeams', () => {
+  it('pairs adjacent picks (1&2 vs 3&4)', () => {
+    expect(resolveTeams(players, 'adjacent')).toEqual([
+      ['a', 'b'],
+      ['c', 'd'],
+    ]);
+  });
+
+  it('pairs across picks (1&3 vs 2&4)', () => {
+    expect(resolveTeams(players, 'across')).toEqual([
+      ['a', 'c'],
+      ['b', 'd'],
+    ]);
+  });
+});
+
+describe('handPoints', () => {
+  it('made (3–4 tricks) scores the makers 1', () => {
+    expect(handPoints('made', false)).toEqual({ maker: 1, defenders: 0 });
+  });
+
+  it('march (all 5) scores the makers 2', () => {
+    expect(handPoints('march', false)).toEqual({ maker: 2, defenders: 0 });
+  });
+
+  it('lone march scores 4 with the alone bonus on (default)', () => {
+    expect(handPoints('march', true)).toEqual({ maker: 4, defenders: 0 });
+  });
+
+  it('lone march scores just 2 with the alone bonus off', () => {
+    expect(handPoints('march', true, { aloneBonus: false, loneEuchreBonus: false })).toEqual({
+      maker: 2,
+      defenders: 0,
+    });
+  });
+
+  it('going alone and taking only 3–4 still scores 1', () => {
+    expect(handPoints('made', true)).toEqual({ maker: 1, defenders: 0 });
+  });
+
+  it('euchred scores the defenders 2', () => {
+    expect(handPoints('euchred', false)).toEqual({ maker: 0, defenders: 2 });
+  });
+
+  it('euchring a lone caller scores 4 only when that bonus is on', () => {
+    expect(handPoints('euchred', true, { aloneBonus: true, loneEuchreBonus: true })).toEqual({
+      maker: 0,
+      defenders: 4,
+    });
+    // alone but bonus off → still 2
+    expect(handPoints('euchred', true, DEFAULT_OPTIONS)).toEqual({ maker: 0, defenders: 2 });
+    // lone-euchre bonus only applies to a lone caller, not an ordinary euchre
+    expect(handPoints('euchred', false, { aloneBonus: true, loneEuchreBonus: true })).toEqual({
+      maker: 0,
+      defenders: 2,
+    });
+  });
+});
+
+describe('scoreEuchre', () => {
+  it('gives both partners the team points and opponents nothing on a made hand', () => {
+    expect(scoreEuchre(mk({ maker: 0, result: 'made' }))).toEqual({ a: 1, b: 1, c: 0, d: 0 });
+  });
+
+  it('scores a march to both makers', () => {
+    expect(scoreEuchre(mk({ maker: 1, result: 'march' }))).toEqual({ a: 0, b: 0, c: 2, d: 2 });
+  });
+
+  it('scores a lone march 4 to both makers (default bonus)', () => {
+    const out = scoreEuchre(mk({ maker: 0, result: 'march', alone: true, alonePlayer: 'a' }));
+    expect(out).toEqual({ a: 4, b: 4, c: 0, d: 0 });
+  });
+
+  it('awards a euchre to the defending team, not the makers', () => {
+    expect(scoreEuchre(mk({ maker: 0, result: 'euchred' }))).toEqual({ a: 0, b: 0, c: 2, d: 2 });
+  });
+
+  it('honours house-rule options', () => {
+    const loneEuchre = scoreEuchre(mk({ maker: 0, result: 'euchred', alone: true, alonePlayer: 'a' }), {
+      aloneBonus: true,
+      loneEuchreBonus: true,
+    });
+    expect(loneEuchre).toEqual({ a: 0, b: 0, c: 4, d: 4 });
+  });
+
+  it('returns all-zero deltas when the hand is incomplete', () => {
+    expect(scoreEuchre(mk({ maker: null }))).toEqual({ a: 0, b: 0, c: 0, d: 0 });
+    expect(scoreEuchre(mk({ result: null }))).toEqual({ a: 0, b: 0, c: 0, d: 0 });
+  });
+
+  it('only ever moves the score by one team per hand (zero-sum by team)', () => {
+    // exactly one side scores each hand; the other stays flat.
+    for (const res of ['made', 'march', 'euchred'] as const) {
+      const out = scoreEuchre(mk({ maker: 0, result: res }));
+      const makerSide = out.a + out.b;
+      const defSide = out.c + out.d;
+      expect(makerSide === 0 || defSide === 0).toBe(true);
+    }
+  });
+});
+
+describe('validateEuchre', () => {
+  it('accepts a complete hand', () => {
+    expect(validateEuchre(mk({ maker: 0, result: 'made' }))).toBeNull();
+  });
+
+  it('requires a calling team', () => {
+    expect(validateEuchre(mk({ maker: null }))).toMatch(/called trump/i);
+  });
+
+  it('requires a result', () => {
+    expect(validateEuchre(mk({ result: null }))).toMatch(/how the hand went/i);
+  });
+
+  it('requires the lone player when going alone', () => {
+    expect(validateEuchre(mk({ alone: true, alonePlayer: null }))).toMatch(/went alone/i);
+  });
+
+  it('rejects a lone player from the wrong team', () => {
+    expect(validateEuchre(mk({ maker: 0, alone: true, alonePlayer: 'c' }))).toMatch(
+      /must be on the team/i,
+    );
+  });
+
+  it('accepts a valid lone hand', () => {
+    expect(validateEuchre(mk({ maker: 0, alone: true, alonePlayer: 'a' }))).toBeNull();
+  });
+
+  it('needs four players', () => {
+    expect(validateEuchre(mk({ teams: [['a'], ['c']] }))).toMatch(/four players/i);
+  });
+});
+
+describe('describeHand', () => {
+  it('summarises a made hand with the recorded points', () => {
+    expect(describeHand(mk({ maker: 0, result: 'made' }), players, 1)).toBe('✋ Ann & Bo made it +1');
+  });
+
+  it('summarises a lone march with the lone player', () => {
+    const s = describeHand(mk({ maker: 0, result: 'march', alone: true, alonePlayer: 'a' }), players, 4);
+    expect(s).toBe('🧹 Ann & Bo marched — Ann alone +4');
+  });
+
+  it('summarises a euchre naming both teams', () => {
+    expect(describeHand(mk({ maker: 0, result: 'euchred' }), players, 2)).toBe(
+      '🚫 Ann & Bo euchred — Cy & Di +2',
+    );
+  });
+
+  it('derives points from default rules when none are supplied', () => {
+    expect(describeHand(mk({ maker: 1, result: 'march' }), players)).toBe('🧹 Cy & Di marched +2');
+  });
+
+  it('handles an unrecorded hand', () => {
+    expect(describeHand(mk({ maker: null }), players)).toBe('Hand not recorded');
+  });
+});
+
+describe('config coercion', () => {
+  it('pairing defaults to adjacent', () => {
+    expect(pairingFromConfig({})).toBe('adjacent');
+    expect(pairingFromConfig({ pairing: 'across' })).toBe('across');
+  });
+
+  it('options default to the standard rules', () => {
+    expect(optionsFromConfig({})).toEqual({ aloneBonus: true, loneEuchreBonus: false });
+    expect(optionsFromConfig({ aloneBonus: false, loneEuchreBonus: true })).toEqual({
+      aloneBonus: false,
+      loneEuchreBonus: true,
+    });
+  });
+
+  it('target defaults to 10 and ignores junk', () => {
+    expect(targetFromConfig({})).toBe(10);
+    expect(targetFromConfig({ target: 5 })).toBe(5);
+    expect(targetFromConfig({ target: 0 })).toBe(10);
+    expect(targetFromConfig({ target: -3 })).toBe(10);
+  });
+});
+
+describe('euchre module', () => {
+  it('declares itself a fixed-partnership 4-player game', () => {
+    expect(euchre.id).toBe('euchre');
+    expect(euchre.teams).toBe(true);
+    expect(euchre.minPlayers).toBe(4);
+    expect(euchre.maxPlayers).toBe(4);
+    expect(euchre.lowerIsBetter).toBeFalsy();
+  });
+
+  it('creates a round input with teams resolved from pick order + pairing', () => {
+    const input = euchre.createRoundInput(ctx({ pairing: 'across' })) as EuchreInput;
+    expect(input.teams).toEqual([
+      ['a', 'c'],
+      ['b', 'd'],
+    ]);
+    expect(input.maker).toBeNull();
+    expect(input.result).toBeNull();
+    expect(input.alone).toBe(false);
+  });
+
+  it('scores through the module honouring config bonuses', () => {
+    const alone = mk({ maker: 0, result: 'march', alone: true, alonePlayer: 'a' });
+    expect(euchre.scoreRound(alone, ctx())).toEqual({ a: 4, b: 4, c: 0, d: 0 });
+    expect(euchre.scoreRound(alone, ctx({ aloneBonus: false }))).toEqual({
+      a: 2,
+      b: 2,
+      c: 0,
+      d: 0,
+    });
+  });
+
+  it('finishes when a team reaches the target', () => {
+    const info = (config: Record<string, unknown>) => ({ config, roundCount: 8, playerCount: 4 });
+    expect(euchre.isFinished!({ a: 10, b: 10, c: 6, d: 6 }, info({}))).toBe(true);
+    expect(euchre.isFinished!({ a: 9, b: 9, c: 6, d: 6 }, info({}))).toBe(false);
+    expect(euchre.isFinished!({ a: 5, b: 5, c: 3, d: 3 }, info({ target: 5 }))).toBe(true);
+  });
+
+  it('describes a recorded round from its stored deltas', () => {
+    const round = {
+      input: mk({ maker: 0, result: 'euchred' }),
+      deltas: { a: 0, b: 0, c: 2, d: 2 },
+    } as unknown as Round;
+    expect(euchre.describeRound!(round, players)).toBe('🚫 Ann & Bo euchred — Cy & Di +2');
+  });
+
+  it('plays a full game to 10 with both partners tracking the team score', () => {
+    // Team 0 (a,b) racks up: march, made, made, euchre-defence… we just feed maker-team makes.
+    const hands: EuchreInput[] = [
+      mk({ maker: 0, result: 'march' }), // +2 → 2
+      mk({ maker: 0, result: 'made' }), //  +1 → 3
+      mk({ maker: 1, result: 'euchred' }), // team1 euchred → team0 (defenders) +2 → 5
+      mk({ maker: 0, result: 'march', alone: true, alonePlayer: 'a' }), // +4 → 9
+      mk({ maker: 0, result: 'made' }), //  +1 → 10
+    ];
+    const totals: Record<ID, number> = { a: 0, b: 0, c: 0, d: 0 };
+    for (const h of hands) {
+      const d = euchre.scoreRound(h, ctx());
+      for (const id of Object.keys(totals)) totals[id] += d[id] ?? 0;
+    }
+    expect(totals.a).toBe(10);
+    expect(totals.b).toBe(10); // partner mirrors the team score exactly
+    expect(euchre.isFinished!(totals, { config: {}, roundCount: hands.length, playerCount: 4 })).toBe(
+      true,
+    );
+    // every hand shifted only one team
+    expect(sum(euchre.scoreRound(hands[0], ctx()))).toBe(4); // march = 2 to each of two partners
+  });
+});

--- a/src/lib/games/euchre/index.ts
+++ b/src/lib/games/euchre/index.ts
@@ -1,0 +1,102 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './EuchreEditor.svelte';
+import { euchreStats } from './stats';
+import {
+  type EuchreInput,
+  describeHand,
+  optionsFromConfig,
+  pairingFromConfig,
+  resolveTeams,
+  scoreEuchre,
+  targetFromConfig,
+  validateEuchre,
+} from './logic';
+
+export type { EuchreInput } from './logic';
+
+export const euchre: GameModule = {
+  id: 'euchre',
+  name: 'Euchre',
+  tagline: 'Call trump, take tricks, race to 10.',
+  emoji: '🃏',
+  keywords: ['trick taking', 'trump', 'partners', 'teams', 'bower', 'cards'],
+  minPlayers: 4,
+  maxPlayers: 4,
+  teams: true,
+  configFields: [
+    {
+      key: 'pairing',
+      label: 'Partnerships',
+      type: 'select',
+      default: 'adjacent',
+      options: [
+        { value: 'adjacent', label: 'Teams: 1 & 2  vs  3 & 4' },
+        { value: 'across', label: 'Teams: 1 & 3  vs  2 & 4' },
+      ],
+      help: 'How the four players you pick split into two teams (by pick order).',
+    },
+    {
+      key: 'target',
+      label: 'Play to',
+      type: 'number',
+      default: 10,
+      min: 1,
+      help: 'First team to reach this score wins. Classic euchre is 10; some play to 5.',
+    },
+    {
+      key: 'aloneBonus',
+      label: 'Going alone & sweeping all 5 scores 4 (otherwise 2)',
+      type: 'boolean',
+      default: true,
+    },
+    {
+      key: 'loneEuchreBonus',
+      label: 'Euchring a lone caller scores the defenders 4 (otherwise 2)',
+      type: 'boolean',
+      default: false,
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): EuchreInput => ({
+    teams: resolveTeams(ctx.players, pairingFromConfig(ctx.config)),
+    maker: null,
+    alone: false,
+    alonePlayer: null,
+    result: null,
+  }),
+
+  validateRound: (input: EuchreInput): string | null => validateEuchre(input),
+
+  scoreRound: (input: EuchreInput, ctx: RoundContext): Record<ID, number> =>
+    scoreEuchre(input, optionsFromConfig(ctx.config)),
+
+  isFinished: (totals, { config }) => {
+    const target = targetFromConfig(config);
+    return Object.values(totals).some((t) => t >= target);
+  },
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as EuchreInput;
+    const awarded = Math.max(0, ...Object.values(round.deltas ?? {}));
+    return describeHand(input, players, awarded);
+  },
+
+  help: [
+    'Euchre — 4 players in two fixed teams, a 24-card deck, 5 tricks a hand.',
+    'One team names trump — "the makers".',
+    '',
+    'Each hand:',
+    '• Makers take 3 or 4 tricks — 1 point.',
+    '• Makers take all 5 (a "march") — 2 points.',
+    '• A maker goes alone and takes all 5 — 4 points.',
+    '  (Alone but only 3–4 tricks still scores 1.)',
+    '• Makers fail to reach 3 tricks — they are "euchred" and the defenders score 2.',
+    '',
+    'First team to 10 wins (some play to 5).',
+    'The right & left bowers — the two jacks of the trump colour — are the top trumps.',
+  ].join('\n'),
+
+  stats: euchreStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/euchre/logic.ts
+++ b/src/lib/games/euchre/logic.ts
@@ -1,0 +1,166 @@
+import type { ID } from '../../types';
+
+/**
+ * Pure Euchre scoring — no Svelte, no I/O, so it's independently unit-testable and
+ * safe for the stats engine to import.
+ *
+ * Euchre is a fixed-partnership game: 4 players, two teams of two, 5 tricks a hand.
+ * Score King's shell has no partnership model of its own (the `teams` flag is only
+ * declared), so a game keeps team play *inside its module*: both partners on a team
+ * receive the team's hand points, so each partner's running total equals the team
+ * score and the generic scoreboard / leader / winner / target-finish all read as
+ * team semantics with no shell changes.
+ */
+
+export type TeamIndex = 0 | 1;
+export type HandResult = 'made' | 'march' | 'euchred';
+export type Pairing = 'adjacent' | 'across';
+
+export interface EuchreInput {
+  /** Resolved partnerships (two player ids each), fixed for the whole game. */
+  teams: [ID[], ID[]];
+  /** The team that named trump — "the makers". */
+  maker: TeamIndex | null;
+  /** The makers went alone (a partner sat the hand out). */
+  alone: boolean;
+  /** Which maker played the lone hand (set only when `alone`). */
+  alonePlayer: ID | null;
+  /** Outcome of the hand, from the making team's point of view. */
+  result: HandResult | null;
+}
+
+export interface EuchreOptions {
+  /** Going alone and sweeping all 5 scores 4 (otherwise the normal march of 2). */
+  aloneBonus: boolean;
+  /** Euchring a lone caller scores the defenders 4 (otherwise the normal 2). */
+  loneEuchreBonus: boolean;
+}
+
+export const DEFAULT_OPTIONS: EuchreOptions = { aloneBonus: true, loneEuchreBonus: false };
+
+export interface HandPoints {
+  /** Points to the making team this hand. */
+  maker: number;
+  /** Points to the defending team this hand. */
+  defenders: number;
+}
+
+/** Split picked players into two partnerships by pick order. */
+export function resolveTeams<T extends { id: ID }>(
+  players: T[],
+  pairing: Pairing,
+): [ID[], ID[]] {
+  const ids = players.map((p) => p.id);
+  const pick = (...idx: number[]): ID[] => idx.map((i) => ids[i]).filter((x): x is ID => x != null);
+  return pairing === 'across'
+    ? [pick(0, 2), pick(1, 3)]
+    : [pick(0, 1), pick(2, 3)];
+}
+
+/**
+ * Points awarded for a single hand.
+ * - made (3–4 tricks): makers +1.
+ * - march (all 5): makers +2 — or +4 if they went alone (with the alone bonus on).
+ * - euchred (makers took fewer than 3): defenders +2 — or +4 for euchring a lone
+ *   caller (with the lone-euchre bonus on).
+ */
+export function handPoints(
+  result: HandResult,
+  alone: boolean,
+  opts: EuchreOptions = DEFAULT_OPTIONS,
+): HandPoints {
+  switch (result) {
+    case 'made':
+      return { maker: 1, defenders: 0 };
+    case 'march':
+      return { maker: alone && opts.aloneBonus ? 4 : 2, defenders: 0 };
+    case 'euchred':
+      return { maker: 0, defenders: alone && opts.loneEuchreBonus ? 4 : 2 };
+  }
+}
+
+/** Per-player point deltas for a hand: every teammate shares their team's points. */
+export function scoreEuchre(
+  input: EuchreInput,
+  opts: EuchreOptions = DEFAULT_OPTIONS,
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const team of input.teams) for (const id of team) out[id] = 0;
+  if (input.maker == null || input.result == null) return out;
+
+  const pts = handPoints(input.result, input.alone, opts);
+  const makers = input.teams[input.maker] ?? [];
+  const defenders = input.teams[input.maker === 0 ? 1 : 0] ?? [];
+  for (const id of makers) out[id] = pts.maker;
+  for (const id of defenders) out[id] = pts.defenders;
+  return out;
+}
+
+/** Null when the hand is valid to record, otherwise a human-readable reason. */
+export function validateEuchre(input: EuchreInput): string | null {
+  const flat = input.teams.flat();
+  if (flat.length < 4) return 'Euchre needs four players split into two partnerships.';
+  if (input.maker == null) return 'Tap the team that called trump.';
+  if (input.result == null) return 'Record how the hand went.';
+  if (input.alone) {
+    if (!input.alonePlayer) return 'Pick which partner went alone.';
+    const makers = input.teams[input.maker] ?? [];
+    if (!makers.includes(input.alonePlayer)) {
+      return 'The lone player must be on the team that called it.';
+    }
+  }
+  return null;
+}
+
+/**
+ * Short, glanceable summary of a recorded hand for the history table. `awarded` is the
+ * points the scoring team actually got this hand (read from the stored deltas so the
+ * text always matches the recorded score, even under house-rule bonuses); when omitted
+ * it's derived with the default rules.
+ */
+export function describeHand(
+  input: EuchreInput,
+  players: { id: ID; name: string }[],
+  awarded?: number,
+): string {
+  if (input.maker == null || input.result == null) return 'Hand not recorded';
+  const name = (id: ID | null): string =>
+    (id != null && players.find((p) => p.id === id)?.name) || '?';
+  const teamLabel = (idx: TeamIndex): string =>
+    (input.teams[idx] ?? []).map((id) => name(id)).join(' & ') || `Team ${idx + 1}`;
+
+  const makers = teamLabel(input.maker);
+  const defenders = teamLabel(input.maker === 0 ? 1 : 0);
+  const pts =
+    awarded ??
+    (() => {
+      const p = handPoints(input.result, input.alone, DEFAULT_OPTIONS);
+      return input.result === 'euchred' ? p.defenders : p.maker;
+    })();
+  const plus = `+${pts}`;
+
+  if (input.result === 'euchred') {
+    return `🚫 ${makers} euchred — ${defenders} ${plus}`;
+  }
+  const lone = input.alone ? ` — ${name(input.alonePlayer)} alone` : '';
+  if (input.result === 'march') return `🧹 ${makers} marched${lone} ${plus}`;
+  return `✋ ${makers} made it${lone} ${plus}`;
+}
+
+// --- config coercion (config values arrive as `unknown` from stored game config) ---
+
+export function pairingFromConfig(config: Record<string, unknown>): Pairing {
+  return config.pairing === 'across' ? 'across' : 'adjacent';
+}
+
+export function optionsFromConfig(config: Record<string, unknown>): EuchreOptions {
+  return {
+    aloneBonus: config.aloneBonus !== false,
+    loneEuchreBonus: config.loneEuchreBonus === true,
+  };
+}
+
+export function targetFromConfig(config: Record<string, unknown>): number {
+  const t = Number(config.target);
+  return Number.isFinite(t) && t > 0 ? t : 10;
+}

--- a/src/lib/games/euchre/stats.ts
+++ b/src/lib/games/euchre/stats.ts
@@ -1,0 +1,112 @@
+import type { ID } from '../../types';
+import type { EuchreInput } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt, fmtPct } from '../../stats/format';
+
+interface EuAgg {
+  /** Hands this player's team named trump. */
+  called: number;
+  /** Called hands that were made (3–4, a march, or a lone sweep). */
+  makes: number;
+  /** Called hands swept for all five tricks. */
+  marches: number;
+  /** Hands this player's team euchred the makers. */
+  euchresLanded: number;
+  /** Hands this player personally played alone. */
+  loneCalls: number;
+  /** Lone hands that swept all five. */
+  loneSweeps: number;
+}
+
+/**
+ * Euchre stats, derived purely from each hand's recorded maker/result. Team events are
+ * credited to both partners; going alone is credited to the individual who did it, so a
+ * lone hand shows up on the right person. Pure — no Svelte — so it's unit-testable and
+ * safe for the stats engine to import.
+ */
+export function euchreStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, EuAgg>();
+  const get = (id: ID): EuAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { called: 0, makes: 0, marches: 0, euchresLanded: 0, loneCalls: 0, loneSweeps: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let hands = 0;
+  let makes = 0;
+  let marches = 0;
+  let euchres = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as EuchreInput | undefined;
+    if (!input?.teams || input.maker == null || input.result == null) continue;
+
+    const makerTeam = input.teams[input.maker] ?? [];
+    const defTeam = input.teams[input.maker === 0 ? 1 : 0] ?? [];
+    const made = input.result !== 'euchred';
+
+    hands += 1;
+    if (made) makes += 1;
+    if (input.result === 'march') marches += 1;
+    if (input.result === 'euchred') euchres += 1;
+
+    for (const pid of makerTeam) {
+      const a = get(canonical(pid));
+      a.called += 1;
+      if (made) a.makes += 1;
+      if (input.result === 'march') a.marches += 1;
+    }
+    if (input.result === 'euchred') {
+      for (const pid of defTeam) get(canonical(pid)).euchresLanded += 1;
+    }
+    if (input.alone && input.alonePlayer) {
+      const a = get(canonical(input.alonePlayer));
+      a.loneCalls += 1;
+      if (input.result === 'march') a.loneSweeps += 1;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.called) {
+      metrics.push({
+        key: 'eu_make',
+        label: 'Call make rate',
+        value: fmtPct(a.makes / a.called),
+        sub: `${a.makes}/${a.called}`,
+        emoji: '🎯',
+      });
+    }
+    if (a.marches) {
+      metrics.push({ key: 'eu_march', label: 'Marches', value: fmtInt(a.marches), emoji: '🧹' });
+    }
+    if (a.euchresLanded) {
+      metrics.push({ key: 'eu_euchre', label: 'Euchres landed', value: fmtInt(a.euchresLanded), emoji: '🚫' });
+    }
+    if (a.loneCalls) {
+      metrics.push({
+        key: 'eu_lone',
+        label: 'Went alone',
+        value: fmtInt(a.loneCalls),
+        sub: a.loneSweeps ? `${a.loneSweeps} swept` : undefined,
+        emoji: '🐺',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (hands) {
+    global.push({ key: 'eu_make_all', label: 'Make rate', value: fmtPct(makes / hands), emoji: '🎯' });
+    if (marches) global.push({ key: 'eu_march_all', label: 'Marches', value: fmtInt(marches), emoji: '🧹' });
+    if (euchres) global.push({ key: 'eu_euchre_all', label: 'Euchres', value: fmtInt(euchres), emoji: '🚫' });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## 🃏 Euchre

Adds **Euchre** as a first-class, auto-discovered game module. Purely additive — only `src/lib/games/euchre/` is touched (no changes to `registry.ts`, shared components, other games, or `package.json`).

Euchre is a fixed-partnership, trick-taking card game: **4 players in 2 teams**, a 24-card deck, **5 tricks per hand**. Call trump, take tricks, race to the target.

### Scoring (highest total wins)
| Outcome | Points |
| --- | --- |
| Makers win 3–4 tricks | **+1** making team |
| Makers win all 5 (march) | **+2** |
| Makers go **alone** and sweep all 5 | **+4** (alone but only 3–4 → +1) |
| Makers fail to reach 3 tricks (**euchred**) | **+2** defenders |

First team to the **target** (default **10**; some play to 5) wins.

### Teams model
The app shell scores per player and does not consume the `teams` flag on its own, so to stay additive both partners receive their team's hand points — each partner's running total equals the team score. The shared roster, scoreboard, leader/winner highlighting, `isFinished(target)`, and stats all work unchanged. `teams: true` is set.

### Config
- **Pairing** — `adjacent` (1&2 vs 3&4, default) or `across` (1&3 vs 2&4), by pick order.
- **Target** — first to this many points wins (default 10).
- **Going-alone bonus** — lone sweep = 4 (default on).
- **Euchre-a-loner bonus** — euchring a lone caller = 4 (default off).

### Editor & stats
Team-first round entry: pick the making team, optional **going alone** toggle (and who), then **Made / March / Euchred** with a live point preview and a **Rules** popover. Per-player and global stats: call make rate, marches, euchres landed, and lone runs.

### Design
Follows `DESIGN.md`: Crown Gold reserved for leader/winner only, a single Royal Violet primary action, surface-ramp depth, `tabular-nums` on changing points, ≥46px touch targets, never state-by-color-alone, and reduced-motion safe.

### Verification
- `npm run check` — 0 errors, 0 warnings
- `npm test` — all suites pass (incl. new `euchre.test.ts` + registry contract)
- `npm run build` — succeeds; module bundled and auto-discovered