### PR TITLE
Add Wingspan: end-game category scoresheet

### DIFF
--- a/src/lib/games/wingspan/WingspanEditor.svelte
+++ b/src/lib/games/wingspan/WingspanEditor.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import {
+    LEFTOVER_CATEGORY,
+    emptyRow,
+    scoreRow,
+    scoringCategories,
+    tracksFood,
+    type WingspanRow,
+    type WingspanInput,
+  } from './logic';
+  import { wingspan } from './index';
+
+  let { input = $bindable(), ctx }: { input: WingspanInput; ctx: RoundContext } = $props();
+
+  const cats = $derived(scoringCategories(ctx.config));
+  const showFood = $derived(tracksFood(ctx.config));
+  let showHelp = $state(false);
+
+  // Keep the draft's shape in sync with the current players and config, so every stepper always
+  // has a real number to bind to — even if a player joined, or Nectar toggled on, after this
+  // scoresheet draft was first created. Mirrors the custom-game editor's self-healing draft.
+  $effect(() => {
+    if (!input.rows) input.rows = {};
+    const base = emptyRow();
+    for (const p of ctx.players) {
+      let row = input.rows[p.id];
+      if (!row) {
+        input.rows[p.id] = emptyRow();
+        continue;
+      }
+      for (const k of Object.keys(base) as (keyof WingspanRow)[]) {
+        if (typeof row[k] !== 'number') row[k] = base[k];
+      }
+    }
+  });
+
+  function total(id: string): number {
+    return scoreRow(input.rows?.[id]);
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="pill">Final scoresheet 🪶</span>
+    <button
+      type="button"
+      class="btn small ghost"
+      onclick={() => (showHelp = !showHelp)}
+      aria-expanded={showHelp}
+    >
+      Scoring
+    </button>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{wingspan.help}</pre>
+  {/if}
+
+  {#each ctx.players as p (p.id)}
+    <div class="prow">
+      <div class="phead">
+        <span class="who">
+          <Avatar name={p.name} color={p.color} />
+          <strong>{p.name}</strong>
+        </span>
+        <span class="total">
+          <span class="totnum">{total(p.id)}</span>
+          <span class="totlbl">pts</span>
+        </span>
+      </div>
+
+      {#if input.rows?.[p.id]}
+        <div class="grid">
+          {#each cats as c (c.key)}
+            <label class="cell">
+              <span class="clabel"><span class="cemoji" aria-hidden="true">{c.emoji}</span>{c.short}</span>
+              <Stepper bind:value={input.rows[p.id][c.key]} min={0} max={999} />
+            </label>
+          {/each}
+        </div>
+
+        {#if showFood}
+          <div class="tiebreak">
+            <label class="cell">
+              <span class="clabel">
+                <span class="cemoji" aria-hidden="true">{LEFTOVER_CATEGORY.emoji}</span>{LEFTOVER_CATEGORY.label}
+              </span>
+              <Stepper bind:value={input.rows[p.id].leftover} min={0} max={999} />
+            </label>
+            <span class="tienote">Breaks ties · not scored</span>
+          </div>
+        {/if}
+      {/if}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 14px;
+  }
+  .phead {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 12px;
+  }
+  .who {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .who strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .total {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    flex: none;
+  }
+  .totnum {
+    font-size: 1.5rem;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+  .totlbl {
+    font-size: 0.75rem;
+    color: var(--muted);
+    font-weight: 600;
+  }
+  .grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px 18px;
+  }
+  .cell {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .clabel {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--muted);
+  }
+  .cemoji {
+    font-size: 0.95rem;
+  }
+  .tiebreak {
+    display: flex;
+    align-items: flex-end;
+    gap: 14px;
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px dashed var(--border);
+  }
+  .tienote {
+    font-size: 0.75rem;
+    color: var(--muted);
+    padding-bottom: 12px;
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+    line-height: 1.5;
+  }
+</style>

--- a/src/lib/games/wingspan/index.ts
+++ b/src/lib/games/wingspan/index.ts
@@ -1,0 +1,80 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './WingspanEditor.svelte';
+import { wingspanStats } from './stats';
+import {
+  describeWingspanRound,
+  emptyRow,
+  scoreWingspanRound,
+  validateWingspanRound,
+  type WingspanInput,
+} from './logic';
+
+export type { WingspanInput, WingspanRow, WingspanConfig } from './logic';
+
+/**
+ * Wingspan — the engine-building birds game, scored the way the real score pad works: one final
+ * scoresheet with a column per category per player, summed to a total. Highest total reigns.
+ *
+ * The whole game is a single round (`maxRounds = 1`): you enter everyone's end-game categories
+ * once and finish. Scoring lives in {@link ./logic logic.ts} so it stays pure and testable.
+ */
+export const wingspan: GameModule = {
+  id: 'wingspan',
+  name: 'Wingspan',
+  tagline: 'Total the flock — highest score reigns 🪶',
+  emoji: '🪶',
+  keywords: ['birds', 'engine building', 'stonemaier', 'nectar', 'eggs', 'habitat', 'board game', 'oceania'],
+  minPlayers: 1,
+  maxPlayers: 5,
+  configFields: [
+    {
+      key: 'nectar',
+      label: 'Oceania nectar (adds a Nectar category)',
+      type: 'boolean',
+      default: false,
+      help: 'Track nectar majorities scored at game end. Adds a seventh column; the base six always stay.',
+    },
+    {
+      key: 'trackFood',
+      label: 'Track unused food (tiebreaker)',
+      type: 'boolean',
+      default: true,
+      help: 'Wingspan breaks ties by leftover food. Capture each player’s unused food — it settles ties but never adds to the score.',
+    },
+  ],
+
+  // One game = one final scoresheet.
+  maxRounds: () => 1,
+
+  createRoundInput: (ctx: RoundContext): WingspanInput => ({
+    rows: Object.fromEntries(ctx.players.map((p) => [p.id, emptyRow()])),
+  }),
+
+  validateRound: (input: WingspanInput, ctx: RoundContext): string | null =>
+    validateWingspanRound(input, ctx.players),
+
+  scoreRound: (input: WingspanInput, ctx: RoundContext): Record<ID, number> =>
+    scoreWingspanRound(input, ctx.players),
+
+  describeRound: (round: Round, players): string =>
+    describeWingspanRound(round.input as WingspanInput, players),
+
+  help: [
+    'Wingspan is scored once, at game end. Total each player’s categories — highest wins.',
+    '',
+    '🐦 Birds — points printed on the birds you played',
+    '🎯 Bonus cards — points from your bonus card conditions',
+    '🎖️ End-of-round goals — points from the four goal tiles',
+    '🥚 Eggs — 1 point each, on your bird cards',
+    '🌰 Cached food — 1 point per food tucked on your birds',
+    '🃏 Tucked cards — 1 point per card tucked under your birds',
+    '🌸 Nectar — habitat majorities (Oceania), when enabled',
+    '',
+    '🍽️ Unused food breaks ties — most leftover food wins. Tied totals show as co-leaders,',
+    'so settle a dead heat at the table with the food column.',
+  ].join('\n'),
+
+  stats: wingspanStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/wingspan/logic.ts
+++ b/src/lib/games/wingspan/logic.ts
@@ -1,0 +1,187 @@
+import type { ID, Player } from '../../types';
+
+/**
+ * The pure, deterministic scoring core for Wingspan — no Svelte, no IndexedDB, no I/O.
+ * {@link ./index index.ts} wraps these into a `GameModule`; keeping them here (mirroring
+ * `skullking`, `hearts` and the `custom` engine) makes the maths independently unit-testable
+ * and safe for `stats.ts` to import.
+ *
+ * Wingspan is an **end-game category scorer**: at game end each player totals points from a
+ * handful of categories and the highest total wins. Score King models one game as a single
+ * final scoresheet (one round, a column per category per player) — exactly like the real
+ * Wingspan score pad.
+ */
+
+export interface WingspanConfig {
+  /** Oceania expansion — adds a Nectar scoring category. */
+  nectar?: boolean;
+  /** Track each player's leftover food to settle ties (default on). Never scores points. */
+  trackFood?: boolean;
+}
+
+/** One player's column of category values on the final scoresheet. */
+export interface WingspanRow {
+  /** Points printed on the birds you played. */
+  birds: number;
+  /** Points from your bonus cards. */
+  bonus: number;
+  /** Points from the end-of-round goal tiles. */
+  goals: number;
+  /** 1 point per egg on your birds. */
+  eggs: number;
+  /** 1 point per food cached on your birds. */
+  food: number;
+  /** 1 point per card tucked under your birds. */
+  tucked: number;
+  /** Nectar majorities, scored per habitat (Oceania). Stays 0 unless the expansion is on. */
+  nectar: number;
+  /** Leftover food tokens — the tiebreaker only, never added to the score. */
+  leftover: number;
+}
+
+export interface WingspanInput {
+  rows: Record<ID, WingspanRow>;
+}
+
+export interface CategoryDef {
+  key: keyof WingspanRow;
+  label: string;
+  /** Compact label for the entry grid. */
+  short: string;
+  emoji: string;
+  help: string;
+}
+
+/** The base six categories — always present, in the order they sit on the real score pad. */
+export const BASE_CATEGORIES: CategoryDef[] = [
+  { key: 'birds', label: 'Birds', short: 'Birds', emoji: '🐦', help: 'Points printed on the birds in your habitats.' },
+  { key: 'bonus', label: 'Bonus cards', short: 'Bonus', emoji: '🎯', help: "Points from your bonus cards' conditions." },
+  { key: 'goals', label: 'End-of-round goals', short: 'Goals', emoji: '🎖️', help: 'Points from the four end-of-round goal tiles.' },
+  { key: 'eggs', label: 'Eggs', short: 'Eggs', emoji: '🥚', help: '1 point per egg on your bird cards.' },
+  { key: 'food', label: 'Cached food', short: 'Cached', emoji: '🌰', help: '1 point per food token cached on your bird cards.' },
+  { key: 'tucked', label: 'Tucked cards', short: 'Tucked', emoji: '🃏', help: '1 point per card tucked under your birds.' },
+];
+
+/** Oceania's Nectar category, shown only when the expansion is toggled on. */
+export const NECTAR_CATEGORY: CategoryDef = {
+  key: 'nectar',
+  label: 'Nectar',
+  short: 'Nectar',
+  emoji: '🌸',
+  help: 'Nectar majorities scored per habitat (Oceania expansion).',
+};
+
+/** The leftover-food tiebreaker — captured, shown apart, and never scored. */
+export const LEFTOVER_CATEGORY: CategoryDef = {
+  key: 'leftover',
+  label: 'Unused food',
+  short: 'Food left',
+  emoji: '🍽️',
+  help: 'Leftover food tokens settle ties — the most unused food wins. Never added to the score.',
+};
+
+/** Every scoring key, in pad order. Nectar is always summed; it stays 0 when the toggle is off. */
+export const SCORING_KEYS: (keyof WingspanRow)[] = [
+  'birds',
+  'bonus',
+  'goals',
+  'eggs',
+  'food',
+  'tucked',
+  'nectar',
+];
+
+export function isNectarOn(config: WingspanConfig | Record<string, unknown> | undefined): boolean {
+  return !!(config as WingspanConfig | undefined)?.nectar;
+}
+
+/** Tiebreaker tracking defaults ON — only an explicit `false` turns the leftover column off. */
+export function tracksFood(config: WingspanConfig | Record<string, unknown> | undefined): boolean {
+  return (config as WingspanConfig | undefined)?.trackFood !== false;
+}
+
+/** The scoring columns the editor should show for a given config (base six, plus Nectar). */
+export function scoringCategories(
+  config: WingspanConfig | Record<string, unknown> | undefined,
+): CategoryDef[] {
+  return isNectarOn(config) ? [...BASE_CATEGORIES, NECTAR_CATEGORY] : [...BASE_CATEGORIES];
+}
+
+/** A fresh, all-zero column for one player. */
+export function emptyRow(): WingspanRow {
+  return { birds: 0, bonus: 0, goals: 0, eggs: 0, food: 0, tucked: 0, nectar: 0, leftover: 0 };
+}
+
+/** Coerce anything into a safe numeric contribution. */
+function num(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * One player's final score: the sum of the scoring categories. Config-independent by design —
+ * disabled categories (e.g. Nectar) are simply left at 0, so `describeRound` and `stats.ts`
+ * can total a row without knowing the game's config, and the number can never drift.
+ */
+export function scoreRow(row: WingspanRow | undefined): number {
+  if (!row) return 0;
+  let sum = 0;
+  for (const k of SCORING_KEYS) sum += num(row[k]);
+  return sum;
+}
+
+/** Score the whole scoresheet: every player's final total, keyed by player id. */
+export function scoreWingspanRound(
+  input: WingspanInput | undefined,
+  players: Player[],
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const p of players) out[p.id] = scoreRow(input?.rows?.[p.id]);
+  return out;
+}
+
+/** Look up a friendly label for any row field (for validation messages). */
+export function fieldLabel(key: keyof WingspanRow): string {
+  if (key === NECTAR_CATEGORY.key) return NECTAR_CATEGORY.label;
+  if (key === LEFTOVER_CATEGORY.key) return LEFTOVER_CATEGORY.label;
+  return BASE_CATEGORIES.find((c) => c.key === key)?.label ?? String(key);
+}
+
+const MAX_FIELD = 999;
+
+/**
+ * Validate a scoresheet: every entered value must be a whole number in `0..999`. Returns the
+ * first human-readable problem, or `null` when the sheet is clean. Config-free — unused columns
+ * sit at 0 and always pass.
+ */
+export function validateWingspanRound(
+  input: WingspanInput | undefined,
+  players: Player[],
+): string | null {
+  const keys = Object.keys(emptyRow()) as (keyof WingspanRow)[];
+  for (const p of players) {
+    const row = input?.rows?.[p.id];
+    if (!row) continue;
+    for (const key of keys) {
+      const v = Number(row[key]);
+      if (!Number.isFinite(v) || v < 0) return `${p.name}: ${fieldLabel(key)} can't be negative.`;
+      if (!Number.isInteger(v)) return `${p.name}: ${fieldLabel(key)} must be a whole number.`;
+      if (v > MAX_FIELD) return `${p.name}: ${fieldLabel(key)} looks too high — double-check it.`;
+    }
+  }
+  return null;
+}
+
+/** A concise, glanceable per-player summary of a recorded scoresheet for the history table. */
+export function describeWingspanRound(
+  input: WingspanInput | undefined,
+  players: Player[],
+): string {
+  const parts: string[] = [];
+  for (const p of players) {
+    const row = input?.rows?.[p.id];
+    if (!row) continue;
+    parts.push(`${p.name} ${scoreRow(row)}`);
+  }
+  return parts.length ? parts.join(' · ') : 'no scores';
+}

--- a/src/lib/games/wingspan/stats.ts
+++ b/src/lib/games/wingspan/stats.ts
@@ -1,0 +1,71 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg, fmtInt } from '../../stats/format';
+import { scoreRow, type WingspanInput } from './logic';
+
+interface WSAgg {
+  games: number;
+  total: number;
+  birds: number;
+  eggs: number;
+  best: number;
+}
+
+/**
+ * Wingspan stats, derived purely from each recorded scoresheet — no Svelte, so it's
+ * independently unit-testable and safe for the engine to import. Mirrors `skullkingStats`:
+ * one aggregate per canonical member, folded into per-player + global metrics.
+ */
+export function wingspanStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, WSAgg>();
+  const get = (id: ID): WSAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { games: 0, total: 0, birds: 0, eggs: 0, best: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as WingspanInput | undefined;
+    if (!input?.rows) continue;
+    for (const [pid, row] of Object.entries(input.rows)) {
+      const a = get(canonical(pid));
+      const total = scoreRow(row);
+      a.games += 1;
+      a.total += total;
+      a.birds += Number(row?.birds) || 0;
+      a.eggs += Number(row?.eggs) || 0;
+      if (total > a.best) a.best = total;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let grandTotal = 0;
+  let grandGames = 0;
+  let highScore = 0;
+  for (const [id, a] of per) {
+    if (!a.games) continue;
+    grandTotal += a.total;
+    grandGames += a.games;
+    if (a.best > highScore) highScore = a.best;
+
+    const metrics: Metric[] = [
+      { key: 'ws_avg', label: 'Avg score', value: fmtAvg(a.total / a.games), emoji: '🪶' },
+      { key: 'ws_birds', label: 'Avg birds', value: fmtAvg(a.birds / a.games), emoji: '🐦' },
+      { key: 'ws_eggs', label: 'Avg eggs', value: fmtAvg(a.eggs / a.games), emoji: '🥚' },
+      { key: 'ws_best', label: 'Best game', value: fmtInt(a.best), emoji: '⭐' },
+    ];
+    perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (grandGames) {
+    global.push({ key: 'ws_avg_all', label: 'Avg final score', value: fmtAvg(grandTotal / grandGames), emoji: '🪶' });
+    global.push({ key: 'ws_high', label: 'High score', value: fmtInt(highScore), emoji: '⭐' });
+  }
+  return { perPlayer, global };
+}

--- a/src/lib/games/wingspan/wingspan.test.ts
+++ b/src/lib/games/wingspan/wingspan.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+import type { Player, Round, RoundContext } from '../../types';
+import { defaultWinners } from '../../types';
+import {
+  BASE_CATEGORIES,
+  LEFTOVER_CATEGORY,
+  NECTAR_CATEGORY,
+  describeWingspanRound,
+  emptyRow,
+  fieldLabel,
+  isNectarOn,
+  scoreRow,
+  scoreWingspanRound,
+  scoringCategories,
+  tracksFood,
+  validateWingspanRound,
+  type WingspanInput,
+  type WingspanRow,
+} from './logic';
+import { wingspan } from './index';
+
+const P = (id: string, name = id): Player => ({ id, name, color: '#7c5cff', createdAt: 0 });
+
+function row(partial: Partial<WingspanRow>): WingspanRow {
+  return { ...emptyRow(), ...partial };
+}
+
+function ctxFor(players: Player[], config: Record<string, unknown> = {}): RoundContext {
+  return { players, config } as unknown as RoundContext;
+}
+
+describe('wingspan row scoring', () => {
+  it('starts every column at zero', () => {
+    const r = emptyRow();
+    expect(Object.values(r).every((v) => v === 0)).toBe(true);
+    expect(Object.keys(r)).toHaveLength(8);
+  });
+
+  it('sums the base six categories into a total', () => {
+    // 40 + 8 + 6 + 12 + 5 + 9 = 80
+    expect(scoreRow(row({ birds: 40, bonus: 8, goals: 6, eggs: 12, food: 5, tucked: 9 }))).toBe(80);
+  });
+
+  it('adds Nectar to the total when present', () => {
+    expect(scoreRow(row({ birds: 40, nectar: 11 }))).toBe(51);
+  });
+
+  it('never counts unused food (the tiebreaker) toward the score', () => {
+    expect(scoreRow(row({ birds: 20, leftover: 9 }))).toBe(20);
+    expect(scoreRow(row({ leftover: 50 }))).toBe(0);
+  });
+
+  it('treats a missing row as zero', () => {
+    expect(scoreRow(undefined)).toBe(0);
+  });
+
+  it('coerces non-finite values to zero rather than NaN', () => {
+    expect(scoreRow(row({ birds: Number('nope'), eggs: 3 }))).toBe(3);
+  });
+});
+
+describe('scoreWingspanRound', () => {
+  it('totals every player, keyed by id', () => {
+    const players = [P('a'), P('b')];
+    const input: WingspanInput = {
+      rows: {
+        a: row({ birds: 30, eggs: 10, tucked: 4 }), // 44
+        b: row({ birds: 25, bonus: 7, goals: 3 }), // 35
+      },
+    };
+    expect(scoreWingspanRound(input, players)).toEqual({ a: 44, b: 35 });
+  });
+
+  it('scores a player with no entered row as zero', () => {
+    expect(scoreWingspanRound({ rows: {} }, [P('a')])).toEqual({ a: 0 });
+  });
+});
+
+describe('category configuration', () => {
+  it('shows exactly the base six by default', () => {
+    const cats = scoringCategories({});
+    expect(cats).toHaveLength(6);
+    expect(cats.map((c) => c.key)).toEqual(['birds', 'bonus', 'goals', 'eggs', 'food', 'tucked']);
+  });
+
+  it('appends Nectar as a seventh column when Oceania is on', () => {
+    const cats = scoringCategories({ nectar: true });
+    expect(cats).toHaveLength(7);
+    expect(cats[cats.length - 1].key).toBe('nectar');
+  });
+
+  it('base categories are unique and never the reserved tiebreaker', () => {
+    const keys = BASE_CATEGORIES.map((c) => c.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).not.toContain(LEFTOVER_CATEGORY.key);
+    expect(NECTAR_CATEGORY.key).toBe('nectar');
+    expect(LEFTOVER_CATEGORY.key).toBe('leftover');
+  });
+
+  it('reads the config toggles with the right defaults', () => {
+    expect(isNectarOn(undefined)).toBe(false);
+    expect(isNectarOn({ nectar: true })).toBe(true);
+    expect(tracksFood(undefined)).toBe(true); // tracked unless explicitly disabled
+    expect(tracksFood({ trackFood: false })).toBe(false);
+  });
+});
+
+describe('validateWingspanRound', () => {
+  const players = [P('a', 'Robin')];
+
+  it('accepts a clean sheet', () => {
+    expect(validateWingspanRound({ rows: { a: row({ birds: 42, eggs: 6 }) } }, players)).toBeNull();
+  });
+
+  it('rejects negative values with the player name', () => {
+    const msg = validateWingspanRound({ rows: { a: row({ birds: -1 }) } }, players);
+    expect(msg).toContain('Robin');
+    expect(msg).toContain('negative');
+  });
+
+  it('rejects fractional values', () => {
+    expect(validateWingspanRound({ rows: { a: row({ eggs: 2.5 }) } }, players)).toContain('whole number');
+  });
+
+  it('rejects absurdly high typos', () => {
+    expect(validateWingspanRound({ rows: { a: row({ birds: 1000 }) } }, players)).toContain('too high');
+  });
+
+  it('validates the unused-food tiebreaker column too', () => {
+    expect(validateWingspanRound({ rows: { a: row({ leftover: -3 }) } }, players)).toContain('negative');
+  });
+
+  it('is lenient about a player who has no row yet', () => {
+    expect(validateWingspanRound({ rows: {} }, players)).toBeNull();
+  });
+});
+
+describe('fieldLabel', () => {
+  it('maps every row key to a friendly label', () => {
+    expect(fieldLabel('birds')).toBe('Birds');
+    expect(fieldLabel('nectar')).toBe('Nectar');
+    expect(fieldLabel('leftover')).toBe('Unused food');
+  });
+});
+
+describe('describeWingspanRound', () => {
+  it('summarises each player total for the history table', () => {
+    const players = [P('a', 'Ava'), P('b', 'Ben')];
+    const input: WingspanInput = { rows: { a: row({ birds: 80 }), b: row({ birds: 55 }) } };
+    expect(describeWingspanRound(input, players)).toBe('Ava 80 · Ben 55');
+  });
+
+  it('reads "no scores" for an empty sheet', () => {
+    expect(describeWingspanRound({ rows: {} }, [])).toBe('no scores');
+  });
+});
+
+describe('winner resolution (highest reigns)', () => {
+  it('crowns the highest total', () => {
+    expect(defaultWinners(wingspan, { a: 88, b: 91, c: 77 })).toEqual(['b']);
+  });
+
+  it('returns co-leaders on an exact tie (settle by unused food at the table)', () => {
+    expect(defaultWinners(wingspan, { a: 85, b: 85, c: 70 }).sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('wingspan game module', () => {
+  it('exposes faithful metadata and a single final scoresheet', () => {
+    expect(wingspan.id).toBe('wingspan');
+    expect(wingspan.minPlayers).toBeGreaterThanOrEqual(1);
+    expect(wingspan.maxPlayers).toBeGreaterThanOrEqual(wingspan.minPlayers);
+    expect(wingspan.lowerIsBetter).toBeFalsy();
+    expect(wingspan.maxRounds?.({}, 4)).toBe(1);
+  });
+
+  it('ships the expansion + tiebreaker toggles with the right defaults', () => {
+    const byKey = Object.fromEntries((wingspan.configFields ?? []).map((f) => [f.key, f]));
+    expect(byKey.nectar?.default).toBe(false);
+    expect(byKey.trackFood?.default).toBe(true);
+  });
+
+  it('creates a fresh, all-zero row per player', () => {
+    const players = [P('a'), P('b')];
+    const input = wingspan.createRoundInput(ctxFor(players)) as WingspanInput;
+    expect(Object.keys(input.rows).sort()).toEqual(['a', 'b']);
+    expect(scoreRow(input.rows.a)).toBe(0);
+  });
+
+  it('wires scoreRound to the pure engine', () => {
+    const players = [P('a'), P('b')];
+    const input: WingspanInput = {
+      rows: { a: row({ birds: 50, eggs: 10 }), b: row({ birds: 40, nectar: 5 }) },
+    };
+    expect(wingspan.scoreRound(input, ctxFor(players))).toEqual({ a: 60, b: 45 });
+  });
+
+  it('validates through the module surface', () => {
+    const players = [P('a', 'Sky')];
+    expect(wingspan.validateRound({ rows: { a: row({ birds: 3.3 }) } }, ctxFor(players))).toContain(
+      'whole number',
+    );
+  });
+
+  it('describes a recorded round', () => {
+    const players = [P('a', 'Ava')];
+    const round = { input: { rows: { a: row({ birds: 61 }) } } } as unknown as Round;
+    expect(wingspan.describeRound?.(round, players)).toBe('Ava 61');
+  });
+});


### PR DESCRIPTION
﻿## 🪶 Wingspan

Adds a first-class built-in module for **Wingspan**, the engine-building birds game. Wingspan is an **end-game category scorer**: at game end each player totals points from several categories and the highest total reigns. This models one game as a **single final scoresheet** — one round, a column per category per player, summed to a total — exactly like the real Wingspan score pad.

The registry **auto-discovers** the new `index.ts`, so no shared files change.

### Scoring categories
The **base six** are always present:

| | Category | Points |
|---|---|---|
| 🐦 | Birds | printed on your played birds |
| 🎯 | Bonus cards | your bonus card conditions |
| 🎖️ | End-of-round goals | the four goal tiles |
| 🥚 | Eggs | 1 each |
| 🌰 | Cached food | 1 per cached food |
| 🃏 | Tucked cards | 1 per tucked card |

Final score = sum of the categories. **Highest wins.** Exact ties show as co-leaders — settle a dead heat at the table with the unused-food column.

### Config
- **🌸 Oceania nectar** *(default off)* — adds a seventh Nectar column for habitat majorities. The base six always stay.
- **🍽️ Track unused food (tiebreaker)** *(default on)* — captures each player's leftover food. It settles ties but **never** adds to the score, so it sits apart from the scoring grid with a "Breaks ties · not scored" note.

### Design
Follows `DESIGN.md` strictly: identical chrome, personality via 🪶 emoji + copy only. The category grid reuses the shared `Avatar` and `Stepper` (>=46px targets, one-handed). Every total is `tabular-nums`; the single Royal Violet action stays the shell's **Save round**; no Crown Gold misuse (leader/winner only); the tiebreaker row is visually subordinate. No animations added, so `prefers-reduced-motion` is a no-op.

### Files (purely additive — only `src/lib/games/wingspan/`)
- `logic.ts` — pure per-category summation + validation, no Svelte imports
- `index.ts` — `GameModule` (`maxRounds = 1`), config, help
- `WingspanEditor.svelte` — per-player category grid with live per-player totals
- `stats.ts` — avg score / birds / eggs + best game per player
- `wingspan.test.ts` — 29 tests over the pure logic + module wiring

### Verification
- npm run check — 0 errors, 0 warnings
- npm test — 104 passed (29 new; registry auto-discovery test also validates the module)
- npm run build — succeeds, PWA generated
- Manually played a 3-player game in the browser (nectar on): totals, tiebreaker exclusion, help popover, and catalog tile all render correctly with no console errors.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
