### PR TITLE
Add Salad Bowl (Fishbowl) team word game 🥗

### DIFF
--- a/src/lib/games/saladbowl/SaladBowlEditor.svelte
+++ b/src/lib/games/saladbowl/SaladBowlEditor.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import {
+    bowlTotal,
+    makeTeams,
+    pointsPerWord,
+    roundCount,
+    teamCount,
+    themeFor,
+    turnSeconds,
+    wordsFor,
+    type SaladBowlInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: SaladBowlInput; ctx: RoundContext } = $props();
+
+  const teams = $derived(makeTeams(ctx.players.map((p) => p.id), teamCount(ctx.config)));
+  const playerById = $derived(new Map(ctx.players.map((p) => [p.id, p])));
+  const perWord = $derived(pointsPerWord(ctx.config));
+  const rounds = $derived(roundCount(ctx.config));
+  const theme = $derived(themeFor(ctx.roundIndex));
+  const next = $derived(ctx.roundIndex + 1 < rounds ? themeFor(ctx.roundIndex + 1) : null);
+  const turn = $derived(turnSeconds(ctx.config));
+  const bowl = $derived(bowlTotal(input, teams));
+
+  // Keep the draft's per-team array in step with the team count (defensive: on a
+  // fresh round `createRoundInput` already sizes it; this covers edited/legacy rounds).
+  $effect(() => {
+    const need = teams.length;
+    if (!Array.isArray(input.guessed)) {
+      input.guessed = Array.from({ length: need }, () => 0);
+    } else if (input.guessed.length < need) {
+      input.guessed = [
+        ...input.guessed,
+        ...Array.from({ length: need - input.guessed.length }, () => 0),
+      ];
+    }
+  });
+</script>
+
+<div class="stack">
+  <div class="theme">
+    <span class="temoji" aria-hidden="true">{theme.emoji}</span>
+    <div class="tmeta">
+      <div class="row spread">
+        <strong>Round {ctx.roundIndex + 1} · {theme.name}</strong>
+        {#if next}
+          <span class="pill">next {next.emoji} {next.name}</span>
+        {:else}
+          <span class="pill">last round</span>
+        {/if}
+      </div>
+      <div class="muted rule">{theme.rule}</div>
+    </div>
+  </div>
+
+  <div class="row spread meta">
+    <span class="muted">⏱️ {turn}s per turn</span>
+    <span class="pill bowl">🥗 {bowl} {bowl === 1 ? 'word' : 'words'} this round</span>
+  </div>
+
+  {#each teams as t (t.index)}
+    <div class="team">
+      <div class="row spread thead">
+        <span class="row" style="gap: 8px">
+          <span class="badge" aria-hidden="true">{t.emoji}</span>
+          <strong>{t.name}</strong>
+        </span>
+        <span class="pts">+{wordsFor(input, t.index) * perWord}<span class="unit">pts</span></span>
+      </div>
+
+      {#if t.playerIds.length}
+        <div class="members">
+          {#each t.playerIds as pid (pid)}
+            {@const p = playerById.get(pid)}
+            {#if p}
+              <span class="mem"><Avatar name={p.name} color={p.color} size={22} />{p.name}</span>
+            {/if}
+          {/each}
+        </div>
+      {/if}
+
+      <div class="row spread entry">
+        <span class="muted">Words guessed</span>
+        <Stepper bind:value={input.guessed[t.index]} min={0} />
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .theme {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px 14px;
+  }
+  .temoji {
+    font-size: 1.7rem;
+    line-height: 1;
+  }
+  .tmeta {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .rule {
+    font-size: 0.85rem;
+    line-height: 1.4;
+  }
+  .meta {
+    padding: 0 2px;
+  }
+  .bowl {
+    font-variant-numeric: tabular-nums;
+  }
+  .team {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
+    background: var(--surface-3);
+    font-size: 1.1rem;
+  }
+  .pts {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+  }
+  .pts .unit {
+    margin-left: 3px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--muted);
+  }
+  .members {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 10px;
+  }
+  .mem {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.88rem;
+    color: var(--muted);
+  }
+  .entry {
+    padding-top: 2px;
+  }
+</style>

--- a/src/lib/games/saladbowl/index.ts
+++ b/src/lib/games/saladbowl/index.ts
@@ -1,0 +1,118 @@
+import type { GameModule, Round, RoundContext } from '../../types';
+import Editor from './SaladBowlEditor.svelte';
+import { saladbowlStats } from './stats';
+import {
+  createInput,
+  describe,
+  makeTeams,
+  pointsPerWord,
+  roundCount,
+  score,
+  teamCount,
+  validate,
+  type SaladBowlInput,
+} from './logic';
+
+export type { SaladBowlInput };
+
+/** Build this game's teams from the round context (players + config). */
+function teamsFor(ctx: RoundContext) {
+  return makeTeams(
+    ctx.players.map((p) => p.id),
+    teamCount(ctx.config),
+  );
+}
+
+export const saladbowl: GameModule = {
+  id: 'saladbowl',
+  name: 'Salad Bowl',
+  tagline: 'One bowl of words, three ways to guess it 🥗',
+  emoji: '🥗',
+  keywords: [
+    'fishbowl',
+    'salad bowl',
+    'party',
+    'word game',
+    'charades',
+    'taboo',
+    'celebrity',
+    'teams',
+    'guessing',
+  ],
+  // A word game wants a clue-giver and guessers per team, so 2 teams of 2 is the floor.
+  minPlayers: 4,
+  maxPlayers: 12,
+  teams: true,
+  configFields: [
+    {
+      key: 'teams',
+      label: 'Number of teams',
+      type: 'select',
+      default: '2',
+      options: [
+        { value: '2', label: '2 teams' },
+        { value: '3', label: '3 teams' },
+        { value: '4', label: '4 teams' },
+      ],
+      help: 'Players split into teams by the order you pick them — first team first.',
+    },
+    {
+      key: 'rounds',
+      label: 'Number of rounds',
+      type: 'number',
+      default: 3,
+      min: 2,
+      max: 4,
+      help: 'Classic Salad Bowl is 3: Describe, One Word, Charades. Add a 4th for Sculptor.',
+    },
+    {
+      key: 'pointsPerWord',
+      label: 'Points per word guessed',
+      type: 'number',
+      default: 1,
+      min: 1,
+      max: 10,
+    },
+    {
+      key: 'turnSeconds',
+      label: 'Turn timer (seconds — a reminder, not enforced)',
+      type: 'number',
+      default: 60,
+      min: 15,
+      max: 300,
+      step: 15,
+    },
+  ],
+  // Highest total wins (shell default). Teammates share a total, so the whole team wins.
+
+  maxRounds: (config) => roundCount(config),
+
+  createRoundInput: (ctx: RoundContext): SaladBowlInput => createInput(teamsFor(ctx).length),
+
+  validateRound: (input: SaladBowlInput, ctx: RoundContext): string | null =>
+    validate(input, teamsFor(ctx)),
+
+  scoreRound: (input: SaladBowlInput, ctx: RoundContext) =>
+    score(input, teamsFor(ctx), pointsPerWord(ctx.config)),
+
+  describeRound: (round: Round): string => describe(round),
+
+  help: [
+    'Everyone secretly writes a handful of words/names and drops them in the bowl.',
+    'Teams take turns: on the clock, guess as many bowl words as you can — a team',
+    'scores 1 point per word guessed (adjust "points per word" in setup).',
+    '',
+    'The SAME words are played across each round, only the clue rule gets harder:',
+    '• Round 1 — 🗣️ Describe: say anything but the word itself.',
+    '• Round 2 — ☝️ One Word: exactly one word as your clue.',
+    '• Round 3 — 🎭 Charades: no talking, act it out.',
+    '• Round 4 — 🗿 Sculptor (optional): mould a teammate into the word.',
+    '',
+    'Enter each team’s words-guessed for the round. Points add up across all rounds;',
+    'the team with the highest total wins. 🏆',
+  ].join('\n'),
+
+  stats: saladbowlStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/saladbowl/logic.ts
+++ b/src/lib/games/saladbowl/logic.ts
@@ -1,0 +1,187 @@
+import type { ID } from '../../types';
+
+/**
+ * Salad Bowl (a.k.a. Fishbowl) — pure scoring, team-building, validation and copy.
+ *
+ * NO Svelte imports live here so the real game logic stays independently
+ * unit-testable (see `saladbowl.test.ts`) and safe for the stats engine to reach.
+ *
+ * The bowl is a TEAM game, but the app shell scores strictly per-player
+ * (`Record<ID, number>`) and crowns whoever holds the best total. So a team is
+ * modelled as a *shared-score group*: every member of a team receives that team's
+ * points for the round, which makes each teammate's cumulative total equal the
+ * team's total. The shell's default winner logic then lights up the whole winning
+ * team — no shared/engine change required.
+ */
+
+/** One recorded round: how many words each team guessed, indexed by team. */
+export interface SaladBowlInput {
+  /** Words guessed by each team this round; `guessed[teamIndex]`. */
+  guessed: number[];
+}
+
+/** A team is a stable, ordered group of the game's players. */
+export interface Team {
+  index: number; // 0-based
+  name: string; // "Team 1"
+  emoji: string; // veggie badge, so teams read without relying on colour
+  playerIds: ID[];
+}
+
+/** Veggie badges — one per team, on-theme and colour-independent. */
+export const TEAM_EMOJI = ['🥬', '🍅', '🥕', '🌽'] as const;
+
+/** The escalating constraints, one per round. The first `rounds` are used. */
+export interface RoundTheme {
+  emoji: string;
+  name: string;
+  /** One-line "what you may do" rule for the round. */
+  rule: string;
+}
+
+export const ROUND_THEMES: RoundTheme[] = [
+  {
+    emoji: '🗣️',
+    name: 'Describe',
+    rule: 'Say anything to get it guessed — just never the word itself (Taboo-style).',
+  },
+  {
+    emoji: '☝️',
+    name: 'One Word',
+    rule: 'Give exactly ONE word as your clue. Just one. Then move on.',
+  },
+  {
+    emoji: '🎭',
+    name: 'Charades',
+    rule: 'No talking — act it out. Same words, now mimed.',
+  },
+  {
+    emoji: '🗿',
+    name: 'Sculptor',
+    rule: 'No talking — mould a teammate like clay into the word.',
+  },
+];
+
+const MIN_TEAMS = 2;
+const MAX_TEAMS = 4;
+const MIN_ROUNDS = 1;
+const MAX_ROUNDS = ROUND_THEMES.length; // 4
+
+function clampInt(value: unknown, min: number, max: number, fallback: number): number {
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, n));
+}
+
+/** Configured number of teams (2–4), defaulting to 2. */
+export function teamCount(config: Record<string, unknown>): number {
+  return clampInt(config?.teams, MIN_TEAMS, MAX_TEAMS, MIN_TEAMS);
+}
+
+/** Configured number of rounds (1–4), defaulting to the classic 3. */
+export function roundCount(config: Record<string, unknown>): number {
+  return clampInt(config?.rounds, MIN_ROUNDS, MAX_ROUNDS, 3);
+}
+
+/** Points awarded per word guessed (>=1), defaulting to 1. */
+export function pointsPerWord(config: Record<string, unknown>): number {
+  return clampInt(config?.pointsPerWord, 1, 1000, 1);
+}
+
+/** Turn timer length in seconds — informational only, never enforced. */
+export function turnSeconds(config: Record<string, unknown>): number {
+  return clampInt(config?.turnSeconds, 5, 3600, 60);
+}
+
+/** The escalating constraint for a given 0-based round index. */
+export function themeFor(roundIndex: number): RoundTheme {
+  const i = Math.min(Math.max(0, Math.floor(roundIndex) || 0), ROUND_THEMES.length - 1);
+  return ROUND_THEMES[i];
+}
+
+/**
+ * Partition players into `count` teams by CONTIGUOUS selection order, as evenly as
+ * possible (earlier teams absorb the remainder). Selecting players in team order
+ * ("my team, then yours") therefore builds exactly the teams you'd expect. The team
+ * count is capped at the player count so a team is never empty.
+ */
+export function makeTeams(playerIds: ID[], count: number): Team[] {
+  const n = playerIds.length;
+  if (n === 0) return [];
+  const t = Math.max(1, Math.min(Math.floor(count) || 1, n));
+  const base = Math.floor(n / t);
+  const extra = n % t; // first `extra` teams get one more
+  const teams: Team[] = [];
+  let cursor = 0;
+  for (let i = 0; i < t; i++) {
+    const size = base + (i < extra ? 1 : 0);
+    teams.push({
+      index: i,
+      name: `Team ${i + 1}`,
+      emoji: TEAM_EMOJI[i] ?? '🥗',
+      playerIds: playerIds.slice(cursor, cursor + size),
+    });
+    cursor += size;
+  }
+  return teams;
+}
+
+/** A fresh round draft: zero words guessed for each of `teamsLength` teams. */
+export function createInput(teamsLength: number): SaladBowlInput {
+  return { guessed: Array.from({ length: Math.max(0, teamsLength) }, () => 0) };
+}
+
+/** Words a team guessed this round, coerced to a non-negative integer. */
+export function wordsFor(input: SaladBowlInput, teamIndex: number): number {
+  const raw = input?.guessed?.[teamIndex];
+  return Math.max(0, Math.floor(Number(raw) || 0));
+}
+
+/** Total words pulled from the bowl this round, across every team. */
+export function bowlTotal(input: SaladBowlInput, teams: Team[]): number {
+  return teams.reduce((sum, t) => sum + wordsFor(input, t.index), 0);
+}
+
+/** null when the round is valid, otherwise a human-readable reason. */
+export function validate(input: SaladBowlInput, teams: Team[]): string | null {
+  if (teams.length < 2) {
+    return 'Salad Bowl needs at least 2 teams — add more players.';
+  }
+  for (const t of teams) {
+    const raw = input?.guessed?.[t.index];
+    const n = Number(raw);
+    if (raw != null && (!Number.isFinite(n) || n < 0 || !Number.isInteger(n))) {
+      return `${t.emoji} ${t.name}: enter whole words guessed (0 or more).`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Per-player deltas for the round: every member of a team receives that team's
+ * `words × pointsPerWord`, so teammates always share an identical running total.
+ */
+export function score(
+  input: SaladBowlInput,
+  teams: Team[],
+  perWord: number,
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const t of teams) {
+    const pts = wordsFor(input, t.index) * perWord;
+    for (const pid of t.playerIds) out[pid] = pts;
+  }
+  return out;
+}
+
+/** Short history summary, e.g. "🗣️ Describe — 🥬 5 · 🍅 3". */
+export function describe(round: { index: number; input: unknown }): string {
+  const input = round.input as SaladBowlInput | undefined;
+  const theme = themeFor(round.index);
+  const guessed = Array.isArray(input?.guessed) ? input!.guessed : [];
+  if (guessed.length === 0) return `${theme.emoji} ${theme.name}`;
+  const parts = guessed.map(
+    (g, i) => `${TEAM_EMOJI[i] ?? '🥗'} ${Math.max(0, Math.floor(Number(g) || 0))}`,
+  );
+  return `${theme.emoji} ${theme.name} — ${parts.join(' · ')}`;
+}

--- a/src/lib/games/saladbowl/saladbowl.test.ts
+++ b/src/lib/games/saladbowl/saladbowl.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+import { defaultWinners, type GameModule, type ID } from '../../types';
+import {
+  ROUND_THEMES,
+  TEAM_EMOJI,
+  bowlTotal,
+  createInput,
+  describe as describeRound,
+  makeTeams,
+  pointsPerWord,
+  roundCount,
+  score,
+  teamCount,
+  themeFor,
+  turnSeconds,
+  validate,
+  wordsFor,
+  type SaladBowlInput,
+} from './logic';
+
+/** Sum an array of per-player delta maps into cumulative totals. */
+function accumulate(deltaMaps: Record<ID, number>[]): Record<ID, number> {
+  const totals: Record<ID, number> = {};
+  for (const m of deltaMaps) {
+    for (const [id, d] of Object.entries(m)) totals[id] = (totals[id] ?? 0) + d;
+  }
+  return totals;
+}
+
+describe('makeTeams', () => {
+  it('splits an even roster into equal contiguous teams', () => {
+    const teams = makeTeams(['a', 'b', 'c', 'd'], 2);
+    expect(teams.map((t) => t.playerIds)).toEqual([
+      ['a', 'b'],
+      ['c', 'd'],
+    ]);
+  });
+
+  it('gives the remainder to the earlier teams', () => {
+    const teams = makeTeams(['a', 'b', 'c', 'd', 'e'], 2);
+    expect(teams.map((t) => t.playerIds)).toEqual([
+      ['a', 'b', 'c'],
+      ['d', 'e'],
+    ]);
+  });
+
+  it('handles 3 teams from 7 players → 3 / 2 / 2', () => {
+    const teams = makeTeams(['a', 'b', 'c', 'd', 'e', 'f', 'g'], 3);
+    expect(teams.map((t) => t.playerIds.length)).toEqual([3, 2, 2]);
+    // Every player lands in exactly one team, order preserved.
+    expect(teams.flatMap((t) => t.playerIds)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+  });
+
+  it('never creates an empty team: caps team count at the player count', () => {
+    const teams = makeTeams(['a', 'b', 'c'], 4);
+    expect(teams).toHaveLength(3);
+    expect(teams.every((t) => t.playerIds.length === 1)).toBe(true);
+  });
+
+  it('supports a single team', () => {
+    const teams = makeTeams(['a', 'b', 'c'], 1);
+    expect(teams).toHaveLength(1);
+    expect(teams[0].playerIds).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns no teams for an empty roster', () => {
+    expect(makeTeams([], 2)).toEqual([]);
+  });
+
+  it('labels teams with a name and a distinct veggie badge', () => {
+    const teams = makeTeams(['a', 'b', 'c', 'd'], 2);
+    expect(teams[0].name).toBe('Team 1');
+    expect(teams[1].name).toBe('Team 2');
+    expect(teams[0].emoji).toBe(TEAM_EMOJI[0]);
+    expect(teams[1].emoji).toBe(TEAM_EMOJI[1]);
+  });
+});
+
+describe('config accessors', () => {
+  it('teamCount defaults to 2 and clamps to 2–4', () => {
+    expect(teamCount({})).toBe(2);
+    expect(teamCount({ teams: '3' })).toBe(3); // select stores strings
+    expect(teamCount({ teams: 4 })).toBe(4);
+    expect(teamCount({ teams: 9 })).toBe(4);
+    expect(teamCount({ teams: 1 })).toBe(2);
+    expect(teamCount({ teams: 'nonsense' })).toBe(2);
+  });
+
+  it('roundCount defaults to 3 and clamps to 1–4', () => {
+    expect(roundCount({})).toBe(3);
+    expect(roundCount({ rounds: 2 })).toBe(2);
+    expect(roundCount({ rounds: 4 })).toBe(4);
+    expect(roundCount({ rounds: 99 })).toBe(4);
+    expect(roundCount({ rounds: 0 })).toBe(1);
+  });
+
+  it('pointsPerWord defaults to 1 and stays >= 1', () => {
+    expect(pointsPerWord({})).toBe(1);
+    expect(pointsPerWord({ pointsPerWord: 5 })).toBe(5);
+    expect(pointsPerWord({ pointsPerWord: 0 })).toBe(1);
+    expect(pointsPerWord({ pointsPerWord: -3 })).toBe(1);
+  });
+
+  it('turnSeconds defaults to 60', () => {
+    expect(turnSeconds({})).toBe(60);
+    expect(turnSeconds({ turnSeconds: 90 })).toBe(90);
+    expect(turnSeconds({ turnSeconds: 'x' })).toBe(60);
+  });
+});
+
+describe('themeFor', () => {
+  it('maps each round index to its escalating constraint', () => {
+    expect(themeFor(0).name).toBe('Describe');
+    expect(themeFor(1).name).toBe('One Word');
+    expect(themeFor(2).name).toBe('Charades');
+    expect(themeFor(3).name).toBe('Sculptor');
+  });
+
+  it('clamps out-of-range indices', () => {
+    expect(themeFor(-1)).toBe(ROUND_THEMES[0]);
+    expect(themeFor(10)).toBe(ROUND_THEMES[ROUND_THEMES.length - 1]);
+  });
+});
+
+describe('createInput', () => {
+  it('builds a zeroed slot per team', () => {
+    expect(createInput(3)).toEqual({ guessed: [0, 0, 0] });
+    expect(createInput(0)).toEqual({ guessed: [] });
+  });
+});
+
+describe('wordsFor / bowlTotal', () => {
+  const teams = makeTeams(['a', 'b', 'c', 'd'], 2);
+
+  it('coerces to a non-negative integer', () => {
+    expect(wordsFor({ guessed: [5, 3] }, 0)).toBe(5);
+    expect(wordsFor({ guessed: [2.9, 3] }, 0)).toBe(2);
+    expect(wordsFor({ guessed: [-4, 3] }, 0)).toBe(0);
+    expect(wordsFor({ guessed: [] }, 0)).toBe(0);
+  });
+
+  it('sums the bowl across teams', () => {
+    expect(bowlTotal({ guessed: [5, 3] }, teams)).toBe(8);
+    expect(bowlTotal({ guessed: [0, 0] }, teams)).toBe(0);
+  });
+});
+
+describe('validate', () => {
+  const teams = makeTeams(['a', 'b', 'c', 'd'], 2);
+
+  it('accepts a well-formed round', () => {
+    expect(validate({ guessed: [5, 3] }, teams)).toBeNull();
+    expect(validate({ guessed: [0, 0] }, teams)).toBeNull();
+  });
+
+  it('requires at least two teams', () => {
+    const solo = makeTeams(['a'], 1);
+    expect(validate({ guessed: [1] }, solo)).toMatch(/at least 2 teams/i);
+  });
+
+  it('rejects negative or fractional counts', () => {
+    expect(validate({ guessed: [-1, 2] }, teams)).toMatch(/whole words/i);
+    expect(validate({ guessed: [1.5, 2] }, teams)).toMatch(/whole words/i);
+  });
+
+  it('tolerates missing per-team entries', () => {
+    expect(validate({ guessed: [] }, teams)).toBeNull();
+  });
+});
+
+describe('score', () => {
+  it('awards every teammate their team’s words × pointsPerWord', () => {
+    const teams = makeTeams(['a', 'b', 'c', 'd'], 2);
+    const out = score({ guessed: [5, 3] }, teams, 1);
+    expect(out).toEqual({ a: 5, b: 5, c: 3, d: 3 });
+  });
+
+  it('applies points-per-word', () => {
+    const teams = makeTeams(['a', 'b', 'c', 'd'], 2);
+    expect(score({ guessed: [4, 1] }, teams, 2)).toEqual({ a: 8, b: 8, c: 2, d: 2 });
+  });
+
+  it('floors fractional and floors negative words to zero', () => {
+    const teams = makeTeams(['a', 'b', 'c', 'd'], 2);
+    expect(score({ guessed: [2.8, -3] }, teams, 1)).toEqual({ a: 2, b: 2, c: 0, d: 0 });
+  });
+
+  it('returns a delta for every selected player', () => {
+    const teams = makeTeams(['a', 'b', 'c', 'd', 'e'], 2);
+    const out = score({ guessed: [1, 1] }, teams, 1);
+    expect(Object.keys(out).sort()).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+});
+
+describe('describe', () => {
+  it('summarises the round with its theme and per-team tallies', () => {
+    expect(describeRound({ index: 0, input: { guessed: [5, 3] } })).toBe('🗣️ Describe — 🥬 5 · 🍅 3');
+    expect(describeRound({ index: 2, input: { guessed: [1, 4] } })).toBe('🎭 Charades — 🥬 1 · 🍅 4');
+  });
+
+  it('degrades gracefully with no recorded teams', () => {
+    expect(describeRound({ index: 1, input: { guessed: [] } })).toBe('☝️ One Word');
+    expect(describeRound({ index: 0, input: undefined })).toBe('🗣️ Describe');
+  });
+});
+
+describe('a full game accumulates per team and the highest team wins', () => {
+  it('crowns the whole leading team via the shell default winner logic', () => {
+    const players = ['p1', 'p2', 'p3', 'p4'];
+    const teams = makeTeams(players, 2); // [p1,p2] vs [p3,p4]
+
+    // Three escalating rounds of words guessed per team.
+    const rounds: SaladBowlInput[] = [
+      { guessed: [5, 3] }, // Describe
+      { guessed: [2, 4] }, // One Word
+      { guessed: [6, 1] }, // Charades
+    ];
+    const totals = accumulate(rounds.map((r) => score(r, teams, 1)));
+
+    // Team 1 = 13 each, Team 2 = 8 each.
+    expect(totals).toEqual({ p1: 13, p2: 13, p3: 8, p4: 8 });
+
+    const winners = defaultWinners({} as GameModule, totals).sort();
+    expect(winners).toEqual(['p1', 'p2']);
+  });
+
+  it('ties across teams crown both teams', () => {
+    const teams = makeTeams(['a', 'b', 'c', 'd'], 2);
+    const totals = accumulate([score({ guessed: [4, 4] }, teams, 1)]);
+    expect(defaultWinners({} as GameModule, totals).sort()).toEqual(['a', 'b', 'c', 'd']);
+  });
+});

--- a/src/lib/games/saladbowl/stats.ts
+++ b/src/lib/games/saladbowl/stats.ts
@@ -1,0 +1,76 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt } from '../../stats/format';
+import { makeTeams, teamCount, wordsFor, type SaladBowlInput } from './logic';
+
+interface SBAgg {
+  words: number; // words this member's teams pulled from the bowl
+  rounds: number; // team-rounds the member took part in
+  best: number; // best single-round haul by one of their teams
+}
+
+/**
+ * Salad Bowl stats from each round's recorded per-team words. Teams are
+ * reconstructed purely from the game's saved config + player order (the same
+ * `makeTeams` the module scores with), so a member's tally is their team's tally —
+ * "words your teams pulled from the bowl". Pure & Svelte-free, safe for the engine.
+ */
+export function saladbowlStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameById = new Map(games.map((g) => [g.id, g]));
+  const teamsByGame = new Map(
+    games.map((g) => [g.id, makeTeams(g.playerIds, teamCount(g.config))] as const),
+  );
+
+  const per = new Map<ID, SBAgg>();
+  const get = (id: ID): SBAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { words: 0, rounds: 0, best: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let totalWords = 0;
+  let biggest = 0;
+
+  for (const r of rounds) {
+    const g = gameById.get(r.gameId);
+    if (!g) continue;
+    const teams = teamsByGame.get(g.id) ?? [];
+    const input = r.input as SaladBowlInput | undefined;
+    if (!input || !Array.isArray(input.guessed)) continue;
+    for (const t of teams) {
+      const w = wordsFor(input, t.index);
+      totalWords += w;
+      if (w > biggest) biggest = w;
+      for (const pid of t.playerIds) {
+        const a = get(canonical(pid));
+        a.words += w;
+        a.rounds += 1;
+        if (w > a.best) a.best = w;
+      }
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.words) {
+      metrics.push({ key: 'sb_words', label: 'Words guessed', value: fmtInt(a.words), emoji: '🥗' });
+    }
+    if (a.best) {
+      metrics.push({ key: 'sb_best', label: 'Best round', value: fmtInt(a.best), emoji: '🔥' });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totalWords) {
+    global.push({ key: 'sb_words_all', label: 'Words from the bowl', value: fmtInt(totalWords), emoji: '🥗' });
+  }
+  if (biggest) {
+    global.push({ key: 'sb_best_all', label: 'Biggest round haul', value: fmtInt(biggest), emoji: '🔥' });
+  }
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## 🥗 Salad Bowl (a.k.a. Fishbowl)

Adds the party word game **Salad Bowl / Fishbowl** as a first-class, self-contained game module. Purely additive — only new files under `src/lib/games/saladbowl/`. No shared shell, registry, or dependency changes.

### The game
Everyone secretly loads a bowl of words. Teams then play the **same** set of words across escalating rounds, each with a tighter clue rule:

| Round | Constraint |
|------|------------|
| 1 · 🗣️ **Describe** | Say anything to get it guessed — never the word itself (Taboo-style) |
| 2 · ☝️ **One Word** | Exactly one word as your clue |
| 3 · 🎭 **Charades** | No talking — act it out |
| 4 · 🗿 **Sculptor** *(optional)* | No talking — mould a teammate into the word |

A team scores **1 point per word guessed** on its timed turns (configurable). Points accumulate per team across every round; the **highest team total wins**. 🏆

### Scoring & the team model
The app shell scores strictly **per-player** (`Record<ID, number>`) and crowns whoever holds the best total — there is no engine-level team concept (only an inert `teams?` flag on the contract). Rather than request a shared change, teams are modelled cleanly **within the module** as *shared-score groups*:

- Selected players are partitioned into N teams by **contiguous selection order**, as evenly as possible (pick your first team, then the next — earlier teams absorb any remainder). `orderedPlayers` follows the stable `playerIds` order, so team assignment is deterministic.
- Each round, every member of a team receives that team's `words × pointsPerWord`, so **each teammate's cumulative total equals the team total**.
- The shell's default winner logic then lights up the **entire** leading team, and ties across teams crown both — no shell/registry edit required. `teams: true` is declared for correct intent (future-proofing).

All scoring, team-building, validation, round themes and history copy live in a Svelte-free `logic.ts`, exercised by a thorough `saladbowl.test.ts`.

### Config
- **Number of teams** — 2 / 3 / 4 (default 2)
- **Number of rounds** — 2–4 (default 3: Describe, One Word, Charades)
- **Points per word** — ≥1 (default 1)
- **Turn timer** — seconds, an informational reminder only (default 60)

`maxRounds` is driven by the rounds config, and each shell round maps to its escalating constraint. Min 4 players (two teams of two), max 12.

### Design
Follows PRODUCT.md / DESIGN.md strictly: chrome unchanged, personality via 🥗 emoji + copy only. **No** Royal Violet fill in the editor (the single primary action is the shell's Save button); **no** Crown Gold (reserved for leader/winner). Teams are distinguished by veggie badge + label + member avatars — never colour alone. Depth via the surface ramp (`surface-2` cards, `surface-3` badges), changing numbers use `tabular-nums`, the shared `Stepper` keeps ≥46px one-handed targets, and no new motion is introduced (reduced-motion safe).

### Stats
`stats.ts` reconstructs teams purely from each game's saved config + player order and reports **words your teams pulled from the bowl** (per-player + global) plus the biggest single-round haul.

### Verification
- ✅ `npm run check` — 0 errors, 0 warnings
- ✅ `npm test` — 103 passed (incl. new suite)
- ✅ `npm run build` — succeeds

The registry auto-discovers `saladbowl/index.ts`, so routing (`/saladbowl`), players, history, stats, and persistence work with no registration step.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
