### PR TITLE
Add Codenames team tracker (Red vs Blue)

### DIFF
--- a/src/lib/games/codenames/CodenamesEditor.svelte
+++ b/src/lib/games/codenames/CodenamesEditor.svelte
@@ -1,0 +1,371 @@
+<script lang="ts">
+  import type { ID, RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import {
+    TEAMS,
+    TEAM_META,
+    teamCounts,
+    tally,
+    type CodenamesInput,
+    type Team,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: CodenamesInput; ctx: RoundContext } = $props();
+
+  const trackAssassin = $derived(ctx.config.trackAssassin !== false);
+  const playerIds = $derived(ctx.players.map((p) => p.id));
+  const counts = $derived(teamCounts(input.teams, playerIds));
+  const prior = $derived(tally(ctx.rounds));
+  const priorGames = $derived(prior.red + prior.blue);
+  /** Round 0 has no carried teams, so the roster is front-and-centre; later it tucks away. */
+  const setupOpen = $derived(ctx.roundIndex === 0);
+
+  function teamOf(id: ID): Team {
+    return input.teams[id] === 'blue' ? 'blue' : 'red';
+  }
+  function flip(id: ID) {
+    input.teams[id] = teamOf(id) === 'red' ? 'blue' : 'red';
+  }
+</script>
+
+<div class="stack">
+  <div class="tallybar" class:first={priorGames === 0}>
+    {#if priorGames > 0}
+      <span class="tlabel">Match so far</span>
+      <span class="tscore" aria-label="Red {prior.red}, Blue {prior.blue}">
+        <span class="tteam">🔴 {prior.red}</span>
+        <span class="tdash" aria-hidden="true">–</span>
+        <span class="tteam">{prior.blue} 🔵</span>
+      </span>
+    {:else}
+      <span class="tlabel">🕵️ First game of the match</span>
+    {/if}
+  </div>
+
+  <div class="field">
+    <span class="flabel">Who won this game?</span>
+    <div class="winner" role="group" aria-label="Winning team">
+      {#each TEAMS as t (t)}
+        <button
+          type="button"
+          class="teamwin {t}"
+          class:on={input.winner === t}
+          aria-pressed={input.winner === t}
+          onclick={() => (input.winner = t)}
+        >
+          <span class="wemoji" aria-hidden="true">{TEAM_META[t].emoji}</span>
+          <span class="wname">{TEAM_META[t].label}</span>
+          <span class="wtag">{input.winner === t ? '✓ won' : 'tap if they won'}</span>
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  {#if trackAssassin}
+    <div class="field">
+      <span class="flabel">How did it end?</span>
+      <div class="ending" role="group" aria-label="How the game ended">
+        <button
+          type="button"
+          class="endbtn agents"
+          class:on={input.ending === 'agents'}
+          aria-pressed={input.ending === 'agents'}
+          onclick={() => (input.ending = 'agents')}
+        >
+          🎉 Found all agents
+        </button>
+        <button
+          type="button"
+          class="endbtn assassin"
+          class:on={input.ending === 'assassin'}
+          aria-pressed={input.ending === 'assassin'}
+          onclick={() => (input.ending = 'assassin')}
+        >
+          💀 Assassin
+        </button>
+      </div>
+      {#if input.ending === 'assassin'}
+        <p class="hint">💀 The losing team revealed the assassin — an instant loss.</p>
+      {/if}
+    </div>
+  {/if}
+
+  {#snippet roster()}
+    <div class="stack roster">
+      {#each ctx.players as p (p.id)}
+        {@const team = teamOf(p.id)}
+        <div class="prow">
+          <span class="who">
+            <Avatar name={p.name} color={p.color} />
+            <span class="pname">{p.name}</span>
+          </span>
+          <button
+            type="button"
+            class="teamtog {team}"
+            onclick={() => flip(p.id)}
+            aria-label="{p.name} is on {TEAM_META[team].label} team. Tap to switch."
+          >
+            <span class="dot" aria-hidden="true">{TEAM_META[team].emoji}</span>
+            <span class="tname">{TEAM_META[team].label}</span>
+            <span class="swap" aria-hidden="true">⇄</span>
+          </button>
+        </div>
+      {/each}
+    </div>
+  {/snippet}
+
+  {#if setupOpen}
+    <div class="field">
+      <span class="flabel">Teams · 🔴 {counts.red} vs 🔵 {counts.blue}</span>
+      {@render roster()}
+    </div>
+  {:else}
+    <details class="teams-details">
+      <summary>
+        <span>Teams</span>
+        <span class="summ">🔴 {counts.red} vs {counts.blue} 🔵 · tap to adjust</span>
+      </summary>
+      {@render roster()}
+    </details>
+  {/if}
+</div>
+
+<style>
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .flabel {
+    font-size: 0.9rem;
+    color: var(--muted);
+    font-weight: 600;
+  }
+
+  /* Match tally */
+  .tallybar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 10px 14px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .tallybar.first {
+    justify-content: center;
+  }
+  .tlabel {
+    font-size: 0.85rem;
+    color: var(--muted);
+    font-weight: 600;
+  }
+  .tscore {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+  .tdash {
+    color: var(--muted);
+  }
+
+  /* Winner chooser — the hero choice */
+  .winner {
+    display: flex;
+    gap: 10px;
+  }
+  .teamwin {
+    --tc: var(--muted);
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3px;
+    min-height: 72px;
+    padding: 12px 8px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease, transform 0.05s ease;
+  }
+  .teamwin.red {
+    --tc: #e5484d;
+  }
+  .teamwin.blue {
+    --tc: #4c7dff;
+  }
+  .teamwin:hover {
+    border-color: var(--tc);
+  }
+  .teamwin:active {
+    transform: translateY(1px);
+  }
+  .teamwin.on {
+    border-color: var(--tc);
+    background: color-mix(in srgb, var(--tc) 16%, var(--surface-2));
+  }
+  .teamwin:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .wemoji {
+    font-size: 1.5rem;
+    line-height: 1;
+  }
+  .wname {
+    font-weight: 700;
+    font-size: 1.05rem;
+  }
+  .wtag {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: var(--muted);
+    text-transform: uppercase;
+  }
+  .teamwin.on .wtag {
+    color: var(--tc);
+  }
+
+  /* Ending toggle — semantic green (clean) vs coral (assassin) */
+  .ending {
+    display: flex;
+    gap: 10px;
+  }
+  .endbtn {
+    flex: 1 1 0;
+    min-height: 46px;
+    padding: 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    color: var(--text);
+    font-weight: 700;
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .endbtn:active {
+    transform: translateY(1px);
+  }
+  .endbtn:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .endbtn.agents.on {
+    border-color: color-mix(in srgb, var(--good) 60%, var(--border));
+    background: color-mix(in srgb, var(--good) 16%, var(--surface-2));
+  }
+  .endbtn.assassin.on {
+    border-color: color-mix(in srgb, var(--bad) 60%, var(--border));
+    background: color-mix(in srgb, var(--bad) 16%, var(--surface-2));
+  }
+  .hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+    line-height: 1.4;
+  }
+
+  /* Team roster */
+  .roster {
+    gap: 8px;
+  }
+  .prow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 8px 10px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+  }
+  .who {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .pname {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .teamtog {
+    --tc: #e5484d;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    flex: none;
+    min-height: 46px;
+    padding: 0 12px;
+    border: 1px solid var(--tc);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--tc) 12%, var(--surface));
+    color: var(--text);
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.15s ease;
+  }
+  .teamtog.blue {
+    --tc: #4c7dff;
+  }
+  .teamtog:active {
+    transform: translateY(1px);
+  }
+  .teamtog:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .swap {
+    color: var(--muted);
+    font-weight: 400;
+  }
+
+  .teams-details {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0 12px;
+  }
+  .teams-details summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 46px;
+    cursor: pointer;
+    font-weight: 700;
+    list-style: none;
+  }
+  .teams-details summary::-webkit-details-marker {
+    display: none;
+  }
+  .teams-details .summ {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .teams-details[open] summary {
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 10px;
+  }
+  .teams-details .roster {
+    padding-bottom: 12px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .teamwin,
+    .endbtn,
+    .teamtog {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/games/codenames/codenames.test.ts
+++ b/src/lib/games/codenames/codenames.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import type { Game, ID, Player, Round, RoundContext } from '../../types';
+import {
+  carryTeams,
+  createInput,
+  defaultTeams,
+  describe as summarize,
+  matchOver,
+  otherTeam,
+  pickWinners,
+  score,
+  tally,
+  teamCounts,
+  validate,
+  type CodenamesInput,
+  type Team,
+} from './logic';
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+const player = (id: string): Player => ({ id, name: id.toUpperCase(), color: '#7c5cff', createdAt: 0 });
+const players = (...ids: string[]): Player[] => ids.map(player);
+
+const input = (
+  teams: Record<ID, Team>,
+  winner: Team | null = null,
+  ending: CodenamesInput['ending'] = 'agents',
+): CodenamesInput => ({ teams, winner, ending });
+
+const round = (index: number, inp: CodenamesInput): Round => ({
+  id: `r${index}`,
+  gameId: 'g',
+  index,
+  input: inp,
+  deltas: {},
+  createdAt: index,
+});
+
+const ctx = (ps: Player[], rounds: Round[] = [], config: Record<string, unknown> = {}): RoundContext => {
+  const game: Game = {
+    id: 'g',
+    type: 'codenames',
+    config,
+    playerIds: ps.map((p) => p.id),
+    status: 'active',
+    createdAt: 0,
+    roundCount: rounds.length,
+  };
+  return { game, players: ps, config, roundIndex: rounds.length, totals: {}, rounds };
+};
+
+// ── team helpers ──────────────────────────────────────────────────────────────
+describe('defaultTeams', () => {
+  it('alternates Red/Blue by seat order', () => {
+    expect(defaultTeams(['a', 'b', 'c', 'd'])).toEqual({ a: 'red', b: 'blue', c: 'red', d: 'blue' });
+  });
+  it('handles a single player', () => {
+    expect(defaultTeams(['solo'])).toEqual({ solo: 'red' });
+  });
+});
+
+describe('carryTeams', () => {
+  it('defaults when there is no previous map', () => {
+    expect(carryTeams(undefined, ['a', 'b', 'c'])).toEqual(defaultTeams(['a', 'b', 'c']));
+  });
+  it('keeps known players and defaults new ones', () => {
+    expect(carryTeams({ a: 'blue', b: 'red' }, ['a', 'b', 'c'])).toEqual({ a: 'blue', b: 'red', c: 'red' });
+  });
+  it('drops players no longer in the game', () => {
+    const out = carryTeams({ a: 'blue', gone: 'red' }, ['a', 'b']);
+    expect(out).toEqual({ a: 'blue', b: 'blue' });
+    expect('gone' in out).toBe(false);
+  });
+  it('ignores a corrupt team value and falls back to the default', () => {
+    expect(carryTeams({ a: 'green' as unknown as Team }, ['a'])).toEqual({ a: 'red' });
+  });
+});
+
+describe('teamCounts', () => {
+  it('counts each side over the given roster only', () => {
+    expect(teamCounts({ a: 'red', b: 'blue', c: 'red' }, ['a', 'b', 'c'])).toEqual({ red: 2, blue: 1 });
+  });
+  it('only counts players in the roster', () => {
+    expect(teamCounts({ a: 'red', b: 'blue' }, ['a'])).toEqual({ red: 1, blue: 0 });
+  });
+});
+
+describe('otherTeam', () => {
+  it('flips sides', () => {
+    expect(otherTeam('red')).toBe('blue');
+    expect(otherTeam('blue')).toBe('red');
+  });
+});
+
+// ── createInput ───────────────────────────────────────────────────────────────
+describe('createInput', () => {
+  it('starts a fresh match with balanced teams and no winner', () => {
+    const out = createInput(ctx(players('a', 'b', 'c')));
+    expect(out).toEqual({ teams: { a: 'red', b: 'blue', c: 'red' }, winner: null, ending: 'agents' });
+  });
+  it('carries the previous game\'s teams forward and clears the winner', () => {
+    const prev = round(0, input({ a: 'blue', b: 'blue', c: 'red' }, 'blue', 'assassin'));
+    const out = createInput(ctx(players('a', 'b', 'c'), [prev]));
+    expect(out.teams).toEqual({ a: 'blue', b: 'blue', c: 'red' });
+    expect(out.winner).toBeNull();
+    expect(out.ending).toBe('agents');
+  });
+  it('carries from the highest-index round regardless of array order', () => {
+    const r0 = round(0, input({ a: 'red', b: 'blue' }, 'red'));
+    const r1 = round(1, input({ a: 'blue', b: 'red' }, 'blue'));
+    const out = createInput(ctx(players('a', 'b'), [r1, r0]));
+    expect(out.teams).toEqual({ a: 'blue', b: 'red' });
+  });
+});
+
+// ── validate ──────────────────────────────────────────────────────────────────
+describe('validate', () => {
+  const ids = ['a', 'b'];
+  it('passes when both teams are staffed and a winner is chosen', () => {
+    expect(validate(input({ a: 'red', b: 'blue' }, 'red'), ids)).toBeNull();
+  });
+  it('rejects an empty side', () => {
+    expect(validate(input({ a: 'red', b: 'red' }, 'red'), ids)).toMatch(/each team/i);
+  });
+  it('rejects a missing winner', () => {
+    expect(validate(input({ a: 'red', b: 'blue' }, null), ids)).toMatch(/won this game/i);
+  });
+});
+
+// ── score ─────────────────────────────────────────────────────────────────────
+describe('score', () => {
+  it('awards +1 to the winning team and 0 to the rest', () => {
+    const ids = ['a', 'b', 'c'];
+    const out = score(input({ a: 'red', b: 'red', c: 'blue' }, 'red'), ids);
+    expect(out).toEqual({ a: 1, b: 1, c: 0 });
+  });
+  it('flips when the other team wins', () => {
+    const ids = ['a', 'b', 'c'];
+    const out = score(input({ a: 'red', b: 'red', c: 'blue' }, 'blue'), ids);
+    expect(out).toEqual({ a: 0, b: 0, c: 1 });
+  });
+});
+
+// ── pickWinners ───────────────────────────────────────────────────────────────
+describe('pickWinners', () => {
+  it('returns nothing for an empty or scoreless match', () => {
+    expect(pickWinners({})).toEqual([]);
+    expect(pickWinners({ a: 0, b: 0 })).toEqual([]);
+  });
+  it('returns the leading team', () => {
+    expect(pickWinners({ a: 2, b: 2, c: 1 }).sort()).toEqual(['a', 'b']);
+  });
+  it('returns both teams (co-winners) when the match is level', () => {
+    expect(pickWinners({ a: 3, b: 3 }).sort()).toEqual(['a', 'b']);
+  });
+});
+
+// ── matchOver ─────────────────────────────────────────────────────────────────
+describe('matchOver', () => {
+  it('is open-ended when the target is 0 or missing', () => {
+    expect(matchOver({ a: 5 }, 0)).toBe(false);
+    expect(matchOver({ a: 5 }, Number.NaN)).toBe(false);
+  });
+  it('ends once a team reaches the target', () => {
+    expect(matchOver({ a: 3, b: 1 }, 3)).toBe(true);
+    expect(matchOver({ a: 2, b: 1 }, 3)).toBe(false);
+  });
+});
+
+// ── tally ─────────────────────────────────────────────────────────────────────
+describe('tally', () => {
+  it('counts games won per side and ignores unresolved rounds', () => {
+    const rounds = [
+      round(0, input({ a: 'red', b: 'blue' }, 'red')),
+      round(1, input({ a: 'red', b: 'blue' }, 'blue')),
+      round(2, input({ a: 'red', b: 'blue' }, 'red')),
+      round(3, input({ a: 'red', b: 'blue' }, null)),
+    ];
+    expect(tally(rounds)).toEqual({ red: 2, blue: 1 });
+  });
+});
+
+// ── describe ──────────────────────────────────────────────────────────────────
+describe('describe', () => {
+  it('summarises a clean win', () => {
+    expect(summarize(input({ a: 'red' }, 'red', 'agents'))).toBe('🔴 Red won');
+  });
+  it('flags an assassin ending', () => {
+    expect(summarize(input({ a: 'blue' }, 'blue', 'assassin'))).toBe('🔵 Blue won · 💀 assassin');
+  });
+  it('handles an unrecorded winner', () => {
+    expect(summarize(input({ a: 'red' }, null))).toBe('No winner recorded');
+  });
+});
+
+// ── end-to-end match ──────────────────────────────────────────────────────────
+describe('a full match', () => {
+  it('accumulates game wins and crowns the leading team', () => {
+    const ids = ['a', 'b', 'c'];
+    const teams: Record<ID, Team> = { a: 'red', b: 'red', c: 'blue' };
+    const games: Array<Team> = ['red', 'blue', 'red']; // Red 2, Blue 1
+
+    const totals: Record<ID, number> = { a: 0, b: 0, c: 0 };
+    for (const winner of games) {
+      const deltas = score(input(teams, winner), ids);
+      for (const id of ids) totals[id] += deltas[id];
+    }
+
+    expect(totals).toEqual({ a: 2, b: 2, c: 1 });
+    expect(pickWinners(totals).sort()).toEqual(['a', 'b']);
+    expect(matchOver(totals, 2)).toBe(true);
+  });
+});

--- a/src/lib/games/codenames/index.ts
+++ b/src/lib/games/codenames/index.ts
@@ -1,0 +1,93 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './CodenamesEditor.svelte';
+import { codenamesStats } from './stats';
+import {
+  createInput,
+  describe,
+  matchOver,
+  pickWinners,
+  score,
+  validate,
+  type CodenamesInput,
+} from './logic';
+
+export type { CodenamesInput, Team, Ending } from './logic';
+
+const playerIdsOf = (ctx: RoundContext): ID[] => ctx.players.map((p) => p.id);
+
+/**
+ * Codenames — a Red vs Blue **tracker** rather than a point counter. Each round
+ * is one game: tap the winning team (and, optionally, whether the losers hit the
+ * assassin). The winning team's players each bank +1, so standings read as
+ * "games won", the crown sits with the leading team, and `pickWinners` resolves
+ * the match to that team. See `logic.ts` for the full modelling note.
+ */
+export const codenames: GameModule = {
+  id: 'codenames',
+  name: 'Codenames',
+  tagline: 'Red vs Blue — track who cracks the grid',
+  emoji: '🕵️',
+  keywords: [
+    'party',
+    'word game',
+    'spymaster',
+    'agents',
+    'assassin',
+    'team',
+    'red vs blue',
+    'head to head',
+  ],
+  minPlayers: 2,
+  maxPlayers: 12,
+  teams: true,
+  configFields: [
+    {
+      key: 'trackAssassin',
+      label: 'Track assassin losses',
+      type: 'boolean',
+      default: true,
+      help: 'Record when a game ends by the losing team revealing the assassin.',
+    },
+    {
+      key: 'winTarget',
+      label: 'Games to win the match (0 = open-ended)',
+      type: 'number',
+      default: 0,
+      min: 0,
+      help: 'Play a best-of series: the match ends when a team reaches this many wins.',
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): CodenamesInput => createInput(ctx),
+
+  validateRound: (input: CodenamesInput, ctx: RoundContext): string | null =>
+    validate(input, playerIdsOf(ctx)),
+
+  scoreRound: (input: CodenamesInput, ctx: RoundContext): Record<ID, number> =>
+    score(input, playerIdsOf(ctx)),
+
+  isFinished: (totals, { config }) => matchOver(totals, Number(config.winTarget) || 0),
+
+  pickWinners: (totals): ID[] => pickWinners(totals),
+
+  describeRound: (round: Round): string => describe(round.input as CodenamesInput),
+
+  help: [
+    'A tracker for the team word game — record who won each game, not points.',
+    '',
+    'Two teams, 🔴 Red and 🔵 Blue, each with a spymaster giving one-word clues so',
+    'their operatives find their agents on the grid — while dodging the 💀 assassin.',
+    '',
+    'Each round is one game:',
+    '• Assign every player to a team (set once — it carries to the next game).',
+    '• Tap the team that won.',
+    '• Optionally mark whether the losers tripped the assassin (an instant loss).',
+    '',
+    'The winning team banks a game; the team ahead wears the crown. Finish the match',
+    'to record the leading team — or set a “games to win” target for a best-of series.',
+  ].join('\n'),
+
+  stats: codenamesStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/codenames/logic.ts
+++ b/src/lib/games/codenames/logic.ts
@@ -1,0 +1,169 @@
+import type { ID, Round, RoundContext } from '../../types';
+
+/**
+ * Codenames is a team word game, not a point counter — so this module is a
+ * head-to-head **tracker**. Each recorded round is one game between two fixed
+ * teams (🔴 Red vs 🔵 Blue); a Score King "game" is a match/series of those.
+ *
+ * Modelling a scoreless team game inside the per-player {@link import('../../types').GameModule}
+ * contract: players are grouped into two teams, the winning team's players each
+ * score **+1** for the game, so a player's running total is "games my team won".
+ * `pickWinners` then returns the players on the team that won the most games.
+ *
+ * Everything here is pure and Svelte-free so `codenames.test.ts` can exercise the
+ * real scoring/validation without pulling in the round editor.
+ */
+
+export type Team = 'red' | 'blue';
+
+/** How a game ended — the two iconic Codenames outcomes. */
+export type Ending = 'agents' | 'assassin';
+
+export interface CodenamesInput {
+  /**
+   * Each player's team for this game. Persisted per-round and carried forward by
+   * {@link createInput}, so fixed teams stay stable across a match while still
+   * being editable if the table reshuffles.
+   */
+  teams: Record<ID, Team>;
+  /** The team that won this game. `null` until the scorer taps a winner. */
+  winner: Team | null;
+  /** `agents` = winners found all their agents; `assassin` = losers hit the assassin. */
+  ending: Ending;
+}
+
+export const TEAMS: readonly Team[] = ['red', 'blue'];
+
+export interface TeamMeta {
+  label: string;
+  emoji: string;
+}
+
+export const TEAM_META: Record<Team, TeamMeta> = {
+  red: { label: 'Red', emoji: '🔴' },
+  blue: { label: 'Blue', emoji: '🔵' },
+};
+
+export function otherTeam(team: Team): Team {
+  return team === 'red' ? 'blue' : 'red';
+}
+
+function isTeam(value: unknown): value is Team {
+  return value === 'red' || value === 'blue';
+}
+
+/** Balanced starting split: alternate players Red/Blue by seat order. */
+export function defaultTeams(playerIds: ID[]): Record<ID, Team> {
+  const teams: Record<ID, Team> = {};
+  playerIds.forEach((id, i) => {
+    teams[id] = i % 2 === 0 ? 'red' : 'blue';
+  });
+  return teams;
+}
+
+/**
+ * Team map for the current roster: keep each player's previous team when known,
+ * fall back to the balanced default for anyone new, and drop players no longer
+ * in the game. Keeps fixed teams stable game-to-game.
+ */
+export function carryTeams(
+  prev: Record<ID, Team> | undefined,
+  playerIds: ID[],
+): Record<ID, Team> {
+  const base = defaultTeams(playerIds);
+  const teams: Record<ID, Team> = {};
+  for (const id of playerIds) {
+    const carried = prev?.[id];
+    teams[id] = isTeam(carried) ? carried : base[id];
+  }
+  return teams;
+}
+
+export function teamCounts(
+  teams: Record<ID, Team>,
+  playerIds: ID[],
+): Record<Team, number> {
+  const counts: Record<Team, number> = { red: 0, blue: 0 };
+  for (const id of playerIds) {
+    const t = teams[id];
+    if (isTeam(t)) counts[t] += 1;
+  }
+  return counts;
+}
+
+/** Latest recorded round's input, if any (defensively ordered by index). */
+function lastInput(rounds: Round[]): CodenamesInput | undefined {
+  if (rounds.length === 0) return undefined;
+  let latest = rounds[0];
+  for (const r of rounds) if (r.index >= latest.index) latest = r;
+  return latest.input as CodenamesInput | undefined;
+}
+
+/** Fresh draft for the next game: teams carried forward, winner unset. */
+export function createInput(ctx: RoundContext): CodenamesInput {
+  const playerIds = ctx.players.map((p) => p.id);
+  return {
+    teams: carryTeams(lastInput(ctx.rounds)?.teams, playerIds),
+    winner: null,
+    ending: 'agents',
+  };
+}
+
+export function validate(input: CodenamesInput, playerIds: ID[]): string | null {
+  const counts = teamCounts(input.teams, playerIds);
+  if (counts.red === 0 || counts.blue === 0) {
+    return 'Put at least one player on each team — 🔴 Red and 🔵 Blue.';
+  }
+  if (!isTeam(input.winner)) {
+    return 'Tap the team that won this game.';
+  }
+  return null;
+}
+
+/** Winning team's players each score +1 for the game; everyone else 0. */
+export function score(input: CodenamesInput, playerIds: ID[]): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) {
+    out[id] = input.teams[id] === input.winner ? 1 : 0;
+  }
+  return out;
+}
+
+/**
+ * The leading team: players tied at the highest games-won total. Empty when no
+ * games have been won yet (nothing to crown); a level match returns both teams
+ * as co-winners.
+ */
+export function pickWinners(totals: Record<ID, number>): ID[] {
+  const ids = Object.keys(totals);
+  if (ids.length === 0) return [];
+  const best = Math.max(...ids.map((id) => totals[id] ?? 0));
+  if (best <= 0) return [];
+  return ids.filter((id) => (totals[id] ?? 0) === best);
+}
+
+/** Best-of-series end: any team reaches the win target (0 = open-ended). */
+export function matchOver(totals: Record<ID, number>, winTarget: number): boolean {
+  const target = Number(winTarget) || 0;
+  if (target <= 0) return false;
+  return Object.values(totals).some((t) => t >= target);
+}
+
+/** Count games won by each team across recorded rounds. */
+export function tally(rounds: Round[]): Record<Team, number> {
+  const counts: Record<Team, number> = { red: 0, blue: 0 };
+  for (const r of rounds) {
+    const w = (r.input as CodenamesInput | undefined)?.winner;
+    if (isTeam(w)) counts[w] += 1;
+  }
+  return counts;
+}
+
+/** One-line history summary: winner, plus the assassin flourish when it applies. */
+export function describe(input: CodenamesInput): string {
+  if (!isTeam(input.winner)) return 'No winner recorded';
+  const meta = TEAM_META[input.winner];
+  let out = `${meta.emoji} ${meta.label} won`;
+  if (input.ending === 'assassin') out += ' · 💀 assassin';
+  return out;
+}

--- a/src/lib/games/codenames/stats.ts
+++ b/src/lib/games/codenames/stats.ts
@@ -1,0 +1,104 @@
+import type { ID } from '../../types';
+import type { CodenamesInput, Team } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt } from '../../stats/format';
+
+interface CodenamesAgg {
+  /** Games lost because this player's team hit the assassin. */
+  assassinLosses: number;
+  /** Games won by finding all agents (no assassin drama). */
+  cleanWins: number;
+}
+
+function isTeam(value: unknown): value is Team {
+  return value === 'red' || value === 'blue';
+}
+
+/**
+ * Codenames stats from each recorded game's team map + outcome. Pure and
+ * Svelte-free (mirrors the module's own `logic.ts`), so the engine can import it
+ * without touching the round editor.
+ */
+export function codenamesStats({
+  games,
+  rounds,
+  canonical,
+}: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, CodenamesAgg>();
+  const get = (id: ID): CodenamesAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { assassinLosses: 0, cleanWins: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  const teamWins: Record<Team, number> = { red: 0, blue: 0 };
+  let assassinGames = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as CodenamesInput | undefined;
+    if (!input?.teams || !isTeam(input.winner)) continue;
+
+    const winner = input.winner;
+    const byAssassin = input.ending === 'assassin';
+    teamWins[winner] += 1;
+    if (byAssassin) assassinGames += 1;
+
+    for (const [pid, team] of Object.entries(input.teams)) {
+      if (!isTeam(team)) continue;
+      const a = get(canonical(pid));
+      if (team === winner) {
+        if (!byAssassin) a.cleanWins += 1;
+      } else if (byAssassin) {
+        a.assassinLosses += 1;
+      }
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.cleanWins) {
+      metrics.push({
+        key: 'cn_clean',
+        label: 'Clean sweeps',
+        value: fmtInt(a.cleanWins),
+        emoji: '🎉',
+      });
+    }
+    if (a.assassinLosses) {
+      metrics.push({
+        key: 'cn_assassin',
+        label: 'Assassin losses',
+        value: fmtInt(a.assassinLosses),
+        emoji: '💀',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  const totalGames = teamWins.red + teamWins.blue;
+  if (totalGames) {
+    global.push({
+      key: 'cn_teams',
+      label: 'Red vs Blue',
+      value: `🔴 ${fmtInt(teamWins.red)} – ${fmtInt(teamWins.blue)} 🔵`,
+      sub: `${fmtInt(totalGames)} games tracked`,
+    });
+  }
+  if (assassinGames) {
+    global.push({
+      key: 'cn_assassin_all',
+      label: 'Assassin endings',
+      value: fmtInt(assassinGames),
+      emoji: '💀',
+    });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
﻿## 🕵️ Codenames — a Red vs Blue tracker

Adds **Codenames** as a new game module, purely additive under `src/lib/games/codenames/` (auto-discovered by the registry — no `registry.ts` edit).

Codenames is a **team word game, not a point counter**, so this ships as a head-to-head **tracker**.

### The scoreless-team model (within the per-player `GameModule` contract)
Score King scores per player: `scoreRound` → per-player deltas, `computeTotals` sums them, `pickWinners(totals)` returns winning player IDs, the Scoreboard ranks players. To fit a team game onto that:

- **Each recorded round = one Codenames game**; a Score King "game" = a **match/series** of games.
- Players are grouped into two teams, **🔴 Red / 🔵 Blue** (assignment stored per round and **carried forward** via `createRoundInput` reading `ctx.rounds`, so fixed teams stay stable but editable).
- `scoreRound`: every player on the **winning team** banks **+1** → a player's total is "games my team won" (**score = games won**).
- `pickWinners(totals)`: the team tied at the top total — the leading team wears the 👑; a level match returns both teams as co-winners.
- **Open-ended** by default; an optional **best-of** target ends the match via `isFinished`.

### Round entry
- **Who won?** — a large, accessible 🔴/🔵 winner chooser (the hero choice).
- **How did it end?** — 🎉 Found all agents vs 💀 Assassin (gated by config), powering assassin-loss stats.
- **Teams** — assign each player a side; front-and-centre on game 1, tucked into a `<details>` afterwards. A glanceable `🔴 x – y 🔵` match tally sits on top.

### Config
- **Track assassin losses** (default on) — show the ending selector + record assassin instant-losses.
- **Games to win the match** (default 0 = open-ended) — a best-of series target.

### Stats (`stats.ts`)
Per player: 🎉 clean sweeps, 💀 assassin losses. Global: `🔴 x – y 🔵` overall tally + assassin endings.

### Design
Follows `DESIGN.md`: chrome unchanged; personality via emoji/copy + restrained team accents. **Crown Gold stays reserved for the leader/winner — never used for the teams.** No second violet primary (the shell's "Save round" stays the one primary action); team identity is always emoji **+ label** (never colour alone); tabular-nums tally; ≥46px targets; honors `prefers-reduced-motion`.

### Verification
- `npm test` — 102 passed (27 new, over pure `logic.ts`)
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — clean

Constraints honored: only `src/lib/games/codenames/` added; no shared components, other games, `registry.ts`, `README.md`, or `package.json`/lockfile touched.
