### PR TITLE
Add Wyrmspan game module 🐉

### DIFF
--- a/src/lib/games/wyrmspan/WyrmspanEditor.svelte
+++ b/src/lib/games/wyrmspan/WyrmspanEditor.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import {
+    activeCategories,
+    categoryVP,
+    scoreRow,
+    type WyrmspanConfig,
+    type WyrmspanInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: WyrmspanInput; ctx: RoundContext } = $props();
+
+  const config = $derived<Partial<WyrmspanConfig>>({ scoreLeftover: ctx.config.scoreLeftover !== false });
+  const cats = $derived(activeCategories(config));
+
+  const totals = $derived(
+    Object.fromEntries(ctx.players.map((p) => [p.id, scoreRow(input.rows[p.id], config)])) as Record<
+      string,
+      number
+    >,
+  );
+
+  // Provisional leader = the one player strictly ahead (and above zero). Crown Gold is
+  // reserved for the leader/winner, so a tie or an all-zero sheet shows no crown yet.
+  const leaderId = $derived.by(() => {
+    let best = 0;
+    let who: string | null = null;
+    let tie = false;
+    for (const p of ctx.players) {
+      const t = totals[p.id];
+      if (t > best) {
+        best = t;
+        who = p.id;
+        tie = false;
+      } else if (t === best && best > 0) {
+        tie = true;
+      }
+    }
+    return tie ? null : who;
+  });
+
+  let showHelp = $state(false);
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="pill">🐉 Final scoresheet</span>
+    <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+      Categories
+    </button>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{cats.map((c) => `${c.emoji} ${c.label} — ${c.help}`).join('\n')}</pre>
+  {/if}
+
+  {#each ctx.players as p (p.id)}
+    {@const row = input.rows[p.id]}
+    {@const lead = leaderId === p.id}
+    <div class="prow">
+      <div class="row spread phead">
+        <span class="row" style="gap: 8px">
+          <Avatar name={p.name} color={p.color} />
+          <strong>{p.name}</strong>
+        </span>
+        <span class="total" class:lead>
+          {#if lead}<span aria-hidden="true">👑</span><span class="sr-only">leading</span>{/if}
+          <span class="num">{totals[p.id]}</span>
+          <span class="unit">VP</span>
+        </span>
+      </div>
+
+      <div class="cats">
+        {#each cats as cat (cat.key)}
+          {@const vp = categoryVP(cat, row[cat.key])}
+          <label class="cat">
+            <span class="cat-label">
+              <span class="emoji" aria-hidden="true">{cat.emoji}</span>
+              <span class="cat-name">
+                {cat.short}
+                {#if cat.kind === 'bundle'}
+                  <small class="sub">1 VP per {cat.per} · +{vp}</small>
+                {/if}
+              </span>
+            </span>
+            {#if cat.kind === 'vp'}
+              <input
+                class="vpinput"
+                type="number"
+                min="0"
+                step="1"
+                inputmode="numeric"
+                bind:value={row[cat.key]}
+                aria-label={cat.label}
+              />
+            {:else}
+              <Stepper bind:value={row[cat.key]} min={0} />
+            {/if}
+          </label>
+        {/each}
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+  }
+  .phead {
+    margin-bottom: 8px;
+  }
+  .total {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    font-variant-numeric: tabular-nums;
+    font-weight: 800;
+  }
+  .total .num {
+    font-size: 1.15rem;
+  }
+  .total .unit {
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: var(--muted);
+  }
+  .total.lead .unit {
+    color: inherit;
+  }
+  .cats {
+    display: flex;
+    flex-direction: column;
+  }
+  .cat {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 52px;
+    padding: 4px 0;
+    margin: 0;
+    /* override the global block label so rows sit inline */
+    color: var(--text);
+    font-size: 1rem;
+  }
+  .cat + .cat {
+    border-top: 1px solid var(--border);
+  }
+  .cat-label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+  .cat-label .emoji {
+    font-size: 1.25rem;
+    line-height: 1;
+    flex: none;
+  }
+  .cat-name {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.2;
+  }
+  .cat-name .sub {
+    font-size: 0.72rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .vpinput {
+    width: 92px;
+    text-align: center;
+    flex: none;
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    /* hide the native spinners — keyboard + typing is the input here */
+    appearance: textfield;
+    -moz-appearance: textfield;
+  }
+  .vpinput::-webkit-outer-spin-button,
+  .vpinput::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    appearance: none;
+    margin: 0;
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/wyrmspan/index.ts
+++ b/src/lib/games/wyrmspan/index.ts
@@ -1,0 +1,82 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './WyrmspanEditor.svelte';
+import { wyrmspanStats } from './stats';
+import {
+  activeCategories,
+  emptyRow,
+  scoreWyrmspan,
+  validateRow,
+  type WyrmspanConfig,
+  type WyrmspanInput,
+} from './logic';
+
+export type { WyrmspanConfig, WyrmspanInput, WyrmspanRow } from './logic';
+
+function cfg(config: Record<string, unknown>): Partial<WyrmspanConfig> {
+  return { scoreLeftover: config.scoreLeftover !== false };
+}
+
+export const wyrmspan: GameModule = {
+  id: 'wyrmspan',
+  name: 'Wyrmspan',
+  tagline: 'Hoard the most VP across your caves 🐉',
+  emoji: '🐉',
+  keywords: ['wingspan', 'dragon', 'engine builder', 'stonemaier', 'end game', 'categories', 'eggs'],
+  minPlayers: 1,
+  maxPlayers: 5,
+
+  // One game = one final scoresheet: tally every category once, then it's done.
+  maxRounds: () => 1,
+
+  configFields: [
+    {
+      key: 'scoreLeftover',
+      label: 'Score leftover items (+1 VP per 4 spare resources/cards)',
+      type: 'boolean',
+      default: true,
+      help: 'The final "excess items" step. Coins always score 1 VP each; turn this off to skip counting the odds and ends.',
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): WyrmspanInput => ({
+    rows: Object.fromEntries(ctx.players.map((p) => [p.id, emptyRow()])),
+  }),
+
+  validateRound: (input: WyrmspanInput, ctx: RoundContext): string | null => {
+    for (const p of ctx.players) {
+      const err = validateRow(input.rows[p.id], p.name);
+      if (err) return err;
+    }
+    return null;
+  },
+
+  scoreRound: (input: WyrmspanInput, ctx: RoundContext): Record<ID, number> =>
+    scoreWyrmspan(
+      input,
+      ctx.players.map((p) => p.id),
+      cfg(ctx.config),
+    ),
+
+  describeRound: (round: Round, players): string => {
+    // The recorded deltas already hold each player's config-correct final total.
+    const deltas = round.deltas ?? {};
+    return players
+      .map((p) => (p.id in deltas ? `${p.name} ${deltas[p.id]}` : ''))
+      .filter(Boolean)
+      .join(' · ');
+  },
+
+  help: [
+    'Wyrmspan — the dragon-hoard cousin of Wingspan. One final scoresheet: add up every',
+    'category, and the highest total reigns. 🐉',
+    '',
+    'Enter each player’s end-game totals:',
+    ...activeCategories({ scoreLeftover: true }).map((c) => `${c.emoji} ${c.label} — ${c.help}`),
+    '',
+    'Tiebreaker: most visible dragons on your mat (not tucked). Still tied? Share the crown.',
+  ].join('\n'),
+
+  stats: wyrmspanStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/wyrmspan/logic.ts
+++ b/src/lib/games/wyrmspan/logic.ts
@@ -1,0 +1,230 @@
+import type { ID } from '../../types';
+
+/**
+ * Pure, deterministic scoring core for Wyrmspan — no Svelte, no I/O — so it can be
+ * unit-tested on its own and imported by both the module and its stats hook.
+ *
+ * Wyrmspan (Stonemaier, 2024) is the dragon-themed cousin of Wingspan: an end-game
+ * CATEGORY scorer. A game is a single final scoresheet — one column per category per
+ * player, summed — and the HIGHEST total reigns. The eight categories below are the
+ * official end-game scoring steps (Dragon Guild, printed dragon VP, end-game abilities,
+ * eggs, cached resources, tucked cards, public objectives, and leftover coins/items).
+ */
+
+export interface WyrmspanConfig {
+  /** Include the "leftover items" category (1 VP per 4 spare resources/cards). */
+  scoreLeftover: boolean;
+}
+
+/** One player's final tally — a raw entry per scoring category (never negative). */
+export interface WyrmspanRow {
+  /** VP from your marker's spaces on the Dragon Guild. */
+  guild: number;
+  /** Printed VP on visible dragons on your player mat. */
+  dragons: number;
+  /** VP from end-game abilities on visible dragons. */
+  abilities: number;
+  /** VP from public objectives (end-of-round goals). */
+  objectives: number;
+  /** Eggs on your dragons — 1 VP each. */
+  eggs: number;
+  /** Resources cached on your dragons — 1 VP each. */
+  cached: number;
+  /** Cards tucked under your dragons — 1 VP each. */
+  tucked: number;
+  /** Coins remaining — 1 VP each. */
+  coins: number;
+  /** Other leftover items (resources + dragon/cave cards) — 1 VP per 4, rounded down. */
+  leftover: number;
+}
+
+export interface WyrmspanInput {
+  rows: Record<ID, WyrmspanRow>;
+}
+
+export type WyrmspanField = keyof WyrmspanRow;
+
+/**
+ * How a category turns its raw entry into VP:
+ * - `vp`    the entered number IS the VP (read a total off the board),
+ * - `count` 1 VP per item (`per` = 1),
+ * - `bundle` 1 VP per `per` items, rounded down (leftover items, `per` = 4).
+ */
+export type WyrmspanKind = 'vp' | 'count' | 'bundle';
+
+export interface WyrmspanCategory {
+  key: WyrmspanField;
+  /** Full name for the help sheet. */
+  label: string;
+  /** Compact name for the entry grid. */
+  short: string;
+  emoji: string;
+  kind: WyrmspanKind;
+  /** Items per VP: `vp`/`count` = 1, `bundle` = 4. */
+  per: number;
+  help: string;
+  /** Gated by a config toggle (only `leftover` today). */
+  optional?: boolean;
+}
+
+/** The eight end-game categories, in the order the rulebook tallies them. */
+export const WYRMSPAN_CATEGORIES: readonly WyrmspanCategory[] = [
+  {
+    key: 'guild',
+    label: 'Dragon Guild',
+    short: 'Guild',
+    emoji: '🏛️',
+    kind: 'vp',
+    per: 1,
+    help: 'VP printed on the spaces your marker reached on the Dragon Guild.',
+  },
+  {
+    key: 'dragons',
+    label: 'Dragons',
+    short: 'Dragons',
+    emoji: '🐉',
+    kind: 'vp',
+    per: 1,
+    help: 'Total printed VP on the visible dragons on your player mat (not tucked, not in hand).',
+  },
+  {
+    key: 'abilities',
+    label: 'End-game abilities',
+    short: 'Abilities',
+    emoji: '✨',
+    kind: 'vp',
+    per: 1,
+    help: 'VP from the end-game (🏆) abilities on your visible dragons — tally each and enter the sum.',
+  },
+  {
+    key: 'objectives',
+    label: 'Public objectives',
+    short: 'Objectives',
+    emoji: '🎯',
+    kind: 'vp',
+    per: 1,
+    help: 'VP awarded for your markers on the end-of-round goals. Ties are friendly — tied players share the higher award.',
+  },
+  {
+    key: 'eggs',
+    label: 'Eggs',
+    short: 'Eggs',
+    emoji: '🥚',
+    kind: 'count',
+    per: 1,
+    help: 'Eggs on your dragons — 1 VP each.',
+  },
+  {
+    key: 'cached',
+    label: 'Cached resources',
+    short: 'Cached',
+    emoji: '📦',
+    kind: 'count',
+    per: 1,
+    help: 'Resources cached (stored) on your dragons — 1 VP each.',
+  },
+  {
+    key: 'tucked',
+    label: 'Tucked cards',
+    short: 'Tucked',
+    emoji: '🗂️',
+    kind: 'count',
+    per: 1,
+    help: 'Cards tucked under your dragons — 1 VP each.',
+  },
+  {
+    key: 'coins',
+    label: 'Coins',
+    short: 'Coins',
+    emoji: '🪙',
+    kind: 'count',
+    per: 1,
+    help: 'Coins remaining in your supply — 1 VP each.',
+  },
+  {
+    key: 'leftover',
+    label: 'Leftover items',
+    short: 'Leftover',
+    emoji: '🧺',
+    kind: 'bundle',
+    per: 4,
+    help: 'Other leftover items — resources plus dragon and cave cards — 1 VP for every 4, rounded down.',
+    optional: true,
+  },
+];
+
+const BY_KEY: Record<WyrmspanField, WyrmspanCategory> = Object.fromEntries(
+  WYRMSPAN_CATEGORIES.map((c) => [c.key, c]),
+) as Record<WyrmspanField, WyrmspanCategory>;
+
+/** A fresh, all-zero tally. */
+export function emptyRow(): WyrmspanRow {
+  return {
+    guild: 0,
+    dragons: 0,
+    abilities: 0,
+    objectives: 0,
+    eggs: 0,
+    cached: 0,
+    tucked: 0,
+    coins: 0,
+    leftover: 0,
+  };
+}
+
+/** Coerce any input into a non-negative whole number (blank/NaN → 0). */
+export function cleanValue(value: unknown): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/** VP a single category's raw entry is worth. */
+export function categoryVP(cat: WyrmspanCategory, value: unknown): number {
+  const v = cleanValue(value);
+  return cat.kind === 'vp' ? v : Math.floor(v / cat.per);
+}
+
+/** Whether a config actually enables the leftover-items category. */
+export function leftoverEnabled(config?: Partial<WyrmspanConfig>): boolean {
+  return config?.scoreLeftover !== false;
+}
+
+/** The categories in play for a given config (drops optional ones that are toggled off). */
+export function activeCategories(config?: Partial<WyrmspanConfig>): WyrmspanCategory[] {
+  const leftover = leftoverEnabled(config);
+  return WYRMSPAN_CATEGORIES.filter((c) => !c.optional || (c.key === 'leftover' ? leftover : true));
+}
+
+/** Sum one player's tally into a final score, honoring the active categories. */
+export function scoreRow(row: WyrmspanRow | undefined, config?: Partial<WyrmspanConfig>): number {
+  if (!row) return 0;
+  let sum = 0;
+  for (const cat of activeCategories(config)) sum += categoryVP(cat, row[cat.key]);
+  return sum;
+}
+
+/** Per-player final scores for a whole scoresheet. */
+export function scoreWyrmspan(
+  input: WyrmspanInput | undefined,
+  playerIds: ID[],
+  config?: Partial<WyrmspanConfig>,
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) out[id] = scoreRow(input?.rows?.[id], config);
+  return out;
+}
+
+/** Null when the scoresheet is valid; otherwise a human-readable reason. */
+export function validateRow(row: WyrmspanRow | undefined, name = 'A player'): string | null {
+  if (!row) return null;
+  for (const cat of WYRMSPAN_CATEGORIES) {
+    const raw = Number(row[cat.key]);
+    if (Number.isFinite(raw) && raw < 0) return `${name}: ${cat.label} can't be negative.`;
+  }
+  return null;
+}
+
+/** Look a category up by key (handy for the editor + stats). */
+export function category(key: WyrmspanField): WyrmspanCategory {
+  return BY_KEY[key];
+}

--- a/src/lib/games/wyrmspan/stats.ts
+++ b/src/lib/games/wyrmspan/stats.ts
@@ -1,0 +1,75 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg, fmtInt } from '../../stats/format';
+import { cleanValue, scoreRow, type WyrmspanInput } from './logic';
+
+interface WyrmAgg {
+  games: number;
+  dragonVP: number;
+  eggs: number;
+  cached: number;
+  tucked: number;
+  best: number;
+}
+
+/**
+ * Wyrmspan stats, derived purely from each game's final scoresheet. Category counts
+ * (dragon VP, eggs, tucked) come straight from the recorded entries; the best score
+ * prefers the round's recorded deltas (config-correct) and falls back to a recompute.
+ * Pure — no Svelte — so it's independently testable and safe for the engine to import.
+ */
+export function wyrmspanStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, WyrmAgg>();
+  const get = (id: ID): WyrmAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { games: 0, dragonVP: 0, eggs: 0, cached: 0, tucked: 0, best: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as WyrmspanInput | undefined;
+    if (!input?.rows) continue;
+    const deltas = r.deltas ?? {};
+    for (const [pid, row] of Object.entries(input.rows)) {
+      if (!row) continue;
+      const a = get(canonical(pid));
+      a.games += 1;
+      a.dragonVP += cleanValue(row.dragons);
+      a.eggs += cleanValue(row.eggs);
+      a.cached += cleanValue(row.cached);
+      a.tucked += cleanValue(row.tucked);
+      const score = pid in deltas ? deltas[pid] : scoreRow(row);
+      if (score > a.best) a.best = score;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let totGames = 0;
+  let topScore = 0;
+  for (const [id, a] of per) {
+    if (!a.games) continue;
+    totGames += a.games;
+    if (a.best > topScore) topScore = a.best;
+    const metrics: Metric[] = [
+      { key: 'wy_dragons', label: 'Dragon VP / game', value: fmtAvg(a.dragonVP / a.games), emoji: '🐉' },
+      { key: 'wy_best', label: 'Best hoard', value: fmtInt(a.best), emoji: '🏆' },
+    ];
+    if (a.eggs) metrics.push({ key: 'wy_eggs', label: 'Eggs laid', value: fmtInt(a.eggs), emoji: '🥚' });
+    if (a.tucked) metrics.push({ key: 'wy_tucked', label: 'Cards tucked', value: fmtInt(a.tucked), emoji: '🗂️' });
+    perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (topScore > 0) {
+    global.push({ key: 'wy_top', label: 'Biggest hoard', value: fmtInt(topScore), emoji: '🐲' });
+  }
+  if (totGames > 0) {
+    global.push({ key: 'wy_games', label: 'Scoresheets tallied', value: fmtInt(totGames), emoji: '📜' });
+  }
+  return { perPlayer, global };
+}

--- a/src/lib/games/wyrmspan/wyrmspan.test.ts
+++ b/src/lib/games/wyrmspan/wyrmspan.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest';
+import type { Player, Round, RoundContext } from '../../types';
+import { defaultWinners } from '../../types';
+import {
+  activeCategories,
+  categoryVP,
+  category,
+  cleanValue,
+  emptyRow,
+  leftoverEnabled,
+  scoreRow,
+  scoreWyrmspan,
+  validateRow,
+  WYRMSPAN_CATEGORIES,
+  type WyrmspanInput,
+  type WyrmspanRow,
+} from './logic';
+import { wyrmspan } from './index';
+
+function row(partial: Partial<WyrmspanRow>): WyrmspanRow {
+  return { ...emptyRow(), ...partial };
+}
+
+// A full, hand-computed tally used across several cases.
+// 5 + 24 + 6 + 9 + 7 + 3 + 4 + 5 + floor(11/4)=2  = 65  (63 without leftover)
+const FULL: WyrmspanRow = {
+  guild: 5,
+  dragons: 24,
+  abilities: 6,
+  objectives: 9,
+  eggs: 7,
+  cached: 3,
+  tucked: 4,
+  coins: 5,
+  leftover: 11,
+};
+
+describe('wyrmspan categories', () => {
+  it('defines the eight official end-game categories in tally order', () => {
+    expect(WYRMSPAN_CATEGORIES.map((c) => c.key)).toEqual([
+      'guild',
+      'dragons',
+      'abilities',
+      'objectives',
+      'eggs',
+      'cached',
+      'tucked',
+      'coins',
+      'leftover',
+    ]);
+  });
+
+  it('only the leftover category is optional, and it bundles 4 items per VP', () => {
+    const optional = WYRMSPAN_CATEGORIES.filter((c) => c.optional).map((c) => c.key);
+    expect(optional).toEqual(['leftover']);
+    expect(category('leftover').kind).toBe('bundle');
+    expect(category('leftover').per).toBe(4);
+  });
+
+  it('every category has label, short, emoji and help copy', () => {
+    for (const c of WYRMSPAN_CATEGORIES) {
+      expect(c.label.length, c.key).toBeGreaterThan(0);
+      expect(c.short.length, c.key).toBeGreaterThan(0);
+      expect(c.emoji.length, c.key).toBeGreaterThan(0);
+      expect(c.help.length, c.key).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('cleanValue', () => {
+  it('keeps non-negative whole numbers', () => {
+    expect(cleanValue(0)).toBe(0);
+    expect(cleanValue(7)).toBe(7);
+  });
+  it('floors fractions and coerces strings', () => {
+    expect(cleanValue(3.9)).toBe(3);
+    expect(cleanValue('5')).toBe(5);
+  });
+  it('clamps negatives, NaN, blanks and junk to 0', () => {
+    expect(cleanValue(-4)).toBe(0);
+    expect(cleanValue(NaN)).toBe(0);
+    expect(cleanValue('')).toBe(0);
+    expect(cleanValue(undefined)).toBe(0);
+    expect(cleanValue('nope')).toBe(0);
+  });
+});
+
+describe('categoryVP', () => {
+  it('vp categories score their entered value directly', () => {
+    expect(categoryVP(category('dragons'), 24)).toBe(24);
+    expect(categoryVP(category('guild'), 0)).toBe(0);
+  });
+  it('count categories score 1 VP per item', () => {
+    expect(categoryVP(category('eggs'), 7)).toBe(7);
+    expect(categoryVP(category('coins'), 5)).toBe(5);
+  });
+  it('the leftover bundle scores 1 VP per 4, rounded down', () => {
+    const left = category('leftover');
+    expect(categoryVP(left, 0)).toBe(0);
+    expect(categoryVP(left, 3)).toBe(0);
+    expect(categoryVP(left, 4)).toBe(1);
+    expect(categoryVP(left, 7)).toBe(1);
+    expect(categoryVP(left, 8)).toBe(2);
+    expect(categoryVP(left, 11)).toBe(2);
+  });
+});
+
+describe('activeCategories / leftoverEnabled', () => {
+  it('includes all nine categories by default', () => {
+    expect(activeCategories().length).toBe(9);
+    expect(activeCategories({ scoreLeftover: true }).map((c) => c.key)).toContain('leftover');
+  });
+  it('drops the leftover category when disabled', () => {
+    expect(leftoverEnabled({ scoreLeftover: false })).toBe(false);
+    const keys = activeCategories({ scoreLeftover: false }).map((c) => c.key);
+    expect(keys).not.toContain('leftover');
+    expect(keys.length).toBe(8);
+  });
+  it('treats a missing toggle as enabled (faithful default)', () => {
+    expect(leftoverEnabled(undefined)).toBe(true);
+    expect(leftoverEnabled({})).toBe(true);
+  });
+});
+
+describe('scoreRow', () => {
+  it('sums the full sheet, bundling leftover items', () => {
+    expect(scoreRow(FULL)).toBe(65);
+  });
+  it('excludes leftover VP when the toggle is off', () => {
+    expect(scoreRow(FULL, { scoreLeftover: false })).toBe(63);
+  });
+  it('an empty sheet is worth zero', () => {
+    expect(scoreRow(emptyRow())).toBe(0);
+    expect(scoreRow(undefined)).toBe(0);
+  });
+  it('ignores negative junk in any field', () => {
+    expect(scoreRow(row({ dragons: -10, eggs: 4 }))).toBe(4);
+  });
+  it('adds up a simple mixed sheet', () => {
+    // 3 guild + 2 eggs + 2 tucked + floor(6/4)=1 = 8
+    expect(scoreRow(row({ guild: 3, eggs: 2, tucked: 2, leftover: 6 }))).toBe(8);
+  });
+});
+
+describe('scoreWyrmspan', () => {
+  const input: WyrmspanInput = { rows: { a: FULL, b: row({ dragons: 10, eggs: 2 }) } };
+
+  it('scores every requested player', () => {
+    expect(scoreWyrmspan(input, ['a', 'b'])).toEqual({ a: 65, b: 12 });
+  });
+  it('treats an absent player as zero', () => {
+    expect(scoreWyrmspan(input, ['a', 'z'])).toEqual({ a: 65, z: 0 });
+  });
+  it('respects the leftover toggle for all players', () => {
+    expect(scoreWyrmspan(input, ['a', 'b'], { scoreLeftover: false })).toEqual({ a: 63, b: 12 });
+  });
+  it('handles empty/undefined input', () => {
+    expect(scoreWyrmspan(undefined, ['a'])).toEqual({ a: 0 });
+  });
+});
+
+describe('validateRow', () => {
+  it('accepts zero and positive entries', () => {
+    expect(validateRow(emptyRow())).toBeNull();
+    expect(validateRow(FULL)).toBeNull();
+    expect(validateRow(undefined)).toBeNull();
+  });
+  it('rejects a negative entry and names the category + player', () => {
+    const err = validateRow(row({ eggs: -1 }), 'Vera');
+    expect(err).toContain('Vera');
+    expect(err).toContain('Eggs');
+  });
+});
+
+// --- The assembled GameModule (index.ts) ---------------------------------------
+
+function mkPlayers(...names: string[]): Player[] {
+  return names.map((name, i) => ({
+    id: `p${i}`,
+    name,
+    color: '#7c5cff',
+    createdAt: 0,
+  }));
+}
+
+function mkCtx(players: Player[], config: Record<string, unknown> = {}): RoundContext {
+  return {
+    game: {
+      id: 'g1',
+      type: 'wyrmspan',
+      config,
+      playerIds: players.map((p) => p.id),
+      status: 'active',
+      createdAt: 0,
+      roundCount: 0,
+    },
+    players,
+    config,
+    roundIndex: 0,
+    totals: Object.fromEntries(players.map((p) => [p.id, 0])),
+    rounds: [],
+  };
+}
+
+describe('wyrmspan module', () => {
+  it('is identified by its folder and flagged highest-wins', () => {
+    expect(wyrmspan.id).toBe('wyrmspan');
+    expect(wyrmspan.lowerIsBetter).toBeFalsy();
+    expect(wyrmspan.minPlayers).toBe(1);
+    expect(wyrmspan.maxPlayers).toBe(5);
+  });
+
+  it('is a single-scoresheet game (one round)', () => {
+    expect(wyrmspan.maxRounds?.({}, 3)).toBe(1);
+  });
+
+  it('exposes the leftover variant toggle, defaulting on', () => {
+    const toggle = wyrmspan.configFields?.find((f) => f.key === 'scoreLeftover');
+    expect(toggle?.type).toBe('boolean');
+    expect(toggle?.default).toBe(true);
+  });
+
+  it('creates a fresh zeroed sheet for every player', () => {
+    const players = mkPlayers('Vera', 'Milo');
+    const input = wyrmspan.createRoundInput(mkCtx(players)) as WyrmspanInput;
+    expect(Object.keys(input.rows)).toEqual(['p0', 'p1']);
+    expect(input.rows.p0).toEqual(emptyRow());
+  });
+
+  it('validates and then scores a round for the roster', () => {
+    const players = mkPlayers('Vera', 'Milo');
+    const ctx = mkCtx(players);
+    const input: WyrmspanInput = { rows: { p0: FULL, p1: row({ dragons: 30, coins: 3 }) } };
+    expect(wyrmspan.validateRound(input, ctx)).toBeNull();
+    expect(wyrmspan.scoreRound(input, ctx)).toEqual({ p0: 65, p1: 33 });
+  });
+
+  it('surfaces a validation error with the offending player name', () => {
+    const players = mkPlayers('Vera', 'Milo');
+    const ctx = mkCtx(players);
+    const input: WyrmspanInput = { rows: { p0: emptyRow(), p1: row({ tucked: -2 }) } };
+    expect(wyrmspan.validateRound(input, ctx)).toContain('Milo');
+  });
+
+  it('honors the leftover toggle through the module', () => {
+    const players = mkPlayers('Vera');
+    const ctx = mkCtx(players, { scoreLeftover: false });
+    const input: WyrmspanInput = { rows: { p0: FULL } };
+    expect(wyrmspan.scoreRound(input, ctx)).toEqual({ p0: 63 });
+  });
+
+  it('picks the highest total as the winner', () => {
+    const totals = { p0: 65, p1: 33 };
+    expect(defaultWinners(wyrmspan, totals)).toEqual(['p0']);
+  });
+
+  it('describes a recorded round from its computed deltas', () => {
+    const players = mkPlayers('Vera', 'Milo');
+    const round = {
+      id: 'r1',
+      gameId: 'g1',
+      index: 0,
+      input: { rows: { p0: FULL, p1: row({ dragons: 30 }) } },
+      deltas: { p0: 65, p1: 30 },
+      createdAt: 0,
+    } as unknown as Round;
+    expect(wyrmspan.describeRound?.(round, players)).toBe('Vera 65 · Milo 30');
+  });
+
+  it('ships help text that lists every scoring category', () => {
+    for (const c of WYRMSPAN_CATEGORIES) {
+      expect(wyrmspan.help ?? '').toContain(c.label);
+    }
+  });
+});


### PR DESCRIPTION
## 🐉 Wyrmspan

Adds **Wyrmspan** (Stonemaier Games, 2024) — the dragon-themed cousin of Wingspan — as a first-class, auto-discovered game module. Wyrmspan is an **end-game category scorer**: a game is a single *final scoresheet* with one column per category per player, summed, and the **highest total reigns**.

### Scoring categories (faithful to the official rules)
Each player's final tally sums these eight end-game categories:

| Category | How it scores |
|---|---|
| 🏛️ **Dragon Guild** | VP printed on the spaces your marker reached |
| 🐉 **Dragons** | Printed VP on visible dragons on your mat |
| ✨ **End-game abilities** | VP from end-game (🏆) abilities on visible dragons |
| 🎯 **Public objectives** | VP from the end-of-round goals (friendly ties) |
| 🥚 **Eggs** | 1 VP each |
| 📦 **Cached resources** | 1 VP each |
| 🗂️ **Tucked cards** | 1 VP each |
| 🪙 **Coins** | 1 VP each |
| 🧺 **Leftover items** | 1 VP per 4 spare resources/cards, rounded down |

The rulebook's final step ("excess items and coins") is split into **Coins** (always 1:1) and **Leftover items** (the 1-per-4 bundle) for clarity. Tiebreaker per the rules is *most visible dragons, else shared* — the app's default highest-total winner handles the shared-crown fallback, and the physical dragon tiebreaker is noted in the in-game help.

### Config
- **Score leftover items** (default on) — toggles the fiddly 1-VP-per-4 excess-items step; coins always count.

### Research sources
- Official **Dized** interactive rules — *Game end and scoring* (https://rules.dized.com/game/cYAioTZqRWi-jFCZSJmAdw/YAO5si3FTSK5wVrQ5AKSVw/game-end-and-scoring) — the authoritative list of the eight categories, the leftover 1-per-4 rule, friendly public-objective ties, and the visible-dragon tiebreaker.
- **Stonemaier Games** Wyrmspan Rules & FAQ.

### Design
Follows `DESIGN.md`/`PRODUCT.md` strictly — the chrome is unchanged; dragon personality lives in emoji + copy only:
- One-handed entry: **Steppers** for the small count categories, number inputs for the larger VP totals; touch targets ≥46px.
- **Crown Gold** appears only on the provisional **leader**'s total (👑 + gold ink, co-signalled, never colour-alone); no second Royal Violet action added.
- Changing numbers use `tabular-nums`; depth via the surface ramp; `prefers-reduced-motion` honoured through the global motion rules.
- A "Categories" help popover explains every scoring step.

### Scope & verification
Purely **additive** — only `src/lib/games/wyrmspan/` is touched (`logic.ts`, `index.ts`, `WyrmspanEditor.svelte`, `stats.ts`, `wyrmspan.test.ts`). No edits to `registry.ts`, shared components, other games, or `package.json`. The registry auto-discovers the new `index.ts`.

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 108 passed (incl. a thorough new `wyrmspan.test.ts` and the registry contract)
- `npm run build` — succeeds

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
