### PR TITLE
Add Cornhole 🌽 — cancellation scoring to 21

### DIFF
--- a/src/lib/games/cornhole/CornholeEditor.svelte
+++ b/src/lib/games/cornhole/CornholeEditor.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import {
+    BAGS_PER_SIDE,
+    IN_HOLE_POINTS,
+    ON_BOARD_POINTS,
+    readConfig,
+    scoreCornhole,
+    sideRaw,
+    type CornholeInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: CornholeInput; ctx: RoundContext } = $props();
+
+  const n = $derived(ctx.roundIndex + 1);
+  const cfg = $derived(readConfig(ctx.config));
+  const sideNoun = $derived(cfg.format === '2v2' ? 'Team' : 'Side');
+  const ids = $derived(ctx.players.map((p) => p.id) as [string, string]);
+  const outcome = $derived(scoreCornhole([ids[0], ids[1]], input, ctx.totals, cfg));
+  const gainer = $derived(ctx.players.find((p) => p.id === outcome.gainerId) ?? null);
+
+  function bag(id: string): { inHole: number; onBoard: number } {
+    return input.sides[id] ?? { inHole: 0, onBoard: 0 };
+  }
+  function used(id: string): number {
+    const t = bag(id);
+    return (Number(t.inHole) || 0) + (Number(t.onBoard) || 0);
+  }
+  function left(id: string): number {
+    return Math.max(0, BAGS_PER_SIDE - used(id));
+  }
+  function raw(id: string): number {
+    return sideRaw(bag(id));
+  }
+  function totalBefore(id: string): number {
+    return Number(ctx.totals[id]) || 0;
+  }
+  function projected(id: string): number {
+    return totalBefore(id) + (outcome.deltas[id] ?? 0);
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread head">
+    <span class="row" style="gap: 8px">
+      <span class="pill">Round {n}</span>
+      <span class="pill">to {cfg.target}{cfg.winBy > 1 ? ` · by ${cfg.winBy}` : ''}</span>
+    </span>
+    {#if gainer}
+      <span class="row result" style="gap: 8px">
+        <span class="score-good net">🌽 {gainer.name} +{outcome.net}</span>
+        {#if outcome.busted}<span class="pill bust">💥 Bust → 15</span>{/if}
+      </span>
+    {:else}
+      <span class="muted result">🌽 Wash — no one scores</span>
+    {/if}
+  </div>
+
+  {#each ctx.players as p, i (p.id)}
+    {#if i === 1}<div class="vs" aria-hidden="true">vs</div>{/if}
+    <div class="side" class:scoring={outcome.gainerId === p.id}>
+      <div class="row spread" style="margin-bottom: 12px">
+        <span class="row who" style="gap: 8px">
+          <Avatar name={p.name} color={p.color} />
+          <span class="name">
+            <span class="overline">{sideNoun} {i === 0 ? 'A' : 'B'}</span>
+            <strong>{p.name}</strong>
+          </span>
+        </span>
+        <span class="tally">
+          <span class="cur">{totalBefore(p.id)}</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span
+            class="proj"
+            class:score-good={projected(p.id) > totalBefore(p.id)}
+            class:score-bad={projected(p.id) < totalBefore(p.id)}
+          >{projected(p.id)}{#if outcome.busted && outcome.gainerId === p.id}<span class="burst" aria-hidden="true"> 💥</span>{/if}</span>
+        </span>
+      </div>
+
+      <div class="fields">
+        <label class="f">
+          <span class="flabel">In the hole <span class="x">×{IN_HOLE_POINTS}</span></span>
+          <Stepper bind:value={input.sides[p.id].inHole} min={0} max={BAGS_PER_SIDE - (Number(bag(p.id).onBoard) || 0)} />
+        </label>
+        <label class="f">
+          <span class="flabel">On the board <span class="x">×{ON_BOARD_POINTS}</span></span>
+          <Stepper bind:value={input.sides[p.id].onBoard} min={0} max={BAGS_PER_SIDE - (Number(bag(p.id).inHole) || 0)} />
+        </label>
+      </div>
+
+      <div class="row spread meta">
+        <span class="pts">🌽 {raw(p.id)} pts this round</span>
+        <span class="left" class:score-bad={used(p.id) > BAGS_PER_SIDE}>
+          {left(p.id)} {left(p.id) === 1 ? 'bag' : 'bags'} left
+        </span>
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .head {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .result {
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+  .net {
+    font-weight: 800;
+  }
+  .bust {
+    color: var(--bad);
+    border-color: color-mix(in srgb, var(--bad) 55%, var(--border));
+  }
+  .side {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 14px;
+  }
+  /* The side that would score this round lifts one step up the surface ramp — depth, not a stripe. */
+  .side.scoring {
+    background: var(--surface-3);
+    border-color: color-mix(in srgb, var(--good) 45%, var(--border));
+  }
+  .name {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.15;
+  }
+  .overline {
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .tally {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+  }
+  .tally .cur {
+    color: var(--muted);
+  }
+  .tally .arrow {
+    color: var(--muted);
+  }
+  .tally .proj {
+    font-weight: 800;
+    font-size: 1.15rem;
+  }
+  .fields {
+    display: flex;
+    gap: 14px;
+    flex-wrap: wrap;
+  }
+  .f {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .flabel {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .flabel .x {
+    font-weight: 700;
+    color: var(--text);
+  }
+  .meta {
+    margin-top: 12px;
+    font-size: 0.82rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .vs {
+    align-self: center;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin: -4px 0;
+  }
+</style>

--- a/src/lib/games/cornhole/cornhole.test.ts
+++ b/src/lib/games/cornhole/cornhole.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round, RoundContext } from '../../types';
+import { cornhole } from './index';
+import {
+  applyBust,
+  BAGS_PER_SIDE,
+  cancel,
+  type CornholeConfig,
+  type CornholeInput,
+  isWon,
+  readConfig,
+  scoreCornhole,
+  sideRaw,
+} from './logic';
+
+const DEFAULT: CornholeConfig = { target: 21, bust: false, winBy: 1, format: '1v1' };
+
+function player(id: ID, name: string): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+function ctxOf(
+  totals: Record<ID, number>,
+  config: Record<string, unknown> = {},
+  roundIndex = 0,
+): RoundContext {
+  return {
+    game: {} as Game,
+    players: [player('a', 'Aces'), player('b', 'Bombers')],
+    config,
+    roundIndex,
+    totals,
+    rounds: [],
+  };
+}
+function input(a: [number, number], b: [number, number]): CornholeInput {
+  return {
+    sides: {
+      a: { inHole: a[0], onBoard: a[1] },
+      b: { inHole: b[0], onBoard: b[1] },
+    },
+  };
+}
+
+describe('cornhole: raw side points', () => {
+  it('scores 3 per bag in the hole, 1 per bag on the board', () => {
+    expect(sideRaw({ inHole: 0, onBoard: 0 })).toBe(0);
+    expect(sideRaw({ inHole: 1, onBoard: 0 })).toBe(3);
+    expect(sideRaw({ inHole: 0, onBoard: 1 })).toBe(1);
+    expect(sideRaw({ inHole: 2, onBoard: 1 })).toBe(7); // 6 + 1
+    expect(sideRaw({ inHole: 4, onBoard: 0 })).toBe(12); // a four-bagger
+  });
+
+  it('ignores junk / negative bag counts', () => {
+    expect(sideRaw(undefined)).toBe(0);
+    expect(sideRaw({ inHole: -3, onBoard: 2 })).toBe(2);
+    expect(sideRaw({ inHole: 1.9, onBoard: 0 })).toBe(3); // truncates
+  });
+});
+
+describe('cornhole: cancellation', () => {
+  it('only the higher side scores, and only the difference', () => {
+    expect(cancel(7, 4)).toEqual({ gainer: 'a', net: 3 });
+    expect(cancel(4, 7)).toEqual({ gainer: 'b', net: 3 });
+  });
+
+  it('equal points are a wash — nobody scores', () => {
+    expect(cancel(0, 0)).toEqual({ gainer: null, net: 0 });
+    expect(cancel(6, 6)).toEqual({ gainer: null, net: 0 });
+  });
+
+  it('resolves the canonical example: A 7, B 4 -> A +3, B +0', () => {
+    const out = scoreCornhole(['a', 'b'], input([2, 1], [1, 1]), { a: 0, b: 0 }, DEFAULT);
+    expect(out.deltas).toEqual({ a: 3, b: 0 });
+    expect(out.gainerId).toBe('a');
+    expect(out.net).toBe(3);
+    expect(out.busted).toBe(false);
+  });
+
+  it('a wash leaves both sides unchanged', () => {
+    const out = scoreCornhole(['a', 'b'], input([1, 0], [1, 0]), { a: 5, b: 5 }, DEFAULT);
+    expect(out.deltas).toEqual({ a: 0, b: 0 });
+    expect(out.gainerId).toBeNull();
+  });
+});
+
+describe('cornhole: bust variant (reset to 15)', () => {
+  const bustCfg: CornholeConfig = { ...DEFAULT, bust: true };
+
+  it('overshooting the target drops the scoring side to 15', () => {
+    // A at 20, sinks two bags (6) vs nothing -> would hit 26 -> bust to 15.
+    const out = scoreCornhole(['a', 'b'], input([2, 0], [0, 0]), { a: 20, b: 12 }, bustCfg);
+    expect(out.busted).toBe(true);
+    expect(out.deltas.a).toBe(-5); // 20 -> 15
+    expect(20 + out.deltas.a).toBe(15);
+  });
+
+  it('a bust from below 15 still lands exactly on 15', () => {
+    // A at 14, four-bagger (12) -> 26 -> bust to 15 (net delta +1).
+    const out = scoreCornhole(['a', 'b'], input([4, 0], [0, 0]), { a: 14, b: 3 }, bustCfg);
+    expect(out.busted).toBe(true);
+    expect(out.deltas.a).toBe(1);
+    expect(14 + out.deltas.a).toBe(15);
+  });
+
+  it('landing exactly on the target is a win, never a bust', () => {
+    // A at 18, sinks one bag (3) -> exactly 21.
+    const out = scoreCornhole(['a', 'b'], input([1, 0], [0, 0]), { a: 18, b: 10 }, bustCfg);
+    expect(out.busted).toBe(false);
+    expect(18 + out.deltas.a).toBe(21);
+  });
+
+  it('with bust off, the side simply sails past the target', () => {
+    const out = scoreCornhole(['a', 'b'], input([2, 0], [0, 0]), { a: 20, b: 12 }, DEFAULT);
+    expect(out.busted).toBe(false);
+    expect(20 + out.deltas.a).toBe(26);
+  });
+
+  it('does not bite when the target is not above 15 (reset would not punish)', () => {
+    const shortBust: CornholeConfig = { ...bustCfg, target: 11 };
+    const res = applyBust(10, 4, shortBust); // 14 > 11, but target <= 15
+    expect(res.busted).toBe(false);
+    expect(res.delta).toBe(4);
+  });
+});
+
+describe('cornhole: win detection', () => {
+  it('first side to the target wins (win-by 1)', () => {
+    expect(isWon({ a: 21, b: 15 }, DEFAULT)).toBe(true);
+    expect(isWon({ a: 20, b: 19 }, DEFAULT)).toBe(false);
+    expect(isWon({ a: 24, b: 12 }, DEFAULT)).toBe(true); // over the top counts (no bust)
+  });
+
+  it('win-by margin keeps the game alive until the lead is big enough', () => {
+    const winBy2: CornholeConfig = { ...DEFAULT, winBy: 2 };
+    expect(isWon({ a: 21, b: 20 }, winBy2)).toBe(false);
+    expect(isWon({ a: 21, b: 19 }, winBy2)).toBe(true);
+    expect(isWon({ a: 22, b: 20 }, winBy2)).toBe(true);
+  });
+
+  it('nobody wins before the target', () => {
+    expect(isWon({ a: 0, b: 0 }, DEFAULT)).toBe(false);
+    expect(isWon({}, DEFAULT)).toBe(false);
+  });
+});
+
+describe('cornhole: config parsing', () => {
+  it('fills sensible defaults', () => {
+    expect(readConfig({})).toEqual({ target: 21, bust: false, winBy: 1, format: '1v1' });
+  });
+  it('coerces and guards raw values', () => {
+    expect(readConfig({ target: '15', bust: true, winBy: 0, format: '2v2' })).toEqual({
+      target: 15,
+      bust: true,
+      winBy: 1, // clamped up from 0
+      format: '2v2',
+    });
+    expect(readConfig({ format: 'nonsense' }).format).toBe('1v1');
+  });
+});
+
+describe('cornhole: module wiring', () => {
+  it('is a two-sided, higher-wins game with the right identity', () => {
+    expect(cornhole.id).toBe('cornhole');
+    expect(cornhole.minPlayers).toBe(2);
+    expect(cornhole.maxPlayers).toBe(2);
+    expect(cornhole.lowerIsBetter).toBeFalsy();
+  });
+
+  it('seeds an empty throw for each side', () => {
+    const draft = cornhole.createRoundInput(ctxOf({ a: 0, b: 0 })) as CornholeInput;
+    expect(draft.sides.a).toEqual({ inHole: 0, onBoard: 0 });
+    expect(draft.sides.b).toEqual({ inHole: 0, onBoard: 0 });
+  });
+
+  it('scoreRound routes through cancellation + config', () => {
+    const deltas = cornhole.scoreRound(input([3, 0], [1, 0]), ctxOf({ a: 0, b: 0 }));
+    expect(deltas).toEqual({ a: 6, b: 0 }); // 9 vs 3 -> A +6
+  });
+
+  it('scoreRound honors the bust config from ctx', () => {
+    const deltas = cornhole.scoreRound(input([2, 0], [0, 0]), ctxOf({ a: 20, b: 0 }, { bust: true }));
+    expect(20 + deltas.a).toBe(15);
+  });
+
+  it('isFinished fires exactly at the target', () => {
+    expect(cornhole.isFinished!({ a: 20, b: 10 }, { config: {}, roundCount: 8, playerCount: 2 })).toBe(false);
+    expect(cornhole.isFinished!({ a: 21, b: 10 }, { config: {}, roundCount: 9, playerCount: 2 })).toBe(true);
+  });
+
+  it('validateRound rejects more than four bags a side', () => {
+    const ctx = ctxOf({ a: 0, b: 0 });
+    expect(cornhole.validateRound(input([3, 2], [0, 0]), ctx)).toMatch(/bags per round/i);
+    expect(cornhole.validateRound(input([-1, 0], [0, 0]), ctx)).toMatch(/negative/i);
+    expect(cornhole.validateRound(input([BAGS_PER_SIDE, 0], [1, 3]), ctx)).toBeNull();
+  });
+
+  it('describeRound narrates the cancelled result', () => {
+    const players = [player('a', 'Aces'), player('b', 'Bombers')];
+    const round = { input: input([2, 1], [1, 1]) } as unknown as Round;
+    expect(cornhole.describeRound!(round, players)).toBe('🌽 Aces +3 · 7–4');
+    const washed = { input: input([1, 0], [1, 0]) } as unknown as Round;
+    expect(cornhole.describeRound!(washed, players)).toMatch(/Wash/);
+  });
+});

--- a/src/lib/games/cornhole/index.ts
+++ b/src/lib/games/cornhole/index.ts
@@ -1,0 +1,103 @@
+import type { GameModule, ID, Player, Round, RoundContext } from '../../types';
+import Editor from './CornholeEditor.svelte';
+import { cornholeStats } from './stats';
+import {
+  BAGS_PER_SIDE,
+  cancel,
+  type CornholeInput,
+  emptyThrow,
+  isWon,
+  readConfig,
+  scoreCornhole,
+  sideRaw,
+} from './logic';
+
+/** The two seats are the two sides — first is Side A, second is Side B. */
+function sideIds(ctx: RoundContext): [ID, ID] {
+  return [ctx.players[0]?.id, ctx.players[1]?.id];
+}
+
+export const cornhole: GameModule = {
+  id: 'cornhole',
+  name: 'Cornhole',
+  tagline: 'Toss the bags. Cancel & climb to 21.',
+  emoji: '🌽',
+  keywords: ['bags', 'bag toss', 'corn toss', 'baggo', 'cornhole', 'tailgate', 'backyard'],
+  // Two sides — 1v1 or 2v2. Each seat is a side, so the board shows two scores to 21.
+  minPlayers: 2,
+  maxPlayers: 2,
+  configFields: [
+    { key: 'target', label: 'Play to', type: 'number', default: 21, min: 11, max: 51, help: 'First side to reach this wins. Backyard standard is 21.' },
+    { key: 'bust', label: 'Bust — overshoot and you drop to 15', type: 'boolean', default: false, help: 'Blow past the target and your side tumbles back to 15. Land it exactly to win.' },
+    { key: 'winBy', label: 'Win by', type: 'number', default: 1, min: 1, max: 5, help: 'Margin needed to close it out. 1 = first side to the target takes it.' },
+    {
+      key: 'format',
+      label: 'Sides',
+      type: 'select',
+      default: '1v1',
+      options: [
+        { value: '1v1', label: 'Singles (1v1)' },
+        { value: '2v2', label: 'Doubles (2v2)' },
+      ],
+      help: 'Flavor only — solo duel or partners, it is always two sides racing to the target.',
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): CornholeInput => ({
+    sides: Object.fromEntries(ctx.players.map((p) => [p.id, emptyThrow()])),
+  }),
+
+  validateRound: (input: CornholeInput, ctx: RoundContext): string | null => {
+    if (ctx.players.length !== 2) return 'Cornhole is played by exactly two sides.';
+    for (const p of ctx.players) {
+      const t = input.sides?.[p.id];
+      const inHole = Math.trunc(Number(t?.inHole) || 0);
+      const onBoard = Math.trunc(Number(t?.onBoard) || 0);
+      if (inHole < 0 || onBoard < 0) return `${p.name}: bag counts can't be negative.`;
+      if (inHole + onBoard > BAGS_PER_SIDE) {
+        return `${p.name}: only ${BAGS_PER_SIDE} bags per round (got ${inHole + onBoard}).`;
+      }
+    }
+    return null;
+  },
+
+  scoreRound: (input: CornholeInput, ctx: RoundContext): Record<ID, number> =>
+    scoreCornhole(sideIds(ctx), input, ctx.totals, readConfig(ctx.config)).deltas,
+
+  isFinished: (totals, { config }) => isWon(totals, readConfig(config)),
+
+  describeRound: (round: Round, players: Player[]): string => {
+    const input = round.input as CornholeInput;
+    const [a, b] = players;
+    if (!a || !b) return '🌽 —';
+    const aRaw = sideRaw(input.sides?.[a.id]);
+    const bRaw = sideRaw(input.sides?.[b.id]);
+    const { gainer, net } = cancel(aRaw, bRaw);
+    if (!gainer) return `🌽 Wash · ${aRaw}–${bRaw}`;
+    const name = gainer === 'a' ? a.name : b.name;
+    return `🌽 ${name} +${net} · ${aRaw}–${bRaw}`;
+  },
+
+  help: [
+    'Cornhole — cancellation scoring, two sides, first to 21.',
+    '',
+    'Each round both sides toss their 4 bags:',
+    '• In the hole (a "drano") = 3 points',
+    '• On the board (a "woody") = 1 point',
+    '• On the ground = nothing',
+    '',
+    'The two sides then CANCEL: only the higher side scores, and only the',
+    'difference. Side A gets 7, Side B gets 4 → A scores +3, B scores 0. A tie',
+    'is a "wash" — nobody scores.',
+    '',
+    'First side to the target (21 by default) wins. Land it exactly for the',
+    'cleanest finish.',
+    '',
+    'Bust variant (optional): overshoot the target and your side drops back to',
+    '15 — so a four-bagger at the wrong moment can undo you.',
+  ].join('\n'),
+
+  stats: cornholeStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/cornhole/logic.ts
+++ b/src/lib/games/cornhole/logic.ts
@@ -1,0 +1,150 @@
+import type { ID } from '../../types';
+
+/**
+ * Pure Cornhole scoring — no Svelte, no I/O, fully unit-testable. `index.ts` and the
+ * editor import from here so the exact math the game plays is the exact math the tests
+ * exercise. Cornhole is a two-SIDE game (1v1 or 2v2); in this app each side is one
+ * "player" seat, so the board always shows two scores racing to the target.
+ */
+
+/** Bag in the hole ("drano" / "cornhole"). */
+export const IN_HOLE_POINTS = 3;
+/** Bag resting on the board ("woody"). */
+export const ON_BOARD_POINTS = 1;
+/** Bags each side throws per round (frame). */
+export const BAGS_PER_SIDE = 4;
+/** Where the bust variant sends an overshooting side. */
+export const BUST_TO = 15;
+
+/** One side's bags for a single round. */
+export interface SideThrow {
+  /** Bags that went in the hole (×3). */
+  inHole: number;
+  /** Bags resting on the board (×1). */
+  onBoard: number;
+}
+
+/** A round's input: each side's bags, keyed by that side's player id. */
+export interface CornholeInput {
+  sides: Record<ID, SideThrow>;
+}
+
+export type CornholeFormat = '1v1' | '2v2';
+
+/** Normalized, validated config the scorer actually runs on. */
+export interface CornholeConfig {
+  target: number;
+  bust: boolean;
+  winBy: number;
+  format: CornholeFormat;
+}
+
+/** Full result of resolving one round — deltas plus the pieces the UI narrates. */
+export interface RoundOutcome {
+  /** Per-side point deltas to apply this round (the loser/wash side is 0). */
+  deltas: Record<ID, number>;
+  /** Raw round points for side A (first seat) before cancellation. */
+  aRaw: number;
+  /** Raw round points for side B (second seat) before cancellation. */
+  bRaw: number;
+  /** The side that scored this round, or null on a wash (tie). */
+  gainerId: ID | null;
+  /** Net points the leader won this round (after cancellation, before bust). */
+  net: number;
+  /** True when the bust rule pulled the scoring side back to {@link BUST_TO}. */
+  busted: boolean;
+}
+
+/** Read raw, possibly-untrusted config into a clean {@link CornholeConfig}. */
+export function readConfig(config: Record<string, unknown> = {}): CornholeConfig {
+  const target = Math.max(1, Math.trunc(Number(config.target)) || 21);
+  const winBy = Math.max(1, Math.trunc(Number(config.winBy)) || 1);
+  return {
+    target,
+    bust: config.bust === true,
+    winBy,
+    format: config.format === '2v2' ? '2v2' : '1v1',
+  };
+}
+
+/** A fresh, empty throw for one side. */
+export function emptyThrow(): SideThrow {
+  return { inHole: 0, onBoard: 0 };
+}
+
+/** Clamp a bag count to a sane non-negative integer. */
+function bags(n: unknown): number {
+  return Math.max(0, Math.trunc(Number(n) || 0));
+}
+
+/** Raw round points for one side: in-hole ×3 + on-board ×1. */
+export function sideRaw(t: SideThrow | undefined): number {
+  if (!t) return 0;
+  return bags(t.inHole) * IN_HOLE_POINTS + bags(t.onBoard) * ON_BOARD_POINTS;
+}
+
+/** Cancellation: the higher side keeps the difference; equal is a wash. */
+export function cancel(a: number, b: number): { gainer: 'a' | 'b' | null; net: number } {
+  if (a > b) return { gainer: 'a', net: a - b };
+  if (b > a) return { gainer: 'b', net: b - a };
+  return { gainer: null, net: 0 };
+}
+
+/**
+ * Apply the bust variant to a scoring side. Returns the delta to record (which can be
+ * negative when a bust drags the side back to {@link BUST_TO}). Bust only bites when the
+ * target is above 15 — otherwise "back to 15" wouldn't be a setback, so it's ignored.
+ */
+export function applyBust(
+  oldTotal: number,
+  net: number,
+  cfg: Pick<CornholeConfig, 'target' | 'bust'>,
+): { delta: number; busted: boolean } {
+  const projected = oldTotal + net;
+  if (cfg.bust && cfg.target > BUST_TO && projected > cfg.target) {
+    return { delta: BUST_TO - oldTotal, busted: true };
+  }
+  return { delta: net, busted: false };
+}
+
+/**
+ * Resolve a round for the two sides (in seat order). `totals` are the cumulative
+ * scores BEFORE this round, needed so the bust rule can reset the scoring side.
+ */
+export function scoreCornhole(
+  ids: [ID, ID],
+  input: CornholeInput,
+  totals: Record<ID, number>,
+  cfg: CornholeConfig,
+): RoundOutcome {
+  const [aId, bId] = ids;
+  const aRaw = sideRaw(input.sides?.[aId]);
+  const bRaw = sideRaw(input.sides?.[bId]);
+  const { gainer, net } = cancel(aRaw, bRaw);
+
+  const deltas: Record<ID, number> = { [aId]: 0, [bId]: 0 };
+  let gainerId: ID | null = null;
+  let busted = false;
+
+  if (gainer) {
+    gainerId = gainer === 'a' ? aId : bId;
+    const { delta, busted: b } = applyBust(Number(totals[gainerId]) || 0, net, cfg);
+    deltas[gainerId] = delta;
+    busted = b;
+  }
+
+  return { deltas, aRaw, bRaw, gainerId, net, busted };
+}
+
+/**
+ * True once a side has won: it has reached the target AND leads by at least `winBy`.
+ * With the default `winBy` of 1 this is simply "first side to the target".
+ */
+export function isWon(totals: Record<ID, number>, cfg: CornholeConfig): boolean {
+  const vals = Object.values(totals);
+  if (vals.length === 0) return false;
+  const sorted = [...vals].sort((x, y) => y - x);
+  const top = sorted[0] ?? 0;
+  const second = sorted.length > 1 ? (sorted[1] ?? 0) : -Infinity;
+  return top >= cfg.target && top - second >= cfg.winBy;
+}

--- a/src/lib/games/cornhole/stats.ts
+++ b/src/lib/games/cornhole/stats.ts
@@ -1,0 +1,80 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt, fmtPct } from '../../stats/format';
+import { BAGS_PER_SIDE, type CornholeInput, sideRaw } from './logic';
+
+interface SideAgg {
+  /** Bags sunk in the hole ("dranos"). */
+  inHole: number;
+  /** Bags landed on the board ("woodies"). */
+  onBoard: number;
+  /** Rounds where this side put all four bags in the hole. */
+  fourBaggers: number;
+  /** Rounds this side threw in. */
+  rounds: number;
+}
+
+/**
+ * Cornhole stats from each round's recorded bags. Pure and dependency-free (mirrors the
+ * module's own `sideRaw`), so a finished game contributes stats the same way it scores.
+ * Every "player" here is a SIDE (1v1 or 2v2), matching how the game is modeled.
+ */
+export function cornholeStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, SideAgg>();
+  const get = (id: ID): SideAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { inHole: 0, onBoard: 0, fourBaggers: 0, rounds: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let washes = 0;
+  let scoredRounds = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as CornholeInput | undefined;
+    if (!input?.sides) continue;
+
+    const raws: number[] = [];
+    for (const [pid, t] of Object.entries(input.sides)) {
+      const id = canonical(pid);
+      const a = get(id);
+      const inHole = Math.max(0, Math.trunc(Number(t?.inHole) || 0));
+      const onBoard = Math.max(0, Math.trunc(Number(t?.onBoard) || 0));
+      a.inHole += inHole;
+      a.onBoard += onBoard;
+      a.rounds += 1;
+      if (inHole >= BAGS_PER_SIDE) a.fourBaggers += 1;
+      raws.push(sideRaw(t));
+    }
+
+    scoredRounds += 1;
+    if (raws.length === 2 && raws[0] === raws[1]) washes += 1;
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let totalInHole = 0;
+  let totalFourBaggers = 0;
+
+  for (const [id, a] of per) {
+    totalInHole += a.inHole;
+    totalFourBaggers += a.fourBaggers;
+    const metrics: Metric[] = [];
+    if (a.inHole) metrics.push({ key: 'ch_hole', label: 'Bags in the hole', value: fmtInt(a.inHole), emoji: '🕳️' });
+    if (a.fourBaggers) metrics.push({ key: 'ch_four', label: 'Four-baggers', value: fmtInt(a.fourBaggers), emoji: '💣' });
+    const bags = a.inHole + a.onBoard;
+    if (bags) metrics.push({ key: 'ch_acc', label: 'On-target bags', value: fmtPct((a.inHole + a.onBoard) / (a.rounds * BAGS_PER_SIDE)), emoji: '🎯' });
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totalInHole) global.push({ key: 'ch_hole_all', label: 'Bags in the hole', value: fmtInt(totalInHole), emoji: '🕳️' });
+  if (totalFourBaggers) global.push({ key: 'ch_four_all', label: 'Four-baggers', value: fmtInt(totalFourBaggers), emoji: '💣' });
+  if (scoredRounds) global.push({ key: 'ch_wash', label: 'Washed rounds', value: fmtPct(washes / scoredRounds), emoji: '🧺' });
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
﻿## 🌽 Cornhole

Adds a first-class **Cornhole** game module — the backyard/tailgate bag-toss, built for one-handed scoring in the sun.

### How it scores (cancellation)
Two sides, 1v1 or 2v2. Each round both sides toss their **4 bags**:
- **In the hole** ("drano") = **3 points**
- **On the board** ("woody") = **1 point**

The two sides'' round points **cancel** — only the higher side scores, and only the **difference**. So *Side A 7, Side B 4 -> A +3, B +0*. A tie is a **wash** (nobody scores). First side to **21** wins.

### Config (variants)
- **Play to** — target score (default 21)
- **Bust** — overshoot the target and your side tumbles back to **15**; land it exactly to win (guarded so it only bites when the target is above 15)
- **Win by** — margin needed to close it out (1 = first to target)
- **Sides** — Singles (1v1) / Doubles (2v2) flavor

### Design decision — two sides = two seats
Cornhole''s scoreboard is fundamentally two scores racing to 21 (even in 2v2 there are only two team scores), so each seat is a **side**. That keeps the board clean — two rows, one gold leader — maps cancellation perfectly, and avoids invalid odd player counts. In doubles, name the two seats as your teams.

### What''s in the box
- `logic.ts` — pure cancellation + bust + win detection (no Svelte)
- `index.ts` — the `GameModule` (`isFinished` at the target, `describeRound`, help/slang)
- `CornholeEditor.svelte` — per-side **in-the-hole / on-the-board** steppers with a live cancellation preview and a running *18 -> 21* tally
- `cornhole.test.ts` — cancellation, bust reset-to-15, exact-21, win-by, washes, module wiring
- `stats.ts` — bags in the hole, four-baggers, washed rounds

### Design & a11y
Chrome unchanged — personality is emoji + copy only (🌽, drano/woody/wash/four-bagger). No new Crown Gold (leader/winner stays the board''s job); depth via the surface ramp, not stripes/shadows. Every changing number is `tabular-nums`, touch targets reuse the shared >=46px Stepper, and state never rides on color alone (arrows, `+N`, 💥 all co-signal). Reuses `Avatar`/`Stepper`; no shared components or deps touched.

### Verification
`npm run check` (0 errors) - `npm test` (98 passed) - `npm run build` all green.

Purely additive under `src/lib/games/cornhole/` — auto-discovered by the registry, so `registry.ts` and everything else are untouched.
