### PR TITLE
Add Finspan game (fish-themed end-game category scorer)

### DIFF
--- a/src/lib/games/finspan/FinspanEditor.svelte
+++ b/src/lib/games/finspan/FinspanEditor.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import {
+    FINSPAN_CATEGORIES,
+    FINSPAN_HELP,
+    categoryPoints,
+    emptyRow,
+    scoreRow,
+    type FinspanInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: FinspanInput; ctx: RoundContext } = $props();
+
+  // Guarantee every seated player has a row, even one added after the sheet was created.
+  $effect(() => {
+    for (const p of ctx.players) {
+      if (!input.values[p.id]) input.values[p.id] = emptyRow();
+    }
+  });
+
+  let showHelp = $state(false);
+
+  function total(id: string): number {
+    return scoreRow(input.values[id]);
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="pill">🐟 Final scoresheet · week 4</span>
+    <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+      Scoring
+    </button>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{FINSPAN_HELP}</pre>
+  {/if}
+
+  {#each ctx.players as p (p.id)}
+    {@const row = input.values[p.id]}
+    {#if row}
+      <div class="prow">
+        <div class="row spread phead">
+          <span class="row" style="gap: 8px">
+            <Avatar name={p.name} color={p.color} />
+            <strong>{p.name}</strong>
+          </span>
+          <span class="total">{total(p.id)}<span class="unit">pts</span></span>
+        </div>
+        <div class="grid">
+          {#each FINSPAN_CATEGORIES as c (c.key)}
+            <div class="f">
+              <span class="flabel">
+                <span aria-hidden="true">{c.emoji}</span>
+                {c.label}{#if c.per !== 1}<span class="mult">×{c.per}</span>{/if}
+              </span>
+              {#if c.entry === 'count'}
+                <Stepper bind:value={row[c.key]} min={0} />
+              {:else}
+                <input
+                  class="pts"
+                  type="number"
+                  min="0"
+                  step="1"
+                  inputmode="numeric"
+                  aria-label={`${p.name} ${c.label}`}
+                  bind:value={row[c.key]}
+                />
+              {/if}
+              {#if c.per !== 1}
+                <span class="contrib">= {categoryPoints(c, row[c.key])} pts</span>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+  {/each}
+</div>
+
+<style>
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+  }
+  .phead {
+    margin-bottom: 10px;
+  }
+  .total {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    font-weight: 800;
+    font-size: 1.1rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .unit {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--muted);
+  }
+  .grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 16px;
+  }
+  .f {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .flabel {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+  .mult {
+    font-weight: 700;
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+  }
+  .pts {
+    width: 88px;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+  .contrib {
+    font-size: 0.72rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/finspan/finspan.test.ts
+++ b/src/lib/games/finspan/finspan.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, Player, Round, RoundContext } from '../../types';
+import { defaultWinners } from '../../types';
+import {
+  FINSPAN_CATEGORIES,
+  FINSPAN_HELP,
+  categoryPoints,
+  describeFinspan,
+  emptyInput,
+  emptyRow,
+  scoreFinspan,
+  scoreRow,
+  validateFinspan,
+  type FinspanRow,
+} from './logic';
+import { finspan } from './index';
+
+function player(id: string, name = id): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+const players = [player('a', 'Ada'), player('b', 'Bo')];
+
+function ctxWith(ps: Player[]): RoundContext {
+  const game: Game = {
+    id: 'g',
+    type: 'finspan',
+    config: {},
+    playerIds: ps.map((p) => p.id),
+    status: 'active',
+    createdAt: 0,
+    roundCount: 0,
+  };
+  return {
+    game,
+    players: ps,
+    config: {},
+    roundIndex: 0,
+    totals: Object.fromEntries(ps.map((p) => [p.id, 0])),
+    rounds: [],
+  };
+}
+
+function row(overrides: Record<string, number> = {}): FinspanRow {
+  return { ...emptyRow(), ...overrides };
+}
+
+const cat = (key: string) => FINSPAN_CATEGORIES.find((c) => c.key === key)!;
+
+describe('Finspan categories', () => {
+  it('has the eight official end-game categories with unique keys', () => {
+    expect(FINSPAN_CATEGORIES).toHaveLength(8);
+    const keys = FINSPAN_CATEGORIES.map((c) => c.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).toEqual(['week1', 'week2', 'week3', 'gameEnd', 'fish', 'consumed', 'eggsYoung', 'schools']);
+  });
+
+  it('scores schools at 6 each and everything else at 1', () => {
+    expect(cat('schools').per).toBe(6);
+    for (const c of FINSPAN_CATEGORIES) {
+      if (c.key !== 'schools') expect(c.per).toBe(1);
+    }
+  });
+
+  it('marks token categories as counts and printed points as points', () => {
+    expect(cat('consumed').entry).toBe('count');
+    expect(cat('eggsYoung').entry).toBe('count');
+    expect(cat('schools').entry).toBe('count');
+    expect(cat('week1').entry).toBe('points');
+    expect(cat('gameEnd').entry).toBe('points');
+    expect(cat('fish').entry).toBe('points');
+  });
+
+  it('gives every category a label, emoji and hint', () => {
+    for (const c of FINSPAN_CATEGORIES) {
+      expect(c.label.length).toBeGreaterThan(0);
+      expect(c.emoji.length).toBeGreaterThan(0);
+      expect(c.hint.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('categoryPoints', () => {
+  it('multiplies schools by 6', () => {
+    expect(categoryPoints(cat('schools'), 3)).toBe(18);
+    expect(categoryPoints(cat('schools'), 0)).toBe(0);
+  });
+
+  it('passes point categories through unchanged', () => {
+    expect(categoryPoints(cat('fish'), 46)).toBe(46);
+    expect(categoryPoints(cat('week1'), 7)).toBe(7);
+  });
+
+  it('coerces blank / null / NaN to 0', () => {
+    expect(categoryPoints(cat('schools'), undefined)).toBe(0);
+    expect(categoryPoints(cat('schools'), null)).toBe(0);
+    expect(categoryPoints(cat('fish'), Number.NaN)).toBe(0);
+  });
+});
+
+describe('scoreRow', () => {
+  it('is 0 for an empty or missing row', () => {
+    expect(scoreRow(emptyRow())).toBe(0);
+    expect(scoreRow(undefined)).toBe(0);
+  });
+
+  it('matches the official rulebook worked example', () => {
+    // Yellow ability 3 + visible fish 46 + consumed 4 + eggs & young 8 + 3 schools (×6 = 18) = 79.
+    const example = row({ gameEnd: 3, fish: 46, consumed: 4, eggsYoung: 8, schools: 3 });
+    expect(scoreRow(example)).toBe(79);
+  });
+
+  it('adds weekly achievements and multiplies schools', () => {
+    expect(scoreRow(row({ week1: 5, week2: 6, week3: 8 }))).toBe(19);
+    expect(scoreRow(row({ schools: 4 }))).toBe(24);
+    expect(scoreRow(row({ fish: 40, schools: 2 }))).toBe(52);
+  });
+
+  it('sums a fully-populated sheet', () => {
+    const full = row({
+      week1: 7, week2: 6, week3: 8, gameEnd: 3, fish: 46, consumed: 4, eggsYoung: 8, schools: 3,
+    });
+    // 7+6+8 + 3 + 46 + 4 + 8 + 18
+    expect(scoreRow(full)).toBe(100);
+  });
+
+  it('treats a NaN entry as 0', () => {
+    const r = emptyRow();
+    (r as Record<string, number>).fish = Number.NaN;
+    expect(scoreRow(r)).toBe(0);
+  });
+});
+
+describe('scoreFinspan', () => {
+  it('returns each seated player total', () => {
+    const input = emptyInput(players);
+    input.values.a = row({ fish: 40, schools: 2 });
+    input.values.b = row({ week1: 5, eggsYoung: 3 });
+    expect(scoreFinspan(input, players)).toEqual({ a: 52, b: 8 });
+  });
+
+  it('scores a player with no row as 0', () => {
+    const input = emptyInput([players[0]]);
+    input.values.a = row({ fish: 12 });
+    expect(scoreFinspan(input, players)).toEqual({ a: 12, b: 0 });
+  });
+
+  it('is 0 for everyone with an undefined input', () => {
+    expect(scoreFinspan(undefined, players)).toEqual({ a: 0, b: 0 });
+  });
+});
+
+describe('validateFinspan', () => {
+  it('accepts a fresh or fully-filled sheet', () => {
+    expect(validateFinspan(emptyInput(players), players)).toBeNull();
+    const input = emptyInput(players);
+    input.values.a = row({ fish: 46, schools: 3 });
+    expect(validateFinspan(input, players)).toBeNull();
+  });
+
+  it('rejects negative entries, naming the player and category', () => {
+    const input = emptyInput(players);
+    input.values.a.fish = -3;
+    const err = validateFinspan(input, players);
+    expect(err).toContain('Ada');
+    expect(err).toContain('Fish');
+  });
+
+  it('rejects fractional entries', () => {
+    const input = emptyInput(players);
+    input.values.b.week1 = 2.5;
+    expect(validateFinspan(input, players)).toMatch(/whole number/);
+  });
+
+  it('treats blank / NaN as 0 rather than an error', () => {
+    const r = emptyRow();
+    (r as Record<string, number>).fish = Number.NaN;
+    expect(validateFinspan({ values: { a: r } }, [player('a')])).toBeNull();
+  });
+
+  it('is null for an undefined input or a player with no row', () => {
+    expect(validateFinspan(undefined, players)).toBeNull();
+    expect(validateFinspan({ values: {} }, players)).toBeNull();
+  });
+});
+
+describe('describeFinspan', () => {
+  it('summarises each player total', () => {
+    const input = emptyInput(players);
+    input.values.a = row({ gameEnd: 3, fish: 46, consumed: 4, eggsYoung: 8, schools: 3 });
+    input.values.b = row({ schools: 2 });
+    const rd = { id: 'r', gameId: 'g', index: 0, input, deltas: {}, createdAt: 0 } as Round;
+    expect(describeFinspan(rd, players)).toBe('Ada 79 · Bo 12');
+  });
+
+  it('returns empty string when nothing is recorded', () => {
+    const rd = { id: 'r', gameId: 'g', index: 0, input: undefined, deltas: {}, createdAt: 0 } as Round;
+    expect(describeFinspan(rd, players)).toBe('');
+  });
+});
+
+describe('finspan module', () => {
+  it('declares faithful catalog metadata', () => {
+    expect(finspan.id).toBe('finspan');
+    expect(finspan.name).toBe('Finspan');
+    expect(finspan.emoji).toBe('🐟');
+    expect(finspan.minPlayers).toBe(1);
+    expect(finspan.maxPlayers).toBe(5);
+  });
+
+  it('is a single final scoresheet', () => {
+    expect(finspan.maxRounds?.({}, 4)).toBe(1);
+  });
+
+  it('seeds a zeroed row per player', () => {
+    const input = finspan.createRoundInput(ctxWith(players)) as ReturnType<typeof emptyInput>;
+    expect(Object.keys(input.values).sort()).toEqual(['a', 'b']);
+    for (const p of players) {
+      for (const c of FINSPAN_CATEGORIES) expect(input.values[p.id][c.key]).toBe(0);
+    }
+  });
+
+  it('wires scoring and validation to the logic core', () => {
+    const input = emptyInput(players);
+    input.values.a = row({ fish: 40, schools: 2 });
+    input.values.b = row({ week1: 8 });
+    expect(finspan.scoreRound(input, ctxWith(players))).toEqual({ a: 52, b: 8 });
+    expect(finspan.validateRound(input, ctxWith(players))).toBeNull();
+    input.values.a.consumed = -1;
+    expect(finspan.validateRound(input, ctxWith(players))).toContain('Ada');
+  });
+
+  it('awards the win to the highest total, sharing ties', () => {
+    expect(defaultWinners(finspan, { a: 79, b: 12 })).toEqual(['a']);
+    expect(defaultWinners(finspan, { a: 40, b: 40 }).sort()).toEqual(['a', 'b']);
+  });
+
+  it('ships a scoring help reference that states the schools value', () => {
+    expect(finspan.help).toBe(FINSPAN_HELP);
+    expect(finspan.help).toContain('6 points');
+  });
+});

--- a/src/lib/games/finspan/index.ts
+++ b/src/lib/games/finspan/index.ts
@@ -1,0 +1,46 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './FinspanEditor.svelte';
+import { finspanStats } from './stats';
+import {
+  FINSPAN_HELP,
+  describeFinspan,
+  emptyInput,
+  scoreFinspan,
+  validateFinspan,
+  type FinspanInput,
+} from './logic';
+
+/**
+ * Finspan — a faithful end-game category scorer for Stonemaier's fish-themed
+ * Wingspan-family game (2025). One final scoresheet per game: a column per scoring
+ * category, summed to a total, highest wins. All scoring lives in the Svelte-free
+ * `logic.ts`; this module just wires it into the `GameModule` contract.
+ */
+export const finspan: GameModule = {
+  id: 'finspan',
+  name: 'Finspan',
+  tagline: 'Tally your ocean — biggest catch wins.',
+  emoji: '🐟',
+  keywords: ['fish', 'ocean', 'sea', 'wingspan', 'stonemaier', 'category', 'end game', 'scoresheet'],
+  minPlayers: 1,
+  maxPlayers: 5,
+
+  // A single final scoresheet — one round, then the game is complete.
+  maxRounds: () => 1,
+
+  createRoundInput: (ctx: RoundContext): FinspanInput => emptyInput(ctx.players),
+
+  validateRound: (input: FinspanInput, ctx: RoundContext): string | null =>
+    validateFinspan(input, ctx.players),
+
+  scoreRound: (input: FinspanInput, ctx: RoundContext): Record<ID, number> =>
+    scoreFinspan(input, ctx.players),
+
+  describeRound: (round: Round, players): string => describeFinspan(round, players),
+
+  help: FINSPAN_HELP,
+
+  stats: finspanStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/finspan/logic.ts
+++ b/src/lib/games/finspan/logic.ts
@@ -1,0 +1,201 @@
+import type { ID, Player, Round } from '../../types';
+
+/**
+ * Finspan — the fish-themed end-game category scorer.
+ * ---------------------------------------------------
+ * Finspan (Stonemaier Games, 2025) is played over four "weeks" in the Sunlight,
+ * Twilight and Midnight zones of the ocean; at the end there is one final scoresheet
+ * that totals each researcher's ocean, and the highest total wins. This module is the
+ * pure, Svelte-free scoring core — a column per end-game category, summed to a total —
+ * so `finspan.test.ts` can exercise the real math without importing the editor.
+ *
+ * Categories and point values follow the official end-of-game sequence verbatim:
+ *   1. Weeks 1-3 achievements — points banked on the scorepad during play.
+ *   2. Game End (yellow) fish abilities.
+ *   3. Fish        — points printed on your visible (uncovered) fish.
+ *   4. Consumed    — 1 point per consumed fish (cards and forage).
+ *   5. Eggs & young — 1 point for each egg and each young.
+ *   6. Schools     — 6 points each.
+ * There are no personal bonus cards and no depth-zone point multipliers.
+ */
+
+/** How a category value is entered on the sheet. */
+export type FinspanEntry = 'points' | 'count';
+
+export interface FinspanCategory {
+  /** Stable key stored on the round input. */
+  key: string;
+  /** Short scorepad label. */
+  label: string;
+  emoji: string;
+  /** Points awarded per unit entered — 6 for schools, otherwise 1. */
+  per: number;
+  /**
+   * `points` — the entered value already *is* points (fish, abilities, achievements).
+   * `count`  — the value is a token/card count the sheet multiplies by {@link per}.
+   */
+  entry: FinspanEntry;
+  /** One-line scoring reference, shown in the editor and the help popover. */
+  hint: string;
+}
+
+/** The Finspan scoresheet columns, in official end-of-game order. */
+export const FINSPAN_CATEGORIES: readonly FinspanCategory[] = [
+  {
+    key: 'week1',
+    label: 'Week 1',
+    emoji: '🏅',
+    per: 1,
+    entry: 'points',
+    hint: 'Achievement points you banked at the end of week 1.',
+  },
+  {
+    key: 'week2',
+    label: 'Week 2',
+    emoji: '🏅',
+    per: 1,
+    entry: 'points',
+    hint: 'Achievement points you banked at the end of week 2.',
+  },
+  {
+    key: 'week3',
+    label: 'Week 3',
+    emoji: '🏅',
+    per: 1,
+    entry: 'points',
+    hint: 'Achievement points you banked at the end of week 3.',
+  },
+  {
+    key: 'gameEnd',
+    label: 'Game end',
+    emoji: '🟡',
+    per: 1,
+    entry: 'points',
+    hint: 'Points from yellow "GAME END" fish abilities (visible fish only).',
+  },
+  {
+    key: 'fish',
+    label: 'Fish',
+    emoji: '🐟',
+    per: 1,
+    entry: 'points',
+    hint: 'Points printed on your visible (uncovered) fish.',
+  },
+  {
+    key: 'consumed',
+    label: 'Consumed',
+    emoji: '🍽️',
+    per: 1,
+    entry: 'count',
+    hint: '1 point for each consumed fish — cards and forage.',
+  },
+  {
+    key: 'eggsYoung',
+    label: 'Eggs & young',
+    emoji: '🥚',
+    per: 1,
+    entry: 'count',
+    hint: '1 point for each egg and each young in your ocean.',
+  },
+  {
+    key: 'schools',
+    label: 'Schools',
+    emoji: '🐠',
+    per: 6,
+    entry: 'count',
+    hint: '6 points for each school — three young shoal into one school.',
+  },
+] as const;
+
+/** Per-player row: category key -> raw value entered on the sheet. */
+export type FinspanRow = Record<string, number>;
+
+export interface FinspanInput {
+  /** player id -> their scoresheet row. */
+  values: Record<ID, FinspanRow>;
+}
+
+/** A fresh, all-zero row covering every category. */
+export function emptyRow(): FinspanRow {
+  const row: FinspanRow = {};
+  for (const c of FINSPAN_CATEGORIES) row[c.key] = 0;
+  return row;
+}
+
+/** A fresh scoresheet for the given players. */
+export function emptyInput(players: Player[]): FinspanInput {
+  return { values: Object.fromEntries(players.map((p) => [p.id, emptyRow()])) };
+}
+
+/** Coerce any stored value to a finite number (0 when blank / NaN). */
+function num(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Points a single category contributes for a raw entered value. */
+export function categoryPoints(cat: FinspanCategory, value: unknown): number {
+  return num(value) * cat.per;
+}
+
+/** Total points for one player's row across every category. */
+export function scoreRow(row: FinspanRow | undefined): number {
+  let sum = 0;
+  for (const c of FINSPAN_CATEGORIES) sum += categoryPoints(c, row?.[c.key]);
+  return sum;
+}
+
+/** Per-player point totals for the whole scoresheet. */
+export function scoreFinspan(
+  input: FinspanInput | undefined,
+  players: Player[],
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const p of players) out[p.id] = scoreRow(input?.values?.[p.id]);
+  return out;
+}
+
+/** Validate the sheet: every entry a whole, non-negative number. Null when valid. */
+export function validateFinspan(
+  input: FinspanInput | undefined,
+  players: Player[],
+): string | null {
+  if (!input?.values) return null;
+  for (const p of players) {
+    const row = input.values[p.id];
+    if (!row) continue;
+    for (const c of FINSPAN_CATEGORIES) {
+      const n = Number(row[c.key]);
+      if (!Number.isFinite(n)) continue; // blank -> treated as 0, like scoreRow
+      if (n < 0) return `${p.name}: ${c.label} can't be negative.`;
+      if (!Number.isInteger(n)) return `${p.name}: ${c.label} must be a whole number.`;
+    }
+  }
+  return null;
+}
+
+/** A concise per-player summary of the recorded scoresheet for the history table. */
+export function describeFinspan(round: Round, players: Player[]): string {
+  const input = round.input as FinspanInput | undefined;
+  if (!input?.values) return '';
+  const parts: string[] = [];
+  for (const p of players) {
+    if (input.values[p.id]) parts.push(`${p.name} ${scoreRow(input.values[p.id])}`);
+  }
+  return parts.length ? parts.join(' · ') : 'no score';
+}
+
+/** Reference text for the in-game help popover — scoring only, fishy in voice. */
+export const FINSPAN_HELP = [
+  'Total your ocean after week 4 — the biggest catch wins. 🐟',
+  '',
+  'Weeks 1-3 🏅: the achievement points you banked at the end of each week.',
+  'Game end 🟡: points from yellow "GAME END" fish abilities.',
+  'Fish 🐟: points printed on your visible (uncovered) fish.',
+  'Consumed 🍽️: 1 point per consumed fish (cards and forage).',
+  'Eggs & young 🥚: 1 point for each egg and each young.',
+  'Schools 🐠: 6 points each (three young shoal into one school).',
+  '',
+  'No bonus cards, no depth bonuses — just a deep, well-fed ocean.',
+  'Tie? The tied player holding the most fish cards wins.',
+].join('\n');

--- a/src/lib/games/finspan/stats.ts
+++ b/src/lib/games/finspan/stats.ts
@@ -1,0 +1,84 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt } from '../../stats/format';
+import { scoreRow, type FinspanInput } from './logic';
+
+interface FSAgg {
+  games: number;
+  sum: number;
+  best: number;
+  schools: number;
+  eggsYoung: number;
+}
+
+/**
+ * Finspan stats, derived purely from each game's single final scoresheet. A Finspan
+ * game is one round (the scoresheet), so every recorded round is a full game total.
+ * Pure — no Svelte — so it is independently unit-testable and safe for the engine.
+ */
+export function finspanStats({ games, rounds, players, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const nameById = new Map(players.map((p) => [p.id, p.name]));
+  const per = new Map<ID, FSAgg>();
+  const get = (id: ID): FSAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { games: 0, sum: 0, best: 0, schools: 0, eggsYoung: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let topScore = 0;
+  let topHolder: ID | undefined;
+  let winSum = 0;
+  let winGames = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as FinspanInput | undefined;
+    if (!input?.values) continue;
+    let gameBest = -Infinity;
+    for (const [pid, row] of Object.entries(input.values)) {
+      const id = canonical(pid);
+      const a = get(id);
+      const total = scoreRow(row);
+      a.games += 1;
+      a.sum += total;
+      if (total > a.best) a.best = total;
+      a.schools += Number(row?.schools) || 0;
+      a.eggsYoung += Number(row?.eggsYoung) || 0;
+      if (total > topScore) {
+        topScore = total;
+        topHolder = id;
+      }
+      if (total > gameBest) gameBest = total;
+    }
+    if (gameBest > -Infinity) {
+      winSum += gameBest;
+      winGames += 1;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    if (!a.games) continue;
+    const metrics: Metric[] = [
+      { key: 'fs_avg', label: 'Avg ocean', value: fmtInt(a.sum / a.games), emoji: '🐟' },
+      { key: 'fs_best', label: 'Best ocean', value: fmtInt(a.best), emoji: '⭐' },
+    ];
+    if (a.schools) {
+      metrics.push({ key: 'fs_schools', label: 'Schools formed', value: fmtInt(a.schools), emoji: '🐠' });
+    }
+    perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (winGames) {
+    global.push({ key: 'fs_avgwin', label: 'Avg winning ocean', value: fmtInt(winSum / winGames), emoji: '🏅' });
+  }
+  if (topHolder) {
+    global.push({ key: 'fs_top', label: 'Deepest ocean', value: fmtInt(topScore), sub: nameById.get(topHolder), emoji: '🐟' });
+  }
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## 🐟 Finspan

Adds **Finspan** (Stonemaier Games, 2025) — the fish-themed game in the Wingspan family — as a first-class game module. Finspan is an end-game **category scorer**: each game is a single final scoresheet with **one column per scoring category per player, summed to a total, highest wins**.

### Scoring categories (official end-of-game sequence)
Entered on the scoresheet in rulebook order:

| Category | Value | Entered as |
|---|---|---|
| 🏅 Week 1 / Week 2 / Week 3 achievements | points banked each week | points |
| 🟡 Game end (yellow) fish abilities | printed | points |
| 🐟 Fish | points printed on visible fish | points |
| 🍽️ Consumed fish (cards + forage) | **1 each** | count |
| 🥚 Eggs & young | **1 each** | count |
| 🐠 Schools | **6 each** | count → ×6 |

Token categories are entered as **counts** and the sheet does the math (schools ×6), so the bookkeeping disappears — you count what's in front of you and read the total. There are **no personal bonus cards** and **no depth-zone point multipliers** in Finspan (a key difference from Wingspan). Tie-break is a copy note (most fish cards in hand). Winner = highest total.

### How it's built
Purely additive — only `src/lib/games/finspan/`. The registry **auto-discovers** it; no shared files were touched.

- **`logic.ts`** — pure, Svelte-free category summation + validation (the scoring core).
- **`index.ts`** — `export const finspan: GameModule` (`id: 'finspan'`, 1–5 players, `maxRounds: () => 1` = one final scoresheet).
- **`FinspanEditor.svelte`** — per-player category grid reusing `Avatar` + `Stepper`, with a live per-player total; point columns use numeric inputs, count columns use steppers, and schools show their `×6` contribution.
- **`stats.ts`** — Finspan-specific stats (avg/best ocean, schools formed, deepest ocean).
- **`finspan.test.ts`** — thorough tests over `logic.ts`, including the **official rulebook worked example** (3 + 46 + 4 + 8 + 18 = **79**).

### Design (PRODUCT.md / DESIGN.md)
Chrome is untouched — personality is emoji + copy only (fishy voice: "biggest catch", "shoal", "well-fed ocean"). No new Royal Violet action (the shell owns the primary "Save round"); **no Crown Gold** in the editor (the Scoreboard owns leader/winner gold). Changing numbers use `tabular-nums`; steppers/inputs are ≥46px; depth comes from the surface ramp (`--surface-2`), not stacked shadows; no motion added (respects reduced-motion); state is never color-alone (number + `pts` + emoji labels).

### Research sources
Categories and values verified against the **official Dized digital rulebook** (Stonemaier-authorized), cross-checked with a rulebook-verified summary and multiple independent reviews:
- Dized — end of game: `https://rules.dized.com/game/Gsh82VYHTjGN0sQazNGGjg/UlPUcAH1RJC22ZFTSL9pWQ/end-of-game-1`
- Dized — end of week (achievements): `https://rules.dized.com/game/Gsh82VYHTjGN0sQazNGGjg/R50gYoenSdK9qxemwxIGXQ/end-of-week-1`
- Dized — intro (zone names): `https://rules.dized.com/game/Gsh82VYHTjGN0sQazNGGjg/finspan`
- lehi-innovation rules summary (rulebook-verified), plus GamingTrend / WhatBoardGame / Tabletopping reviews.

One source conflict (schools 3 vs 6 pts) was adjudicated to **6** via the Dized worked example (18 = 3 × 6).

### Verification
- `npm run check` — 0 errors
- `npm test` — 103 passed (8 files; new Finspan suite + registry auto-discovery)
- `npm run build` — success

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
