### PR TITLE
Add Exploding Kittens match tracker

### DIFF
--- a/src/lib/games/explodingkittens/ExplodingKittensEditor.svelte
+++ b/src/lib/games/explodingkittens/ExplodingKittensEditor.svelte
@@ -1,0 +1,218 @@
+<script lang="ts">
+  import type { ID, RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import { ordinal } from '../../stats/format';
+  import type { EKInput } from './logic';
+
+  let { input = $bindable(), ctx }: { input: EKInput; ctx: RoundContext } = $props();
+
+  const trackOrder = $derived(ctx.config.trackOrder !== false);
+  const imploding = $derived(!!ctx.config.imploding);
+
+  const outIndex = (id: ID): number => input.order.indexOf(id);
+  const isOut = (id: ID): boolean => outIndex(id) >= 0;
+
+  const alive = $derived(ctx.players.filter((p) => !input.order.includes(p.id)));
+  // In elimination-order mode the survivor is whoever's left once everyone else has
+  // exploded — crowned automatically so entry is a string of single taps.
+  const survivorId = $derived(trackOrder ? (alive.length === 1 ? alive[0].id : null) : input.winner);
+
+  function syncWinner() {
+    input.winner = alive.length === 1 ? alive[0].id : null;
+  }
+
+  function eliminate(id: ID) {
+    if (!input.order.includes(id)) input.order = [...input.order, id];
+    syncWinner();
+  }
+  function revive(id: ID) {
+    input.order = input.order.filter((x) => x !== id);
+    syncWinner();
+  }
+  // trackOrder off: one tap picks the lone survivor (tap again to clear).
+  function crown(id: ID) {
+    input.winner = input.winner === id ? null : id;
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="muted">
+      {#if trackOrder}
+        Tap each kitten as they 💥 explode — the survivor is crowned.
+      {:else}
+        Tap the last kitten standing 👑
+      {/if}
+    </span>
+    {#if survivorId}
+      <span class="pill survived">👑 {ctx.players.find((p) => p.id === survivorId)?.name} survives</span>
+    {:else if trackOrder}
+      <span class="pill"><span class="num">{alive.length}</span> still in play</span>
+    {:else}
+      <span class="pill">no survivor yet</span>
+    {/if}
+  </div>
+
+  {#if imploding}
+    <div class="reminder">☠️ <span>Imploding Kitten in play — it can’t be defused.</span></div>
+  {/if}
+
+  <div class="stack list">
+    {#each ctx.players as p (p.id)}
+      {#if survivorId === p.id}
+        <div class="krow survivor" aria-label="{p.name} is the last kitten standing">
+          <span class="who">
+            <Avatar name={p.name} color={p.color} />
+            <strong>{p.name}</strong>
+          </span>
+          <span class="badge crown">👑 Survivor</span>
+        </div>
+      {:else if trackOrder && isOut(p.id)}
+        <button
+          type="button"
+          class="krow out"
+          onclick={() => revive(p.id)}
+          aria-label="Bring {p.name} back in — they were the {ordinal(outIndex(p.id) + 1)} out"
+        >
+          <span class="who">
+            <Avatar name={p.name} color={p.color} />
+            <span class="name">{p.name}</span>
+          </span>
+          <span class="badge boom">💥 <span class="num">{ordinal(outIndex(p.id) + 1)}</span> out</span>
+        </button>
+      {:else if trackOrder}
+        <button
+          type="button"
+          class="krow"
+          onclick={() => eliminate(p.id)}
+          aria-label="{p.name} exploded"
+        >
+          <span class="who">
+            <Avatar name={p.name} color={p.color} />
+            <strong>{p.name}</strong>
+          </span>
+          <span class="badge action">💥 Out</span>
+        </button>
+      {:else}
+        <button
+          type="button"
+          class="krow pick"
+          class:on={input.winner === p.id}
+          onclick={() => crown(p.id)}
+          aria-pressed={input.winner === p.id}
+        >
+          <span class="who">
+            <Avatar name={p.name} color={p.color} />
+            <strong>{p.name}</strong>
+          </span>
+          <span class="badge">{input.winner === p.id ? '👑 Survivor' : 'Tap to crown'}</span>
+        </button>
+      {/if}
+    {/each}
+  </div>
+</div>
+
+<style>
+  .list {
+    gap: 8px;
+  }
+  .krow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    min-height: 56px;
+    padding: 10px 12px;
+    text-align: left;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease;
+  }
+  button.krow:hover {
+    background: var(--surface-3);
+  }
+  button.krow:active {
+    transform: translateY(1px);
+  }
+  button.krow:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .who {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+  .who strong,
+  .who .name {
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .badge {
+    flex: none;
+    font-weight: 700;
+    font-size: 0.9rem;
+    color: var(--muted);
+  }
+  .badge.action {
+    color: var(--text);
+  }
+  .num {
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Eliminated: dimmed and struck, carried by the 💥 chip + rank number, never
+     colour alone. Not coral — being out isn't an error, just out. */
+  .krow.out {
+    background: var(--surface);
+    opacity: 0.72;
+  }
+  .krow.out .name {
+    text-decoration: line-through;
+    color: var(--muted);
+  }
+  .badge.boom {
+    color: var(--muted);
+  }
+
+  /* Survivor: the restrained Crown Gold wash + underline the scoreboard uses for a
+     winner — the 👑 and the gold carry it, so gold stays a hint, never a block. */
+  .krow.survivor {
+    background: color-mix(in srgb, var(--accent) 13%, var(--surface-2));
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  }
+  .badge.crown {
+    color: var(--accent-ink);
+  }
+  .krow.pick.on {
+    background: color-mix(in srgb, var(--accent) 13%, var(--surface-2));
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  }
+  .krow.pick.on .badge {
+    color: var(--accent-ink);
+  }
+
+  .pill.survived {
+    color: var(--accent-ink);
+    border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  }
+
+  .reminder {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 12px;
+    border-radius: 10px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+</style>

--- a/src/lib/games/explodingkittens/explodingkittens.test.ts
+++ b/src/lib/games/explodingkittens/explodingkittens.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round, RoundContext } from '../../types';
+import {
+  emptyInput,
+  finishingPositions,
+  matchLimit,
+  pickMatchLeaders,
+  scoreMatch,
+  validateMatch,
+  type EKInput,
+} from './logic';
+import { explodingkittens } from './index';
+import { explodingKittensStats } from './stats';
+
+const player = (id: string, name = id): Player => ({ id, name, color: '#7c5cff', createdAt: 0 });
+
+function ctxFor(playerIds: string[], config: Record<string, unknown> = {}): RoundContext {
+  return {
+    game: {
+      id: 'g',
+      type: 'explodingkittens',
+      config,
+      playerIds,
+      status: 'active',
+      createdAt: 0,
+      roundCount: 0,
+    } as Game,
+    players: playerIds.map((id) => player(id)),
+    config,
+    roundIndex: 0,
+    totals: Object.fromEntries(playerIds.map((id) => [id, 0])),
+    rounds: [],
+  };
+}
+
+function mkRound(gameId: string, index: number, input: EKInput, players: string[]): Round {
+  return { id: `${gameId}-r${index}`, gameId, index, input, deltas: scoreMatch(input, players), createdAt: 0 };
+}
+
+describe('scoreMatch — a match win is +1 to the survivor', () => {
+  it('gives the survivor +1 and everyone else 0', () => {
+    expect(scoreMatch({ winner: 'A', order: ['C', 'B'] }, ['A', 'B', 'C'])).toEqual({ A: 1, B: 0, C: 0 });
+  });
+
+  it('keys every seat so the whole table appears on the scorecard', () => {
+    const out = scoreMatch({ winner: 'B', order: ['A'] }, ['A', 'B']);
+    expect(Object.keys(out).sort()).toEqual(['A', 'B']);
+    expect(out).toEqual({ A: 0, B: 1 });
+  });
+
+  it('scores nobody when there is no survivor', () => {
+    expect(scoreMatch({ winner: null, order: [] }, ['A', 'B'])).toEqual({ A: 0, B: 0 });
+  });
+
+  it('ignores a winner who is not one of the players', () => {
+    expect(scoreMatch({ winner: 'Z', order: [] }, ['A', 'B'])).toEqual({ A: 0, B: 0 });
+  });
+});
+
+describe('validateMatch — survivor only (track order off)', () => {
+  it('requires a survivor', () => {
+    expect(validateMatch({ winner: null, order: [] }, ['A', 'B'], false)).toMatch(/last player standing/i);
+  });
+
+  it('accepts a valid survivor', () => {
+    expect(validateMatch({ winner: 'A', order: [] }, ['A', 'B'], false)).toBeNull();
+  });
+
+  it('rejects a survivor who is not in the game', () => {
+    expect(validateMatch({ winner: 'Z', order: [] }, ['A', 'B'], false)).toMatch(/one of the players/i);
+  });
+});
+
+describe('validateMatch — full elimination order (track order on)', () => {
+  it('accepts a complete order with the correct auto-survivor', () => {
+    expect(validateMatch({ winner: 'A', order: ['C', 'B'] }, ['A', 'B', 'C'], true)).toBeNull();
+  });
+
+  it('nudges while players are still in play', () => {
+    expect(validateMatch({ winner: null, order: ['B'] }, ['A', 'B', 'C'], true)).toMatch(/2 still in play/);
+  });
+
+  it('requires the survivor to be crowned once one remains', () => {
+    expect(validateMatch({ winner: null, order: ['C', 'B'] }, ['A', 'B', 'C'], true)).toMatch(/last kitten standing/i);
+  });
+
+  it('rejects a duplicate explosion', () => {
+    expect(validateMatch({ winner: null, order: ['B', 'B'] }, ['A', 'B', 'C'], true)).toMatch(/only explode once/i);
+  });
+
+  it('rejects an unknown player in the order', () => {
+    expect(validateMatch({ winner: null, order: ['Z'] }, ['A', 'B', 'C'], true)).toMatch(/isn’t in this game/i);
+  });
+
+  it('rejects a survivor who also appears in the elimination pile', () => {
+    expect(validateMatch({ winner: 'B', order: ['C', 'B'] }, ['A', 'B', 'C'], true)).toMatch(/elimination pile/i);
+  });
+
+  it('rejects a match where everybody exploded', () => {
+    expect(validateMatch({ winner: null, order: ['A', 'B', 'C'] }, ['A', 'B', 'C'], true)).toMatch(/has to survive/i);
+  });
+});
+
+describe('pickMatchLeaders — most match wins leads', () => {
+  it('returns the single leader', () => {
+    expect(pickMatchLeaders({ A: 2, B: 1, C: 0 })).toEqual(['A']);
+  });
+
+  it('returns everyone tied for the lead', () => {
+    expect(pickMatchLeaders({ A: 2, B: 2, C: 1 }).sort()).toEqual(['A', 'B']);
+  });
+
+  it('crowns nobody before a match has been won', () => {
+    expect(pickMatchLeaders({ A: 0, B: 0 })).toEqual([]);
+  });
+
+  it('handles an empty table', () => {
+    expect(pickMatchLeaders({})).toEqual([]);
+  });
+});
+
+describe('finishingPositions — 1 = survivor, first-out finishes last', () => {
+  it('orders a full 3-player match', () => {
+    expect(finishingPositions({ winner: 'A', order: ['C', 'B'] }, ['A', 'B', 'C'])).toEqual({ A: 1, B: 2, C: 3 });
+  });
+
+  it('only positions the players it knows about', () => {
+    expect(finishingPositions({ winner: 'A', order: [] }, ['A', 'B'])).toEqual({ A: 1 });
+  });
+});
+
+describe('matchLimit', () => {
+  it('is open-ended by default', () => {
+    expect(matchLimit({})).toBeNull();
+    expect(matchLimit({ matches: 0 })).toBeNull();
+  });
+
+  it('caps to a positive match count', () => {
+    expect(matchLimit({ matches: 5 })).toBe(5);
+    expect(matchLimit({ matches: '3' })).toBe(3);
+  });
+});
+
+describe('explodingkittens module', () => {
+  it('has the folder id and party-friendly seat range', () => {
+    expect(explodingkittens.id).toBe('explodingkittens');
+    expect(explodingkittens.minPlayers).toBe(2);
+    expect(explodingkittens.maxPlayers).toBe(10);
+    expect(typeof explodingkittens.emoji).toBe('string');
+  });
+
+  it('creates a fresh, empty match', () => {
+    expect(explodingkittens.createRoundInput(ctxFor(['A', 'B']))).toEqual(emptyInput());
+    expect(emptyInput()).toEqual({ winner: null, order: [] });
+  });
+
+  it('caps rounds by the matches config', () => {
+    expect(explodingkittens.maxRounds!({ matches: 3 }, 4)).toBe(3);
+    expect(explodingkittens.maxRounds!({ matches: 0 }, 4)).toBeNull();
+  });
+
+  it('validates & scores a round through the context (order tracked by default)', () => {
+    const ctx = ctxFor(['A', 'B', 'C']);
+    const input: EKInput = { winner: 'A', order: ['C', 'B'] };
+    expect(explodingkittens.validateRound(input, ctx)).toBeNull();
+    expect(explodingkittens.scoreRound(input, ctx)).toEqual({ A: 1, B: 0, C: 0 });
+  });
+
+  it('honors the track-order-off config', () => {
+    const ctx = ctxFor(['A', 'B', 'C'], { trackOrder: false });
+    expect(explodingkittens.validateRound({ winner: 'B', order: [] }, ctx)).toBeNull();
+  });
+
+  it('picks the leaderboard winner from totals', () => {
+    expect(explodingkittens.pickWinners!({ A: 3, B: 1 }, {})).toEqual(['A']);
+  });
+
+  it('describes a match with survivor and first-out', () => {
+    const players = [player('Ana'), player('Bo'), player('Cy')];
+    const round = mkRound('g', 0, { winner: 'Ana', order: ['Cy', 'Bo'] }, ['Ana', 'Bo', 'Cy']);
+    const desc = explodingkittens.describeRound!(round, players);
+    expect(desc).toContain('Ana');
+    expect(desc).toContain('👑');
+    expect(desc).toMatch(/Cy out first/);
+  });
+});
+
+describe('explodingKittensStats', () => {
+  const games: Game[] = [
+    { id: 'g', type: 'explodingkittens', config: {}, playerIds: ['A', 'B', 'C'], status: 'finished', createdAt: 0, roundCount: 2 } as Game,
+  ];
+  const rounds: Round[] = [
+    mkRound('g', 0, { winner: 'A', order: ['C', 'B'] }, ['A', 'B', 'C']),
+    mkRound('g', 1, { winner: 'B', order: ['A', 'C'] }, ['A', 'B', 'C']),
+  ];
+  const out = explodingKittensStats({ games, rounds, players: [], canonical: (id: ID) => id });
+
+  it('counts first-to-explode per player', () => {
+    expect(out.perPlayer?.['C']?.find((m) => m.key === 'ek_first')?.value).toBe('1');
+    expect(out.perPlayer?.['A']?.find((m) => m.key === 'ek_first')?.value).toBe('1');
+  });
+
+  it('counts runner-up finishes', () => {
+    expect(out.perPlayer?.['B']?.find((m) => m.key === 'ek_runnerup')?.value).toBe('1');
+    expect(out.perPlayer?.['C']?.find((m) => m.key === 'ek_runnerup')?.value).toBe('1');
+  });
+
+  it('averages finishing position', () => {
+    // A finished 1st then 3rd -> avg 2; B finished 2nd then 1st -> avg 1.5
+    expect(out.perPlayer?.['A']?.find((m) => m.key === 'ek_finish')?.value).toBe('2');
+    expect(out.perPlayer?.['B']?.find((m) => m.key === 'ek_finish')?.value).toBe('1.5');
+  });
+
+  it('totals kittens exploded globally', () => {
+    expect(out.global?.find((m) => m.key === 'ek_boom')?.value).toBe('4');
+  });
+
+  it('maps merged players to their canonical id', () => {
+    const merged = explodingKittensStats({
+      games,
+      rounds: [mkRound('g', 0, { winner: 'A', order: ['C2', 'B'] }, ['A', 'B', 'C2'])],
+      players: [],
+      canonical: (id: ID) => (id === 'C2' ? 'C' : id),
+    });
+    expect(merged.perPlayer?.['C']?.find((m) => m.key === 'ek_first')?.value).toBe('1');
+  });
+
+  it('contributes nothing when elimination order is not tracked', () => {
+    const noOrder = explodingKittensStats({
+      games,
+      rounds: [mkRound('g', 0, { winner: 'A', order: [] }, ['A', 'B', 'C'])],
+      players: [],
+      canonical: (id: ID) => id,
+    });
+    expect(noOrder.perPlayer).toEqual({});
+    expect(noOrder.global).toEqual([]);
+  });
+});

--- a/src/lib/games/explodingkittens/index.ts
+++ b/src/lib/games/explodingkittens/index.ts
@@ -1,0 +1,94 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './ExplodingKittensEditor.svelte';
+import { explodingKittensStats } from './stats';
+import {
+  emptyInput,
+  matchLimit,
+  pickMatchLeaders,
+  scoreMatch,
+  validateMatch,
+  type EKInput,
+} from './logic';
+
+export type { EKInput } from './logic';
+
+const trackOrderOn = (config: Record<string, unknown>): boolean => config.trackOrder !== false;
+
+export const explodingkittens: GameModule = {
+  id: 'explodingkittens',
+  name: 'Exploding Kittens',
+  tagline: 'Draw til you blow up — last kitten standing wins 💥🐱',
+  emoji: '💥',
+  keywords: ['exploding', 'imploding', 'kittens', 'party', 'elimination', 'cards', 'defuse'],
+  // Base game is 2–5; the Imploding Kittens expansion adds a 6th seat, and two
+  // combined decks stretch to a full party — so the tracker is generous by design.
+  minPlayers: 2,
+  maxPlayers: 10,
+  configFields: [
+    {
+      key: 'imploding',
+      label: 'Imploding Kittens expansion (☠️ can’t be defused)',
+      type: 'boolean',
+      default: false,
+      help: 'Adds the face-up/face-down Imploding Kitten, streaking and targeted attacks — a reminder in the tracker; the last kitten standing still wins the match.',
+    },
+    {
+      key: 'trackOrder',
+      label: 'Track elimination order (who exploded when)',
+      type: 'boolean',
+      default: true,
+      help: 'On: tap each kitten as they explode and the survivor is crowned automatically — unlocks first-to-explode and finish stats. Off: just tap who survived.',
+    },
+    {
+      key: 'matches',
+      label: 'Number of matches (0 = open-ended)',
+      type: 'number',
+      default: 0,
+      min: 0,
+      max: 50,
+      help: 'Play a set number of matches then crown the leaderboard, or leave at 0 to keep dealing all night.',
+    },
+  ],
+
+  // Higher match-win total leads (default win direction).
+
+  maxRounds: (config) => matchLimit(config),
+
+  createRoundInput: (): EKInput => emptyInput(),
+
+  validateRound: (input: EKInput, ctx: RoundContext): string | null =>
+    validateMatch(input, ctx.players.map((p) => p.id), trackOrderOn(ctx.config)),
+
+  scoreRound: (input: EKInput, ctx: RoundContext): Record<ID, number> =>
+    scoreMatch(input, ctx.players.map((p) => p.id)),
+
+  pickWinners: (totals): ID[] => pickMatchLeaders(totals),
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as EKInput;
+    const name = (id: ID | null | undefined) => players.find((p) => p.id === id)?.name ?? '?';
+    if (!input?.winner && (!input?.order || input.order.length === 0)) return 'no result';
+    const head = input.winner ? `👑 ${name(input.winner)} survived` : 'no survivor';
+    if (input.order && input.order.length) {
+      return `${head} · 💥 ${name(input.order[0])} out first`;
+    }
+    return head;
+  },
+
+  help: [
+    '💥🐱 Exploding Kittens — a match tracker.',
+    '',
+    'Play a match: draw cards until someone flips an Exploding Kitten they can’t',
+    'Defuse — they’re OUT. Keep going until ONE player remains: the last kitten',
+    'standing wins the match and banks +1 on the leaderboard. Most match wins leads.',
+    '',
+    'Each round here = one match. With “Track elimination order” on, tap each player',
+    'as they explode and the survivor is crowned for you; turn it off to just tap the',
+    'winner. Imploding Kittens on? The ☠️ Imploding Kitten can’t be defused — flip it',
+    'and you’re out on the spot.',
+  ].join('\n'),
+
+  stats: explodingKittensStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/explodingkittens/logic.ts
+++ b/src/lib/games/explodingkittens/logic.ts
@@ -1,0 +1,119 @@
+import type { ID } from '../../types';
+
+/**
+ * Exploding Kittens is an *elimination* game: players draw until someone flips an
+ * Exploding Kitten they can't Defuse — they're OUT — and play continues until a
+ * single player is left standing, who wins the match. There are no points to add
+ * up inside a match, so we model it against Score King's point-oriented contract
+ * by making **one round = one match** and scoring a **match win as +1** for the
+ * lone survivor (everyone else +0). Cumulative totals are therefore each player's
+ * match-win tally, and the leaderboard is "most matches won". This file is pure
+ * (no Svelte, no I/O) so `explodingkittens.test.ts` can exercise the real rules.
+ */
+export interface EKInput {
+  /** The last player standing — the winner of this match. */
+  winner: ID | null;
+  /**
+   * Elimination order, earliest first: `order[0]` was the first to explode (💥),
+   * the final entry was the runner-up. Populated when "track elimination order"
+   * is on; left empty when the group only records who survived.
+   */
+  order: ID[];
+}
+
+/** A fresh, empty match: nobody eliminated, no survivor crowned yet. */
+export function emptyInput(): EKInput {
+  return { winner: null, order: [] };
+}
+
+/**
+ * Score one match: the survivor banks a match win (+1); everyone else scores 0 so
+ * they still appear on the scorecard. Keyed over the match's players, not just the
+ * winner, so `computeTotals` sees a delta for each seat.
+ */
+export function scoreMatch(input: EKInput, playerIds: ID[]): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) out[id] = 0;
+  if (input.winner && Object.prototype.hasOwnProperty.call(out, input.winner)) {
+    out[input.winner] = 1;
+  }
+  return out;
+}
+
+/**
+ * Validate a recorded match. When `trackOrder` is on we require a *complete*
+ * elimination order — everyone but the survivor exploded, exactly how a real match
+ * ends — which also gives clean finishing positions for stats. When it's off we
+ * only need the survivor. Returns `null` when valid, else a human-readable reason.
+ */
+export function validateMatch(
+  input: EKInput,
+  playerIds: ID[],
+  trackOrder: boolean,
+): string | null {
+  const known = new Set(playerIds);
+  const seen = new Set<ID>();
+  for (const id of input.order) {
+    if (!known.has(id)) return 'Elimination order lists a player who isn’t in this game.';
+    if (seen.has(id)) return 'A player can only explode once per match.';
+    seen.add(id);
+  }
+  if (input.winner && seen.has(input.winner)) {
+    return 'The survivor can’t also be in the elimination pile.';
+  }
+
+  if (trackOrder) {
+    const remaining = playerIds.filter((id) => !seen.has(id));
+    if (remaining.length > 1) {
+      const left = remaining.length;
+      return `Tap each kitten as they explode — ${left} still in play.`;
+    }
+    if (remaining.length === 0) {
+      return 'Someone has to survive — bring the last kitten back in.';
+    }
+    if (!input.winner || input.winner !== remaining[0]) {
+      return 'Crown the last kitten standing as the survivor.';
+    }
+    return null;
+  }
+
+  if (!input.winner) return 'Tap the last player standing to record the survivor.';
+  if (!known.has(input.winner)) return 'The survivor must be one of the players.';
+  return null;
+}
+
+/**
+ * Match leaders: the player(s) with the most match wins. Ties return everyone tied
+ * for the lead. Before anyone has won a match there is no leader, so return `[]`
+ * rather than crowning the whole table.
+ */
+export function pickMatchLeaders(totals: Record<ID, number>): ID[] {
+  const ids = Object.keys(totals);
+  if (ids.length === 0) return [];
+  const best = Math.max(...ids.map((id) => totals[id] ?? 0));
+  if (best <= 0) return [];
+  return ids.filter((id) => (totals[id] ?? 0) === best);
+}
+
+/**
+ * Finishing positions for a match (1 = survivor). With `n` players, the player who
+ * exploded first (`order[0]`) finishes last (`n`), the runner-up finishes 2nd, and
+ * the survivor finishes 1st. Players outside `order`/`winner` are omitted.
+ */
+export function finishingPositions(input: EKInput, playerIds: ID[]): Record<ID, number> {
+  const known = new Set(playerIds);
+  const pos: Record<ID, number> = {};
+  const order = input.order.filter((id) => known.has(id));
+  const n = playerIds.length;
+  order.forEach((id, i) => {
+    pos[id] = n - i;
+  });
+  if (input.winner && known.has(input.winner)) pos[input.winner] = 1;
+  return pos;
+}
+
+/** Read the number of matches to play; 0 (or unset) means open-ended. */
+export function matchLimit(config: Record<string, unknown>): number | null {
+  const m = Number(config.matches) || 0;
+  return m > 0 ? m : null;
+}

--- a/src/lib/games/explodingkittens/stats.ts
+++ b/src/lib/games/explodingkittens/stats.ts
@@ -1,0 +1,91 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg } from '../../stats/format';
+import { finishingPositions, type EKInput } from './logic';
+
+interface EKAgg {
+  firstOut: number;
+  runnerUp: number;
+  finishSum: number;
+  finishCount: number;
+}
+
+/**
+ * Exploding Kittens flavour stats, derived from each match's recorded survivor and
+ * elimination order. The generic engine already carries match wins (the leaderboard
+ * is literally "most matches won"), so this hook adds only what it can't: who blows
+ * up first, who keeps reaching the final two, and average finishing position. All
+ * pure; mirrors the module's own `finishingPositions`. With "track elimination
+ * order" off there's no order data, so this gracefully contributes nothing.
+ */
+export function explodingKittensStats({
+  games,
+  rounds,
+  canonical,
+}: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, EKAgg>();
+  const get = (id: ID): EKAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { firstOut: 0, runnerUp: 0, finishSum: 0, finishCount: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let totalExploded = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const raw = r.input as EKInput | undefined;
+    if (!raw) continue;
+
+    const order = (raw.order ?? []).map(canonical);
+    const winner = raw.winner ? canonical(raw.winner) : null;
+    const players = [...new Set(Object.keys(r.deltas).map(canonical))];
+
+    totalExploded += order.length;
+    if (order.length) get(order[0]).firstOut += 1;
+
+    // Finishing positions only make sense for a completed match (everyone but the
+    // survivor exploded); guard so avg finish isn't skewed by a partial entry.
+    const complete = !!winner && order.length === players.length - 1 && order.length > 0;
+    if (complete) {
+      const pos = finishingPositions({ winner, order }, players);
+      for (const [id, p] of Object.entries(pos)) {
+        const a = get(id);
+        a.finishSum += p;
+        a.finishCount += 1;
+        if (p === 2) a.runnerUp += 1;
+      }
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.firstOut) {
+      metrics.push({ key: 'ek_first', label: 'First to explode', value: `${a.firstOut}`, emoji: '💥' });
+    }
+    if (a.runnerUp) {
+      metrics.push({ key: 'ek_runnerup', label: 'Runner-up', value: `${a.runnerUp}`, emoji: '🥈' });
+    }
+    if (a.finishCount) {
+      metrics.push({
+        key: 'ek_finish',
+        label: 'Avg finish',
+        value: fmtAvg(a.finishSum / a.finishCount),
+        emoji: '🏁',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totalExploded) {
+    global.push({ key: 'ek_boom', label: 'Kittens exploded', value: `${totalExploded}`, emoji: '💥' });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## 💥🐱 Exploding Kittens — match tracker

Adds a first-class `explodingkittens` game module. Purely additive: only touches `src/lib/games/explodingkittens/` (the registry auto-discovers it; nothing else changed).

### Modeling an elimination game against a point contract
Exploding Kittens has no in-match points — you draw until you flip an Exploding Kitten you can't Defuse, you're OUT, and the **last player standing wins the match**. To fit Score King's point-oriented `GameModule` cleanly:

- **One round = one match.** `scoreRound` gives the survivor **+1** (a match win); everyone else +0 so the whole table stays on the scorecard.
- **Totals = match wins**, so the leaderboard is literally "most matches won." `pickWinners` returns the player(s) with the most match wins (and nobody before a match is decided).
- Higher total leads (default win direction).

Input shape: `{ winner, order }` where `order[0]` was the first to explode and the final entry is the runner-up.

### Config
- **Imploding Kittens expansion** (`imploding`, default off) — surfaces a ☠️ "can't be defused" reminder in the editor; flavor, not a rules change.
- **Track elimination order** (`trackOrder`, default on) — tap each kitten as they explode and the survivor is crowned automatically; unlocks first-to-explode / runner-up / avg-finish stats. Turn off to just tap who survived (one tap).
- **Number of matches** (`matches`, default 0 = open-ended) — caps rounds via `maxRounds`, or deal all night.

### Editor (one-handed, DESIGN.md-compliant)
- Chrome unchanged — personality is emoji + copy only (💥🐱👑☠️).
- Two flows on one shared row vocabulary: tap-to-explode (order on) or single-select survivor (order off). Every elimination is reversible (tap an out kitten to bring them back).
- Crown Gold used **only** on the survivor (the match winner) as the restrained scoreboard-style wash; eliminated players are muted + struck with a 💥 rank chip — **never colour alone** (👑 / 💥 / rank number / text co-signal).
- ≥56px targets, `tabular-nums` on changing counts, no new shadows (surface ramp only), reduced-motion safe. No second Royal Violet fill — the shell's "Save round" stays the one primary action.

### Stats
`stats.ts` adds only what the generic leaderboard can't: **first to explode** 💥, **runner-up** 🥈, **average finish** 🏁, and a global **kittens exploded** 💥 counter. Degrades to nothing when elimination order isn't tracked.

### Verification
- `npm run check` — 0 errors, 0 warnings
- `npm test` — 110 passed (35 new in `explodingkittens.test.ts`)
- `npm run build` — success
