### PR TITLE
Add Werewords game tracker 🐺

### DIFF
--- a/src/lib/games/werewords/WerewordsEditor.svelte
+++ b/src/lib/games/werewords/WerewordsEditor.svelte
@@ -1,0 +1,334 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import { resolveOutcome, type WerewordsInput } from './logic';
+
+  let { input = $bindable(), ctx }: { input: WerewordsInput; ctx: RoundContext } = $props();
+
+  const seerOn = $derived(!!ctx.config.seer);
+  const expectedWolves = $derived(Math.max(1, Number(ctx.config.werewolves) || 1));
+  const wolfCount = $derived(input.werewolves.length);
+  const outcome = $derived(resolveOutcome(input));
+
+  function isWolf(id: string): boolean {
+    return input.werewolves.includes(id);
+  }
+  function roleLabel(id: string): string {
+    if (isWolf(id)) return 'Werewolf';
+    if (input.mayor === id) return 'Mayor';
+    if (input.seer === id) return 'Seer';
+    return 'Villager';
+  }
+
+  function clearSeer() {
+    input.seer = null;
+    input.werewolfFoundSeer = false;
+  }
+
+  function toggleWolf(id: string) {
+    if (isWolf(id)) {
+      input.werewolves = input.werewolves.filter((w) => w !== id);
+    } else {
+      input.werewolves = [...input.werewolves, id];
+      if (input.mayor === id) input.mayor = null;
+      if (input.seer === id) clearSeer();
+    }
+  }
+  function toggleMayor(id: string) {
+    input.mayor = input.mayor === id ? null : id;
+    if (input.mayor === id) {
+      input.werewolves = input.werewolves.filter((w) => w !== id);
+      if (input.seer === id) clearSeer();
+    }
+  }
+  function toggleSeer(id: string) {
+    if (input.seer === id) {
+      clearSeer();
+      return;
+    }
+    input.seer = id;
+    input.werewolfFoundSeer = false;
+    input.werewolves = input.werewolves.filter((w) => w !== id);
+    if (input.mayor === id) input.mayor = null;
+  }
+
+  function setGuessed(g: boolean) {
+    input.guessed = g;
+    // Only one twist can apply at a time — clear the branch that no longer fits.
+    if (g) input.mayorFoundWerewolf = false;
+    else input.werewolfFoundSeer = false;
+  }
+
+  const showSeerTwist = $derived(input.guessed && seerOn && input.seer != null);
+  const showMayorTwist = $derived(!input.guessed);
+  const mayorName = $derived(ctx.players.find((p) => p.id === input.mayor)?.name ?? '');
+</script>
+
+<div class="stack">
+  <label class="field">
+    <span class="fieldlabel">🔮 Secret word</span>
+    <input
+      type="text"
+      autocapitalize="characters"
+      autocomplete="off"
+      spellcheck="false"
+      placeholder="e.g. PYRAMID"
+      bind:value={input.word}
+    />
+  </label>
+
+  <div class="row spread">
+    <span class="muted">Tap each player’s role — untapped are Villagers.</span>
+    <span class="pill" class:score-bad={wolfCount !== expectedWolves}>🐺 {wolfCount}/{expectedWolves}</span>
+  </div>
+
+  {#each ctx.players as p (p.id)}
+    <div class="prow">
+      <span class="who">
+        <Avatar name={p.name} color={p.color} />
+        <span class="name">
+          <strong>{p.name}</strong>
+          <span class="role muted">{roleLabel(p.id)}</span>
+        </span>
+      </span>
+      <span class="roles">
+        <button
+          type="button"
+          class="rbtn"
+          class:on={input.mayor === p.id}
+          aria-pressed={input.mayor === p.id}
+          aria-label={`${p.name}: Mayor`}
+          title="Mayor"
+          onclick={() => toggleMayor(p.id)}
+        >👑</button>
+        {#if seerOn}
+          <button
+            type="button"
+            class="rbtn"
+            class:on={input.seer === p.id}
+            aria-pressed={input.seer === p.id}
+            aria-label={`${p.name}: Seer`}
+            title="Seer"
+            onclick={() => toggleSeer(p.id)}
+          >🔮</button>
+        {/if}
+        <button
+          type="button"
+          class="rbtn"
+          class:on={isWolf(p.id)}
+          aria-pressed={isWolf(p.id)}
+          aria-label={`${p.name}: Werewolf`}
+          title="Werewolf"
+          onclick={() => toggleWolf(p.id)}
+        >🐺</button>
+      </span>
+    </div>
+  {/each}
+
+  <div class="result">
+    <span class="fieldlabel">Did the village crack it in time?</span>
+    <div class="choice" role="radiogroup" aria-label="Did the village guess the word in time?">
+      <button
+        type="button"
+        role="radio"
+        aria-checked={input.guessed}
+        class="ch"
+        class:on={input.guessed}
+        onclick={() => setGuessed(true)}
+      >✅ Guessed it</button>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={!input.guessed}
+        class="ch"
+        class:on={!input.guessed}
+        onclick={() => setGuessed(false)}
+      >⏳ Ran out of time</button>
+    </div>
+
+    {#if showSeerTwist}
+      <button
+        type="button"
+        class="twist"
+        class:on={input.werewolfFoundSeer}
+        aria-pressed={input.werewolfFoundSeer}
+        onclick={() => (input.werewolfFoundSeer = !input.werewolfFoundSeer)}
+      >
+        🐺 A werewolf then named the Seer
+      </button>
+    {:else if showMayorTwist}
+      <button
+        type="button"
+        class="twist"
+        class:on={input.mayorFoundWerewolf}
+        aria-pressed={input.mayorFoundWerewolf}
+        onclick={() => (input.mayorFoundWerewolf = !input.mayorFoundWerewolf)}
+      >
+        🕵️ {mayorName ? `${mayorName} (Mayor)` : 'The Mayor'} then named a werewolf
+      </button>
+    {/if}
+
+    <div class="banner" class:wolves={outcome.team === 'werewolf'}>
+      <div class="verdict">
+        <span>{outcome.team === 'werewolf' ? '🐺 Werewolves win' : '🏘️ Villagers win'}</span>
+        {#if outcome.twist}<span class="pill twistpill">🔀 Twist!</span>{/if}
+      </div>
+      <div class="reason muted">{outcome.reason}</div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .field {
+    display: flex;
+    flex-direction: column;
+  }
+  .prow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 10px 12px;
+  }
+  .who {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .name {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.15;
+    min-width: 0;
+  }
+  .name strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .role {
+    font-size: 0.75rem;
+  }
+  .roles {
+    display: inline-flex;
+    gap: 6px;
+    flex: none;
+  }
+  .rbtn {
+    min-width: 46px;
+    height: 46px;
+    padding: 0;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--text);
+    font-size: 1.15rem;
+    cursor: pointer;
+    filter: grayscale(0.55);
+    opacity: 0.75;
+    transition: background 0.12s ease, border-color 0.12s ease, opacity 0.12s ease, filter 0.12s ease;
+  }
+  .rbtn:hover {
+    border-color: var(--primary);
+  }
+  .rbtn.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    filter: none;
+    opacity: 1;
+  }
+  .rbtn:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+
+  .result {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 4px;
+  }
+  .choice {
+    display: flex;
+    gap: 4px;
+    padding: 4px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .ch {
+    flex: 1 1 0;
+    min-height: 46px;
+    padding: 0 10px;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--muted);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
+  }
+  .ch:hover {
+    color: var(--text);
+  }
+  .ch.on {
+    background: var(--primary);
+    color: #fff;
+  }
+  .ch:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+
+  .twist {
+    min-height: 46px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--text);
+    font-weight: 700;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.12s ease, border-color 0.12s ease;
+  }
+  .twist:hover {
+    border-color: var(--primary);
+  }
+  .twist.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .twist:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+
+  .banner {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px 14px;
+  }
+  .verdict {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    font-weight: 800;
+    font-size: 1.05rem;
+  }
+  .twistpill {
+    flex: none;
+  }
+  .reason {
+    font-size: 0.85rem;
+    margin-top: 2px;
+  }
+</style>

--- a/src/lib/games/werewords/index.ts
+++ b/src/lib/games/werewords/index.ts
@@ -1,0 +1,84 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './WerewordsEditor.svelte';
+import { werewordsStats } from './stats';
+import {
+  describeWerewords,
+  scoreWerewords,
+  validateWerewords,
+  type WerewordsInput,
+} from './logic';
+
+export type { WerewordsInput, WerewordsTeam, WerewordsOutcome } from './logic';
+export { resolveOutcome, teamOf, isWerewolf } from './logic';
+
+const ids = (ctx: RoundContext): ID[] => ctx.players.map((p) => p.id);
+
+export const werewords: GameModule = {
+  id: 'werewords',
+  name: 'Werewords',
+  tagline: 'Crack the secret word before the wolves win',
+  emoji: '🐺',
+  keywords: [
+    'social deduction',
+    'word game',
+    'party',
+    'werewolf',
+    'guessing',
+    'mayor',
+    'seer',
+    'hidden roles',
+  ],
+  minPlayers: 3,
+  maxPlayers: 12,
+  configFields: [
+    { key: 'werewolves', label: 'Werewolves', type: 'number', default: 1, min: 1, max: 4 },
+    { key: 'seer', label: 'Include the Seer', type: 'boolean', default: true },
+    {
+      key: 'timer',
+      label: 'Timer (minutes)',
+      type: 'number',
+      default: 4,
+      min: 1,
+      max: 15,
+      help: 'For your reference at the table — the app doesn’t run the clock.',
+    },
+  ],
+
+  createRoundInput: (): WerewordsInput => ({
+    word: '',
+    mayor: null,
+    seer: null,
+    werewolves: [],
+    guessed: true,
+    werewolfFoundSeer: false,
+    mayorFoundWerewolf: false,
+  }),
+
+  validateRound: (input: WerewordsInput, ctx: RoundContext): string | null =>
+    validateWerewords(input, ids(ctx)),
+
+  scoreRound: (input: WerewordsInput, ctx: RoundContext): Record<ID, number> =>
+    scoreWerewords(input, ids(ctx)),
+
+  describeRound: (round: Round): string => describeWerewords(round.input as WerewordsInput),
+
+  help: [
+    'One secret word per round. The Mayor knows it and answers only “yes”, “no”, or',
+    '“maybe” as the table asks questions. Race the timer to guess the word.',
+    '',
+    'Village team: the Mayor, the Seer, and the Villagers.',
+    'Werewolf team: the werewolves — they know the word and want it to stay hidden.',
+    '',
+    'How a round lands:',
+    '• Guessed in time → Villagers win… unless a werewolf then names the Seer → Werewolves win.',
+    '• Never guessed → Werewolves win… unless the Mayor then names a werewolf → Villagers win.',
+    '',
+    'Each round, tap the werewolf/wolves (and optionally the Mayor and Seer), enter the word,',
+    'mark whether it was guessed, then flip the twist if it happened. Everyone on the winning',
+    'side banks a point — so the leaderboard is simply who has won the most rounds.',
+  ].join('\n'),
+
+  stats: werewordsStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/werewords/logic.ts
+++ b/src/lib/games/werewords/logic.ts
@@ -1,0 +1,128 @@
+import type { ID } from '../../types';
+
+/**
+ * Pure, Svelte-free Werewords logic — the twist outcomes, per-player scoring, and
+ * validation live here so `werewords.test.ts` can exercise the real rules without
+ * pulling in the round editor. `index.ts` wires these into the GameModule.
+ *
+ * Werewords is a scoreless, timed social-deduction word game. Each round has one
+ * secret word. The **Village** team (Mayor, Seer, and Villagers) races to guess it
+ * from yes/no questions before time runs out; the **Werewolves** — who also know the
+ * word — try to run out the clock. We model this into the point-oriented GameModule
+ * contract by banking one point per round for every player on the winning side, so a
+ * player's total is simply the number of rounds their side won.
+ */
+
+export type WerewordsTeam = 'village' | 'werewolf';
+
+export interface WerewordsInput {
+  /** The secret magic word for this round. */
+  word: string;
+  /** The Mayor (knows the word, answers questions). Optional role reference. */
+  mayor: ID | null;
+  /** The Seer (knows the word and the wolves). Optional; only when the Seer is in play. */
+  seer: ID | null;
+  /** Everyone tapped as a werewolf this round — the hidden side. Drives scoring. */
+  werewolves: ID[];
+  /** Did the Village guess the word before time ran out? */
+  guessed: boolean;
+  /** Guessed twist: a werewolf then correctly named the Seer, stealing the win. */
+  werewolfFoundSeer: boolean;
+  /** Not-guessed twist: the Mayor correctly named a werewolf, stealing the win back. */
+  mayorFoundWerewolf: boolean;
+}
+
+/** The runtime config an editor/scorer reads (all optional — defaults live in `index.ts`). */
+export interface WerewordsConfig {
+  werewolves?: number;
+  seer?: boolean;
+  timer?: number;
+}
+
+export interface WerewordsOutcome {
+  /** Which side won the round after the twists resolve. */
+  team: WerewordsTeam;
+  /** True when a twist overturned the base guessed/not-guessed result. */
+  twist: boolean;
+  /** Short, past-tense reason describing how the round landed. */
+  reason: string;
+}
+
+/**
+ * Resolve the winning side of a round, applying both twist rules:
+ *
+ *  • Guessed → Village wins, UNLESS a werewolf identifies the Seer → Werewolves.
+ *  • Not guessed → Werewolves win, UNLESS the Mayor identifies a werewolf → Village.
+ */
+export function resolveOutcome(input: WerewordsInput): WerewordsOutcome {
+  if (input.guessed) {
+    if (input.werewolfFoundSeer) {
+      return {
+        team: 'werewolf',
+        twist: true,
+        reason: 'guessed in time — but a werewolf unmasked the Seer',
+      };
+    }
+    return { team: 'village', twist: false, reason: 'the word was guessed in time' };
+  }
+  if (input.mayorFoundWerewolf) {
+    return {
+      team: 'village',
+      twist: true,
+      reason: 'never guessed — but the Mayor unmasked a werewolf',
+    };
+  }
+  return { team: 'werewolf', twist: false, reason: 'the word ran out the clock' };
+}
+
+/** True when a player sat on the werewolf side this round. */
+export function isWerewolf(input: WerewordsInput, id: ID): boolean {
+  return (input.werewolves ?? []).includes(id);
+}
+
+/** Which side a player was on this round (everyone not tapped as a wolf is Village). */
+export function teamOf(input: WerewordsInput, id: ID): WerewordsTeam {
+  return isWerewolf(input, id) ? 'werewolf' : 'village';
+}
+
+/**
+ * Per-player deltas: every player on the winning side banks +1, everyone else 0.
+ * Totals therefore read as "rounds won", and the leader is whoever has won most.
+ */
+export function scoreWerewords(
+  input: WerewordsInput,
+  playerIds: ID[],
+): Record<ID, number> {
+  const winner = resolveOutcome(input).team;
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) {
+    out[id] = teamOf(input, id) === winner ? 1 : 0;
+  }
+  return out;
+}
+
+/** Return null when the round is valid to save, otherwise a friendly message. */
+export function validateWerewords(input: WerewordsInput, playerIds: ID[]): string | null {
+  if (!input.word || !input.word.trim()) return 'Enter the secret magic word 🔮.';
+
+  const roster = new Set(playerIds);
+  const wolves = new Set((input.werewolves ?? []).filter((id) => roster.has(id)));
+  if (wolves.size < 1) return 'Tap at least one werewolf 🐺.';
+  if (wolves.size > playerIds.length - 1) {
+    return 'At least one villager has to stay in the village.';
+  }
+  if (input.mayor && wolves.has(input.mayor)) return 'The Mayor can’t also be a werewolf.';
+  if (input.seer && wolves.has(input.seer)) return 'The Seer can’t also be a werewolf.';
+  if (input.mayor && input.seer && input.mayor === input.seer) {
+    return 'The Mayor and the Seer have to be different players.';
+  }
+  return null;
+}
+
+/** A one-line summary of a round for the scorecard / history: the word + how it landed. */
+export function describeWerewords(input: WerewordsInput): string {
+  const { team, reason } = resolveOutcome(input);
+  const word = input.word?.trim() ? `“${input.word.trim().toUpperCase()}”` : 'the word';
+  const badge = team === 'werewolf' ? '🐺 Werewolves' : '🏘️ Villagers';
+  return `${badge} win · ${word} — ${reason}`;
+}

--- a/src/lib/games/werewords/stats.ts
+++ b/src/lib/games/werewords/stats.ts
@@ -1,0 +1,85 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtPct } from '../../stats/format';
+import { resolveOutcome, teamOf, type WerewordsInput } from './logic';
+
+interface WWAgg {
+  played: number;
+  won: number;
+  wolfGames: number;
+  wolfWins: number;
+  mayor: number;
+  seer: number;
+}
+
+/**
+ * Werewords stats, derived purely from each round's recorded roles + outcome via the
+ * module's own {@link resolveOutcome}. A player "won" a round when their side (Village
+ * unless they were tapped as a werewolf) took it. Pure — no Svelte, no I/O — so it is
+ * independently unit-testable and safe for the stats engine to import.
+ */
+export function werewordsStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const roster = new Map<string, ID[]>();
+  for (const g of games) roster.set(g.id, g.playerIds);
+
+  const per = new Map<ID, WWAgg>();
+  const get = (id: ID): WWAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { played: 0, won: 0, wolfGames: 0, wolfWins: 0, mayor: 0, seer: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let totalRounds = 0;
+  let guessedRounds = 0;
+  let wolfTeamWins = 0;
+
+  for (const r of rounds) {
+    const playerIds = roster.get(r.gameId);
+    if (!playerIds) continue;
+    const input = r.input as WerewordsInput | undefined;
+    if (!input || !Array.isArray(input.werewolves)) continue;
+
+    const winner = resolveOutcome(input).team;
+    totalRounds += 1;
+    if (input.guessed) guessedRounds += 1;
+    if (winner === 'werewolf') wolfTeamWins += 1;
+
+    for (const pid of playerIds) {
+      const a = get(canonical(pid));
+      a.played += 1;
+      const side = teamOf(input, pid);
+      if (side === winner) a.won += 1;
+      if (side === 'werewolf') {
+        a.wolfGames += 1;
+        if (winner === 'werewolf') a.wolfWins += 1;
+      }
+    }
+    if (input.mayor) get(canonical(input.mayor)).mayor += 1;
+    if (input.seer) get(canonical(input.seer)).seer += 1;
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.played) {
+      metrics.push({ key: 'ww_win', label: 'Round win rate', value: fmtPct(a.won / a.played), emoji: '🏆' });
+    }
+    if (a.wolfGames) {
+      metrics.push({ key: 'ww_wolf', label: 'As werewolf', value: `${a.wolfWins}/${a.wolfGames}`, emoji: '🐺' });
+    }
+    if (a.mayor) {
+      metrics.push({ key: 'ww_mayor', label: 'Mayor rounds', value: `${a.mayor}`, emoji: '👑' });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totalRounds) {
+    global.push({ key: 'ww_cracked', label: 'Words cracked', value: fmtPct(guessedRounds / totalRounds), emoji: '🧩' });
+    global.push({ key: 'ww_wolves', label: 'Werewolf wins', value: fmtPct(wolfTeamWins / totalRounds), emoji: '🐺' });
+  }
+  return { perPlayer, global };
+}

--- a/src/lib/games/werewords/werewords.test.ts
+++ b/src/lib/games/werewords/werewords.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import {
+  describeWerewords,
+  resolveOutcome,
+  scoreWerewords,
+  teamOf,
+  validateWerewords,
+  type WerewordsInput,
+} from './logic';
+
+/** A valid baseline round: word set, one wolf (C) among four players, guessed, no twist. */
+function base(overrides: Partial<WerewordsInput> = {}): WerewordsInput {
+  return {
+    word: 'PYRAMID',
+    mayor: 'A',
+    seer: 'B',
+    werewolves: ['C'],
+    guessed: true,
+    werewolfFoundSeer: false,
+    mayorFoundWerewolf: false,
+    ...overrides,
+  };
+}
+
+const FOUR = ['A', 'B', 'C', 'D'];
+
+describe('resolveOutcome — the four ways a round lands', () => {
+  it('guessed in time → Villagers win (no twist)', () => {
+    const o = resolveOutcome(base({ guessed: true }));
+    expect(o.team).toBe('village');
+    expect(o.twist).toBe(false);
+  });
+
+  it('guessed, but a werewolf names the Seer → Werewolves steal it (twist)', () => {
+    const o = resolveOutcome(base({ guessed: true, werewolfFoundSeer: true }));
+    expect(o.team).toBe('werewolf');
+    expect(o.twist).toBe(true);
+  });
+
+  it('never guessed → Werewolves win (no twist)', () => {
+    const o = resolveOutcome(base({ guessed: false }));
+    expect(o.team).toBe('werewolf');
+    expect(o.twist).toBe(false);
+  });
+
+  it('never guessed, but the Mayor names a werewolf → Villagers steal it back (twist)', () => {
+    const o = resolveOutcome(base({ guessed: false, mayorFoundWerewolf: true }));
+    expect(o.team).toBe('village');
+    expect(o.twist).toBe(true);
+  });
+
+  it('ignores the mayor twist while the word was guessed', () => {
+    // mayorFoundWerewolf only matters when the word was NOT guessed.
+    const o = resolveOutcome(base({ guessed: true, mayorFoundWerewolf: true }));
+    expect(o.team).toBe('village');
+    expect(o.twist).toBe(false);
+  });
+
+  it('ignores the seer twist while the word was missed', () => {
+    // werewolfFoundSeer only matters when the word WAS guessed.
+    const o = resolveOutcome(base({ guessed: false, werewolfFoundSeer: true }));
+    expect(o.team).toBe('werewolf');
+    expect(o.twist).toBe(false);
+  });
+});
+
+describe('teamOf — everyone not tapped as a wolf is Village', () => {
+  it('classifies wolves and villagers', () => {
+    const input = base({ werewolves: ['C', 'D'] });
+    expect(teamOf(input, 'C')).toBe('werewolf');
+    expect(teamOf(input, 'D')).toBe('werewolf');
+    expect(teamOf(input, 'A')).toBe('village');
+    expect(teamOf(input, 'B')).toBe('village');
+  });
+});
+
+describe('scoreWerewords — winning side each banks a point', () => {
+  it('Villager win: everyone except the wolf scores 1', () => {
+    const deltas = scoreWerewords(base({ guessed: true }), FOUR);
+    expect(deltas).toEqual({ A: 1, B: 1, C: 0, D: 1 });
+  });
+
+  it('Werewolf win: only the wolves score 1', () => {
+    const deltas = scoreWerewords(base({ guessed: false }), FOUR);
+    expect(deltas).toEqual({ A: 0, B: 0, C: 1, D: 0 });
+  });
+
+  it('two wolves both score on a werewolf win', () => {
+    const input = base({ guessed: false, werewolves: ['C', 'D'] });
+    expect(scoreWerewords(input, FOUR)).toEqual({ A: 0, B: 0, C: 1, D: 1 });
+  });
+
+  it('the seer twist flips who banks the point', () => {
+    const input = base({ guessed: true, werewolfFoundSeer: true });
+    expect(scoreWerewords(input, FOUR)).toEqual({ A: 0, B: 0, C: 1, D: 0 });
+  });
+
+  it('the mayor twist flips a missed word into a Village sweep', () => {
+    const input = base({ guessed: false, mayorFoundWerewolf: true });
+    expect(scoreWerewords(input, FOUR)).toEqual({ A: 1, B: 1, C: 0, D: 1 });
+  });
+
+  it('every player is scored exactly once per round (0 or 1)', () => {
+    const deltas = scoreWerewords(base(), FOUR);
+    const values = Object.values(deltas);
+    expect(values).toHaveLength(FOUR.length);
+    expect(values.every((v) => v === 0 || v === 1)).toBe(true);
+  });
+});
+
+describe('validateWerewords', () => {
+  it('accepts a well-formed round', () => {
+    expect(validateWerewords(base(), FOUR)).toBeNull();
+  });
+
+  it('requires a word', () => {
+    expect(validateWerewords(base({ word: '   ' }), FOUR)).toMatch(/word/i);
+  });
+
+  it('requires at least one werewolf', () => {
+    expect(validateWerewords(base({ werewolves: [] }), FOUR)).toMatch(/werewolf/i);
+  });
+
+  it('leaves at least one villager standing', () => {
+    const allWolves = base({ werewolves: ['A', 'B', 'C', 'D'], mayor: null, seer: null });
+    expect(validateWerewords(allWolves, FOUR)).toMatch(/villager/i);
+  });
+
+  it('rejects a Mayor who is also a werewolf', () => {
+    expect(validateWerewords(base({ mayor: 'C' }), FOUR)).toMatch(/Mayor/i);
+  });
+
+  it('rejects a Seer who is also a werewolf', () => {
+    expect(validateWerewords(base({ seer: 'C' }), FOUR)).toMatch(/Seer/i);
+  });
+
+  it('rejects the same player as both Mayor and Seer', () => {
+    expect(validateWerewords(base({ mayor: 'A', seer: 'A' }), FOUR)).toMatch(/different/i);
+  });
+
+  it('ignores stale wolf ids that are not in the roster', () => {
+    // A wolf id for a player who left the table shouldn't count toward the roster limits.
+    const input = base({ werewolves: ['C', 'ghost'] });
+    expect(validateWerewords(input, FOUR)).toBeNull();
+  });
+});
+
+describe('describeWerewords — narrates the word + outcome', () => {
+  it('mentions the winning side and the upper-cased word', () => {
+    const s = describeWerewords(base({ word: 'pyramid', guessed: true }));
+    expect(s).toContain('Villagers');
+    expect(s).toContain('PYRAMID');
+  });
+
+  it('calls out a werewolf victory when the clock runs out', () => {
+    const s = describeWerewords(base({ guessed: false }));
+    expect(s).toContain('Werewolves');
+  });
+
+  it('handles a blank word gracefully', () => {
+    const s = describeWerewords(base({ word: '' }));
+    expect(s).toContain('the word');
+  });
+});


### PR DESCRIPTION
## 🐺 Werewords — a scoreless team game, tracked

Adds a first-class **Werewords** tracker. Werewords is a fast, timed word-guessing social-deduction game: there's one secret magic word each round. The **Village** — the Mayor (knows the word, answers yes/no), the Seer (knows the word *and* the wolves), and the Villagers — races to guess it before time runs out, while the **Werewolves**, who also know the word, try to run out the clock.

### Modeling a scoreless game into the point-oriented `GameModule` contract
Each round the **winning side banks +1 for every player on it**; the losing side gets 0. So `computeTotals` turns the leaderboard into **rounds won**, the leader (crown) is whoever's side has won the most, and the default `pickWinners` (top total) records the winning side. `describeRound` narrates the word + how the round landed.

- **Werewolves** = the players tapped as wolves that round (required — they define the two sides).
- **Village** = every other selected player. Mayor & Seer are optional role reference.

### Twist outcomes (the heart of the game)
- Guessed in time → **Villagers win**… *unless* a werewolf then names the Seer → **Werewolves steal it**.
- Never guessed → **Werewolves win**… *unless* the Mayor then names a werewolf → **Villagers steal it back**.

The editor only offers the twist that can actually apply (seer-twist when guessed, mayor-twist when missed) and shows a **live verdict banner** as you enter the round.

### Config
- **Werewolves** (count, default 1) · **Include the Seer** (toggle, default on) · **Timer** (minutes, *informational* — the app doesn't run the clock).

### Optional stats
Per-player round win rate 🏆, as-werewolf record 🐺, Mayor rounds 👑; global words-cracked 🧩 and werewolf-win rate 🐺 — all derived purely from recorded roles + `resolveOutcome`.

### Design
Keeps the chrome identical; personality via emoji/copy only. Reuses `Avatar` and shared tokens/utilities, Royal Violet for active state **only** (no Crown Gold in the editor), ≥46px touch targets, roles co-signalled by emoji **and** label (never colour alone), and honours the global reduced-motion rule.

### Scope & verification
Purely **additive** — only `src/lib/games/werewords/` (logic, index, editor, stats, 24 tests). Registry auto-discovers the module; no shared files touched.

- ✅ `npm run check` — 0 errors, 0 warnings
- ✅ `npm test` — 99 passed (24 new)
- ✅ `npm run build` — succeeds