### PR TITLE
Add Spikeball (Roundnet) game module

### DIFF
--- a/src/lib/games/spikeball/SpikeballEditor.svelte
+++ b/src/lib/games/spikeball/SpikeballEditor.svelte
@@ -1,0 +1,302 @@
+<script lang="ts">
+  import type { Player, RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import {
+    readConfig,
+    gameWinner,
+    gamePointTeam,
+    isMatchPoint,
+    gamesToWin,
+    requiredPlayers,
+    type SpikeballInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: SpikeballInput; ctx: RoundContext } = $props();
+
+  const sides = [0, 1] as const;
+
+  const cfg = $derived(readConfig(ctx.config));
+  const need = $derived(gamesToWin(cfg.bestOf));
+  const needPlayers = $derived(requiredPlayers(cfg.format));
+  const mismatch = $derived(ctx.players.length !== needPlayers);
+
+  const byId = $derived(new Map(ctx.players.map((p) => [p.id, p])));
+  function members(team: 0 | 1): Player[] {
+    return (input.teams?.[team] ?? [])
+      .map((id) => byId.get(id))
+      .filter((p): p is Player => !!p);
+  }
+  const teamA = $derived(members(0));
+  const teamB = $derived(members(1));
+  const nameA = $derived(teamA.map((p) => p.name).join(' & ') || 'Team A');
+  const nameB = $derived(teamB.map((p) => p.name).join(' & ') || 'Team B');
+
+  // Games won before this game. Teammates always move together, so read any member's total.
+  const gamesA = $derived(Number(ctx.totals[input.teams?.[0]?.[0] ?? ''] ?? 0));
+  const gamesB = $derived(Number(ctx.totals[input.teams?.[1]?.[0] ?? ''] ?? 0));
+  const gameNo = $derived(gamesA + gamesB + 1);
+  const gamesLeader = $derived(gamesA === gamesB ? null : gamesA > gamesB ? 0 : 1);
+
+  const a = $derived(Number(input.a) || 0);
+  const b = $derived(Number(input.b) || 0);
+  const winner = $derived(gameWinner(a, b, cfg.target, cfg.winByTwo));
+  const gp = $derived(gamePointTeam(a, b, cfg.target, cfg.winByTwo));
+  const matchPoint = $derived(isMatchPoint(gp, gamesA, gamesB, cfg.bestOf));
+  const done = $derived(winner !== null);
+
+  const rules = $derived(`First to ${cfg.target}${cfg.winByTwo ? ' · win by 2' : ''}`);
+
+  function add(team: 0 | 1) {
+    if (done || mismatch) return;
+    if (team === 0) input.a = a + 1;
+    else input.b = b + 1;
+  }
+  function sub(team: 0 | 1) {
+    if (team === 0) input.a = Math.max(0, a - 1);
+    else input.b = Math.max(0, b - 1);
+  }
+</script>
+
+<div class="stack">
+  <div class="row wrap meta">
+    <span class="pill">{cfg.bestOf === 1 ? 'Single game' : `Best of ${cfg.bestOf}`}</span>
+    <span class="pill">Game {gameNo}</span>
+    <span class="pill">{rules}</span>
+  </div>
+
+  <div class="stack teams">
+    {#each sides as team (team)}
+      {@const mem = team === 0 ? teamA : teamB}
+      {@const teamName = team === 0 ? nameA : nameB}
+      {@const score = team === 0 ? a : b}
+      {@const games = team === 0 ? gamesA : gamesB}
+      {@const isLeader = gamesLeader === team}
+      {@const isWinner = done && winner === team}
+      {@const atPoint = !done && gp === team}
+      <div class="teamcard" class:won={isWinner}>
+        <div class="thead row spread">
+          <span class="row who">
+            {#each mem as m (m.id)}
+              <Avatar name={m.name} color={m.color} size={26} />
+            {/each}
+            <span class="tname">{teamName}</span>
+          </span>
+          <span class="games" class:lead={isLeader}>
+            {#if isLeader}<span aria-hidden="true">👑</span>{/if}
+            <span class="gnum">{games}</span>
+            <span class="glabel">{games === 1 ? 'game' : 'games'}</span>
+          </span>
+        </div>
+
+        <div class="scorewrap">
+          <button
+            type="button"
+            class="iconbtn minus"
+            onclick={() => sub(team)}
+            disabled={score <= 0}
+            aria-label={`Remove a point from ${teamName}`}
+          >−</button>
+          {#key score}
+            <span class="bigscore">{score}</span>
+          {/key}
+          {#if isWinner}
+            <span class="tag win">🏐 Won</span>
+          {:else if atPoint}
+            <span class="tag point">{matchPoint ? '🔵 Match pt' : '🔵 Game pt'}</span>
+          {:else}
+            <span class="tag ghost" aria-hidden="true">&nbsp;</span>
+          {/if}
+        </div>
+
+        <button
+          type="button"
+          class="plus"
+          onclick={() => add(team)}
+          disabled={done || mismatch}
+          aria-label={`Add a rally point for ${teamName}`}
+        >
+          <span class="plussign">＋1</span>
+          <span class="pluslabel">rally point</span>
+        </button>
+      </div>
+    {/each}
+  </div>
+
+  <div class="status" role="status" aria-live="polite">
+    {#if mismatch}
+      <span class="warn">⚠️ {cfg.format} needs {needPlayers} players — you have {ctx.players.length}. Start a new game with {needPlayers}.</span>
+    {:else if done}
+      <span class="score-good"
+        >🏐 {winner === 0 ? nameA : nameB} win {Math.max(a, b)}–{Math.min(a, b)} — tap “Save round” to record it.</span
+      >
+    {:else if gp !== null}
+      <span class="pointmsg"
+        >{matchPoint ? '🔵 Match point' : '🔵 Game point'} — {gp === 0 ? nameA : nameB}{matchPoint
+          ? ', serving to win it all!'
+          : '.'}</span
+      >
+    {:else}
+      <span class="muted">Tap ＋1 for the team that won each rally. {rules}.</span>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .meta {
+    gap: 8px;
+  }
+  .teams {
+    gap: 10px;
+  }
+  .teamcard {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  /* A finished game reads as success (green) — distinct from the match winner's gold. */
+  .teamcard.won {
+    border-color: color-mix(in srgb, var(--good) 55%, var(--border));
+    background: color-mix(in srgb, var(--good) 12%, var(--surface-2));
+  }
+  .who {
+    gap: 6px;
+    min-width: 0;
+  }
+  .tname {
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .games {
+    flex: none;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  .games .gnum {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .games.lead .gnum {
+    color: var(--accent-ink);
+    font-weight: 800;
+  }
+  .games.lead .glabel {
+    color: var(--accent-ink);
+  }
+
+  .scorewrap {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .bigscore {
+    flex: 1;
+    text-align: center;
+    font-size: 3.2rem;
+    line-height: 1;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    min-width: 2ch;
+    animation: sb-pop 0.16s ease-out;
+  }
+  @keyframes sb-pop {
+    from {
+      transform: scale(1.14);
+    }
+    to {
+      transform: scale(1);
+    }
+  }
+  .minus {
+    flex: none;
+  }
+  .tag {
+    flex: none;
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 3px 9px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    white-space: nowrap;
+    min-width: 84px;
+    text-align: center;
+  }
+  .tag.ghost {
+    color: var(--muted);
+    visibility: hidden;
+  }
+  .tag.win {
+    color: var(--good);
+    border-color: color-mix(in srgb, var(--good) 45%, var(--border));
+    background: color-mix(in srgb, var(--good) 12%, transparent);
+    visibility: visible;
+  }
+  .tag.point {
+    color: var(--text);
+    border-color: color-mix(in srgb, var(--warn) 55%, var(--border));
+    background: color-mix(in srgb, var(--warn) 14%, transparent);
+  }
+
+  /* The rally tap: large and thumb-friendly, but a surface control — the one violet
+     primary on this screen stays the shell's "Save round" button below the editor. */
+  .plus {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    width: 100%;
+    min-height: 60px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-3);
+    color: var(--text);
+    cursor: pointer;
+    font: inherit;
+    transition: transform 0.05s ease, background 0.15s ease, border-color 0.15s ease;
+  }
+  .plus:hover {
+    background: color-mix(in srgb, var(--text) 6%, var(--surface-3));
+    border-color: var(--primary);
+  }
+  .plus:active {
+    transform: translateY(1px);
+  }
+  .plus:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .plussign {
+    font-size: 1.5rem;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .pluslabel {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--muted);
+  }
+  .plus:hover .pluslabel {
+    color: var(--text);
+  }
+
+  .status {
+    min-height: 1.4em;
+    font-size: 0.95rem;
+    text-align: center;
+  }
+  .status .warn {
+    color: var(--warn);
+  }
+  .status .pointmsg {
+    font-weight: 700;
+  }
+</style>

--- a/src/lib/games/spikeball/index.ts
+++ b/src/lib/games/spikeball/index.ts
@@ -1,0 +1,110 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './SpikeballEditor.svelte';
+import { spikeballStats } from './stats';
+import {
+  readConfig,
+  splitTeams,
+  gamesToWin,
+  scoreDeltas,
+  summarize,
+  validate,
+  type SpikeballInput,
+} from './logic';
+
+export type { SpikeballInput } from './logic';
+
+const playerIds = (ctx: RoundContext): ID[] => ctx.players.map((p) => p.id);
+
+/**
+ * Spikeball / Roundnet — a live rally scorer. Each Score King "round" is one *game*
+ * (rally scoring to a target, win by two); the module tallies games won, and a
+ * best-of-N match finishes when a team wins the majority. Teams are the first half vs.
+ * the second half of the selected roster, so 2 players play 1v1 and 4 players play 2v2.
+ */
+export const spikeball: GameModule = {
+  id: 'spikeball',
+  name: 'Spikeball',
+  tagline: 'Rally scoring for Roundnet — first to 21, win by 2',
+  emoji: '🔵',
+  keywords: ['roundnet', 'spikeball', 'rally', 'net', 'doubles', '2v2', 'outdoor', 'beach'],
+  minPlayers: 2,
+  maxPlayers: 4,
+  teams: true,
+  configFields: [
+    {
+      key: 'format',
+      label: 'Format',
+      type: 'select',
+      default: '2v2',
+      options: [
+        { value: '2v2', label: '2v2 (doubles)' },
+        { value: '1v1', label: '1v1 (singles)' },
+      ],
+      help: '2v2 needs 4 players, 1v1 needs 2. Teams are the first half vs. the second half of your player list.',
+    },
+    {
+      key: 'target',
+      label: 'Game to',
+      type: 'select',
+      default: '21',
+      options: [
+        { value: '21', label: '21 points' },
+        { value: '15', label: '15 points' },
+        { value: '11', label: '11 points' },
+      ],
+      help: 'First team to reach this score takes the game.',
+    },
+    {
+      key: 'winByTwo',
+      label: 'Win by 2',
+      type: 'boolean',
+      default: true,
+      help: 'Play on past the target until a team leads by two.',
+    },
+    {
+      key: 'bestOf',
+      label: 'Match length',
+      type: 'select',
+      default: '3',
+      options: [
+        { value: '1', label: 'Single game' },
+        { value: '3', label: 'Best of 3' },
+        { value: '5', label: 'Best of 5' },
+      ],
+      help: 'How many games decide the match.',
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): SpikeballInput => {
+    const cfg = readConfig(ctx.config);
+    return { teams: splitTeams(playerIds(ctx), cfg.format), a: 0, b: 0 };
+  },
+
+  validateRound: (input: SpikeballInput, ctx: RoundContext): string | null =>
+    validate(input, playerIds(ctx), readConfig(ctx.config)),
+
+  scoreRound: (input: SpikeballInput, ctx: RoundContext): Record<ID, number> =>
+    scoreDeltas(input, playerIds(ctx), readConfig(ctx.config)),
+
+  // Open-ended: a match is 2 or 3 games (best of 3), so end on games won, not a round cap.
+  isFinished: (totals, { config }) => {
+    const need = gamesToWin(readConfig(config).bestOf);
+    return Object.values(totals).some((t) => t >= need);
+  },
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as SpikeballInput;
+    const nameOf = (id: ID) => players.find((p) => p.id === id)?.name ?? '?';
+    return summarize(input, nameOf);
+  },
+
+  help:
+    'Spikeball (Roundnet) is rally scoring: every rally is a point, whoever wins it. ' +
+    'Games go to the target (21/15/11); with win-by-2 you play on until a team leads by two. ' +
+    'Tap ＋1 for the team that won each rally. When a game ends, Save round to bank it — ' +
+    'the first team to win the majority of a best-of-3 (or 5) takes the match.',
+
+  stats: spikeballStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/spikeball/logic.ts
+++ b/src/lib/games/spikeball/logic.ts
@@ -1,0 +1,174 @@
+import type { ID } from '../../types';
+
+/**
+ * Pure, Svelte-free Spikeball (Roundnet) logic. Everything the module and its editor
+ * need to reason about a game/match lives here so it can be unit-tested without pulling
+ * in a component. A Score King "round" is one *game* of Spikeball; the module tallies
+ * games won, so a player's cumulative total is simply how many games their team has won.
+ */
+
+export type Format = '1v1' | '2v2';
+
+export interface SpikeballConfig {
+  format: Format;
+  /** Points that win a game (before win-by-2). */
+  target: number;
+  /** Keep playing past the target until a team leads by two. */
+  winByTwo: boolean;
+  /** Games in the match: 1 (single), 3 (best of 3), 5 (best of 5). */
+  bestOf: number;
+}
+
+/** One recorded game: the two teams (by player id) and their final rally points. */
+export interface SpikeballInput {
+  /** teams[0] scored `a` points, teams[1] scored `b`. */
+  teams: [ID[], ID[]];
+  a: number;
+  b: number;
+}
+
+export const TARGET_OPTIONS = [21, 15, 11] as const;
+export const BEST_OF_OPTIONS = [1, 3, 5] as const;
+
+/** Read the loosely-typed config record (select values arrive as strings) into a typed shape. */
+export function readConfig(config: Record<string, unknown>): SpikeballConfig {
+  const format: Format = config.format === '1v1' ? '1v1' : '2v2';
+  const target = normalizeTarget(Number(config.target));
+  const winByTwo = config.winByTwo !== false; // default on
+  const bestOf = normalizeBestOf(Number(config.bestOf));
+  return { format, target, winByTwo, bestOf };
+}
+
+function normalizeTarget(n: number): number {
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 21;
+}
+
+function normalizeBestOf(n: number): number {
+  return n === 1 || n === 3 || n === 5 ? n : 3;
+}
+
+/** Players on each side for a format. */
+export function teamSize(format: Format): number {
+  return format === '1v1' ? 1 : 2;
+}
+
+/** Number of players a format expects on the roster (both teams). */
+export function requiredPlayers(format: Format): number {
+  return teamSize(format) * 2;
+}
+
+/** Split the ordered roster into two equal teams: first half vs. second half. */
+export function splitTeams(playerIds: ID[], format: Format): [ID[], ID[]] {
+  const n = teamSize(format);
+  return [playerIds.slice(0, n), playerIds.slice(n, n * 2)];
+}
+
+/** Games one team must win to take a best-of-N match. */
+export function gamesToWin(bestOf: number): number {
+  return Math.floor(bestOf / 2) + 1;
+}
+
+/**
+ * Winner of a single game from the two scores, or null if the game isn't over yet.
+ * A game ends when the higher score reaches `target` and (with win-by-2) leads by two.
+ */
+export function gameWinner(
+  a: number,
+  b: number,
+  target: number,
+  winByTwo: boolean,
+): 0 | 1 | null {
+  const hi = Math.max(a, b);
+  const lo = Math.min(a, b);
+  if (hi < target) return null;
+  if (a === b) return null;
+  if (winByTwo && hi - lo < 2) return null;
+  return a > b ? 0 : 1;
+}
+
+/**
+ * Which team is at game point — one rally from winning — or null. A side is at game
+ * point when scoring the next rally would end the game and it hasn't ended already.
+ */
+export function gamePointTeam(
+  a: number,
+  b: number,
+  target: number,
+  winByTwo: boolean,
+): 0 | 1 | null {
+  if (gameWinner(a, b, target, winByTwo) !== null) return null;
+  if (gameWinner(a + 1, b, target, winByTwo) === 0) return 0;
+  if (gameWinner(a, b + 1, target, winByTwo) === 1) return 1;
+  return null;
+}
+
+/** Would winning the current game (for the side at game point) also clinch the match? */
+export function isMatchPoint(
+  gamePoint: 0 | 1 | null,
+  gamesA: number,
+  gamesB: number,
+  bestOf: number,
+): boolean {
+  if (gamePoint === null) return false;
+  const held = gamePoint === 0 ? gamesA : gamesB;
+  return held + 1 >= gamesToWin(bestOf);
+}
+
+/** True once either side has won enough games to take the match. */
+export function matchOver(gamesA: number, gamesB: number, bestOf: number): boolean {
+  const need = gamesToWin(bestOf);
+  return gamesA >= need || gamesB >= need;
+}
+
+/**
+ * Per-player deltas for a completed game: +1 to each player on the winning team, 0 to
+ * everyone else. Accumulated across rounds by the shell, a player's total is games won.
+ */
+export function scoreDeltas(
+  input: SpikeballInput,
+  playerIds: ID[],
+  cfg: SpikeballConfig,
+): Record<ID, number> {
+  const winner = gameWinner(input.a, input.b, cfg.target, cfg.winByTwo);
+  const won = new Set<ID>(winner === null ? [] : (input.teams[winner] ?? []));
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) out[id] = won.has(id) ? 1 : 0;
+  return out;
+}
+
+/** Validate a game entry. Returns null when it's a well-formed, finished game, else why not. */
+export function validate(
+  input: SpikeballInput,
+  playerIds: ID[],
+  cfg: SpikeballConfig,
+): string | null {
+  const need = requiredPlayers(cfg.format);
+  if (playerIds.length !== need) {
+    return cfg.format === '2v2'
+      ? `2v2 needs exactly 4 players — you have ${playerIds.length}. Start a new game with four, or switch to 1v1.`
+      : `1v1 needs exactly 2 players — you have ${playerIds.length}. Start a new game with two, or switch to 2v2.`;
+  }
+  const [ta, tb] = input.teams;
+  if (!ta?.length || !tb?.length) return 'Two teams are needed to score a game.';
+  const a = Number(input.a) || 0;
+  const b = Number(input.b) || 0;
+  if (a < 0 || b < 0) return 'Scores can’t be negative.';
+  if (gameWinner(a, b, cfg.target, cfg.winByTwo) === null) {
+    return `That game isn’t over yet — first to ${cfg.target}${cfg.winByTwo ? ', win by 2' : ''}.`;
+  }
+  return null;
+}
+
+/** One-line summary of a recorded game, e.g. "🏐 Ada & Bo def. Cy & Dot 21–18". */
+export function summarize(input: SpikeballInput, nameOf: (id: ID) => string): string {
+  const label = (ids: ID[]) => (ids.length ? ids.map(nameOf).join(' & ') : '—');
+  const a = Number(input.a) || 0;
+  const b = Number(input.b) || 0;
+  const na = label(input.teams[0] ?? []);
+  const nb = label(input.teams[1] ?? []);
+  if (a === b) return `${na} vs ${nb} ${a}–${b}`;
+  const winnerFirst = a > b;
+  const w = winnerFirst ? na : nb;
+  const l = winnerFirst ? nb : na;
+  return `🏐 ${w} def. ${l} ${Math.max(a, b)}–${Math.min(a, b)}`;
+}

--- a/src/lib/games/spikeball/spikeball.test.ts
+++ b/src/lib/games/spikeball/spikeball.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest';
+import type { Player, RoundContext } from '../../types';
+import { spikeball } from './index';
+import {
+  readConfig,
+  teamSize,
+  requiredPlayers,
+  splitTeams,
+  gamesToWin,
+  gameWinner,
+  gamePointTeam,
+  isMatchPoint,
+  matchOver,
+  scoreDeltas,
+  validate,
+  summarize,
+  type SpikeballConfig,
+  type SpikeballInput,
+} from './logic';
+
+const cfg = (over: Partial<SpikeballConfig> = {}): SpikeballConfig => ({
+  format: '2v2',
+  target: 21,
+  winByTwo: true,
+  bestOf: 3,
+  ...over,
+});
+
+describe('readConfig', () => {
+  it('defaults an empty config to 2v2 · 21 · win-by-2 · best-of-3', () => {
+    expect(readConfig({})).toEqual({ format: '2v2', target: 21, winByTwo: true, bestOf: 3 });
+  });
+
+  it('coerces string select values into numbers/booleans', () => {
+    expect(readConfig({ format: '1v1', target: '15', winByTwo: false, bestOf: '5' })).toEqual({
+      format: '1v1',
+      target: 15,
+      winByTwo: false,
+      bestOf: 5,
+    });
+  });
+
+  it('falls back to sane values for garbage input', () => {
+    expect(readConfig({ target: 'abc', bestOf: 4 })).toMatchObject({ target: 21, bestOf: 3 });
+  });
+});
+
+describe('teams', () => {
+  it('has one player per side in 1v1 and two in 2v2', () => {
+    expect(teamSize('1v1')).toBe(1);
+    expect(teamSize('2v2')).toBe(2);
+    expect(requiredPlayers('1v1')).toBe(2);
+    expect(requiredPlayers('2v2')).toBe(4);
+  });
+
+  it('splits the roster into first-half vs. second-half teams', () => {
+    expect(splitTeams(['a', 'b'], '1v1')).toEqual([['a'], ['b']]);
+    expect(splitTeams(['a', 'b', 'c', 'd'], '2v2')).toEqual([
+      ['a', 'b'],
+      ['c', 'd'],
+    ]);
+  });
+});
+
+describe('gamesToWin (match length)', () => {
+  it('needs a majority of the best-of-N games', () => {
+    expect(gamesToWin(1)).toBe(1);
+    expect(gamesToWin(3)).toBe(2);
+    expect(gamesToWin(5)).toBe(3);
+  });
+});
+
+describe('gameWinner — first to 21, win by 2', () => {
+  it('is undecided before a team reaches the target', () => {
+    expect(gameWinner(20, 18, 21, true)).toBeNull();
+    expect(gameWinner(0, 0, 21, true)).toBeNull();
+  });
+
+  it('awards the game at 21 with a two-point lead', () => {
+    expect(gameWinner(21, 19, 21, true)).toBe(0);
+    expect(gameWinner(19, 21, 21, true)).toBe(1);
+  });
+
+  it('requires a two-point margin: 21–20 keeps playing', () => {
+    expect(gameWinner(21, 20, 21, true)).toBeNull();
+  });
+
+  it('resolves deuce beyond the target once the lead reaches two', () => {
+    expect(gameWinner(22, 20, 21, true)).toBe(0);
+    expect(gameWinner(24, 24, 21, true)).toBeNull();
+    expect(gameWinner(25, 23, 21, true)).toBe(0);
+    expect(gameWinner(23, 25, 21, true)).toBe(1);
+  });
+
+  it('honors alternate targets 15 and 11', () => {
+    expect(gameWinner(15, 13, 15, true)).toBe(0);
+    expect(gameWinner(15, 14, 15, true)).toBeNull();
+    expect(gameWinner(11, 9, 11, true)).toBe(0);
+  });
+
+  it('with win-by-2 off, first to the target wins by one', () => {
+    expect(gameWinner(21, 20, 21, false)).toBe(0);
+    expect(gameWinner(21, 21, 21, false)).toBeNull();
+  });
+});
+
+describe('gamePointTeam', () => {
+  it('flags the side one rally from taking the game', () => {
+    expect(gamePointTeam(20, 18, 21, true)).toBe(0);
+    expect(gamePointTeam(18, 20, 21, true)).toBe(1);
+  });
+
+  it('is null at deuce, where a single point cannot end it', () => {
+    expect(gamePointTeam(20, 20, 21, true)).toBeNull();
+  });
+
+  it('is null once the game is already won', () => {
+    expect(gamePointTeam(21, 19, 21, true)).toBeNull();
+  });
+
+  it('re-flags game point after a deuce lead, e.g. 22–21', () => {
+    expect(gamePointTeam(22, 21, 21, true)).toBe(0);
+  });
+});
+
+describe('match completion', () => {
+  it('isMatchPoint is true only when the game-point win also clinches the match', () => {
+    // Best of 3: leader already has 1 game and is at game point → match point.
+    expect(isMatchPoint(0, 1, 0, 3)).toBe(true);
+    // First game at game point → not yet match point.
+    expect(isMatchPoint(0, 0, 0, 3)).toBe(false);
+    // Nobody at game point.
+    expect(isMatchPoint(null, 1, 1, 3)).toBe(false);
+  });
+
+  it('matchOver reflects a majority of games won', () => {
+    expect(matchOver(0, 0, 3)).toBe(false);
+    expect(matchOver(1, 0, 3)).toBe(false);
+    expect(matchOver(2, 1, 3)).toBe(true);
+    expect(matchOver(1, 0, 1)).toBe(true);
+    expect(matchOver(2, 2, 5)).toBe(false);
+    expect(matchOver(3, 2, 5)).toBe(true);
+  });
+});
+
+describe('scoreDeltas', () => {
+  it('gives every winner +1 game and everyone else 0 (2v2)', () => {
+    const input: SpikeballInput = { teams: [['a', 'b'], ['c', 'd']], a: 21, b: 15 };
+    expect(scoreDeltas(input, ['a', 'b', 'c', 'd'], cfg())).toEqual({ a: 1, b: 1, c: 0, d: 0 });
+  });
+
+  it('awards the trailing team when they win the deuce', () => {
+    const input: SpikeballInput = { teams: [['a', 'b'], ['c', 'd']], a: 20, b: 22 };
+    expect(scoreDeltas(input, ['a', 'b', 'c', 'd'], cfg())).toEqual({ a: 0, b: 0, c: 1, d: 1 });
+  });
+
+  it('awards nothing for an unfinished game', () => {
+    const input: SpikeballInput = { teams: [['a'], ['b']], a: 21, b: 20 };
+    expect(scoreDeltas(input, ['a', 'b'], cfg({ format: '1v1' }))).toEqual({ a: 0, b: 0 });
+  });
+});
+
+describe('validate', () => {
+  it('accepts a well-formed, finished 2v2 game', () => {
+    const input: SpikeballInput = { teams: [['a', 'b'], ['c', 'd']], a: 21, b: 18 };
+    expect(validate(input, ['a', 'b', 'c', 'd'], cfg())).toBeNull();
+  });
+
+  it('rejects the wrong player count for the format', () => {
+    const input: SpikeballInput = { teams: [['a', 'b'], ['c']], a: 21, b: 10 };
+    const msg = validate(input, ['a', 'b', 'c'], cfg());
+    expect(msg).toContain('4 players');
+  });
+
+  it('rejects a game that is not over yet', () => {
+    const input: SpikeballInput = { teams: [['a', 'b'], ['c', 'd']], a: 21, b: 20 };
+    expect(validate(input, ['a', 'b', 'c', 'd'], cfg())).toContain('isn’t over');
+  });
+
+  it('rejects negative scores', () => {
+    const input: SpikeballInput = { teams: [['a'], ['b']], a: -1, b: 21 };
+    expect(validate(input, ['a', 'b'], cfg({ format: '1v1' }))).toContain('negative');
+  });
+});
+
+describe('summarize', () => {
+  const names: Record<string, string> = { a: 'Ada', b: 'Bo', c: 'Cy', d: 'Dot' };
+  const nameOf = (id: string) => names[id] ?? '?';
+
+  it('names the winners and orders the score high–low', () => {
+    const input: SpikeballInput = { teams: [['a', 'b'], ['c', 'd']], a: 18, b: 21 };
+    expect(summarize(input, nameOf)).toBe('🏐 Cy & Dot def. Ada & Bo 21–18');
+  });
+
+  it('reads naturally for 1v1', () => {
+    const input: SpikeballInput = { teams: [['a'], ['c']], a: 21, b: 12 };
+    expect(summarize(input, nameOf)).toBe('🏐 Ada def. Cy 21–12');
+  });
+});
+
+// --- Module wiring: the real GameModule exercised end-to-end (no editor UI). -----------
+const player = (id: string): Player => ({ id, name: id.toUpperCase(), color: '#7c5cff', createdAt: 0 });
+
+function ctx(ids: string[], config: Record<string, unknown>, totals: Record<string, number> = {}): RoundContext {
+  return {
+    game: { id: 'g', type: 'spikeball', config, playerIds: ids, status: 'active', createdAt: 0, roundCount: 0 },
+    players: ids.map(player),
+    config,
+    roundIndex: Object.keys(totals).length ? 1 : 0,
+    totals,
+    rounds: [],
+  };
+}
+
+describe('spikeball GameModule', () => {
+  it('is registered with the expected identity and bounds', () => {
+    expect(spikeball.id).toBe('spikeball');
+    expect(spikeball.minPlayers).toBe(2);
+    expect(spikeball.maxPlayers).toBe(4);
+    expect(spikeball.teams).toBe(true);
+  });
+
+  it('seeds a round with teams split from the roster and 0–0', () => {
+    const input = spikeball.createRoundInput(ctx(['a', 'b', 'c', 'd'], { format: '2v2' })) as SpikeballInput;
+    expect(input).toEqual({ teams: [['a', 'b'], ['c', 'd']], a: 0, b: 0 });
+  });
+
+  it('scores a finished game into per-player game wins', () => {
+    const c = ctx(['a', 'b', 'c', 'd'], { format: '2v2', target: '21' });
+    const input: SpikeballInput = { teams: [['a', 'b'], ['c', 'd']], a: 21, b: 17 };
+    expect(spikeball.scoreRound(input, c)).toEqual({ a: 1, b: 1, c: 0, d: 0 });
+  });
+
+  it('finishes the match when a team reaches the games needed (best of 3 → 2)', () => {
+    const info = { config: { bestOf: '3' }, roundCount: 3, playerCount: 4 };
+    expect(spikeball.isFinished!({ a: 1, b: 1, c: 1, d: 1 }, info)).toBe(false);
+    expect(spikeball.isFinished!({ a: 2, b: 2, c: 1, d: 1 }, info)).toBe(true);
+  });
+
+  it('finishes a single-game match after one game', () => {
+    const info = { config: { bestOf: '1' }, roundCount: 1, playerCount: 2 };
+    expect(spikeball.isFinished!({ a: 1, b: 0 }, info)).toBe(true);
+  });
+
+  it('summarizes a recorded round for the history log', () => {
+    const round = {
+      id: 'r',
+      gameId: 'g',
+      index: 0,
+      input: { teams: [['a', 'b'], ['c', 'd']], a: 21, b: 15 } satisfies SpikeballInput,
+      deltas: {},
+      createdAt: 0,
+    };
+    const players = ['a', 'b', 'c', 'd'].map(player);
+    expect(spikeball.describeRound!(round, players)).toContain('def.');
+  });
+});

--- a/src/lib/games/spikeball/stats.ts
+++ b/src/lib/games/spikeball/stats.ts
@@ -1,0 +1,110 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt, fmtSigned } from '../../stats/format';
+import { readConfig, type SpikeballInput } from './logic';
+
+interface Agg {
+  played: number;
+  won: number;
+  pointsFor: number;
+  pointsAgainst: number;
+  deuce: number;
+}
+
+function blank(): Agg {
+  return { played: 0, won: 0, pointsFor: 0, pointsAgainst: 0, deuce: 0 };
+}
+
+/**
+ * Spikeball stats from each recorded game's teams + final points. Games are tallied per
+ * team, so teammates share the same games/points lines. Pure; mirrors the module's own
+ * scoring (higher rally count wins) and reads win-by-2/deuce from each game's target.
+ */
+export function spikeballStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const targetByGame = new Map<ID, number>(games.map((g) => [g.id, readConfig(g.config).target]));
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, Agg>();
+  const get = (id: ID): Agg => {
+    let a = per.get(id);
+    if (!a) per.set(id, (a = blank()));
+    return a;
+  };
+
+  let totalGames = 0;
+  let totalPoints = 0;
+  let biggestMargin = -1;
+  let biggestLabel = '';
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as SpikeballInput | undefined;
+    if (!input?.teams) continue;
+    const a = Number(input.a) || 0;
+    const b = Number(input.b) || 0;
+    const [teamA, teamB] = input.teams;
+    if (!teamA?.length || !teamB?.length) continue;
+
+    const winner = a === b ? null : a > b ? 0 : 1;
+    const target = targetByGame.get(r.gameId) ?? 21;
+    const deuce = Math.max(a, b) > target;
+
+    totalGames += 1;
+    totalPoints += a + b;
+    const margin = Math.abs(a - b);
+    if (margin > biggestMargin) {
+      biggestMargin = margin;
+      biggestLabel = `${Math.max(a, b)}–${Math.min(a, b)}`;
+    }
+
+    for (const raw of teamA) {
+      const g = get(canonical(raw));
+      g.played += 1;
+      g.pointsFor += a;
+      g.pointsAgainst += b;
+      if (winner === 0) g.won += 1;
+      if (deuce) g.deuce += 1;
+    }
+    for (const raw of teamB) {
+      const g = get(canonical(raw));
+      g.played += 1;
+      g.pointsFor += b;
+      g.pointsAgainst += a;
+      if (winner === 1) g.won += 1;
+      if (deuce) g.deuce += 1;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    if (!a.played) continue;
+    const metrics: Metric[] = [
+      { key: 'sb_won', label: 'Games won', value: `${a.won}`, sub: `of ${a.played}`, emoji: '🏐' },
+      { key: 'sb_pf', label: 'Rally points', value: fmtInt(a.pointsFor), emoji: '🎯' },
+      {
+        key: 'sb_diff',
+        label: 'Point differential',
+        value: fmtSigned(a.pointsFor - a.pointsAgainst),
+        emoji: '📈',
+      },
+    ];
+    if (a.deuce) metrics.push({ key: 'sb_deuce', label: 'Deuce games', value: `${a.deuce}`, emoji: '🥵' });
+    perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totalGames) {
+    global.push({ key: 'sb_games', label: 'Games played', value: fmtInt(totalGames), emoji: '🏐' });
+    global.push({ key: 'sb_points', label: 'Rally points', value: fmtInt(totalPoints), emoji: '🎯' });
+    if (biggestMargin >= 0) {
+      global.push({
+        key: 'sb_blowout',
+        label: 'Biggest blowout',
+        value: biggestLabel,
+        sub: `+${biggestMargin}`,
+        emoji: '💥',
+      });
+    }
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## 🔵 Spikeball (Roundnet)

Adds a live rally scorer for **Spikeball / Roundnet** — built for one-handed outdoor scorekeeping.

### How it scores
- **Rally scoring**: every rally is a point, serving or not — tap **＋1** for whoever won it.
- **Games to a target**: first to **21** (config: 21 / 15 / 11), **win by 2** (toggle).
- **Match**: **best of 3** by default (config: single game / best of 3 / best of 5). The match ends when a team wins the majority.
- Each Score King *round* is one **game**; the module tallies **games won**, and `isFinished` fires at match point.

### Model
Score King has no shared team UI, so teams are modeled **inside the module**: the roster is split first-half vs. second-half. **2v2** uses 4 players (teams of 2), **1v1** uses 2. A game awards +1 to each player on the winning team, so a player's cumulative total *is* their team's games won — the winner logic naturally returns both teammates.

### Config
| Field | Options | Default |
|---|---|---|
| Format | 2v2 / 1v1 | 2v2 |
| Game to | 21 / 15 / 11 | 21 |
| Win by 2 | on / off | on |
| Match length | single / best of 3 / best of 5 | best of 3 |

### Design
- The **one violet primary** stays the shell's *Save round* button — the big **＋1** rally taps are surface controls (≥60px, thumb-friendly).
- **Crown Gold** marks the games **leader only** (👑), never decoration.
- Every changing number is **tabular-nums**, weight 700, big and glanceable.
- **Game point / Match point** and **Won** are called out with copy + emoji, never color alone; a finished game reads green (success), distinct from the match-winner gold.
- `aria-live` status line, `aria-label`ed taps, decorative emoji `aria-hidden`. Reduced-motion honored via the global motion rules.

### Verification
- `npm run check` — 0 errors, 0 warnings
- `npm test` — 108 passed (33 new Spikeball tests: 21 win-by-2, deuce, 15/11, best-of-3, module wiring)
- `npm run build` — succeeds

Purely **additive** — only `src/lib/games/spikeball/` is touched; `registry.ts` auto-discovers the module.