### PR TITLE
Add Uno game module (standard + golf scoring)

### DIFF
--- a/src/lib/games/uno/UnoEditor.svelte
+++ b/src/lib/games/uno/UnoEditor.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { opponentsTotal, readConfig, type UnoInput } from './logic';
+
+  let { input = $bindable(), ctx }: { input: UnoInput; ctx: RoundContext } = $props();
+
+  const cfg = $derived(readConfig(ctx.config));
+  const golf = $derived(cfg.mode === 'golf');
+  const playerIds = $derived(ctx.players.map((p) => p.id));
+  const pot = $derived(opponentsTotal(input, playerIds));
+
+  function goOut(id: string) {
+    if (input.out === id) {
+      input.out = null;
+    } else {
+      input.out = id;
+      input.left[id] = 0; // whoever went out is holding nothing
+    }
+  }
+
+  function add(id: string, amount: number) {
+    input.left[id] = Math.max(0, (Number(input.left[id]) || 0) + amount);
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="muted">
+      {input.out ? 'Now tally everyone else’s leftover cards.' : 'Who emptied their hand? Tap 🎉'}
+    </span>
+    {#if golf}
+      <span class="pill">⛳ Low score wins</span>
+    {:else if input.out}
+      <span class="pill take"><span class="tnum">🎉 +{pot}</span></span>
+    {/if}
+  </div>
+
+  {#each ctx.players as p (p.id)}
+    {@const isOut = input.out === p.id}
+    <div class="prow">
+      <div class="row spread">
+        <span class="row" style="gap: 8px; min-width: 0">
+          <Avatar name={p.name} color={p.color} />
+          <strong class="ellipsis">{p.name}</strong>
+        </span>
+        <button
+          type="button"
+          class="wentout"
+          class:on={isOut}
+          aria-pressed={isOut}
+          onclick={() => goOut(p.id)}
+        >
+          {isOut ? '🎉 Went out' : 'Went out'}
+        </button>
+      </div>
+
+      {#if isOut}
+        <p class="note">
+          {golf
+            ? 'Empty hand — banks 0 this round.'
+            : `Scoops the table · +${pot} point${pot === 1 ? '' : 's'}`}
+        </p>
+      {:else}
+        <div class="entry">
+          <div class="chips">
+            <button type="button" class="chip" onclick={() => add(p.id, cfg.actionValue)}>
+              +{cfg.actionValue}<span class="sub">action</span>
+            </button>
+            <button type="button" class="chip" onclick={() => add(p.id, cfg.wildValue)}>
+              +{cfg.wildValue}<span class="sub">wild</span>
+            </button>
+          </div>
+          <label class="left">
+            <span class="sub">leftover</span>
+            <Stepper bind:value={input.left[p.id]} min={0} />
+          </label>
+        </div>
+      {/if}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .wentout {
+    flex: none;
+    min-height: 46px;
+    padding: 0 14px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--muted);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  }
+  .wentout:hover {
+    color: var(--text);
+  }
+  .wentout.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .wentout:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .note {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+  .entry {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .chips {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    min-height: 46px;
+    padding: 0 14px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease;
+  }
+  .chip:hover {
+    background: var(--surface-3);
+    border-color: var(--primary);
+  }
+  .chip:active {
+    transform: translateY(1px);
+  }
+  .chip:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .left {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    align-items: flex-end;
+  }
+  .sub {
+    color: var(--muted);
+    font-weight: 500;
+    font-size: 0.78rem;
+  }
+  .take {
+    color: var(--good);
+    border-color: color-mix(in srgb, var(--good) 40%, var(--border));
+    font-weight: 700;
+  }
+  .tnum {
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/src/lib/games/uno/index.ts
+++ b/src/lib/games/uno/index.ts
@@ -1,0 +1,92 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './UnoEditor.svelte';
+import { unoStats } from './stats';
+import {
+  createUnoInput,
+  isUnoFinished,
+  opponentsTotal,
+  scoreUno,
+  validateUno,
+  type UnoInput,
+} from './logic';
+
+export type { UnoInput, UnoConfig, UnoMode } from './logic';
+
+export const uno: GameModule = {
+  id: 'uno',
+  name: 'Uno',
+  tagline: 'Ditch your cards, stick everyone else with theirs',
+  emoji: '🃏',
+  keywords: ['uno', 'shedding', 'crazy eights', 'wild', 'draw four', 'cards'],
+  minPlayers: 2,
+  maxPlayers: 10,
+  // Standard: the scooper climbs, highest wins. Golf: you dread points, lowest wins.
+  resolveLowerIsBetter: (c) => c.mode === 'golf',
+  configFields: [
+    { key: 'target', label: 'Play to (points)', type: 'number', default: 500, min: 1, step: 50 },
+    {
+      key: 'mode',
+      label: 'Scoring',
+      type: 'select',
+      default: 'winner',
+      options: [
+        { value: 'winner', label: 'Winner scoops opponents’ cards' },
+        { value: 'golf', label: 'Everyone counts their own — low wins' },
+      ],
+      help: 'Standard Uno banks leftover cards to the player who went out. Golf makes every player carry the cards left in their own hand.',
+    },
+    {
+      key: 'actionValue',
+      label: 'Action card value (Skip · Reverse · Draw Two)',
+      type: 'number',
+      default: 20,
+      min: 0,
+      step: 5,
+    },
+    {
+      key: 'wildValue',
+      label: 'Wild card value (Wild · Wild Draw Four)',
+      type: 'number',
+      default: 50,
+      min: 0,
+      step: 5,
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): UnoInput =>
+    createUnoInput(ctx.players.map((p) => p.id)),
+
+  validateRound: (input: UnoInput, ctx: RoundContext): string | null =>
+    validateUno(input, ctx.players),
+
+  scoreRound: (input: UnoInput, ctx: RoundContext): Record<ID, number> =>
+    scoreUno(input, ctx.players.map((p) => p.id), ctx.config),
+
+  isFinished: (totals, { config }) => isUnoFinished(totals, config),
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as UnoInput;
+    if (!input?.out) return 'no result';
+    const winner = players.find((p) => p.id === input.out)?.name ?? '?';
+    const pot = opponentsTotal(input, players.map((p) => p.id));
+    return `🎉 ${winner} out · +${pot}`;
+  },
+
+  help: [
+    'Empty your hand to end the round and shout “Uno!”.',
+    '',
+    'When you go out, you score the cards left in everyone else’s hands:',
+    '• Number cards 0–9 — face value',
+    '• Skip, Reverse, Draw Two — 20 each',
+    '• Wild, Wild Draw Four — 50 each',
+    '',
+    'First player to the target score (default 500) wins.',
+    '',
+    'Golf mode: nobody scoops. Instead, every player banks the value of the',
+    'cards left in their own hand each round — and the lowest total wins.',
+  ].join('\n'),
+
+  stats: unoStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/uno/logic.ts
+++ b/src/lib/games/uno/logic.ts
@@ -1,0 +1,131 @@
+import type { ID } from '../../types';
+
+/**
+ * Uno scoring — pure and Svelte-free so it can be unit-tested directly and reused by
+ * the editor for live previews (see README "Adding a game").
+ *
+ * A hand ends when one player "goes out" (empties their hand). What happens to the
+ * points left in the other hands depends on the scoring mode:
+ *  - `winner` (standard): the player who went out scoops the SUM of everyone else's
+ *    leftover cards. Highest total wins, race to `target` (default 500).
+ *  - `golf`: every player banks the value of the cards left in their OWN hand each
+ *    round; the one who went out banks nothing. Lowest total wins.
+ *
+ * Card values are counted by the scorekeeper into a single leftover total per player
+ * (number cards = face value, action cards = `actionValue`, wilds = `wildValue`), so
+ * the stored round is just "who went out" + "how many points each hand held" — mode is
+ * a pure function of that, which keeps history re-scorable and the logic trivially pure.
+ */
+
+export type UnoMode = 'winner' | 'golf';
+
+export interface UnoConfig {
+  /** Race-to score that ends the game (default 500). 0 = play forever. */
+  target: number;
+  /** How leftover cards turn into points at the end of a hand. */
+  mode: UnoMode;
+  /** Points for each Skip / Reverse / Draw Two left in a hand (editor quick-add). */
+  actionValue: number;
+  /** Points for each Wild / Wild Draw Four left in a hand (editor quick-add). */
+  wildValue: number;
+}
+
+export interface UnoInput {
+  /** The player who emptied their hand to end the round. */
+  out: ID | null;
+  /** Each player's leftover card points at round end. The player who went out holds 0. */
+  left: Record<ID, number>;
+}
+
+export const UNO_DEFAULTS: UnoConfig = {
+  target: 500,
+  mode: 'winner',
+  actionValue: 20,
+  wildValue: 50,
+};
+
+/** Read a raw config bag into a validated {@link UnoConfig}, falling back on defaults. */
+export function readConfig(config: Record<string, unknown> | undefined): UnoConfig {
+  const c = config ?? {};
+  const num = (v: unknown, d: number): number => {
+    if (v === null || v === undefined || v === '') return d;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : d;
+  };
+  return {
+    target: num(c.target, UNO_DEFAULTS.target),
+    mode: c.mode === 'golf' ? 'golf' : 'winner',
+    actionValue: num(c.actionValue, UNO_DEFAULTS.actionValue),
+    wildValue: num(c.wildValue, UNO_DEFAULTS.wildValue),
+  };
+}
+
+/** A fresh, zeroed round input for the current roster. */
+export function createUnoInput(playerIds: ID[]): UnoInput {
+  return {
+    out: null,
+    left: Object.fromEntries(playerIds.map((id) => [id, 0])),
+  };
+}
+
+/** A player's leftover points, clamped to a non-negative number. */
+export function leftOf(input: UnoInput, id: ID): number {
+  return Math.max(0, Number(input.left[id]) || 0);
+}
+
+/** Sum of the leftover points held by everyone except the player who went out. */
+export function opponentsTotal(input: UnoInput, playerIds: ID[]): number {
+  return playerIds.reduce(
+    (sum, id) => (id === input.out ? sum : sum + leftOf(input, id)),
+    0,
+  );
+}
+
+export function validateUno(
+  input: UnoInput,
+  players: { id: ID; name: string }[],
+): string | null {
+  if (!input.out) return 'Tap the player who went out (emptied their hand).';
+  if (!players.some((p) => p.id === input.out)) {
+    return 'The player who went out is not in this game.';
+  }
+  for (const p of players) {
+    const raw = input.left[p.id];
+    if (raw == null) continue;
+    const v = Number(raw);
+    if (!Number.isFinite(v) || v < 0) {
+      return `${p.name}'s leftover points must be 0 or more.`;
+    }
+  }
+  return null;
+}
+
+/** Compute per-player point deltas for a hand. */
+export function scoreUno(
+  input: UnoInput,
+  playerIds: ID[],
+  config: Record<string, unknown> | undefined,
+): Record<ID, number> {
+  const { mode } = readConfig(config);
+  const out: Record<ID, number> = {};
+  if (mode === 'golf') {
+    // Everyone banks the points still in their own hand; the winner banks nothing.
+    for (const id of playerIds) out[id] = id === input.out ? 0 : leftOf(input, id);
+  } else {
+    // The player who went out scoops every opponent's leftover cards.
+    const scooped = input.out ? opponentsTotal(input, playerIds) : 0;
+    for (const id of playerIds) out[id] = id === input.out ? scooped : 0;
+  }
+  return out;
+}
+
+/** Game ends when any total reaches the target (both modes; low wins in golf). */
+export function isUnoFinished(
+  totals: Record<ID, number>,
+  config: Record<string, unknown> | undefined,
+): boolean {
+  const { target } = readConfig(config);
+  if (target <= 0) return false;
+  const vals = Object.values(totals);
+  return vals.length > 0 && vals.some((t) => t >= target);
+}

--- a/src/lib/games/uno/stats.ts
+++ b/src/lib/games/uno/stats.ts
@@ -1,0 +1,97 @@
+import type { ID } from '../../types';
+import type { UnoInput } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt, fmtPct } from '../../stats/format';
+
+interface UnoAgg {
+  /** Hands this player went out (emptied their hand to end the round). */
+  outs: number;
+  /** Hands this player took part in. */
+  rounds: number;
+  /** Total leftover points this player was caught holding across hands. */
+  stuck: number;
+  /** Most points scooped in a single go-out (standard-mode flavour). */
+  bigScoop: number;
+}
+
+/**
+ * Uno stats from each hand's recorded "who went out" + leftover totals. Pure; mirrors
+ * the module's own scoring so a game contributes stats the same way it contributes
+ * points. Works for both scoring modes — a go-out is a go-out, and the leftover points
+ * a player was stuck with are meaningful whether the winner scooped them or each player
+ * banked their own.
+ */
+export function unoStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, UnoAgg>();
+  const get = (id: ID): UnoAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { outs: 0, rounds: 0, stuck: 0, bigScoop: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as UnoInput | undefined;
+    if (!input?.left) continue;
+    const outId = input.out ? canonical(input.out) : null;
+    let scoop = 0;
+    for (const [pid, raw] of Object.entries(input.left)) {
+      const id = canonical(pid);
+      const a = get(id);
+      a.rounds += 1;
+      const left = Math.max(0, Number(raw) || 0);
+      if (id === outId) {
+        a.outs += 1;
+      } else {
+        scoop += left;
+        a.stuck += left;
+      }
+    }
+    if (outId) {
+      const a = get(outId);
+      if (scoop > a.bigScoop) a.bigScoop = scoop;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let totalOuts = 0;
+  let biggest = 0;
+  for (const [id, a] of per) {
+    totalOuts += a.outs;
+    if (a.bigScoop > biggest) biggest = a.bigScoop;
+    const metrics: Metric[] = [];
+    if (a.outs) {
+      metrics.push({ key: 'u_out', label: 'Hands gone out', value: fmtInt(a.outs), emoji: '🎉' });
+    }
+    if (a.rounds) {
+      metrics.push({
+        key: 'u_rate',
+        label: 'Go-out rate',
+        value: fmtPct(a.outs / a.rounds),
+        emoji: '🏃',
+      });
+    }
+    if (a.stuck) {
+      metrics.push({
+        key: 'u_stuck',
+        label: 'Points caught holding',
+        value: fmtInt(a.stuck),
+        emoji: '🃏',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totalOuts) {
+    global.push({ key: 'u_out_all', label: 'Hands played out', value: fmtInt(totalOuts), emoji: '🎉' });
+  }
+  if (biggest) {
+    global.push({ key: 'u_scoop', label: 'Biggest hand counted', value: fmtInt(biggest), emoji: '💰' });
+  }
+  return { perPlayer, global };
+}

--- a/src/lib/games/uno/uno.test.ts
+++ b/src/lib/games/uno/uno.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round, RoundContext } from '../../types';
+import { defaultWinners } from '../../types';
+import { uno } from './index';
+import { unoStats } from './stats';
+import {
+  createUnoInput,
+  isUnoFinished,
+  opponentsTotal,
+  readConfig,
+  scoreUno,
+  validateUno,
+  type UnoInput,
+} from './logic';
+
+// ---- helpers ---------------------------------------------------------------
+
+function player(id: string, name = id): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+
+const A = player('A', 'Alice');
+const B = player('B', 'Bob');
+const C = player('C', 'Cy');
+const players = [A, B, C];
+const ids = players.map((p) => p.id);
+
+function ctx(config: Record<string, unknown>): RoundContext {
+  return {
+    game: {} as Game,
+    players,
+    config,
+    roundIndex: 0,
+    totals: {},
+    rounds: [],
+  };
+}
+
+function input(out: ID | null, left: Record<ID, number>): UnoInput {
+  return { out, left };
+}
+
+// ---- config ----------------------------------------------------------------
+
+describe('readConfig', () => {
+  it('fills defaults when empty', () => {
+    expect(readConfig({})).toEqual({ target: 500, mode: 'winner', actionValue: 20, wildValue: 50 });
+  });
+
+  it('honours overrides and coerces numeric strings', () => {
+    const c = readConfig({ target: '250', mode: 'golf', actionValue: '15', wildValue: 40 });
+    expect(c).toEqual({ target: 250, mode: 'golf', actionValue: 15, wildValue: 40 });
+  });
+
+  it('falls back on garbage values and unknown modes', () => {
+    const c = readConfig({ target: 'nope', mode: 'chaos', actionValue: null, wildValue: undefined });
+    expect(c).toEqual({ target: 500, mode: 'winner', actionValue: 20, wildValue: 50 });
+  });
+});
+
+// ---- round input -----------------------------------------------------------
+
+describe('createUnoInput', () => {
+  it('starts with nobody out and everyone on zero', () => {
+    expect(createUnoInput(ids)).toEqual({ out: null, left: { A: 0, B: 0, C: 0 } });
+  });
+});
+
+// ---- scoring: standard (winner scoops) -------------------------------------
+
+describe('scoreUno — standard (winner scoops)', () => {
+  it('gives the player who went out the sum of the others’ leftovers', () => {
+    const out = scoreUno(input('A', { A: 0, B: 25, C: 40 }), ids, { mode: 'winner' });
+    expect(out).toEqual({ A: 65, B: 0, C: 0 });
+  });
+
+  it('defaults to winner mode when no mode is set', () => {
+    expect(scoreUno(input('B', { A: 12, B: 0, C: 3 }), ids, {})).toEqual({ A: 0, B: 15, C: 0 });
+  });
+
+  it('scores nothing while no winner is chosen yet', () => {
+    expect(scoreUno(input(null, { A: 5, B: 5, C: 5 }), ids, { mode: 'winner' })).toEqual({
+      A: 0,
+      B: 0,
+      C: 0,
+    });
+  });
+
+  it('ignores any stray leftover on the player who went out', () => {
+    const out = scoreUno(input('A', { A: 999, B: 10, C: 10 }), ids, { mode: 'winner' });
+    expect(out).toEqual({ A: 20, B: 0, C: 0 });
+  });
+});
+
+// ---- scoring: golf (own cards, low wins) -----------------------------------
+
+describe('scoreUno — golf (own cards)', () => {
+  it('each player banks their own leftover; the one who went out banks 0', () => {
+    const out = scoreUno(input('A', { A: 0, B: 25, C: 40 }), ids, { mode: 'golf' });
+    expect(out).toEqual({ A: 0, B: 25, C: 40 });
+  });
+
+  it('forces the winner to 0 even with a stray leftover', () => {
+    const out = scoreUno(input('C', { A: 8, B: 3, C: 50 }), ids, { mode: 'golf' });
+    expect(out).toEqual({ A: 8, B: 3, C: 0 });
+  });
+});
+
+// ---- helpers: opponentsTotal ----------------------------------------------
+
+describe('opponentsTotal', () => {
+  it('sums everyone except the player who went out and clamps negatives', () => {
+    expect(opponentsTotal(input('A', { A: 100, B: 25, C: 40 }), ids)).toBe(65);
+    expect(opponentsTotal(input('A', { A: 0, B: -5, C: 40 }), ids)).toBe(40);
+  });
+});
+
+// ---- validation ------------------------------------------------------------
+
+describe('validateUno', () => {
+  it('requires a player to have gone out', () => {
+    expect(validateUno(input(null, { A: 0, B: 0, C: 0 }), players)).toMatch(/went out/i);
+  });
+
+  it('rejects a winner who is not in the game', () => {
+    expect(validateUno(input('Z', { A: 0, B: 0, C: 0 }), players)).toMatch(/not in this game/i);
+  });
+
+  it('rejects negative leftovers, naming the player', () => {
+    expect(validateUno(input('A', { A: 0, B: -1, C: 0 }), players)).toContain('Bob');
+  });
+
+  it('passes a well-formed hand', () => {
+    expect(validateUno(input('A', { A: 0, B: 20, C: 5 }), players)).toBeNull();
+  });
+});
+
+// ---- end condition ---------------------------------------------------------
+
+describe('isUnoFinished', () => {
+  it('ends when any total reaches the target (standard)', () => {
+    expect(isUnoFinished({ A: 500, B: 120 }, { target: 500 })).toBe(true);
+    expect(isUnoFinished({ A: 499, B: 120 }, { target: 500 })).toBe(false);
+  });
+
+  it('ends in golf too — the low score just wins afterwards', () => {
+    expect(isUnoFinished({ A: 60, B: 100 }, { mode: 'golf', target: 100 })).toBe(true);
+  });
+
+  it('never ends when the target is 0', () => {
+    expect(isUnoFinished({ A: 9999 }, { target: 0 })).toBe(false);
+  });
+});
+
+// ---- module wiring ---------------------------------------------------------
+
+describe('uno module', () => {
+  it('has the expected identity and roster', () => {
+    expect(uno.id).toBe('uno');
+    expect(uno.name).toBe('Uno');
+    expect(uno.minPlayers).toBe(2);
+    expect(uno.maxPlayers).toBe(10);
+  });
+
+  it('resolves win direction from the scoring mode', () => {
+    expect(uno.resolveLowerIsBetter?.({ mode: 'golf' })).toBe(true);
+    expect(uno.resolveLowerIsBetter?.({ mode: 'winner' })).toBe(false);
+    expect(uno.resolveLowerIsBetter?.({})).toBe(false);
+  });
+
+  it('builds a fresh input and validates/scores through the context', () => {
+    const fresh = uno.createRoundInput(ctx({})) as UnoInput;
+    expect(fresh).toEqual({ out: null, left: { A: 0, B: 0, C: 0 } });
+
+    const hand = input('A', { A: 0, B: 25, C: 40 });
+    expect(uno.validateRound(hand, ctx({ mode: 'winner' }))).toBeNull();
+    expect(uno.scoreRound(hand, ctx({ mode: 'winner' }))).toEqual({ A: 65, B: 0, C: 0 });
+    expect(uno.scoreRound(hand, ctx({ mode: 'golf' }))).toEqual({ A: 0, B: 25, C: 40 });
+  });
+
+  it('ends the game via isFinished at the target', () => {
+    expect(uno.isFinished?.({ A: 510, B: 90 }, { config: {}, roundCount: 8, playerCount: 3 })).toBe(
+      true,
+    );
+  });
+
+  it('crowns the highest total in standard and the lowest in golf', () => {
+    const totals = { A: 480, B: 500, C: 260 };
+    expect(defaultWinners(uno, totals, { mode: 'winner' })).toEqual(['B']);
+    expect(defaultWinners(uno, totals, { mode: 'golf' })).toEqual(['C']);
+  });
+
+  it('summarises a recorded round for the history table', () => {
+    const round = { input: input('A', { A: 0, B: 25, C: 40 }) } as Round;
+    expect(uno.describeRound?.(round, players)).toBe('🎉 Alice out · +65');
+  });
+});
+
+// ---- stats -----------------------------------------------------------------
+
+describe('unoStats', () => {
+  const game: Game = {
+    id: 'g1',
+    type: 'uno',
+    config: {},
+    playerIds: ids,
+    status: 'finished',
+    createdAt: 0,
+    roundCount: 2,
+  };
+  const rounds = [
+    { id: 'r1', gameId: 'g1', index: 0, input: input('A', { A: 0, B: 20, C: 35 }), deltas: {}, createdAt: 0 },
+    { id: 'r2', gameId: 'g1', index: 1, input: input('B', { A: 5, B: 0, C: 50 }), deltas: {}, createdAt: 0 },
+  ] as Round[];
+
+  const res = unoStats({ games: [game], rounds, players, canonical: (id) => id });
+  const perPlayer = res.perPlayer ?? {};
+  const global = res.global ?? [];
+
+  it('counts go-outs and go-out rate per player', () => {
+    const a = perPlayer['A'] ?? [];
+    expect(a.find((m) => m.key === 'u_out')?.value).toBe('1');
+    expect(a.find((m) => m.key === 'u_rate')?.value).toBe('50%');
+  });
+
+  it('omits the go-out metric for a player who never went out', () => {
+    const c = perPlayer['C'] ?? [];
+    expect(c.find((m) => m.key === 'u_out')).toBeUndefined();
+    expect(c.find((m) => m.key === 'u_stuck')?.value).toBe('85');
+  });
+
+  it('reports totals and the biggest hand counted globally', () => {
+    expect(global.find((m) => m.key === 'u_out_all')?.value).toBe('2');
+    expect(global.find((m) => m.key === 'u_scoop')?.value).toBe('55');
+  });
+
+  it('ignores rounds from other games', () => {
+    const only = unoStats({ games: [], rounds, players, canonical: (id) => id });
+    expect(only.perPlayer ?? {}).toEqual({});
+    expect(only.global ?? []).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 🃏 Uno

Adds a first-class **Uno** scorer under `src/lib/games/uno/`. The registry auto-discovers
`index.ts`, so no shared files change — this is purely additive.

### How it scores
A hand ends when one player **goes out** (empties their hand). What happens to the cards
left in the other hands depends on the scoring mode:

- **Standard (default):** the player who went out **scoops the sum of everyone else's
  leftover cards** — number cards `0–9` at face value, Skip / Reverse / Draw Two `= 20`,
  Wild / Wild Draw Four `= 50`. First player to the target (**500** by default) wins.
- **Golf (toggle):** nobody scoops. Instead every player **banks the value of the cards
  left in their own hand** each round, and the **lowest** total wins. (A separate session
  owns a distinct `unogolf` game; this keeps golf as an optional mode of standard Uno.)

Win direction is derived from the mode via `resolveLowerIsBetter`, and the game ends in
both modes when any total reaches the target.

### Config
| Field | Default | Notes |
|-------|---------|-------|
| Play to (points) | `500` | race-to score that ends the game |
| Scoring | `winner` | `winner` scoops · `golf` = everyone counts their own, low wins |
| Action card value | `20` | Skip · Reverse · Draw Two |
| Wild card value | `50` | Wild · Wild Draw Four |

### Round entry
Tap **who went out 🎉**, then tally everyone else's leftover cards with the shared
`Stepper` plus quick **+action / +wild** chips (driven by the configured values), with a
live scoop preview of what the winner is about to bank.

### Design
Keeps the chrome identical — personality comes from the 🃏/🎉 copy and accents only.
Royal Violet marks the single "went out" selection; **no Crown Gold in the editor** (it
stays reserved for the leader/winner on the board). Depth uses the surface ramp,
changing numbers use `tabular-nums`, touch targets are ≥46px, state is never carried by
color alone, and the shared components honor `prefers-reduced-motion`.

### Stats
Per-player go-outs, go-out rate, and points caught holding; global hands-played and
biggest hand counted.

### Verification
- `npm run check` — 0 errors, 0 warnings
- `npm test` — 103 passing (28 new Uno tests covering both modes, validation, end
  condition, module wiring, win direction, and stats)
- `npm run build` — succeeds

Files: `logic.ts` (pure, Svelte-free), `index.ts` (`GameModule`), `UnoEditor.svelte`,
`uno.test.ts`, `stats.ts`.
