### PR TITLE
Add Chicken Foot dominoes game

### DIFF
--- a/src/lib/games/chickenfoot/ChickenFootEditor.svelte
+++ b/src/lib/games/chickenfoot/ChickenFootEditor.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { chickenfoot } from './index';
+  import { blankValue, doubleLabel, playerRoundScore, totalRounds, type ChickenFootInput } from './logic';
+
+  let { input = $bindable(), ctx }: { input: ChickenFootInput; ctx: RoundContext } = $props();
+
+  const blankVal = $derived(blankValue(ctx.config));
+  const rounds = $derived(totalRounds(ctx.config));
+  const roundNum = $derived(ctx.roundIndex + 1);
+  let showHelp = $state(false);
+
+  function setOut(id: string) {
+    input.outId = input.outId === id ? null : id;
+    if (input.outId === id) {
+      input.pips[id] = 0;
+      if (input.blankId === id) input.blankId = null;
+    }
+  }
+
+  function setBlank(id: string) {
+    input.blankId = input.blankId === id ? null : id;
+    if (input.blankId === id && input.outId === id) input.outId = null;
+  }
+
+  function score(id: string): number {
+    return playerRoundScore(input, id, blankVal);
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="row" style="gap: 8px">
+      <span class="pill">Round {roundNum} of {rounds}</span>
+      <span class="tile" class:blank={input.double === 0} title={doubleLabel(input.double)}>
+        <span class="half">{input.double}</span>
+        <span class="bar" aria-hidden="true"></span>
+        <span class="half">{input.double}</span>
+      </span>
+    </span>
+    <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+      Rules
+    </button>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{chickenfoot.help}</pre>
+  {:else}
+    <p class="hint muted">Log each hand’s leftover pips, then tap 🐔 for whoever went out.</p>
+  {/if}
+
+  {#each ctx.players as p (p.id)}
+    {@const out = input.outId === p.id}
+    <div class="prow" class:isout={out}>
+      <div class="row spread" style="margin-bottom: 10px">
+        <span class="row" style="gap: 8px">
+          <Avatar name={p.name} color={p.color} />
+          <strong>{p.name}</strong>
+        </span>
+        <span
+          class="preview"
+          class:score-good={score(p.id) === 0}
+          class:score-bad={score(p.id) > 0}
+        >
+          {score(p.id) > 0 ? '+' : ''}{score(p.id)}
+        </span>
+      </div>
+
+      {#if out}
+        <div class="emptyhand">🐔 Went out — empty hand, 0 points</div>
+      {:else}
+        <div class="row spread">
+          <span class="plabel">Pips left</span>
+          <Stepper bind:value={input.pips[p.id]} min={0} />
+        </div>
+      {/if}
+
+      <div class="row toggles">
+        <button
+          type="button"
+          class="toggle out"
+          class:on={out}
+          aria-pressed={out}
+          onclick={() => setOut(p.id)}
+        >
+          🐔 Went out
+        </button>
+        {#if blankVal > 0}
+          <button
+            type="button"
+            class="toggle blank"
+            class:on={input.blankId === p.id}
+            aria-pressed={input.blankId === p.id}
+            disabled={out}
+            onclick={() => setBlank(p.id)}
+          >
+            ⬜ Double-blank <span class="sub">(+{blankVal})</span>
+          </button>
+        {/if}
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  /* A little domino showing the double this round is built on — the personality moment,
+     built from the surface ramp (never gold/violet, which are reserved). */
+  .tile {
+    display: inline-flex;
+    align-items: stretch;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+    overflow: hidden;
+  }
+  .tile .half {
+    min-width: 22px;
+    padding: 5px 7px;
+    text-align: center;
+  }
+  .tile.blank .half {
+    color: var(--muted);
+  }
+  .tile .bar {
+    width: 1px;
+    background: var(--border);
+  }
+
+  .hint {
+    margin: 0;
+    font-size: 0.85rem;
+  }
+
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+  }
+  /* Went-out is the good outcome (lowest pips) — co-signal it with a calm green edge,
+     never color alone: the 🐔, the "empty hand" line and the 0 all say it too. */
+  .prow.isout {
+    border-color: color-mix(in srgb, var(--good) 45%, var(--border));
+  }
+
+  .preview {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .emptyhand {
+    color: var(--good);
+    font-weight: 700;
+    padding: 3px 0;
+  }
+
+  .plabel {
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+
+  .toggles {
+    gap: 8px;
+    margin-top: 10px;
+  }
+  .toggle {
+    flex: 1;
+    min-height: 46px;
+    padding: 9px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+    transition: background 0.15s ease, border-color 0.15s ease;
+  }
+  .toggle:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .toggle .sub {
+    color: var(--muted);
+    font-weight: 500;
+  }
+  /* Selected states use the semantic palette (good / bad), keeping Royal Violet for the
+     shell's one Save action and Crown Gold for the leader alone. */
+  .toggle.out.on {
+    background: color-mix(in srgb, var(--good) 20%, var(--surface));
+    border-color: var(--good);
+  }
+  .toggle.blank.on {
+    background: color-mix(in srgb, var(--bad) 20%, var(--surface));
+    border-color: var(--bad);
+  }
+  .toggle.blank.on .sub {
+    color: var(--bad);
+  }
+
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toggle {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/games/chickenfoot/chickenfoot.test.ts
+++ b/src/lib/games/chickenfoot/chickenfoot.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, Player, Round, RoundContext } from '../../types';
+import { defaultWinners, resolveLower } from '../../types';
+import { getModule } from '../registry';
+import { chickenfoot, type ChickenFootInput } from './index';
+import {
+  blankValue,
+  describeRound,
+  doubleLabel,
+  leadingDouble,
+  playerRoundScore,
+  scoreRound,
+  startDouble,
+  totalRounds,
+  validateRound,
+} from './logic';
+
+const p = (id: string, name: string): Player => ({ id, name, color: '#7c5cff', createdAt: 0 });
+const PLAYERS = [p('a', 'Ada'), p('b', 'Bo'), p('c', 'Cy')];
+
+function ctxOf(config: Record<string, unknown>, roundIndex = 0, players = PLAYERS): RoundContext {
+  return {
+    game: {
+      id: 'g',
+      type: 'chickenfoot',
+      config,
+      playerIds: players.map((pl) => pl.id),
+      status: 'active',
+      createdAt: 0,
+      roundCount: 0,
+    } as Game,
+    players,
+    config,
+    roundIndex,
+    totals: Object.fromEntries(players.map((pl) => [pl.id, 0])),
+    rounds: [],
+  };
+}
+
+function input(partial: Partial<ChickenFootInput> = {}): ChickenFootInput {
+  return {
+    double: 9,
+    pips: { a: 0, b: 0, c: 0 },
+    outId: null,
+    blankId: null,
+    ...partial,
+  };
+}
+
+describe('chicken foot · config helpers', () => {
+  it('defaults to double-9 and parses the offered starting doubles', () => {
+    expect(startDouble({})).toBe(9);
+    expect(startDouble({ startDouble: '6' })).toBe(6);
+    expect(startDouble({ startDouble: '12' })).toBe(12);
+    expect(startDouble({ startDouble: '99' })).toBe(9); // out of range → default
+    expect(startDouble({ startDouble: 'nope' })).toBe(9);
+  });
+
+  it('runs one round per double down to double-blank', () => {
+    expect(totalRounds({ startDouble: '6' })).toBe(7);
+    expect(totalRounds({ startDouble: '9' })).toBe(10);
+    expect(totalRounds({ startDouble: '12' })).toBe(13);
+  });
+
+  it('counts the leading double down each round and clamps at blank', () => {
+    const cfg = { startDouble: '9' };
+    expect(leadingDouble(cfg, 0)).toBe(9);
+    expect(leadingDouble(cfg, 1)).toBe(8);
+    expect(leadingDouble(cfg, 9)).toBe(0);
+    expect(leadingDouble(cfg, 20)).toBe(0);
+  });
+
+  it('labels doubles, with a friendly name for the blank', () => {
+    expect(doubleLabel(7)).toBe('Double-7');
+    expect(doubleLabel(0)).toBe('Double-blank');
+    expect(doubleLabel(-3)).toBe('Double-blank');
+  });
+
+  it('reads the double-blank penalty, treating non-positive as disabled', () => {
+    expect(blankValue({ doubleBlankValue: 50 })).toBe(50);
+    expect(blankValue({ doubleBlankValue: 0 })).toBe(0);
+    expect(blankValue({ doubleBlankValue: -5 })).toBe(0);
+    expect(blankValue({})).toBe(0);
+  });
+});
+
+describe('chicken foot · round scoring', () => {
+  it('scores leftover pips per player', () => {
+    const deltas = scoreRound(input({ pips: { a: 12, b: 3, c: 0 } }), PLAYERS, 50);
+    expect(deltas).toEqual({ a: 12, b: 3, c: 0 });
+  });
+
+  it('gives the player who went out zero, ignoring any stray pips', () => {
+    const deltas = scoreRound(input({ pips: { a: 12, b: 3, c: 7 }, outId: 'b' }), PLAYERS, 50);
+    expect(deltas.b).toBe(0);
+    expect(deltas.a).toBe(12);
+    expect(deltas.c).toBe(7);
+  });
+
+  it('adds the double-blank penalty to whoever holds the 0–0 tile', () => {
+    const deltas = scoreRound(input({ pips: { a: 4, b: 0, c: 0 }, blankId: 'a' }), PLAYERS, 50);
+    expect(deltas.a).toBe(54); // 4 pips + 50 penalty
+    expect(deltas.b).toBe(0);
+  });
+
+  it('scores the double-blank as a plain 0 when the penalty is disabled', () => {
+    const deltas = scoreRound(input({ pips: { a: 4, b: 0, c: 0 }, blankId: 'a' }), PLAYERS, 0);
+    expect(deltas.a).toBe(4);
+  });
+
+  it('never returns negative points from junk input', () => {
+    expect(playerRoundScore(input({ pips: { a: -20 } as never }), 'a', 50)).toBe(0);
+    expect(playerRoundScore(input({ pips: { a: NaN } as never }), 'a', 50)).toBe(0);
+  });
+
+  it('a blocked round (nobody out) scores everyone their hand', () => {
+    const deltas = scoreRound(input({ pips: { a: 5, b: 9, c: 2 }, outId: null }), PLAYERS, 50);
+    expect(deltas).toEqual({ a: 5, b: 9, c: 2 });
+  });
+});
+
+describe('chicken foot · validation', () => {
+  it('accepts a normal round', () => {
+    expect(validateRound(input({ pips: { a: 5, b: 0, c: 3 }, outId: 'b' }), PLAYERS)).toBeNull();
+  });
+
+  it('accepts unset pip entries as zero', () => {
+    expect(validateRound(input({ pips: {} as never }), PLAYERS)).toBeNull();
+  });
+
+  it('rejects negative pips with the offending player named', () => {
+    const err = validateRound(input({ pips: { a: -1, b: 0, c: 0 } }), PLAYERS);
+    expect(err).toMatch(/Ada/);
+    expect(err).toMatch(/negative/);
+  });
+
+  it('rejects the same player being both out and holding the double-blank', () => {
+    const err = validateRound(input({ outId: 'a', blankId: 'a' }), PLAYERS);
+    expect(err).toMatch(/double-blank/);
+  });
+});
+
+describe('chicken foot · round description', () => {
+  const round = (input: ChickenFootInput, deltas: Record<string, number>): Round =>
+    ({ id: 'r', gameId: 'g', index: 0, input, deltas, createdAt: 0 }) as Round;
+
+  it('names the double, who went out, and the biggest hand', () => {
+    const r = round(input({ double: 7, outId: 'b' }), { a: 23, b: 0, c: 4 });
+    const text = describeRound(r, PLAYERS);
+    expect(text).toContain('Double-7');
+    expect(text).toContain('🐔 Bo out');
+    expect(text).toContain('Ada +23');
+  });
+
+  it('marks a blocked round', () => {
+    const r = round(input({ double: 3, outId: null }), { a: 1, b: 2, c: 3 });
+    expect(describeRound(r, PLAYERS)).toContain('blocked');
+  });
+
+  it('uses the blank label for the 0–0 round', () => {
+    const r = round(input({ double: 0, outId: 'a' }), { a: 0, b: 0, c: 0 });
+    expect(describeRound(r, PLAYERS)).toContain('Double-blank');
+  });
+});
+
+describe('chicken foot · module wiring', () => {
+  it('is auto-discovered by the registry', () => {
+    expect(getModule('chickenfoot')).toBe(chickenfoot);
+  });
+
+  it('exposes a lower-is-better dominoes identity', () => {
+    expect(chickenfoot.id).toBe('chickenfoot');
+    expect(chickenfoot.lowerIsBetter).toBe(true);
+    expect(chickenfoot.emoji).toBe('🐔');
+    expect(chickenfoot.minPlayers).toBeLessThanOrEqual(chickenfoot.maxPlayers);
+  });
+
+  it('ends after the double-blank round for each starting double', () => {
+    expect(chickenfoot.maxRounds!({ startDouble: '6' }, 4)).toBe(7);
+    expect(chickenfoot.maxRounds!({ startDouble: '9' }, 4)).toBe(10);
+    expect(chickenfoot.maxRounds!({ startDouble: '12' }, 4)).toBe(13);
+  });
+
+  it('builds a fresh input seeded with the round’s leading double', () => {
+    const draft = chickenfoot.createRoundInput(ctxOf({ startDouble: '9' }, 3)) as ChickenFootInput;
+    expect(draft.double).toBe(6); // 9 − round index 3
+    expect(draft.outId).toBeNull();
+    expect(draft.blankId).toBeNull();
+    expect(draft.pips).toEqual({ a: 0, b: 0, c: 0 });
+  });
+
+  it('scores through the module using the configured penalty', () => {
+    const ctx = ctxOf({ startDouble: '9', doubleBlankValue: 25 });
+    const deltas = chickenfoot.scoreRound(input({ pips: { a: 6, b: 0, c: 0 }, blankId: 'a' }), ctx);
+    expect(deltas.a).toBe(31); // 6 + 25
+  });
+
+  it('lowest cumulative total wins', () => {
+    const config = { startDouble: '9', doubleBlankValue: 50 };
+    expect(resolveLower(chickenfoot, config)).toBe(true);
+    expect(defaultWinners(chickenfoot, { a: 40, b: 12, c: 33 }, config)).toEqual(['b']);
+  });
+});

--- a/src/lib/games/chickenfoot/index.ts
+++ b/src/lib/games/chickenfoot/index.ts
@@ -1,0 +1,85 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './ChickenFootEditor.svelte';
+import { chickenfootStats } from './stats';
+import * as logic from './logic';
+import type { ChickenFootInput } from './logic';
+
+export type { ChickenFootInput };
+export {
+  playerRoundScore,
+  leadingDouble,
+  totalRounds,
+  doubleLabel,
+  blankValue,
+} from './logic';
+
+export const chickenfoot: GameModule = {
+  id: 'chickenfoot',
+  name: 'Chicken Foot',
+  tagline: 'Count the doubles down, dump your bones.',
+  emoji: '🐔',
+  keywords: ['dominoes', 'bones', 'chickie', 'chicken foot', 'doubles', 'mexican train'],
+  minPlayers: 2,
+  maxPlayers: 8,
+  lowerIsBetter: true,
+  configFields: [
+    {
+      key: 'startDouble',
+      label: 'Starting double',
+      type: 'select',
+      default: '9',
+      options: [
+        { value: '6', label: 'Double-6 · 7 rounds' },
+        { value: '9', label: 'Double-9 · 10 rounds' },
+        { value: '12', label: 'Double-12 · 13 rounds' },
+      ],
+      help: 'Play counts down one round per double, from here to double-blank.',
+    },
+    {
+      key: 'doubleBlankValue',
+      label: 'Double-blank penalty',
+      type: 'number',
+      default: 50,
+      min: 0,
+      step: 5,
+      help: 'Points for being caught with the 0–0 tile. Set 0 to score it as a plain blank.',
+    },
+  ],
+
+  maxRounds: (config) => logic.totalRounds(config),
+
+  createRoundInput: (ctx: RoundContext): ChickenFootInput => ({
+    double: logic.leadingDouble(ctx.config, ctx.roundIndex),
+    pips: Object.fromEntries(ctx.players.map((p) => [p.id, 0])),
+    outId: null,
+    blankId: null,
+  }),
+
+  validateRound: (input: ChickenFootInput, ctx: RoundContext): string | null =>
+    logic.validateRound(input, ctx.players),
+
+  scoreRound: (input: ChickenFootInput, ctx: RoundContext): Record<ID, number> =>
+    logic.scoreRound(input, ctx.players, logic.blankValue(ctx.config)),
+
+  describeRound: (round: Round, players): string => logic.describeRound(round, players),
+
+  help: [
+    'Chicken Foot is dominoes played as a countdown of rounds — one per double, from the',
+    'starting double down to double-blank (pick the starting double in Options).',
+    '',
+    'Each round is built on its double — the “chicken foot.” The round ends when one player',
+    'empties their hand, or when nobody can play (a blocked round).',
+    '',
+    'Scoring — lowest total wins:',
+    '• Whoever went out scores 0.',
+    '• Everyone else adds up the pips left in their hand (a blank side = 0).',
+    '• The 0–0 “double-blank” stings — it scores the penalty in Options (default 50).',
+    '',
+    'Each round: log everyone’s leftover pips, tap 🐔 for who went out, and flag ⬜ whoever’s',
+    'stuck holding the double-blank.',
+  ].join('\n'),
+
+  stats: chickenfootStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/chickenfoot/logic.ts
+++ b/src/lib/games/chickenfoot/logic.ts
@@ -1,0 +1,121 @@
+import type { ID, Player, Round } from '../../types';
+
+/**
+ * Pure Chicken Foot scoring — no Svelte, no I/O — so it's independently unit-testable
+ * and safe for the stats engine to import. The GameModule in `index.ts` is a thin
+ * adapter over these helpers; the editor imports the display helpers straight from here.
+ *
+ * Chicken Foot is a dominoes game played as a countdown of rounds — one per starting
+ * double, from the highest double down to double-blank. Each round one player empties
+ * their hand to end it; then EVERY player adds the pip count still in their hand to a
+ * running total. Lowest total wins.
+ */
+export interface ChickenFootInput {
+  /** The leading double this round is built on (startDouble − roundIndex; 0 = double-blank). */
+  double: number;
+  /** Pips still in each player's hand at round's end (a blank side counts 0). */
+  pips: Record<ID, number>;
+  /** Who emptied their hand to end the round. `null` when the round was blocked. */
+  outId: ID | null;
+  /** Who was caught holding the single 0–0 tile — scored via the double-blank penalty. */
+  blankId: ID | null;
+}
+
+/** The starting doubles Score King offers, and how many rounds each implies (double + 1). */
+export const START_DOUBLES = [6, 9, 12] as const;
+
+/** Parse the configured starting double, defaulting to double-9. */
+export function startDouble(config: Record<string, unknown>): number {
+  const n = Number(config.startDouble);
+  return (START_DOUBLES as readonly number[]).includes(n) ? n : 9;
+}
+
+/** One round per double, from the starting double down to double-blank. */
+export function totalRounds(config: Record<string, unknown>): number {
+  return startDouble(config) + 1;
+}
+
+/** The leading double for a 0-based round index, clamped at 0 (double-blank). */
+export function leadingDouble(config: Record<string, unknown>, roundIndex: number): number {
+  return Math.max(0, startDouble(config) - roundIndex);
+}
+
+/** Friendly name for a leading double: "Double-7", or "Double-blank" for the 0–0 round. */
+export function doubleLabel(d: number): string {
+  return d <= 0 ? 'Double-blank' : `Double-${d}`;
+}
+
+/** Penalty for being caught with the 0–0 tile; 0 means it scores as a plain blank. */
+export function blankValue(config: Record<string, unknown>): number {
+  const n = Number(config.doubleBlankValue);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/** Coerce a raw pip entry to a non-negative number (missing/blank/NaN → 0). */
+function pipsOf(input: ChickenFootInput, id: ID): number {
+  const n = Number(input.pips?.[id]);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/**
+ * Points a single player scores this round: 0 if they went out (empty hand),
+ * otherwise their leftover pips plus the double-blank penalty when they hold the 0–0.
+ */
+export function playerRoundScore(input: ChickenFootInput, id: ID, blankVal: number): number {
+  if (input.outId === id) return 0;
+  return pipsOf(input, id) + (input.blankId === id ? blankVal : 0);
+}
+
+/** Per-player point deltas for the round. */
+export function scoreRound(
+  input: ChickenFootInput,
+  players: readonly Pick<Player, 'id'>[],
+  blankVal: number,
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const p of players) out[p.id] = playerRoundScore(input, p.id, blankVal);
+  return out;
+}
+
+/** Return null when the round is valid, otherwise a friendly, specific message. */
+export function validateRound(
+  input: ChickenFootInput,
+  players: readonly Pick<Player, 'id' | 'name'>[],
+): string | null {
+  for (const p of players) {
+    const raw = input.pips?.[p.id];
+    if (raw == null) continue; // unset entry is treated as 0 pips
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return `${p.name}: enter a pip count.`;
+    if (n < 0) return `${p.name}: pip count can’t be negative.`;
+  }
+  // A player who emptied their hand can't also be holding the double-blank tile.
+  if (input.blankId && input.blankId === input.outId) {
+    return 'Whoever went out has an empty hand — they can’t hold the double-blank.';
+  }
+  return null;
+}
+
+/** Short one-line summary for the history table, driven by the round's recorded deltas. */
+export function describeRound(
+  round: Round,
+  players: readonly Pick<Player, 'id' | 'name'>[],
+): string {
+  const input = round.input as ChickenFootInput | undefined;
+  const name = (id: ID | null) => players.find((p) => p.id === id)?.name ?? '?';
+  const parts: string[] = [doubleLabel(input?.double ?? 0)];
+
+  if (input?.outId) parts.push(`🐔 ${name(input.outId)} out`);
+  else parts.push('🚫 blocked');
+
+  let worstId: ID | null = null;
+  let worst = 0;
+  for (const [id, v] of Object.entries(round.deltas ?? {})) {
+    if (v > worst) {
+      worst = v;
+      worstId = id;
+    }
+  }
+  if (worstId && worst > 0) parts.push(`${name(worstId)} +${worst}`);
+  return parts.join(' · ');
+}

--- a/src/lib/games/chickenfoot/stats.ts
+++ b/src/lib/games/chickenfoot/stats.ts
@@ -1,0 +1,75 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg, fmtInt } from '../../stats/format';
+import type { ChickenFootInput } from './logic';
+
+interface CFAgg {
+  rounds: number;
+  out: number;
+  blanks: number;
+  pips: number;
+}
+
+/**
+ * Chicken Foot stats, derived purely from each round's recorded hand. Lower-is-better,
+ * so a tight average hand and a habit of going out are the marks of a strong player.
+ * Pure — no Svelte — so it's independently testable and safe for the engine to import.
+ */
+export function chickenfootStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, CFAgg>();
+  const get = (id: ID): CFAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { rounds: 0, out: 0, blanks: 0, pips: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let totalOut = 0;
+  let biggestHand = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as ChickenFootInput | undefined;
+    if (!input?.pips) continue;
+
+    const outId = input.outId ? canonical(input.outId) : null;
+    const blankId = input.blankId ? canonical(input.blankId) : null;
+
+    for (const [pid, pips] of Object.entries(input.pips)) {
+      const id = canonical(pid);
+      const a = get(id);
+      a.rounds += 1;
+      a.pips += Math.max(0, Number(pips) || 0);
+      if (outId === id) a.out += 1;
+      if (blankId === id) a.blanks += 1;
+    }
+    if (outId) totalOut += 1;
+
+    for (const v of Object.values(r.deltas ?? {})) {
+      if (v > biggestHand) biggestHand = v;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.out) metrics.push({ key: 'cf_out', label: 'Went out', value: fmtInt(a.out), emoji: '🐔' });
+    if (a.blanks) {
+      metrics.push({ key: 'cf_blank', label: 'Double-blank caught', value: fmtInt(a.blanks), emoji: '⬜' });
+    }
+    if (a.rounds) {
+      metrics.push({ key: 'cf_pips', label: 'Avg pips left', value: fmtAvg(a.pips / a.rounds), emoji: '✋' });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totalOut) global.push({ key: 'cf_out_all', label: 'Times gone out', value: fmtInt(totalOut), emoji: '🐔' });
+  if (biggestHand > 0) {
+    global.push({ key: 'cf_big', label: 'Biggest hand left', value: fmtInt(biggestHand), emoji: '💥' });
+  }
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## 🐔 Chicken Foot

Adds **Chicken Foot**, the classic domino game, as a first-class Score King module. Purely additive — everything lives in `src/lib/games/chickenfoot/` and the registry auto-discovers it via `index.ts`. No shared files, other games, `registry.ts`, or dependencies were touched.

### How it scores
Chicken Foot plays as a **countdown of rounds — one per double**, from the starting double down to the double-blank. Each round is built on its double (the "chicken foot"). A round ends when one player **empties their hand** (they score **0**) or when nobody can play (a blocked round). Everyone else adds up the **pips left in their hand**. The lone **0-0 "double-blank"** stings — it carries a configurable penalty. **Lowest cumulative total wins.**

- `maxRounds = startingDouble + 1`, so the game auto-finishes right after the double-blank round (double-9 → 10 rounds).
- Each round stores its own leading double, so history/stats read correctly regardless of config.

### Config
| Option | Default | Notes |
| --- | --- | --- |
| **Starting double** | 9 | 6, 9, or 12 → 7 / 10 / 13 rounds |
| **Double-blank value** | 50 | The 0-0 penalty; set to 0 to disable |

### Input model
`{ double, pips: Record<id, number>, outId: id | null, blankId: id | null }`

Only one 0-0 tile exists, so `blankId` is a single assignment (mirrors Hearts' ♠Q pattern) rather than a per-player flag. `outId` marks who went out (`null` = blocked round → everyone scores their hand).

### Design choices (per DESIGN.md, strictly)
- **App chrome untouched.** Personality comes through the 🐔 emoji, a mini CSS **domino badge** showing the round's leading double, and warm copy — never by restyling the shell.
- **One primary action per screen:** the single Royal Violet CTA stays the shell's *Save round*. Editor toggles use **semantic tints** instead — green for *Went out*, coral for *Double-blank* — and are always **co-signaled** by emoji + text + border + number, never color alone.
- **Crown Gold reserved for the leader/winner** on the scoreboard.
- `tabular-nums` on every changing number; touch targets ≥46px; `aria-pressed` on toggles; honors `prefers-reduced-motion`.
- A **Rules** popover surfaces the module `help` (the round shell doesn't render `help` on its own).

### Files
- `logic.ts` — all pure scoring/validation/helpers (no Svelte imports)
- `index.ts` — `export const chickenfoot: GameModule` (`lowerIsBetter: true`)
- `ChickenFootEditor.svelte` — round entry (Avatar + Stepper + semantic toggles + domino badge + Rules)
- `stats.ts` — went-out count, double-blanks caught, avg pips left, biggest hand
- `chickenfoot.test.ts` — 28 tests over logic + module wiring

### Verification
- ✅ `npm run check` — 0 errors, 0 warnings
- ✅ `npm test` — 99 passed (8 files, incl. 28 new)
- ✅ `npm run build` — succeeds (exit 0)
- ✅ Visually verified the round editor (domino badge, went-out/double-blank states, Rules popover) in a real browser

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
