### PR TITLE
Add Uno Golf game module ⛳

### DIFF
--- a/src/lib/games/unogolf/UnoGolfEditor.svelte
+++ b/src/lib/games/unogolf/UnoGolfEditor.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { handStrokes, resolveConfig, type UnoGolfInput } from './logic';
+
+  let { input = $bindable(), ctx }: { input: UnoGolfInput; ctx: RoundContext } = $props();
+
+  const cfg = $derived(resolveConfig(ctx.config));
+  const hole = $derived(ctx.roundIndex + 1);
+  const totalHoles = $derived(cfg.format === 'holes' ? cfg.holes : null);
+  const parked = $derived(ctx.players.length - (input.out ? 1 : 0));
+
+  let showKey = $state(false);
+
+  function strokes(id: string): number {
+    return input.out === id ? 0 : handStrokes(input.hands[id], cfg);
+  }
+
+  function sink(id: string) {
+    if (input.out === id) {
+      input.out = null;
+    } else {
+      input.out = id;
+      input.hands[id] = { numbers: 0, actions: 0, wilds: 0 };
+    }
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="pill">
+      {#if totalHoles}⛳ Hole {hole} of {totalHoles}{:else}⛳ Hole {hole}{/if}
+    </span>
+    <button
+      type="button"
+      class="btn small ghost"
+      onclick={() => (showKey = !showKey)}
+      aria-expanded={showKey}
+    >
+      Card values
+    </button>
+  </div>
+
+  {#if showKey}
+    <div class="key" role="note">
+      <span class="chip">0–9 = face</span>
+      <span class="chip">Action = {cfg.actionValue}</span>
+      <span class="chip">Wild = {cfg.wildValue}</span>
+    </div>
+  {/if}
+
+  <p class="muted hint">
+    {#if input.out}
+      Tally the cards left in each other hand — number faces, then action &amp; wild counts.
+    {:else}
+      Tap ⛳ to mark who went out, then tally the cards left in every other hand.
+    {/if}
+  </p>
+
+  {#each ctx.players as p (p.id)}
+    {@const isOut = input.out === p.id}
+    <div class="prow" class:out={isOut}>
+      <div class="row spread head">
+        <span class="row who">
+          <Avatar name={p.name} color={p.color} />
+          <strong>{p.name}</strong>
+        </span>
+        <span class="preview" class:score-good={isOut}>
+          {#if isOut}
+            <span class="sank">⛳ 0</span>
+          {:else}
+            +{strokes(p.id)}
+          {/if}
+        </span>
+      </div>
+
+      <div class="row sinkrow">
+        <button
+          type="button"
+          class="toggle"
+          class:on={isOut}
+          onclick={() => sink(p.id)}
+          aria-pressed={isOut}
+        >
+          ⛳ {isOut ? 'Sank the hole' : 'Sank it?'}
+        </button>
+      </div>
+
+      {#if isOut}
+        <p class="cleared muted">Cleared the hole — 0 strokes.</p>
+      {:else}
+        <div class="fields">
+          <label class="f">
+            <span>Number cards</span>
+            <input
+              type="number"
+              min="0"
+              inputmode="numeric"
+              bind:value={input.hands[p.id].numbers}
+            />
+          </label>
+          <label class="f">
+            <span>Actions ×{cfg.actionValue}</span>
+            <Stepper bind:value={input.hands[p.id].actions} min={0} />
+          </label>
+          <label class="f">
+            <span>Wilds ×{cfg.wildValue}</span>
+            <Stepper bind:value={input.hands[p.id].wilds} min={0} />
+          </label>
+        </div>
+      {/if}
+    </div>
+  {/each}
+
+  <p class="muted foot">
+    {#if input.out}
+      {parked}
+      {parked === 1 ? 'player counts' : 'players count'} their leftover strokes this hole.
+    {:else}
+      Someone always goes out to end a hole — mark them with ⛳.
+    {/if}
+  </p>
+</div>
+
+<style>
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .prow.out {
+    background: var(--surface-3);
+    border-color: color-mix(in srgb, var(--primary) 45%, var(--border));
+  }
+  .head {
+    margin-bottom: 10px;
+  }
+  .who {
+    gap: 8px;
+  }
+  .sinkrow {
+    margin-bottom: 10px;
+  }
+  .toggle {
+    flex: 1;
+    min-height: 46px;
+    padding: 10px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  }
+  .toggle.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .preview {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .sank {
+    white-space: nowrap;
+  }
+  .fields {
+    display: flex;
+    gap: 14px;
+    flex-wrap: wrap;
+  }
+  .f {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+  .f input {
+    width: 84px;
+  }
+  .key {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .chip {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 0.8rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .hint {
+    margin: 0;
+    font-size: 0.85rem;
+  }
+  .cleared {
+    margin: 2px 0 0;
+    font-size: 0.85rem;
+  }
+  .foot {
+    margin: 2px 0 0;
+    font-size: 0.82rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .prow,
+    .toggle {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/games/unogolf/index.ts
+++ b/src/lib/games/unogolf/index.ts
@@ -1,0 +1,125 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './UnoGolfEditor.svelte';
+import { unogolfStats } from './stats';
+import {
+  DEFAULTS,
+  emptyHand,
+  resolveConfig,
+  scoreHole,
+  validateHole,
+  type UnoGolfInput,
+} from './logic';
+
+export type { UnoGolfInput, UnoGolfHand, UnoGolfConfig, UnoGolfFormat } from './logic';
+
+const ids = (ctx: RoundContext): ID[] => ctx.players.map((p) => p.id);
+const nameOf = (ctx: RoundContext) => (id: ID) =>
+  ctx.players.find((p) => p.id === id)?.name ?? '?';
+
+export const unogolf: GameModule = {
+  id: 'unogolf',
+  name: 'Uno Golf',
+  tagline: 'Nine holes of Uno — lowest score wins',
+  emoji: '⛳',
+  keywords: ['uno', 'golf', 'holes', 'party', 'cards', 'lowest wins', 'nine holes', 'links'],
+  minPlayers: 2,
+  maxPlayers: 10,
+  lowerIsBetter: true,
+  configFields: [
+    {
+      key: 'format',
+      label: 'Round format',
+      type: 'select',
+      default: DEFAULTS.format,
+      options: [
+        { value: 'holes', label: 'Fixed holes' },
+        { value: 'target', label: 'Play to a target' },
+      ],
+      help: 'Fixed plays a set number of holes; Target plays until someone reaches the score cap. Lowest total always wins.',
+    },
+    {
+      key: 'holes',
+      label: 'Holes to play',
+      type: 'number',
+      default: DEFAULTS.holes,
+      min: 1,
+      max: 18,
+      help: 'A round of golf is 9 holes — go 18 for the full course. (Used in Fixed-holes format.)',
+    },
+    {
+      key: 'target',
+      label: 'Target score (Target format)',
+      type: 'number',
+      default: DEFAULTS.target,
+      min: 10,
+      help: 'In Target format the game ends once any player reaches this — lowest total still wins.',
+    },
+    {
+      key: 'actionValue',
+      label: 'Action card value (Skip / Reverse / Draw Two)',
+      type: 'number',
+      default: DEFAULTS.actionValue,
+      min: 0,
+      step: 5,
+    },
+    {
+      key: 'wildValue',
+      label: 'Wild card value (Wild / Wild Draw Four)',
+      type: 'number',
+      default: DEFAULTS.wildValue,
+      min: 0,
+      step: 5,
+    },
+  ],
+
+  maxRounds: (config) => {
+    const cfg = resolveConfig(config);
+    return cfg.format === 'holes' ? cfg.holes : null;
+  },
+
+  isFinished: (totals, { config }) => {
+    const cfg = resolveConfig(config);
+    if (cfg.format !== 'target') return false;
+    return Object.values(totals).some((t) => t >= cfg.target);
+  },
+
+  createRoundInput: (ctx: RoundContext): UnoGolfInput => ({
+    hands: Object.fromEntries(ctx.players.map((p) => [p.id, emptyHand()])),
+    out: null,
+  }),
+
+  validateRound: (input: UnoGolfInput, ctx: RoundContext): string | null =>
+    validateHole(input, ids(ctx), nameOf(ctx)),
+
+  scoreRound: (input: UnoGolfInput, ctx: RoundContext): Record<ID, number> =>
+    scoreHole(input, ids(ctx), resolveConfig(ctx.config)),
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as UnoGolfInput | undefined;
+    if (!input) return '';
+    const name = (id: ID | null) => players.find((p) => p.id === id)?.name ?? '?';
+    const parts: string[] = [];
+    if (input.out) parts.push(`⛳ ${name(input.out)} sank it`);
+    for (const p of players) {
+      if (input.out === p.id) continue;
+      if (!input.hands?.[p.id]) continue;
+      parts.push(`${p.name} +${Number(round.deltas?.[p.id]) || 0}`);
+    }
+    return parts.join(' · ');
+  },
+
+  help: [
+    'Golf, but with Uno. Play a fixed number of holes (hands) — 9 by default, like a real round of golf. Lowest total after every hole wins.',
+    '',
+    'Each hole, one player goes out (empties their hand) and sinks the hole for 0 strokes. Everyone else counts the cards left in their own hand as strokes:',
+    '• Number cards (0–9): face value',
+    '• Action cards (Skip / Reverse / Draw Two): 20 each (default)',
+    '• Wild / Wild Draw Four: 50 each (default)',
+    '',
+    'Mark who sank the hole with ⛳, then tally each other player’s leftover cards. Prefer a marathon? Switch to Target format and race to a score cap instead of fixed holes — lowest still wins.',
+  ].join('\n'),
+
+  stats: unogolfStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/unogolf/logic.ts
+++ b/src/lib/games/unogolf/logic.ts
@@ -1,0 +1,114 @@
+import type { ID } from '../../types';
+
+/**
+ * Uno Golf — pure scoring & validation. NO Svelte imports so it stays trivially
+ * unit-testable and safe for the stats engine to pull in.
+ *
+ * The game: a golf-style variant of Uno played over a fixed number of *holes*
+ * (hands). Each hole one player goes out (empties their hand) and "sinks the hole"
+ * for 0 strokes; every other player counts the cards left in their own hand as
+ * strokes — number cards at face value, action cards at {@link UnoGolfConfig.actionValue}
+ * each, wilds at {@link UnoGolfConfig.wildValue} each. Play the holes; **lowest**
+ * cumulative score wins, exactly like golf.
+ */
+
+/** A player's leftover hand at the end of a hole, tallied by card kind. */
+export interface UnoGolfHand {
+  /** Sum of the face values of the number cards (0–9) left in hand. */
+  numbers: number;
+  /** Count of action cards left (Skip / Reverse / Draw Two). */
+  actions: number;
+  /** Count of wild cards left (Wild / Wild Draw Four). */
+  wilds: number;
+}
+
+export interface UnoGolfInput {
+  /** Per-player leftover-card tally for this hole. */
+  hands: Record<ID, UnoGolfHand>;
+  /** Who went out (emptied their hand). They sink the hole for 0 strokes. */
+  out: ID | null;
+}
+
+/** How the game ends: a fixed number of holes, or the first to a target score. */
+export type UnoGolfFormat = 'holes' | 'target';
+
+export interface UnoGolfConfig {
+  holes: number;
+  format: UnoGolfFormat;
+  target: number;
+  actionValue: number;
+  wildValue: number;
+}
+
+export const DEFAULTS: UnoGolfConfig = {
+  holes: 9,
+  format: 'holes',
+  target: 100,
+  actionValue: 20,
+  wildValue: 50,
+};
+
+const toNum = (v: unknown, fallback: number): number => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+};
+
+/** Resolve a raw config record into typed, sanitised values with defaults. */
+export function resolveConfig(config: Record<string, unknown> | undefined): UnoGolfConfig {
+  const c = config ?? {};
+  return {
+    holes: Math.max(1, Math.round(toNum(c.holes, DEFAULTS.holes))),
+    format: c.format === 'target' ? 'target' : 'holes',
+    target: Math.max(1, Math.round(toNum(c.target, DEFAULTS.target))),
+    actionValue: Math.max(0, toNum(c.actionValue, DEFAULTS.actionValue)),
+    wildValue: Math.max(0, toNum(c.wildValue, DEFAULTS.wildValue)),
+  };
+}
+
+/** A fresh, empty leftover hand (no cards counted yet). */
+export function emptyHand(): UnoGolfHand {
+  return { numbers: 0, actions: 0, wilds: 0 };
+}
+
+type CardValues = Pick<UnoGolfConfig, 'actionValue' | 'wildValue'>;
+
+/** Strokes a single leftover hand is worth, given the card values in play. */
+export function handStrokes(hand: UnoGolfHand | undefined, cfg: CardValues): number {
+  if (!hand) return 0;
+  const numbers = Math.max(0, toNum(hand.numbers, 0));
+  const actions = Math.max(0, toNum(hand.actions, 0));
+  const wilds = Math.max(0, toNum(hand.wilds, 0));
+  return numbers + actions * cfg.actionValue + wilds * cfg.wildValue;
+}
+
+/** Per-player strokes for one hole. The player who went out scores 0. */
+export function scoreHole(
+  input: UnoGolfInput,
+  playerIds: ID[],
+  cfg: CardValues,
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) {
+    out[id] = input.out === id ? 0 : handStrokes(input.hands?.[id], cfg);
+  }
+  return out;
+}
+
+/** Validate a hole entry. Returns null when valid, else a friendly message. */
+export function validateHole(
+  input: UnoGolfInput,
+  playerIds: ID[],
+  nameOf: (id: ID) => string,
+): string | null {
+  if (!input.out) return 'Tap ⛳ to mark who sank the hole (went out).';
+  if (!playerIds.includes(input.out)) return 'The player who went out isn’t in this game.';
+  for (const id of playerIds) {
+    if (id === input.out) continue;
+    const h = input.hands?.[id];
+    if (!h) continue;
+    if (toNum(h.numbers, 0) < 0 || toNum(h.actions, 0) < 0 || toNum(h.wilds, 0) < 0) {
+      return `${nameOf(id)}: card counts can’t be negative.`;
+    }
+  }
+  return null;
+}

--- a/src/lib/games/unogolf/stats.ts
+++ b/src/lib/games/unogolf/stats.ts
@@ -1,0 +1,76 @@
+import type { ID } from '../../types';
+import type { UnoGolfInput } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg, fmtInt } from '../../stats/format';
+
+interface UGAgg {
+  /** Holes the member appeared in. */
+  holes: number;
+  /** Holes they sank (went out → 0 strokes). */
+  sunk: number;
+  /** Total strokes accumulated across holes. */
+  strokes: number;
+  /** Wild cards (Wild / Wild Draw Four) left in hand across holes — the pricey ones. */
+  wilds: number;
+}
+
+/**
+ * Uno Golf stats, derived purely from each hole's recorded hands. Strokes come
+ * straight from the round's stored deltas (already scored with that game's card
+ * values), so they stay correct regardless of a game's action/wild config. Pure —
+ * no Svelte — so it's independently unit-testable and safe for the engine.
+ */
+export function unogolfStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, UGAgg>();
+  const get = (id: ID): UGAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { holes: 0, sunk: 0, strokes: 0, wilds: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as UnoGolfInput | undefined;
+    if (!input?.hands) continue;
+    for (const [pid, hand] of Object.entries(input.hands)) {
+      const a = get(canonical(pid));
+      a.holes += 1;
+      a.strokes += Number(r.deltas?.[pid]) || 0;
+      a.wilds += Math.max(0, Number(hand?.wilds) || 0);
+    }
+    if (input.out) get(canonical(input.out)).sunk += 1;
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let totSunk = 0;
+  for (const [id, a] of per) {
+    totSunk += a.sunk;
+    const metrics: Metric[] = [];
+    if (a.holes) {
+      metrics.push({
+        key: 'ug_avg',
+        label: 'Scoring average',
+        value: fmtAvg(a.strokes / a.holes),
+        sub: 'strokes per hole',
+        emoji: '📊',
+      });
+    }
+    if (a.sunk) {
+      metrics.push({ key: 'ug_sunk', label: 'Holes sunk', value: fmtInt(a.sunk), emoji: '⛳' });
+    }
+    if (a.wilds) {
+      metrics.push({ key: 'ug_wilds', label: 'Wilds caught', value: fmtInt(a.wilds), emoji: '🌈' });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totSunk) {
+    global.push({ key: 'ug_sunk_all', label: 'Holes sunk', value: fmtInt(totSunk), emoji: '⛳' });
+  }
+  return { perPlayer, global };
+}

--- a/src/lib/games/unogolf/unogolf.test.ts
+++ b/src/lib/games/unogolf/unogolf.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, Player, Round, RoundContext } from '../../types';
+import { defaultWinners } from '../../types';
+import {
+  DEFAULTS,
+  emptyHand,
+  handStrokes,
+  resolveConfig,
+  scoreHole,
+  validateHole,
+  type UnoGolfInput,
+} from './logic';
+import { unogolf } from './index';
+import { unogolfStats } from './stats';
+
+const player = (id: string, name = id.toUpperCase()): Player => ({
+  id,
+  name,
+  color: '#7c5cff',
+  createdAt: 0,
+});
+
+const players = [player('a'), player('b'), player('c')];
+const nameOf = (id: string) => players.find((p) => p.id === id)?.name ?? '?';
+
+function ctxOf(
+  config: Record<string, unknown> = {},
+  roundIndex = 0,
+  ps: Player[] = players,
+): RoundContext {
+  const game: Game = {
+    id: 'g',
+    type: 'unogolf',
+    config,
+    playerIds: ps.map((p) => p.id),
+    status: 'active',
+    createdAt: 0,
+    roundCount: 0,
+  };
+  return {
+    game,
+    players: ps,
+    config,
+    roundIndex,
+    totals: Object.fromEntries(ps.map((p) => [p.id, 0])),
+    rounds: [],
+  };
+}
+
+function mkRound(input: UnoGolfInput, deltas: Record<string, number>, index = 0): Round {
+  return { id: `g-${index}`, gameId: 'g', index, input, deltas, createdAt: 0 };
+}
+
+describe('resolveConfig', () => {
+  it('falls back to sensible defaults', () => {
+    expect(resolveConfig({})).toEqual(DEFAULTS);
+    expect(resolveConfig(undefined)).toEqual(DEFAULTS);
+  });
+
+  it('normalises the format and clamps numbers', () => {
+    const cfg = resolveConfig({
+      format: 'nonsense',
+      holes: 0,
+      target: -5,
+      actionValue: -3,
+      wildValue: 'x',
+    });
+    expect(cfg.format).toBe('holes');
+    expect(cfg.holes).toBe(1); // clamped to >= 1
+    expect(cfg.target).toBe(1); // clamped to >= 1
+    expect(cfg.actionValue).toBe(0); // clamped to >= 0
+    expect(cfg.wildValue).toBe(DEFAULTS.wildValue); // invalid -> default
+  });
+
+  it('accepts a target format and custom card values', () => {
+    const cfg = resolveConfig({ format: 'target', holes: 12, actionValue: 10, wildValue: 25 });
+    expect(cfg).toEqual({ holes: 12, format: 'target', target: 100, actionValue: 10, wildValue: 25 });
+  });
+});
+
+describe('handStrokes', () => {
+  const vals = { actionValue: 20, wildValue: 50 };
+
+  it('sums number faces + action + wild values', () => {
+    expect(handStrokes({ numbers: 7, actions: 1, wilds: 0 }, vals)).toBe(27);
+    expect(handStrokes({ numbers: 12, actions: 2, wilds: 1 }, vals)).toBe(12 + 40 + 50);
+  });
+
+  it('treats an empty or missing hand as zero', () => {
+    expect(handStrokes(emptyHand(), vals)).toBe(0);
+    expect(handStrokes(undefined, vals)).toBe(0);
+  });
+
+  it('clamps negatives and coerces junk to zero', () => {
+    expect(handStrokes({ numbers: -5, actions: -1, wilds: -2 }, vals)).toBe(0);
+    expect(
+      handStrokes({ numbers: NaN as unknown as number, actions: 1, wilds: 0 }, vals),
+    ).toBe(20);
+  });
+
+  it('honours custom card values', () => {
+    expect(handStrokes({ numbers: 5, actions: 2, wilds: 1 }, { actionValue: 10, wildValue: 25 })).toBe(
+      5 + 20 + 25,
+    );
+  });
+});
+
+describe('scoreHole', () => {
+  const input: UnoGolfInput = {
+    hands: {
+      a: { numbers: 5, actions: 1, wilds: 0 },
+      b: emptyHand(),
+      c: { numbers: 12, actions: 2, wilds: 1 },
+    },
+    out: 'b',
+  };
+
+  it('scores the player who went out as zero, others by their hand', () => {
+    const out = scoreHole(input, ['a', 'b', 'c'], DEFAULTS);
+    expect(out).toEqual({ a: 25, b: 0, c: 102 });
+  });
+
+  it('scales with the configured card values', () => {
+    const out = scoreHole(input, ['a', 'b', 'c'], { ...DEFAULTS, actionValue: 10, wildValue: 25 });
+    expect(out).toEqual({ a: 15, b: 0, c: 12 + 20 + 25 });
+  });
+
+  it('emits a zero for a player with no recorded hand', () => {
+    const out = scoreHole({ hands: {}, out: null }, ['a', 'b'], DEFAULTS);
+    expect(out).toEqual({ a: 0, b: 0 });
+  });
+});
+
+describe('validateHole', () => {
+  const good: UnoGolfInput = {
+    hands: { a: { numbers: 5, actions: 0, wilds: 0 }, b: emptyHand(), c: emptyHand() },
+    out: 'b',
+  };
+
+  it('passes a well-formed hole', () => {
+    expect(validateHole(good, ['a', 'b', 'c'], nameOf)).toBeNull();
+  });
+
+  it('requires someone to be marked out', () => {
+    expect(validateHole({ ...good, out: null }, ['a', 'b', 'c'], nameOf)).toMatch(/sank the hole/i);
+  });
+
+  it('rejects an out player who is not in the game', () => {
+    expect(validateHole({ ...good, out: 'z' }, ['a', 'b', 'c'], nameOf)).toMatch(/isn’t in this game/i);
+  });
+
+  it('rejects negative card counts', () => {
+    const bad: UnoGolfInput = { hands: { ...good.hands, a: { numbers: -1, actions: 0, wilds: 0 } }, out: 'b' };
+    expect(validateHole(bad, ['a', 'b', 'c'], nameOf)).toMatch(/can’t be negative/i);
+  });
+});
+
+describe('unogolf module metadata', () => {
+  it('is a lower-is-better game with the expected identity', () => {
+    expect(unogolf.id).toBe('unogolf');
+    expect(unogolf.name).toBe('Uno Golf');
+    expect(unogolf.lowerIsBetter).toBe(true);
+    expect(unogolf.minPlayers).toBeLessThanOrEqual(unogolf.maxPlayers);
+    expect(unogolf.help).toBeTruthy();
+    expect(unogolf.RoundEditor).toBeTruthy();
+  });
+
+  it('picks the lowest total as the winner', () => {
+    expect(defaultWinners(unogolf, { a: 25, b: 3, c: 100 })).toEqual(['b']);
+  });
+});
+
+describe('unogolf round lifecycle', () => {
+  it('creates a fresh input with an empty hand per player and nobody out', () => {
+    const input = unogolf.createRoundInput(ctxOf()) as UnoGolfInput;
+    expect(input.out).toBeNull();
+    expect(Object.keys(input.hands).sort()).toEqual(['a', 'b', 'c']);
+    for (const id of ['a', 'b', 'c']) expect(input.hands[id]).toEqual(emptyHand());
+  });
+
+  it('validates and scores a round through the module using ctx config', () => {
+    const input: UnoGolfInput = {
+      hands: { a: { numbers: 5, actions: 1, wilds: 0 }, b: emptyHand(), c: { numbers: 0, actions: 0, wilds: 1 } },
+      out: 'b',
+    };
+    const ctx = ctxOf({ actionValue: 10, wildValue: 25 });
+    expect(unogolf.validateRound(input, ctx)).toBeNull();
+    expect(unogolf.scoreRound(input, ctx)).toEqual({ a: 15, b: 0, c: 25 });
+  });
+
+  it('describes a round with the sinker and everyone’s strokes', () => {
+    const input: UnoGolfInput = {
+      hands: { a: { numbers: 5, actions: 1, wilds: 0 }, b: emptyHand(), c: { numbers: 12, actions: 2, wilds: 1 } },
+      out: 'b',
+    };
+    const round = mkRound(input, { a: 25, b: 0, c: 102 });
+    const text = unogolf.describeRound!(round, players);
+    expect(text).toContain('⛳ B sank it');
+    expect(text).toContain('A +25');
+    expect(text).toContain('C +102');
+    expect(text).not.toContain('B +');
+  });
+});
+
+describe('unogolf end conditions', () => {
+  it('caps fixed-holes games at the configured hole count', () => {
+    expect(unogolf.maxRounds!({}, 4)).toBe(DEFAULTS.holes);
+    expect(unogolf.maxRounds!({ holes: 18 }, 4)).toBe(18);
+  });
+
+  it('runs target games open-ended (no fixed hole cap)', () => {
+    expect(unogolf.maxRounds!({ format: 'target' }, 4)).toBeNull();
+  });
+
+  it('finishes a target game once a player reaches the cap', () => {
+    const info = { config: { format: 'target', target: 100 }, roundCount: 5, playerCount: 2 };
+    expect(unogolf.isFinished!({ a: 90, b: 40 }, info)).toBe(false);
+    expect(unogolf.isFinished!({ a: 110, b: 40 }, info)).toBe(true);
+  });
+
+  it('never finishes early in fixed-holes format', () => {
+    const info = { config: {}, roundCount: 3, playerCount: 2 };
+    expect(unogolf.isFinished!({ a: 999, b: 0 }, info)).toBe(false);
+  });
+});
+
+describe('unogolfStats', () => {
+  const games: Game[] = [
+    {
+      id: 'g1',
+      type: 'unogolf',
+      config: {},
+      playerIds: ['a', 'b', 'c'],
+      status: 'finished',
+      createdAt: 0,
+      roundCount: 2,
+    },
+  ];
+  const rounds: Round[] = [
+    {
+      id: 'g1-0',
+      gameId: 'g1',
+      index: 0,
+      input: {
+        hands: { a: { numbers: 5, actions: 1, wilds: 0 }, b: emptyHand(), c: { numbers: 0, actions: 0, wilds: 1 } },
+        out: 'b',
+      },
+      deltas: { a: 25, b: 0, c: 50 },
+      createdAt: 0,
+    },
+    {
+      id: 'g1-1',
+      gameId: 'g1',
+      index: 1,
+      input: {
+        hands: { a: emptyHand(), b: { numbers: 3, actions: 0, wilds: 0 }, c: { numbers: 0, actions: 0, wilds: 1 } },
+        out: 'a',
+      },
+      deltas: { a: 0, b: 3, c: 50 },
+      createdAt: 0,
+    },
+  ];
+
+  const res = unogolfStats({ games, rounds, players, canonical: (id) => id });
+  const perPlayer = res.perPlayer ?? {};
+  const global = res.global ?? [];
+
+  it('reports a scoring average per player', () => {
+    expect(perPlayer['a']?.find((m) => m.key === 'ug_avg')?.value).toBe('12.5');
+    expect(perPlayer['b']?.find((m) => m.key === 'ug_avg')?.value).toBe('1.5');
+    expect(perPlayer['c']?.find((m) => m.key === 'ug_avg')?.value).toBe('50');
+  });
+
+  it('counts holes sunk and wilds caught', () => {
+    expect(perPlayer['a']?.find((m) => m.key === 'ug_sunk')?.value).toBe('1');
+    expect(perPlayer['b']?.find((m) => m.key === 'ug_sunk')?.value).toBe('1');
+    // C never sank a hole and carried two wilds.
+    expect(perPlayer['c']?.some((m) => m.key === 'ug_sunk')).toBe(false);
+    expect(perPlayer['c']?.find((m) => m.key === 'ug_wilds')?.value).toBe('2');
+  });
+
+  it('aggregates total holes sunk globally', () => {
+    expect(global.find((m) => m.key === 'ug_sunk_all')?.value).toBe('2');
+  });
+});


### PR DESCRIPTION
## ⛳ Uno Golf

A dedicated, golf-themed game module — a golf-style variant of Uno played over a fixed number of **holes** (hands) where **lowest score wins**, just like golf. Built as its own first-class module, distinct from standard Uno.

### How it scores
Each hole, one player **goes out** (empties their hand) and **sinks the hole** for **0 strokes**. Every *other* player counts the cards left in their own hand as strokes:

| Card | Value |
|------|-------|
| Number cards (0–9) | face value |
| Action cards (Skip / Reverse / Draw Two) | **20** (configurable) |
| Wild / Wild Draw Four | **50** (configurable) |

Add up strokes across every hole; the **lowest cumulative total wins**. The player who goes out getting 0 is the "birdie" of the hole.

### Config
- **Round format** — *Fixed holes* (play a set number of holes) or *Play to a target* (open-ended until someone hits a score cap; lowest still wins).
- **Holes to play** — default **9** (a round of golf), up to 18.
- **Target score** — used by the Target format (default 100).
- **Action card value** — default 20.
- **Wild card value** — default 50.

### UX / design
- Keeps the app chrome identical; personality comes from ⛳ emoji + golf copy, not restyling. Royal Violet is used only for the selection-state "Sank it" toggle (mirroring Hearts' ♠Q toggle) and the shell's own primary action; **Crown Gold is never used** here (reserved for leader/winner).
- Reuses `Avatar` + `Stepper`; per-player card tally with a live stroke **preview**, a "Card values" key, `tabular-nums`, ≥46px touch targets, and a `prefers-reduced-motion` guard. One-handed friendly for game night.
- Mark who sank the hole with ⛳; their inputs clear to 0 and everyone else tallies leftover cards.

### Stats
Per player: **scoring average** (strokes/hole), **holes sunk**, and **wilds caught**; plus a global holes-sunk tally.

### Research
Two "Uno Golf" variants circulate: (a) this **hand-scoring-over-9-holes** house rule (the requested model), and (b) a Six-Card-Golf-style grid played with an Uno deck. Both share the same card values; the hand-scoring model is the cleaner fit for a score-keeper and is what's implemented here. A **Target** format is included as the "target instead of holes" option.

### Scope & verification
Purely **additive** — only adds `src/lib/games/unogolf/` (`logic.ts`, `index.ts`, `UnoGolfEditor.svelte`, `stats.ts`, `unogolf.test.ts`). The registry auto-discovers the module; no shared files touched. `npm run check`, `npm test` (101 passing), and `npm run build` are all green, and the full create-game → enter-a-hole flow was verified in a real browser.
