### PR TITLE
Add Spades game module

### DIFF
--- a/src/lib/games/spades/SpadesEditor.svelte
+++ b/src/lib/games/spades/SpadesEditor.svelte
@@ -1,0 +1,269 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { spades } from './index';
+  import {
+    bagCountsAfter,
+    emptyRow,
+    readConfig,
+    resolveMode,
+    scoreUnitHand,
+    tricksAvailable,
+    unitsFor,
+    type NilKind,
+    type SpadesInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: SpadesInput; ctx: RoundContext } = $props();
+
+  const cfg = $derived(readConfig(ctx.config));
+  const table = $derived(tricksAvailable(ctx.players.length));
+  const mode = $derived(resolveMode(ctx.config, ctx.players.length));
+  const partners = $derived(mode === 'partners');
+  const soloFallback = $derived(cfg.mode === 'partners' && ctx.players.length !== 4);
+  const units = $derived(unitsFor(ctx.players, mode));
+  const byId = $derived(new Map(ctx.players.map((p) => [p.id, p])));
+
+  const prior = $derived(
+    ctx.rounds
+      .filter((r) => r.index < ctx.roundIndex)
+      .sort((a, b) => a.index - b.index)
+      .map((r) => r.input as SpadesInput),
+  );
+  const bagsBefore = $derived(bagCountsAfter(prior, ctx.players, ctx.config));
+  const results = $derived(
+    new Map(
+      units.map((u) => [
+        u.key,
+        scoreUnitHand(
+          u.memberIds.map((id) => input.rows[id] ?? emptyRow()),
+          cfg,
+          bagsBefore[u.key] ?? 0,
+        ),
+      ]),
+    ),
+  );
+  const totalTricks = $derived(
+    ctx.players.reduce((a, p) => a + (Number(input.rows[p.id]?.tricks) || 0), 0),
+  );
+
+  let showHelp = $state(false);
+
+  function setNil(id: string, kind: NilKind) {
+    const row = input.rows[id];
+    if (!row) return;
+    row.nil = row.nil === kind ? 'none' : kind;
+  }
+
+  const signed = (n: number) => (n >= 0 ? `+${n}` : `${n}`);
+</script>
+
+<div class="stack">
+  <div class="row spread wrap">
+    <span class="pill" class:score-bad={totalTricks !== table}>♠ {totalTricks}/{table} tricks</span>
+    <span class="row wrap" style="gap: 8px">
+      <span class="pill">{partners ? '👥 Partners' : '🙋 Solo'}{soloFallback ? ' · need 4 for teams' : ''}</span>
+      <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+        How to score
+      </button>
+    </span>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{spades.help}</pre>
+  {/if}
+
+  {#each units as u (u.key)}
+    {@const res = results.get(u.key)}
+    <div class="unit">
+      <div class="uhead row spread">
+        <span class="uleft row wrap">
+          {#if partners}<span class="team">Team {u.index + 1}</span>{/if}
+          <span class="sub">bid {res?.contract ?? 0} · won {res?.tricks ?? 0}</span>
+          {#if cfg.sandbagging}
+            <span class="bags" class:score-bad={(res?.penalties ?? 0) > 0}>
+              🛍️ {res?.bagsAfter ?? 0}{(res?.penalties ?? 0) > 0 ? ` · −${100 * (res?.penalties ?? 0)}` : ''}
+            </span>
+          {/if}
+        </span>
+        <span class="proj" class:score-good={(res?.score ?? 0) >= 0} class:score-bad={(res?.score ?? 0) < 0}>
+          {signed(res?.score ?? 0)}
+        </span>
+      </div>
+
+      {#each u.memberIds as id (id)}
+        {@const p = byId.get(id)}
+        {@const row = input.rows[id]}
+        {#if p && row}
+          <div class="mrow">
+            <div class="row spread who-row">
+              <span class="who row" style="gap: 8px">
+                <Avatar name={p.name} color={p.color} />
+                <strong>{p.name}</strong>
+              </span>
+              {#if row.nil !== 'none'}
+                <span class="nilhint" class:score-good={(Number(row.tricks) || 0) === 0} class:score-bad={(Number(row.tricks) || 0) > 0}>
+                  {(Number(row.tricks) || 0) === 0 ? 'on track ✓' : 'broken ✗'}
+                </span>
+              {/if}
+            </div>
+
+            <div class="fields row">
+              <label class="f">
+                <span>Bid</span>
+                {#if row.nil === 'none'}
+                  <Stepper bind:value={row.bid} min={0} max={table} />
+                {:else}
+                  <span class="nilbid">{row.nil === 'blind' ? '🙈 Blind nil' : '🚫 Nil'}</span>
+                {/if}
+              </label>
+              <label class="f">
+                <span>Tricks</span>
+                <Stepper bind:value={row.tricks} min={0} max={table} />
+              </label>
+            </div>
+
+            {#if cfg.nil}
+              <div class="niltoggles row">
+                <button
+                  type="button"
+                  class="toggle"
+                  class:on={row.nil === 'nil'}
+                  onclick={() => setNil(id, 'nil')}
+                >
+                  🚫 Nil <span class="sub2">(±100)</span>
+                </button>
+                {#if cfg.blindNil}
+                  <button
+                    type="button"
+                    class="toggle"
+                    class:on={row.nil === 'blind'}
+                    onclick={() => setNil(id, 'blind')}
+                  >
+                    🙈 Blind <span class="sub2">(±200)</span>
+                  </button>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/if}
+      {/each}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .unit {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .uhead {
+    align-items: center;
+  }
+  .uleft {
+    gap: 8px;
+    row-gap: 4px;
+  }
+  .team {
+    font-weight: 700;
+    padding: 3px 10px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    font-size: 0.82rem;
+  }
+  .sub {
+    color: var(--muted);
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .bags {
+    font-size: 0.82rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .proj {
+    font-weight: 800;
+    font-size: 1.05rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .mrow {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .who strong {
+    font-weight: 700;
+  }
+  .nilhint {
+    font-size: 0.78rem;
+    font-weight: 700;
+  }
+  .fields {
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  .f {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+  .nilbid {
+    display: inline-flex;
+    align-items: center;
+    min-height: 46px;
+    font-weight: 700;
+    color: var(--text);
+    font-size: 0.95rem;
+  }
+  .niltoggles {
+    gap: 8px;
+  }
+  .toggle {
+    flex: 1;
+    min-height: 46px;
+    padding: 9px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+  }
+  .toggle .sub2 {
+    color: var(--muted);
+    font-weight: 500;
+    font-size: 0.8rem;
+  }
+  .toggle.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .toggle.on .sub2 {
+    color: rgba(255, 255, 255, 0.8);
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/spades/index.ts
+++ b/src/lib/games/spades/index.ts
@@ -1,0 +1,115 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './SpadesEditor.svelte';
+import { spadesStats } from './stats';
+import {
+  emptyRow,
+  readConfig,
+  scoreLatest,
+  validateHand,
+  type SpadesInput,
+} from './logic';
+
+export type { SpadesInput, SpadesRow, NilKind } from './logic';
+
+/** Prior hands, oldest first — everything strictly before the hand being scored. */
+function priorInputs(ctx: RoundContext): SpadesInput[] {
+  return ctx.rounds
+    .filter((r) => r.index < ctx.roundIndex)
+    .sort((a, b) => a.index - b.index)
+    .map((r) => r.input as SpadesInput);
+}
+
+export const spades: GameModule = {
+  id: 'spades',
+  name: 'Spades',
+  tagline: 'Bid your tricks. Mind the bags.',
+  emoji: '♠️',
+  keywords: ['trick taking', 'partnership', 'bidding', 'nil', 'bags', 'cards'],
+  minPlayers: 3,
+  maxPlayers: 4,
+  teams: true,
+
+  configFields: [
+    {
+      key: 'mode',
+      label: 'Play style',
+      type: 'select',
+      default: 'partners',
+      options: [
+        { value: 'partners', label: 'Partnerships · 2 teams of 2' },
+        { value: 'solo', label: 'Cutthroat · every player solo' },
+      ],
+      help: 'Partnerships need exactly 4 players — otherwise everyone scores solo.',
+    },
+    {
+      key: 'target',
+      label: 'Winning score',
+      type: 'number',
+      default: 500,
+      min: 100,
+      step: 50,
+      help: 'First to reach this wins; the highest total breaks a tie.',
+    },
+    { key: 'nil', label: 'Allow Nil bids (±100)', type: 'boolean', default: true },
+    { key: 'blindNil', label: 'Allow Blind Nil (±200)', type: 'boolean', default: true },
+    {
+      key: 'sandbagging',
+      label: 'Bag penalty',
+      type: 'boolean',
+      default: true,
+      help: 'Overtricks are “bags”. Collect a threshold of them and they cost 100 points.',
+    },
+    { key: 'bagThreshold', label: 'Bags before the −100 hit', type: 'number', default: 10, min: 2, max: 20 },
+  ],
+
+  createRoundInput: (ctx: RoundContext): SpadesInput => ({
+    rows: Object.fromEntries(ctx.players.map((p) => [p.id, emptyRow()])),
+  }),
+
+  validateRound: (input: SpadesInput, ctx: RoundContext): string | null =>
+    validateHand(input, ctx.players, ctx.config),
+
+  scoreRound: (input: SpadesInput, ctx: RoundContext): Record<ID, number> =>
+    scoreLatest(priorInputs(ctx), input, ctx.players, ctx.config),
+
+  isFinished: (totals, { config }) => {
+    const target = readConfig(config).target;
+    if (target <= 0) return false;
+    return Object.values(totals).some((t) => t >= target);
+  },
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as SpadesInput;
+    return players
+      .map((p) => {
+        const r = input?.rows?.[p.id];
+        if (!r) return '';
+        const hit = (Number(r.tricks) || 0) === 0;
+        if (r.nil === 'blind') return `${p.name} 🙈${hit ? '✓' : '✗'}`;
+        if (r.nil === 'nil') return `${p.name} 🚫${hit ? '✓' : '✗'}`;
+        return `${p.name} ${r.bid}/${r.tricks}`;
+      })
+      .filter(Boolean)
+      .join(' · ');
+  },
+
+  help: [
+    'Everyone bids the tricks they’ll take; partners’ bids add up to one team contract.',
+    '',
+    'Make the contract: +10 per bid, +1 for each extra trick (a “bag”).',
+    'Miss it (get “set”): −10 per bid, and no bags that hand.',
+    '',
+    'Bags are sticky. Each 10 your team piles up costs a flat −100 (sandbagging),',
+    'so overtricks you didn’t need come back to bite. Turn it off in setup for a looser game.',
+    '',
+    'Nil: bid zero tricks. Take none → +100; take any → −100.',
+    'Blind Nil: call it before you look → ±200.',
+    '',
+    'Partnerships: the 1st + 2nd players you picked are Team 1, the 3rd + 4th are Team 2;',
+    'both partners share the team’s total. First to the target (500 by default) wins.',
+  ].join('\n'),
+
+  stats: spadesStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/spades/logic.ts
+++ b/src/lib/games/spades/logic.ts
@@ -1,0 +1,271 @@
+import type { ID } from '../../types';
+
+/**
+ * Spades scoring — pure, Svelte-free. Everything the module and its tests need to
+ * turn recorded bids + tricks into per-player point deltas lives here.
+ *
+ * A "unit" is whoever shares a score: a 2-player partnership, or a lone player in
+ * cutthroat. A unit's contract is the sum of its members' numeric bids (a nil bids
+ * for zero, so it adds nothing to the contract). Make the contract and you score
+ * 10 × contract plus 1 per overtrick ("bag"); miss it and you lose 10 × contract.
+ * Bags pile up across hands — every `bagThreshold` of them costs a flat 100 points.
+ * Nil is scored on its own: ±100, or ±200 blind.
+ */
+
+/** How a player declared this hand: an ordinary numbered bid, Nil, or Blind Nil. */
+export type NilKind = 'none' | 'nil' | 'blind';
+
+export interface SpadesRow {
+  /** Numbered bid. Ignored for the contract when {@link nil} isn't 'none'. */
+  bid: number;
+  /** Tricks actually taken this hand. */
+  tricks: number;
+  nil: NilKind;
+}
+
+export interface SpadesInput {
+  rows: Record<ID, SpadesRow>;
+}
+
+export type PlayStyle = 'partners' | 'solo';
+
+export interface SpadesConfig {
+  mode: PlayStyle;
+  target: number;
+  nil: boolean;
+  blindNil: boolean;
+  sandbagging: boolean;
+  bagThreshold: number;
+}
+
+export const DEFAULT_CONFIG: SpadesConfig = {
+  mode: 'partners',
+  target: 500,
+  nil: true,
+  blindNil: true,
+  sandbagging: true,
+  bagThreshold: 10,
+};
+
+/** Points gained/lost on a nil (index 0) and blind nil (index 1). */
+export const NIL_POINTS = 100;
+export const BLIND_NIL_POINTS = 200;
+/** Flat penalty each time a unit's bags cross the threshold. */
+export const BAG_PENALTY = 100;
+
+function numOr(v: unknown, fallback: number): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function readConfig(config: Record<string, unknown> = {}): SpadesConfig {
+  return {
+    mode: config.mode === 'solo' ? 'solo' : 'partners',
+    target: numOr(config.target, DEFAULT_CONFIG.target),
+    nil: config.nil !== false,
+    blindNil: config.blindNil !== false,
+    sandbagging: config.sandbagging !== false,
+    bagThreshold: Math.max(1, Math.round(numOr(config.bagThreshold, DEFAULT_CONFIG.bagThreshold))),
+  };
+}
+
+/** A fresh, unbid row. */
+export function emptyRow(): SpadesRow {
+  return { bid: 0, tricks: 0, nil: 'none' };
+}
+
+/**
+ * Tricks in a hand. Four (or the cutthroat default) players play the full 52-card
+ * deck for 13 tricks; the common three-hand deal removes the 2♣, dealing 17 each.
+ */
+export function tricksAvailable(playerCount: number): number {
+  return playerCount === 3 ? 17 : 13;
+}
+
+/**
+ * Effective play style. Partnerships need exactly four seats; with any other count
+ * we fall back to solo so a game is never wedged into an impossible shape.
+ */
+export function resolveMode(config: Record<string, unknown>, playerCount: number): PlayStyle {
+  return readConfig(config).mode === 'partners' && playerCount === 4 ? 'partners' : 'solo';
+}
+
+export interface Unit {
+  key: string;
+  /** 0-based order — Team 1 / Team 2, or a solo player's seat. */
+  index: number;
+  memberIds: ID[];
+}
+
+/**
+ * Group seats into scoring units. Partnerships pair the seats you picked
+ * adjacently: 1st + 2nd vs 3rd + 4th. Solo is one unit per seat.
+ */
+export function unitsFor(players: readonly { id: ID }[], mode: PlayStyle): Unit[] {
+  if (mode === 'partners' && players.length === 4) {
+    return [
+      { key: 'team-1', index: 0, memberIds: [players[0].id, players[1].id] },
+      { key: 'team-2', index: 1, memberIds: [players[2].id, players[3].id] },
+    ];
+  }
+  return players.map((p, i) => ({ key: p.id, index: i, memberIds: [p.id] }));
+}
+
+function nilResult(row: SpadesRow, cfg: SpadesConfig): number {
+  const took = numOr(row.tricks, 0);
+  if (row.nil === 'blind' && cfg.blindNil) return took === 0 ? BLIND_NIL_POINTS : -BLIND_NIL_POINTS;
+  if (row.nil === 'nil' || (row.nil === 'blind' && !cfg.blindNil)) {
+    return took === 0 ? NIL_POINTS : -NIL_POINTS;
+  }
+  return 0;
+}
+
+export interface UnitHandResult {
+  contract: number;
+  tricks: number;
+  made: boolean;
+  /** ±10 × contract. */
+  base: number;
+  /** Overtricks earned this hand (0 when set). */
+  bags: number;
+  /** Sum of members' nil / blind-nil results. */
+  nilPoints: number;
+  bagsBefore: number;
+  bagsAfter: number;
+  /** How many times the bag threshold was crossed this hand. */
+  penalties: number;
+  /** ≤ 0 — the sandbag penalty applied this hand. */
+  penaltyPoints: number;
+  /** Total hand delta for the unit (mirrored onto every member). */
+  score: number;
+}
+
+/**
+ * Score one unit's hand given its members' rows and the bags it carried in.
+ * Overtricks are worth +1 each *and* feed the running bag count; crossing the
+ * threshold spends 100 points and rolls the remainder forward.
+ */
+export function scoreUnitHand(
+  rows: readonly SpadesRow[],
+  config: SpadesConfig,
+  bagsBefore: number,
+): UnitHandResult {
+  let contract = 0;
+  let tricks = 0;
+  let nilPoints = 0;
+  for (const row of rows) {
+    tricks += numOr(row.tricks, 0);
+    if (row.nil === 'none') contract += Math.max(0, numOr(row.bid, 0));
+    nilPoints += nilResult(row, config);
+  }
+
+  const made = tricks >= contract;
+  const base = made ? 10 * contract : -10 * contract;
+  const bags = made ? tricks - contract : 0;
+
+  const running = bagsBefore + bags;
+  let penalties = 0;
+  let bagsAfter = running;
+  if (config.sandbagging && config.bagThreshold > 0) {
+    penalties = Math.floor(running / config.bagThreshold);
+    bagsAfter = running - penalties * config.bagThreshold;
+  }
+  const penaltyPoints = -BAG_PENALTY * penalties;
+  const score = base + bags + nilPoints + penaltyPoints;
+
+  return { contract, tricks, made, base, bags, nilPoints, bagsBefore, bagsAfter, penalties, penaltyPoints, score };
+}
+
+export interface RoundOutcome {
+  perUnit: Record<string, UnitHandResult>;
+  /** Per-player deltas — both partners receive the shared team score. */
+  deltas: Record<ID, number>;
+}
+
+/**
+ * Replay a whole game hand-by-hand, threading each unit's bag count through the
+ * sequence. Scoring the current hand means replaying every earlier hand first,
+ * because the sandbag penalty is a function of accumulated bags.
+ */
+export function scoreGame(
+  inputs: readonly SpadesInput[],
+  players: readonly { id: ID }[],
+  config: Record<string, unknown>,
+): RoundOutcome[] {
+  const cfg = readConfig(config);
+  const units = unitsFor(players, resolveMode(config, players.length));
+  const counters = new Map<string, number>(units.map((u) => [u.key, 0]));
+  const outcomes: RoundOutcome[] = [];
+
+  for (const input of inputs) {
+    const perUnit: Record<string, UnitHandResult> = {};
+    const deltas: Record<ID, number> = {};
+    for (const u of units) {
+      const rows = u.memberIds.map((id) => input?.rows?.[id] ?? emptyRow());
+      const res = scoreUnitHand(rows, cfg, counters.get(u.key) ?? 0);
+      counters.set(u.key, res.bagsAfter);
+      perUnit[u.key] = res;
+      for (const id of u.memberIds) deltas[id] = res.score;
+    }
+    outcomes.push({ perUnit, deltas });
+  }
+  return outcomes;
+}
+
+/** Per-player deltas for the last hand of `inputs` (the one being entered/edited). */
+export function scoreLatest(
+  priorInputs: readonly SpadesInput[],
+  current: SpadesInput,
+  players: readonly { id: ID }[],
+  config: Record<string, unknown>,
+): Record<ID, number> {
+  const outcomes = scoreGame([...priorInputs, current], players, config);
+  return outcomes[outcomes.length - 1]?.deltas ?? {};
+}
+
+/** Bags each unit carries *into* the next hand after playing `inputs`. */
+export function bagCountsAfter(
+  inputs: readonly SpadesInput[],
+  players: readonly { id: ID }[],
+  config: Record<string, unknown>,
+): Record<string, number> {
+  const cfg = readConfig(config);
+  const units = unitsFor(players, resolveMode(config, players.length));
+  const counters: Record<string, number> = {};
+  for (const u of units) counters[u.key] = 0;
+  for (const input of inputs) {
+    for (const u of units) {
+      const rows = u.memberIds.map((id) => input?.rows?.[id] ?? emptyRow());
+      counters[u.key] = scoreUnitHand(rows, cfg, counters[u.key]).bagsAfter;
+    }
+  }
+  return counters;
+}
+
+/** Validate one hand. Returns null when good, else a friendly message. */
+export function validateHand(
+  input: SpadesInput,
+  players: readonly { id: ID; name: string }[],
+  config: Record<string, unknown>,
+): string | null {
+  const cfg = readConfig(config);
+  const table = tricksAvailable(players.length);
+  let totalTricks = 0;
+
+  for (const p of players) {
+    const row = input?.rows?.[p.id] ?? emptyRow();
+    if (row.nil !== 'none' && !cfg.nil) return `Nil bids are turned off — clear ${p.name}'s nil.`;
+    if (row.nil === 'blind' && !cfg.blindNil) return `Blind nil is turned off — clear ${p.name}'s blind nil.`;
+    const bid = row.nil === 'none' ? numOr(row.bid, 0) : 0;
+    if (bid < 0 || bid > table) return `${p.name}: bid must be between 0 and ${table}.`;
+    const tricks = numOr(row.tricks, 0);
+    if (tricks < 0 || tricks > table) return `${p.name}: tricks must be between 0 and ${table}.`;
+    if (!Number.isInteger(tricks)) return `${p.name}: tricks must be a whole number.`;
+    totalTricks += tricks;
+  }
+
+  if (totalTricks !== table) {
+    return `Tricks must total ${table} (currently ${totalTricks}).`;
+  }
+  return null;
+}

--- a/src/lib/games/spades/spades.test.ts
+++ b/src/lib/games/spades/spades.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect } from 'vitest';
+import type { Player, Round, RoundContext } from '../../types';
+import { spades } from './index';
+import {
+  bagCountsAfter,
+  readConfig,
+  resolveMode,
+  scoreGame,
+  scoreLatest,
+  scoreUnitHand,
+  tricksAvailable,
+  unitsFor,
+  validateHand,
+  type NilKind,
+  type SpadesConfig,
+  type SpadesInput,
+} from './logic';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+function row(bid: number, tricks: number, nil: NilKind = 'none') {
+  return { bid, tricks, nil };
+}
+function hand(rows: Record<string, ReturnType<typeof row>>): SpadesInput {
+  return { rows };
+}
+function cfg(over: Partial<SpadesConfig> = {}): SpadesConfig {
+  return { ...readConfig({}), ...over };
+}
+function player(id: string): Player {
+  return { id, name: id.toUpperCase(), color: '#7c5cff', createdAt: 0 };
+}
+const P3 = ['a', 'b', 'c'].map(player);
+const P4 = ['a', 'b', 'c', 'd'].map(player);
+
+function totalsOf(outcomes: ReturnType<typeof scoreGame>): Record<string, number> {
+  const t: Record<string, number> = {};
+  for (const o of outcomes) for (const [id, d] of Object.entries(o.deltas)) t[id] = (t[id] ?? 0) + d;
+  return t;
+}
+
+// ── config ───────────────────────────────────────────────────────────────
+describe('readConfig', () => {
+  it('applies defaults', () => {
+    expect(readConfig({})).toEqual({
+      mode: 'partners',
+      target: 500,
+      nil: true,
+      blindNil: true,
+      sandbagging: true,
+      bagThreshold: 10,
+    });
+  });
+  it('coerces and clamps', () => {
+    expect(readConfig({ mode: 'solo', target: '250', nil: false, bagThreshold: 0 })).toMatchObject({
+      mode: 'solo',
+      target: 250,
+      nil: false,
+      bagThreshold: 1,
+    });
+  });
+  it('treats unknown mode as partners', () => {
+    expect(readConfig({ mode: 'nonsense' }).mode).toBe('partners');
+  });
+});
+
+describe('tricksAvailable', () => {
+  it('is 17 for three players, 13 otherwise', () => {
+    expect(tricksAvailable(3)).toBe(17);
+    expect(tricksAvailable(4)).toBe(13);
+    expect(tricksAvailable(5)).toBe(13);
+  });
+});
+
+describe('resolveMode', () => {
+  it('needs exactly four seats for partnerships', () => {
+    expect(resolveMode({ mode: 'partners' }, 4)).toBe('partners');
+    expect(resolveMode({ mode: 'partners' }, 3)).toBe('solo');
+    expect(resolveMode({ mode: 'solo' }, 4)).toBe('solo');
+  });
+});
+
+describe('unitsFor', () => {
+  it('pairs adjacent seats into two teams', () => {
+    const u = unitsFor(P4, 'partners');
+    expect(u).toEqual([
+      { key: 'team-1', index: 0, memberIds: ['a', 'b'] },
+      { key: 'team-2', index: 1, memberIds: ['c', 'd'] },
+    ]);
+  });
+  it('makes one unit per player when solo', () => {
+    const u = unitsFor(P3, 'solo');
+    expect(u.map((x) => x.memberIds)).toEqual([['a'], ['b'], ['c']]);
+  });
+});
+
+// ── single-hand scoring ─────────────────────────────────────────────────────
+describe('scoreUnitHand', () => {
+  it('scores an exact make: 10 x contract, no bags', () => {
+    const r = scoreUnitHand([row(7, 7)], cfg(), 0);
+    expect(r).toMatchObject({ contract: 7, tricks: 7, made: true, base: 70, bags: 0, score: 70 });
+  });
+  it('adds +1 per overtrick (bag)', () => {
+    const r = scoreUnitHand([row(7, 9)], cfg(), 0);
+    expect(r).toMatchObject({ base: 70, bags: 2, score: 72, bagsAfter: 2 });
+  });
+  it('scores a set: −10 x contract, no bags', () => {
+    const r = scoreUnitHand([row(7, 6)], cfg(), 0);
+    expect(r).toMatchObject({ made: false, base: -70, bags: 0, score: -70, bagsAfter: 0 });
+  });
+  it('scores a successful nil at +100 with a zero contract', () => {
+    const r = scoreUnitHand([row(0, 0, 'nil')], cfg(), 0);
+    expect(r).toMatchObject({ contract: 0, base: 0, nilPoints: 100, score: 100 });
+  });
+  it('scores a broken nil at −100 and turns its tricks into bags', () => {
+    const r = scoreUnitHand([row(0, 2, 'nil')], cfg(), 0);
+    expect(r).toMatchObject({ contract: 0, tricks: 2, made: true, bags: 2, nilPoints: -100, score: -98 });
+  });
+  it('scores blind nil at ±200', () => {
+    expect(scoreUnitHand([row(0, 0, 'blind')], cfg(), 0).score).toBe(200);
+    expect(scoreUnitHand([row(0, 3, 'blind')], cfg(), 0).nilPoints).toBe(-200);
+  });
+  it('downgrades blind to a normal nil when blind is disabled', () => {
+    const r = scoreUnitHand([row(0, 0, 'blind')], cfg({ blindNil: false }), 0);
+    expect(r.nilPoints).toBe(100);
+  });
+  it('combines a partner nil with the other partner’s contract', () => {
+    const made = scoreUnitHand([row(0, 0, 'nil'), row(4, 5)], cfg(), 0);
+    expect(made).toMatchObject({ contract: 4, tricks: 5, made: true, base: 40, bags: 1, nilPoints: 100, score: 141 });
+  });
+  it('lets a broken nil’s tricks still count toward the team contract', () => {
+    const r = scoreUnitHand([row(0, 2, 'nil'), row(4, 4)], cfg(), 0);
+    // contract 4, team tricks 6 -> made, 2 bags, nil broken -100 => 40 + 2 - 100
+    expect(r).toMatchObject({ contract: 4, tricks: 6, made: true, bags: 2, score: -58 });
+  });
+});
+
+// ── bag accumulation across hands ───────────────────────────────────────────
+describe('bag penalty accumulation', () => {
+  const seat = [player('a')];
+  const four = [hand({ a: row(3, 6) }), hand({ a: row(3, 6) }), hand({ a: row(3, 6) }), hand({ a: row(3, 6) })];
+
+  it('charges −100 when bags cross the threshold and rolls the remainder over', () => {
+    const out = scoreGame(four, seat, { mode: 'solo' });
+    expect(out.map((o) => o.deltas.a)).toEqual([33, 33, 33, -67]);
+    expect(out[3].perUnit.a.bagsAfter).toBe(2); // 12 bags -> penalty, 2 remain
+    expect(totalsOf(out).a).toBe(32);
+  });
+
+  it('never penalises when sandbagging is off, but keeps piling bags', () => {
+    const out = scoreGame(four, seat, { mode: 'solo', sandbagging: false });
+    expect(out.map((o) => o.deltas.a)).toEqual([33, 33, 33, 33]);
+    expect(out[3].perUnit.a.bagsAfter).toBe(12);
+  });
+
+  it('honours a custom bag threshold', () => {
+    const out = scoreGame(four, seat, { mode: 'solo', bagThreshold: 5 });
+    // h1: 3 bags (after 3); h2: 6 -> penalty, 1 left, score 30+3-100; h3: 4; h4: 7 -> penalty, 2 left
+    expect(out.map((o) => o.deltas.a)).toEqual([33, -67, 33, -67]);
+  });
+
+  it('can charge multiple penalties in one brutal hand', () => {
+    const out = scoreGame([hand({ a: row(1, 13) })], seat, { mode: 'solo', bagThreshold: 5 });
+    // 12 bags -> floor(12/5) = 2 penalties
+    expect(out[0].perUnit.a).toMatchObject({ bags: 12, penalties: 2, penaltyPoints: -200, bagsAfter: 2 });
+    expect(out[0].deltas.a).toBe(10 + 12 - 200);
+  });
+});
+
+// ── full games: solo + partners ─────────────────────────────────────────────
+describe('scoreGame', () => {
+  it('scores a cutthroat hand per the classic example', () => {
+    const out = scoreGame(
+      [hand({ a: row(4, 5), b: row(0, 0, 'nil'), c: row(6, 6), d: row(3, 2) })],
+      P4,
+      { mode: 'solo' },
+    );
+    expect(out[0].deltas).toEqual({ a: 41, b: 100, c: 60, d: -30 });
+  });
+
+  it('mirrors a team’s hand score onto both partners', () => {
+    const out = scoreGame(
+      [hand({ a: row(4, 5), b: row(3, 3), c: row(2, 2), d: row(3, 3) })],
+      P4,
+      { mode: 'partners' },
+    );
+    // team1: contract 7, tricks 8 -> 71 ; team2: contract 5, tricks 5 -> 50
+    expect(out[0].deltas).toEqual({ a: 71, b: 71, c: 50, d: 50 });
+  });
+
+  it('keeps partners’ running totals identical', () => {
+    const h = hand({ a: row(4, 5), b: row(3, 3), c: row(2, 2), d: row(3, 3) });
+    const totals = totalsOf(scoreGame([h, h], P4, { mode: 'partners' }));
+    // team1 (a,b) 71/hand, team2 (c,d) 50/hand — partners share, opponents differ.
+    expect(totals).toEqual({ a: 142, b: 142, c: 100, d: 100 });
+  });
+
+  it('threads bags per team, independently', () => {
+    const h = hand({ a: row(1, 4), b: row(1, 1), c: row(6, 6), d: row(2, 2) });
+    // team1 contract 2, tricks 5 -> 3 bags/hand ; team2 contract 8 tricks 8 -> 0 bags
+    const out = scoreGame([h, h, h, h], P4, { mode: 'partners' });
+    expect(out[3].perUnit['team-1'].bagsAfter).toBe(2); // 12 -> penalty, 2 left
+    expect(out[3].perUnit['team-2'].bagsAfter).toBe(0);
+    expect(out[3].deltas.a).toBe(20 + 3 - 100);
+    expect(out[3].deltas.c).toBe(80);
+  });
+});
+
+describe('scoreLatest', () => {
+  it('returns the deltas for the hand being entered', () => {
+    const prior = [hand({ a: row(3, 6) }), hand({ a: row(3, 6) }), hand({ a: row(3, 6) })];
+    const deltas = scoreLatest(prior, hand({ a: row(3, 6) }), [player('a')], { mode: 'solo' });
+    expect(deltas.a).toBe(-67); // 4th hand crosses 10 bags
+  });
+});
+
+describe('bagCountsAfter', () => {
+  it('reports the bags each unit carries forward', () => {
+    const prior = [hand({ a: row(3, 6) }), hand({ a: row(3, 6) })];
+    expect(bagCountsAfter(prior, [player('a')], { mode: 'solo' })).toEqual({ a: 6 });
+  });
+});
+
+// ── validation ──────────────────────────────────────────────────────────────
+describe('validateHand', () => {
+  it('accepts a hand whose tricks total the table size', () => {
+    const h = hand({ a: row(4, 5), b: row(3, 3), c: row(2, 2), d: row(3, 3) });
+    expect(validateHand(h, P4, {})).toBeNull();
+  });
+  it('rejects tricks that do not add up', () => {
+    const h = hand({ a: row(4, 5), b: row(3, 3), c: row(2, 2), d: row(3, 2) });
+    expect(validateHand(h, P4, {})).toMatch(/Tricks must total 13/);
+  });
+  it('uses 17 tricks for three players', () => {
+    const good = hand({ a: row(6, 6), b: row(5, 6), c: row(5, 5) });
+    expect(validateHand(good, P3, {})).toBeNull();
+    const bad = hand({ a: row(6, 6), b: row(5, 5), c: row(5, 5) });
+    expect(validateHand(bad, P3, {})).toMatch(/17/);
+  });
+  it('rejects bids beyond the table size', () => {
+    const h = hand({ a: row(14, 5), b: row(3, 3), c: row(2, 2), d: row(3, 3) });
+    expect(validateHand(h, P4, {})).toMatch(/bid must be between 0 and 13/);
+  });
+  it('blocks nil when nil is disabled', () => {
+    const h = hand({ a: row(0, 0, 'nil'), b: row(3, 3), c: row(2, 2), d: row(5, 5) });
+    expect(validateHand(h, P4, { nil: false })).toMatch(/Nil bids are turned off/);
+  });
+  it('blocks blind nil when blind is disabled', () => {
+    const h = hand({ a: row(0, 0, 'blind'), b: row(3, 3), c: row(2, 2), d: row(5, 5) });
+    expect(validateHand(h, P4, { blindNil: false })).toMatch(/Blind nil is turned off/);
+  });
+});
+
+// ── module wiring ───────────────────────────────────────────────────────────
+function ctxFor(players: Player[], config: Record<string, unknown>, roundIndex: number, rounds: Round[]): RoundContext {
+  return { game: { id: 'g' } as never, players, config, roundIndex, totals: {}, rounds };
+}
+function asRound(index: number, input: SpadesInput): Round {
+  return { id: `r${index}`, gameId: 'g', index, input, deltas: {}, createdAt: 0 };
+}
+
+describe('spades module', () => {
+  it('has the expected identity and player bounds', () => {
+    expect(spades.id).toBe('spades');
+    expect(spades.teams).toBe(true);
+    expect(spades.minPlayers).toBe(3);
+    expect(spades.maxPlayers).toBe(4);
+    expect(spades.configFields?.map((f) => f.key)).toEqual([
+      'mode',
+      'target',
+      'nil',
+      'blindNil',
+      'sandbagging',
+      'bagThreshold',
+    ]);
+  });
+
+  it('creates a blank row for every player', () => {
+    const input = spades.createRoundInput(ctxFor(P4, {}, 0, [])) as SpadesInput;
+    expect(Object.keys(input.rows)).toEqual(['a', 'b', 'c', 'd']);
+    expect(input.rows.a).toEqual({ bid: 0, tricks: 0, nil: 'none' });
+  });
+
+  it('scoreRound accumulates bags from prior rounds only', () => {
+    const prior = [asRound(0, hand({ a: row(3, 6) })), asRound(1, hand({ a: row(3, 6) })), asRound(2, hand({ a: row(3, 6) }))];
+    const deltas = spades.scoreRound(hand({ a: row(3, 6) }), ctxFor([player('a')], { mode: 'solo' }, 3, prior));
+    expect(deltas.a).toBe(-67);
+  });
+
+  it('scoreRound ignores rounds at/after the edited index', () => {
+    // Editing round 1: ctx.rounds contains later rounds, which must not leak into the replay.
+    const rounds = [asRound(0, hand({ a: row(3, 6) })), asRound(1, hand({ a: row(3, 6) })), asRound(2, hand({ a: row(3, 6) }))];
+    const deltas = spades.scoreRound(hand({ a: row(3, 6) }), ctxFor([player('a')], { mode: 'solo' }, 1, rounds));
+    expect(deltas.a).toBe(33); // only round 0 (3 bags) precedes it — no penalty yet
+  });
+
+  it('isFinished when a total reaches the target', () => {
+    expect(spades.isFinished!({ a: 480, b: 480 }, { config: {}, roundCount: 9, playerCount: 4 })).toBe(false);
+    expect(spades.isFinished!({ a: 510, b: 510 }, { config: {}, roundCount: 10, playerCount: 4 })).toBe(true);
+  });
+
+  it('describeRound summarises bids, tricks and nils', () => {
+    const r = asRound(0, hand({ a: row(4, 5), b: row(0, 0, 'nil'), c: row(3, 3), d: row(0, 2, 'blind') }));
+    expect(spades.describeRound!(r, P4)).toBe('A 4/5 · B 🚫✓ · C 3/3 · D 🙈✗');
+  });
+
+  it('never fixes a round count (open-ended)', () => {
+    expect(spades.maxRounds).toBeUndefined();
+  });
+});

--- a/src/lib/games/spades/stats.ts
+++ b/src/lib/games/spades/stats.ts
@@ -1,0 +1,110 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt, fmtPct } from '../../stats/format';
+import { resolveMode, scoreGame, unitsFor, type SpadesInput } from './logic';
+
+interface SpadesAgg {
+  /** Unit-hands this member took part in. */
+  hands: number;
+  contractsMade: number;
+  /** Bags their unit accrued (shared with a partner). */
+  bags: number;
+  nilTries: number;
+  nilMade: number;
+  blindTries: number;
+  blindMade: number;
+}
+
+/**
+ * Spades stats, replayed purely from each game's recorded bids + tricks. Contract
+ * accuracy and bags are team outcomes shared by both partners; nils are personal.
+ * No Svelte, no I/O — independently unit-testable and safe for the stats engine.
+ */
+export function spadesStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const per = new Map<ID, SpadesAgg>();
+  const get = (id: ID): SpadesAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { hands: 0, contractsMade: 0, bags: 0, nilTries: 0, nilMade: 0, blindTries: 0, blindMade: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let unitHands = 0;
+  let unitMade = 0;
+  let totalBags = 0;
+
+  for (const g of games) {
+    const seats = g.playerIds.map((id) => ({ id }));
+    const inputs = rounds
+      .filter((r) => r.gameId === g.id)
+      .sort((a, b) => a.index - b.index)
+      .map((r) => r.input as SpadesInput);
+    if (!inputs.length) continue;
+
+    const units = unitsFor(seats, resolveMode(g.config, seats.length));
+    const outcomes = scoreGame(inputs, seats, g.config);
+
+    for (const outcome of outcomes) {
+      for (const u of units) {
+        const res = outcome.perUnit[u.key];
+        if (!res) continue;
+        unitHands += 1;
+        if (res.made) unitMade += 1;
+        totalBags += res.bags;
+        for (const mid of u.memberIds) {
+          const a = get(canonical(mid));
+          a.hands += 1;
+          if (res.made) a.contractsMade += 1;
+          a.bags += res.bags;
+        }
+      }
+    }
+
+    for (const input of inputs) {
+      for (const [pid, row] of Object.entries(input?.rows ?? {})) {
+        const a = get(canonical(pid));
+        const took = (Number(row.tricks) || 0) === 0;
+        if (row.nil === 'nil') {
+          a.nilTries += 1;
+          if (took) a.nilMade += 1;
+        } else if (row.nil === 'blind') {
+          a.blindTries += 1;
+          if (took) a.blindMade += 1;
+        }
+      }
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let totNilTries = 0;
+  let totNilMade = 0;
+  for (const [id, a] of per) {
+    totNilTries += a.nilTries + a.blindTries;
+    totNilMade += a.nilMade + a.blindMade;
+    const metrics: Metric[] = [];
+    if (a.hands) {
+      metrics.push({ key: 'sp_acc', label: 'Contracts made', value: fmtPct(a.contractsMade / a.hands), emoji: '🎯' });
+    }
+    if (a.nilTries) {
+      metrics.push({ key: 'sp_nil', label: 'Nils nailed', value: `${a.nilMade}/${a.nilTries}`, emoji: '🚫' });
+    }
+    if (a.blindTries) {
+      metrics.push({ key: 'sp_blind', label: 'Blind nils', value: `${a.blindMade}/${a.blindTries}`, emoji: '🙈' });
+    }
+    if (a.bags) {
+      metrics.push({ key: 'sp_bags', label: 'Bags collected', value: fmtInt(a.bags), emoji: '🛍️' });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (unitHands) {
+    global.push({ key: 'sp_acc_all', label: 'Contracts made', value: fmtPct(unitMade / unitHands), emoji: '🎯' });
+  }
+  if (totalBags) global.push({ key: 'sp_bags_all', label: 'Bags collected', value: fmtInt(totalBags), emoji: '🛍️' });
+  if (totNilTries) global.push({ key: 'sp_nil_all', label: 'Nils nailed', value: `${totNilMade}/${totNilTries}`, emoji: '🚫' });
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
﻿## Spades

Adds **Spades** — the partnership trick-taking classic — as a first-class Score King game. Purely additive: everything lives in `src/lib/games/spades/`, so the registry auto-discovers it and no shared files change.

### How it plays
Everyone **bids** the tricks they will take. In partnerships, the two partners' bids combine into one team contract. Take at least what you bid and you are paid; fall short and you are "set".

### Scoring model (pure, in `logic.ts`)
- **Unit** = a 2-player partnership, or a lone player in cutthroat.
- **Made** the contract (unit tricks >= summed bids): **+10 x bid**, **+1** per overtrick (a "bag").
- **Set** (unit tricks < contract): **-10 x bid**, no bags that hand.
- **Bags are sticky** — they accumulate per unit, and every threshold's worth (default **10**) costs a flat **-100**, rolling the remainder forward. This is the sandbagging penalty; it can be turned off.
- **Nil** (bid 0): **+100** if you take no tricks, **-100** if you take any.
- **Blind Nil** (called before looking): **+/-200**. Scored per player.
- **Partnerships** mirror the team's hand score onto both partners, so each partner's running total equals the team total — both co-lead and co-win with no shell changes.
- **13 tricks** per hand (**17** for the common 3-player deal with the 2 of clubs removed).
- **Open-ended**: first to the **target** (500 by default) wins; the highest total breaks a tie.

### Configuration
| Option | Default | Notes |
| --- | --- | --- |
| Play style | Partnerships | Partnerships need exactly 4 players; otherwise everyone scores solo (cutthroat) |
| Winning score | 500 | First to reach it wins |
| Allow Nil (+/-100) | on | |
| Allow Blind Nil (+/-200) | on | |
| Bag penalty | on | The sandbagging -100 hit |
| Bags before the -100 | 10 | Configurable threshold |

Partnerships pair the seats you picked adjacently — **1st + 2nd = Team 1, 3rd + 4th = Team 2** — which reads naturally for a scorekeeper and is spelled out in the editor and help.

### Design choices (per DESIGN.md)
- **One primary action per screen**: the editor adds *no* Royal Violet CTA — the shell's "Save round" stays the single primary action. Nil / Blind chips use violet **selection** state only.
- **Crown Gold is untouched** — reserved for leader/winner, never buttons or decoration.
- Depth comes from the **surface ramp** (`--surface` -> `-2` -> `-3`), not stacked shadows.
- Every changing number (projected score, bag count, trick guide) renders with **`tabular-nums`**.
- Toggles and steppers are **>=46px**; state is never signalled by color alone (check/cross, +/-, and labels back every color cue).

### Personality
Live per-team projected score, a bag counter with the looming -100, a trick-total guide, on-track / broken nil hints, and a stats hook tracking contracts made, nils nailed, blind nils, and bags collected.

### Verification
- `npm run check` -> **0 errors, 0 warnings**
- `npm test` -> **114 passed** (39 new Spades tests covering scoring, bags accumulation/rollover, nil/blind, partnerships, validation, and module wiring)
- `npm run build` -> **succeeds**

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
