### PR TITLE
Add Blood on the Clocktower storyteller tracker

### DIFF
--- a/src/lib/games/botc/BotcEditor.svelte
+++ b/src/lib/games/botc/BotcEditor.svelte
@@ -1,0 +1,504 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { botc } from './index';
+  import type { BotcInput, Nomination, Team } from './logic';
+  import {
+    aliveCount,
+    phaseEmoji,
+    phaseKind,
+    phaseLabel,
+    roleTeam,
+    rolesFor,
+    teamCount,
+    voteThreshold,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: BotcInput; ctx: RoundContext } = $props();
+
+  const script = $derived(String(ctx.config.script ?? 'tb'));
+  const roleList = $derived(rolesFor(script));
+  const kind = $derived(phaseKind(ctx.roundIndex));
+  const label = $derived(phaseLabel(ctx.roundIndex));
+  const emoji = $derived(phaseEmoji(ctx.roundIndex));
+  const alive = $derived(aliveCount(input.states));
+  const threshold = $derived(voteThreshold(alive));
+  const goodN = $derived(teamCount(input.states, 'good'));
+  const evilN = $derived(teamCount(input.states, 'evil'));
+
+  let showGuide = $state(false);
+
+  const nameOf = (id: string | null): string =>
+    ctx.players.find((p) => p.id === id)?.name ?? '—';
+
+  function toggleAlive(id: string) {
+    const st = input.states[id];
+    st.alive = !st.alive;
+    if (st.alive) st.ghostUsed = false;
+  }
+  function setTeam(id: string, team: Team) {
+    input.states[id].team = team;
+  }
+  function onRole(id: string, value: string) {
+    const st = input.states[id];
+    st.role = value;
+    const t = roleTeam(value, script);
+    if (t) st.team = t;
+  }
+  function toggleGhost(id: string) {
+    input.states[id].ghostUsed = !input.states[id].ghostUsed;
+  }
+
+  function addNomination() {
+    const nom: Nomination = { nominatorId: null, nomineeId: null, votes: 0, executed: false };
+    input.nominations = [...input.nominations, nom];
+  }
+  function removeNomination(target: Nomination) {
+    input.nominations = input.nominations.filter((n) => n !== target);
+  }
+  function setResult(team: Team) {
+    input.result = input.result === team ? null : team;
+  }
+</script>
+
+<datalist id="botc-roles">
+  {#each roleList as r (r.name)}
+    <option value={r.name}></option>
+  {/each}
+</datalist>
+
+<div class="stack">
+  <!-- Phase header -->
+  <div class="phase">
+    <span class="phase-name">{emoji} {label}</span>
+    <span class="row" style="gap: 6px">
+      <span class="pill">🌿 {alive} alive</span>
+      <span class="pill">😇 {goodN} · 😈 {evilN}</span>
+      <button type="button" class="btn small ghost" onclick={() => (showGuide = !showGuide)}>
+        {showGuide ? 'Hide' : 'Guide'}
+      </button>
+    </span>
+  </div>
+
+  {#if showGuide}
+    <pre class="help">{botc.help}</pre>
+  {/if}
+
+  <p class="hint">
+    {#if kind === 'night'}
+      🌙 Resolve the night in secret, then tap a player to mark who died.
+    {:else}
+      ☀️ Town talks, nominates, and votes — log the block below.
+    {/if}
+  </p>
+
+  <!-- Roster -->
+  {#each ctx.players as p (p.id)}
+    {@const st = input.states[p.id]}
+    {#if st}
+      <div class="prow" class:dead={!st.alive}>
+        <div class="row spread">
+          <span class="who">
+            <Avatar name={p.name} color={p.color} size={28} />
+            <strong class="nm">{p.name}</strong>
+          </span>
+          <button
+            type="button"
+            class="life"
+            class:isdead={!st.alive}
+            aria-pressed={!st.alive}
+            onclick={() => toggleAlive(p.id)}
+          >
+            {st.alive ? '🌿 Alive' : '💀 Dead'}
+          </button>
+        </div>
+
+        <div class="controls">
+          <input
+            class="role"
+            type="text"
+            list="botc-roles"
+            placeholder="Character…"
+            aria-label={`${p.name}'s character`}
+            value={st.role}
+            oninput={(e) => onRole(p.id, e.currentTarget.value)}
+          />
+          <div class="team" role="group" aria-label={`${p.name}'s team`}>
+            <button type="button" class:on={st.team === 'good'} onclick={() => setTeam(p.id, 'good')}>
+              😇 Good
+            </button>
+            <button type="button" class:on={st.team === 'evil'} onclick={() => setTeam(p.id, 'evil')}>
+              😈 Evil
+            </button>
+          </div>
+        </div>
+
+        {#if !st.alive}
+          <button
+            type="button"
+            class="ghostvote"
+            class:used={st.ghostUsed}
+            aria-pressed={st.ghostUsed}
+            onclick={() => toggleGhost(p.id)}
+          >
+            🗳️ Ghost vote {st.ghostUsed ? 'used' : 'available'}
+          </button>
+        {/if}
+      </div>
+    {/if}
+  {/each}
+
+  <!-- Day: nominations & votes -->
+  {#if kind === 'day'}
+    <div class="noms">
+      <div class="row spread">
+        <span class="section-lbl">Nominations &amp; votes</span>
+        <span class="pill">Majority: {threshold}</span>
+      </div>
+
+      {#each input.nominations as nom (nom)}
+        {@const reaches = (Number(nom.votes) || 0) >= threshold}
+        <div class="nom" class:executed={nom.executed}>
+          <div class="nom-line">
+            <select bind:value={nom.nomineeId} aria-label="Nominated player">
+              <option value={null}>— on the block —</option>
+              {#each ctx.players as p (p.id)}
+                <option value={p.id}>{p.name}</option>
+              {/each}
+            </select>
+            <button
+              type="button"
+              class="rm"
+              aria-label="Remove nomination"
+              title="Remove"
+              onclick={() => removeNomination(nom)}
+            >✕</button>
+          </div>
+          <div class="nom-line by">
+            <span class="by-lbl">by</span>
+            <select bind:value={nom.nominatorId} aria-label="Nominating player">
+              <option value={null}>— nominator (optional) —</option>
+              {#each ctx.players as p (p.id)}
+                <option value={p.id}>{p.name}</option>
+              {/each}
+            </select>
+          </div>
+          <div class="row spread nom-tally">
+            <span class="votes-lbl">
+              Votes
+              <span class="reach" class:hit={reaches}>{reaches ? '· reaches majority' : `· needs ${threshold}`}</span>
+            </span>
+            <span class="row" style="gap: 10px">
+              <Stepper bind:value={nom.votes} min={0} max={ctx.players.length} />
+              <button
+                type="button"
+                class="exec"
+                class:on={nom.executed}
+                aria-pressed={nom.executed}
+                onclick={() => (nom.executed = !nom.executed)}
+              >⚖️ Executed</button>
+            </span>
+          </div>
+        </div>
+      {/each}
+
+      <button type="button" class="btn block ghost add" onclick={addNomination}>
+        ＋ Add nomination
+      </button>
+    </div>
+  {/if}
+
+  <!-- Result recorder -->
+  <div class="result">
+    <span class="section-lbl">End the game</span>
+    <div class="result-btns">
+      <button type="button" class="res good" class:on={input.result === 'good'} aria-pressed={input.result === 'good'} onclick={() => setResult('good')}>
+        😇 Good wins
+      </button>
+      <button type="button" class="res evil" class:on={input.result === 'evil'} aria-pressed={input.result === 'evil'} onclick={() => setResult('evil')}>
+        😈 Evil wins
+      </button>
+    </div>
+    {#if input.result}
+      <p class="recorded">
+        🏁 {input.result === 'good' ? 'Good' : 'Evil'} recorded — Save round, then <strong>Finish &amp; record winner</strong>.
+      </p>
+    {/if}
+  </div>
+
+  <input
+    class="note"
+    type="text"
+    placeholder="Storyteller note (optional)…"
+    aria-label="Storyteller note"
+    bind:value={input.note}
+  />
+</div>
+
+<style>
+  .phase {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .phase-name {
+    font-weight: 800;
+    font-size: 1.05rem;
+  }
+  .hint {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .prow.dead {
+    background: var(--surface);
+  }
+  .who {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .nm {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .prow.dead .nm {
+    color: var(--muted);
+  }
+
+  .life {
+    flex: none;
+    min-height: 40px;
+    padding: 0 14px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface-3);
+    color: var(--text);
+    font-weight: 700;
+    cursor: pointer;
+  }
+  .life.isdead {
+    background: var(--surface-2);
+    color: var(--muted);
+    border-style: dashed;
+  }
+
+  .controls {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .role {
+    flex: 1 1 150px;
+    min-width: 120px;
+  }
+  .team {
+    display: inline-flex;
+    gap: 4px;
+    padding: 4px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
+  .team button {
+    min-height: 38px;
+    padding: 0 12px;
+    border: 0;
+    border-radius: 7px;
+    background: transparent;
+    color: var(--muted);
+    font-weight: 700;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .team button.on {
+    background: var(--surface-3);
+    color: var(--text);
+  }
+
+  .ghostvote {
+    align-self: flex-start;
+    min-height: 38px;
+    padding: 0 12px;
+    border: 1px dashed var(--border);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--muted);
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .ghostvote.used {
+    border-style: solid;
+    color: var(--text);
+    background: var(--surface-2);
+  }
+
+  .section-lbl {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    font-weight: 600;
+  }
+
+  .noms,
+  .result {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-top: 4px;
+    border-top: 1px solid var(--border);
+  }
+  .nom {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .nom.executed {
+    border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+    background: color-mix(in srgb, var(--accent) 8%, var(--surface-2));
+  }
+  .nom-line {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+  .nom-line.by {
+    gap: 6px;
+  }
+  .by-lbl {
+    color: var(--muted);
+    font-size: 0.8rem;
+    flex: none;
+  }
+  .rm {
+    flex: none;
+    width: 42px;
+    height: 42px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--muted);
+    cursor: pointer;
+    font-weight: 700;
+  }
+  .nom-tally {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .votes-lbl {
+    color: var(--muted);
+    font-size: 0.8rem;
+  }
+  .reach {
+    font-weight: 700;
+  }
+  .reach.hit {
+    color: var(--text);
+  }
+  .exec {
+    min-height: 46px;
+    padding: 0 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--muted);
+    font-weight: 700;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .exec.on {
+    background: var(--surface-3);
+    color: var(--text);
+    border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  }
+  .add {
+    color: var(--muted);
+  }
+
+  .result-btns {
+    display: flex;
+    gap: 8px;
+  }
+  .res {
+    flex: 1 1 0;
+    min-height: 46px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    color: var(--text);
+    font-weight: 700;
+    cursor: pointer;
+  }
+  .res.on {
+    background: var(--surface-3);
+    border-color: var(--text);
+    box-shadow: inset 0 0 0 1px var(--text);
+  }
+  .recorded {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  .note {
+    font-size: 0.9rem;
+  }
+
+  .life:focus-visible,
+  .team button:focus-visible,
+  .ghostvote:focus-visible,
+  .rm:focus-visible,
+  .exec:focus-visible,
+  .res:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+
+  .life,
+  .team button,
+  .ghostvote,
+  .exec,
+  .res {
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .life,
+    .team button,
+    .ghostvote,
+    .exec,
+    .res {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/games/botc/botc.test.ts
+++ b/src/lib/games/botc/botc.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round, RoundContext } from '../../types';
+import {
+  aliveCount,
+  aliveTeamCount,
+  carryRoster,
+  describe as describePhase,
+  initialRoster,
+  isResolved,
+  phaseEmoji,
+  phaseKind,
+  phaseLabel,
+  phaseNumber,
+  pickWinners,
+  roleTeam,
+  rolesFor,
+  scoreRound,
+  scriptRef,
+  teamCount,
+  teamOfType,
+  validate,
+  voteThreshold,
+  type BotcInput,
+  type PlayerState,
+} from './logic';
+import { botc } from './index';
+import { botcStats } from './stats';
+
+const player = (id: string, name = id): Player => ({ id, name, color: '#7c5cff', createdAt: 0 });
+
+function state(partial: Partial<PlayerState> = {}): PlayerState {
+  return { role: '', team: 'good', alive: true, ghostUsed: false, ...partial };
+}
+
+function input(partial: Partial<BotcInput> = {}): BotcInput {
+  return { states: {}, nominations: [], result: null, note: '', ...partial };
+}
+
+function ctxFor(
+  playerIds: string[],
+  opts: { roundIndex?: number; config?: Record<string, unknown>; rounds?: Round[] } = {},
+): RoundContext {
+  const config = opts.config ?? { script: 'tb' };
+  return {
+    game: {
+      id: 'g',
+      type: 'botc',
+      config,
+      playerIds,
+      status: 'active',
+      createdAt: 0,
+      roundCount: 0,
+    } as Game,
+    players: playerIds.map((id) => player(id)),
+    config,
+    roundIndex: opts.roundIndex ?? 0,
+    totals: Object.fromEntries(playerIds.map((id) => [id, 0])),
+    rounds: opts.rounds ?? [],
+  };
+}
+
+function mkRound(index: number, inp: BotcInput, playerIds: string[]): Round {
+  return { id: `g-r${index}`, gameId: 'g', index, input: inp, deltas: scoreRound(inp, playerIds), createdAt: 0 };
+}
+
+// ── Phase math ──────────────────────────────────────────────────────────────
+
+describe('phase math — alternates night → day from the first night', () => {
+  it('reads kind straight from the round index', () => {
+    expect(phaseKind(0)).toBe('night');
+    expect(phaseKind(1)).toBe('day');
+    expect(phaseKind(2)).toBe('night');
+    expect(phaseKind(3)).toBe('day');
+  });
+
+  it('numbers each night/day pair', () => {
+    expect(phaseNumber(0)).toBe(1);
+    expect(phaseNumber(1)).toBe(1);
+    expect(phaseNumber(2)).toBe(2);
+    expect(phaseNumber(3)).toBe(2);
+  });
+
+  it('labels and emojis the phase', () => {
+    expect(phaseLabel(0)).toBe('Night 1');
+    expect(phaseLabel(1)).toBe('Day 1');
+    expect(phaseLabel(4)).toBe('Night 3');
+    expect(phaseEmoji(0)).toBe('🌙');
+    expect(phaseEmoji(1)).toBe('☀️');
+  });
+});
+
+// ── Roster ────────────────────────────────────────────────────────────────
+
+describe('initialRoster — everyone alive, unassigned, presumed good', () => {
+  it('seats every player fresh', () => {
+    const r = initialRoster(['A', 'B']);
+    expect(Object.keys(r).sort()).toEqual(['A', 'B']);
+    expect(r.A).toEqual(state());
+  });
+});
+
+describe('carryRoster — persists role/team/alive/ghost between phases', () => {
+  it('carries each seat forward', () => {
+    const prev = { A: state({ role: 'Imp', team: 'evil', alive: false, ghostUsed: true }), B: state() };
+    const next = carryRoster(prev, ['A', 'B']);
+    expect(next.A).toEqual({ role: 'Imp', team: 'evil', alive: false, ghostUsed: true });
+    expect(next.B).toEqual(state());
+  });
+
+  it('seats a brand-new player fresh (defensive)', () => {
+    const next = carryRoster({ A: state({ team: 'evil' }) }, ['A', 'C']);
+    expect(next.C).toEqual(state());
+  });
+
+  it('clones so editing the next phase never mutates the previous one', () => {
+    const prev = { A: state({ role: 'Chef' }) };
+    const next = carryRoster(prev, ['A']);
+    next.A.role = 'Imp';
+    next.A.alive = false;
+    expect(prev.A.role).toBe('Chef');
+    expect(prev.A.alive).toBe(true);
+  });
+
+  it('starts empty when there is no previous roster', () => {
+    expect(carryRoster(undefined, ['A'])).toEqual({ A: state() });
+  });
+});
+
+describe('counts & the vote threshold', () => {
+  const states = {
+    A: state({ alive: true, team: 'good' }),
+    B: state({ alive: false, team: 'good' }),
+    C: state({ alive: true, team: 'evil' }),
+  };
+
+  it('counts the living', () => {
+    expect(aliveCount(states)).toBe(2);
+  });
+
+  it('counts by team and living-by-team', () => {
+    expect(teamCount(states, 'good')).toBe(2);
+    expect(teamCount(states, 'evil')).toBe(1);
+    expect(aliveTeamCount(states, 'good')).toBe(1);
+    expect(aliveTeamCount(states, 'evil')).toBe(1);
+  });
+
+  it('needs a majority of the living to reach the block', () => {
+    expect(voteThreshold(5)).toBe(3);
+    expect(voteThreshold(6)).toBe(3);
+    expect(voteThreshold(1)).toBe(1);
+    expect(voteThreshold(0)).toBe(0);
+  });
+});
+
+// ── Scoring / winners ───────────────────────────────────────────────────────
+
+describe('scoreRound — scoreless until a winner is recorded', () => {
+  const states = { A: state({ team: 'good' }), B: state({ team: 'evil' }), C: state({ team: 'evil' }) };
+
+  it('scores every seat 0 while tracking', () => {
+    expect(scoreRound(input({ states }), ['A', 'B', 'C'])).toEqual({ A: 0, B: 0, C: 0 });
+  });
+
+  it('awards +1 to the whole winning team on the resolving phase', () => {
+    expect(scoreRound(input({ states, result: 'evil' }), ['A', 'B', 'C'])).toEqual({ A: 0, B: 1, C: 1 });
+    expect(scoreRound(input({ states, result: 'good' }), ['A', 'B', 'C'])).toEqual({ A: 1, B: 0, C: 0 });
+  });
+
+  it('keys every seat, even one missing from the roster snapshot', () => {
+    const out = scoreRound(input({ states: { A: state({ team: 'evil' }) }, result: 'evil' }), ['A', 'B']);
+    expect(out).toEqual({ A: 1, B: 0 });
+  });
+});
+
+describe('pickWinners — the winning team shares the top total', () => {
+  it('returns everyone tied at the top once a winner exists', () => {
+    expect(pickWinners({ A: 0, B: 1, C: 1 }).sort()).toEqual(['B', 'C']);
+    expect(pickWinners({ A: 1, B: 0 })).toEqual(['A']);
+  });
+
+  it('crowns nobody before a result is recorded', () => {
+    expect(pickWinners({ A: 0, B: 0 })).toEqual([]);
+    expect(pickWinners({})).toEqual([]);
+  });
+});
+
+describe('isResolved — a result exists once any total crosses zero', () => {
+  it('is false while scoreless and true after a win', () => {
+    expect(isResolved({ A: 0, B: 0 })).toBe(false);
+    expect(isResolved({ A: 0, B: 1 })).toBe(true);
+  });
+});
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+describe('validate — light guardrails for a tracker', () => {
+  it('accepts an ordinary tracking phase', () => {
+    expect(validate(input({ states: { A: state() } }), ['A'])).toBeNull();
+  });
+
+  it('nudges an empty nomination', () => {
+    const bad = input({ nominations: [{ nominatorId: 'A', nomineeId: null, votes: 0, executed: false }] });
+    expect(validate(bad, ['A'])).toMatch(/who was nominated/i);
+  });
+
+  it('rejects negative votes', () => {
+    const bad = input({ nominations: [{ nominatorId: null, nomineeId: 'A', votes: -1, executed: false }] });
+    expect(validate(bad, ['A'])).toMatch(/negative/i);
+  });
+
+  it('refuses to record a win for a team nobody is on', () => {
+    const states = { A: state({ team: 'good' }), B: state({ team: 'good' }) };
+    expect(validate(input({ states, result: 'evil' }), ['A', 'B'])).toMatch(/Evil team/i);
+    expect(validate(input({ states, result: 'good' }), ['A', 'B'])).toBeNull();
+  });
+});
+
+// ── Describe ────────────────────────────────────────────────────────────────
+
+describe('describe — a glanceable one-line phase summary', () => {
+  const nameOf = (id: ID) => ({ A: 'Ana', B: 'Bo', C: 'Cy' })[id] ?? '?';
+
+  it('summarises a night by the living count', () => {
+    const inp = input({ states: { A: state(), B: state({ alive: false }) } });
+    expect(describePhase(inp, 2, nameOf)).toBe('🌙 Night 2 · 1 alive');
+  });
+
+  it('names the executed player on a day', () => {
+    const inp = input({ nominations: [{ nominatorId: 'A', nomineeId: 'B', votes: 4, executed: true }] });
+    expect(describePhase(inp, 1, nameOf)).toBe('☀️ Day 1 · Bo executed');
+  });
+
+  it('reports nominations with no execution', () => {
+    const inp = input({ nominations: [{ nominatorId: 'A', nomineeId: 'B', votes: 1, executed: false }] });
+    expect(describePhase(inp, 1, nameOf)).toBe('☀️ Day 1 · 1 nomination, no execution');
+  });
+
+  it('reports a quiet day', () => {
+    expect(describePhase(input(), 3, nameOf)).toBe('☀️ Day 2 · no nominations');
+  });
+
+  it('always leads with the winner once recorded', () => {
+    expect(describePhase(input({ result: 'evil' }), 2, nameOf)).toBe('🏁 Night 2 · Evil wins');
+  });
+});
+
+// ── Script / role reference ─────────────────────────────────────────────────
+
+describe('script & role reference (data only)', () => {
+  it('maps role types to teams', () => {
+    expect(teamOfType('townsfolk')).toBe('good');
+    expect(teamOfType('outsider')).toBe('good');
+    expect(teamOfType('minion')).toBe('evil');
+    expect(teamOfType('demon')).toBe('evil');
+  });
+
+  it('exposes each edition’s character list', () => {
+    expect(rolesFor('tb').some((r) => r.name === 'Imp' && r.type === 'demon')).toBe(true);
+    expect(rolesFor('snv').some((r) => r.name === 'Vortox')).toBe(true);
+    expect(rolesFor('custom')).toEqual([]);
+  });
+
+  it('infers a known role’s team case-insensitively, else null', () => {
+    expect(roleTeam('imp', 'tb')).toBe('evil');
+    expect(roleTeam('Washerwoman', 'tb')).toBe('good');
+    expect(roleTeam('Poisoner', 'tb')).toBe('evil');
+    expect(roleTeam('Not A Role', 'tb')).toBeNull();
+    expect(roleTeam('', 'tb')).toBeNull();
+  });
+
+  it('falls back to Trouble Brewing for an unknown script', () => {
+    expect(scriptRef('nope').value).toBe('tb');
+    expect(scriptRef(undefined).value).toBe('tb');
+  });
+});
+
+// ── Module wiring ───────────────────────────────────────────────────────────
+
+describe('botc module', () => {
+  it('has the folder id and a Storyteller-sized seat range', () => {
+    expect(botc.id).toBe('botc');
+    expect(botc.minPlayers).toBe(5);
+    expect(botc.maxPlayers).toBe(20);
+    expect(typeof botc.emoji).toBe('string');
+    expect(typeof botc.help).toBe('string');
+    expect(botc.maxRounds).toBeUndefined();
+  });
+
+  it('opens Night 1 with a fresh roster', () => {
+    const first = botc.createRoundInput(ctxFor(['A', 'B', 'C', 'D', 'E'])) as BotcInput;
+    expect(first.states).toEqual(initialRoster(['A', 'B', 'C', 'D', 'E']));
+    expect(first.nominations).toEqual([]);
+    expect(first.result).toBeNull();
+  });
+
+  it('carries the roster forward into later phases but resets phase events', () => {
+    const night1 = mkRound(
+      0,
+      input({ states: { A: state({ role: 'Imp', team: 'evil' }), B: state({ alive: false }) }, note: 'kept me busy' }),
+      ['A', 'B'],
+    );
+    const next = botc.createRoundInput(ctxFor(['A', 'B'], { roundIndex: 1, rounds: [night1] })) as BotcInput;
+    expect(next.states.A).toEqual({ role: 'Imp', team: 'evil', alive: true, ghostUsed: false });
+    expect(next.states.B.alive).toBe(false);
+    expect(next.nominations).toEqual([]);
+    expect(next.result).toBeNull();
+    expect(next.note).toBe('');
+  });
+
+  it('validates & scores a resolving phase through the context', () => {
+    const ctx = ctxFor(['A', 'B', 'C', 'D', 'E']);
+    const inp = input({
+      states: {
+        A: state({ team: 'evil' }),
+        B: state({ team: 'good' }),
+        C: state({ team: 'good' }),
+        D: state({ team: 'good' }),
+        E: state({ team: 'good' }),
+      },
+      result: 'evil',
+    });
+    expect(botc.validateRound(inp, ctx)).toBeNull();
+    expect(botc.scoreRound(inp, ctx)).toEqual({ A: 1, B: 0, C: 0, D: 0, E: 0 });
+  });
+
+  it('finishes only once a winner is recorded, then returns that team', () => {
+    const info = { config: {}, roundCount: 3, playerCount: 5 };
+    expect(botc.isFinished!({ A: 0, B: 0 }, info)).toBe(false);
+    expect(botc.isFinished!({ A: 1, B: 0 }, info)).toBe(true);
+    expect(botc.pickWinners!({ A: 1, B: 1, C: 0 }, {}).sort()).toEqual(['A', 'B']);
+  });
+
+  it('describes a recorded round for the history table', () => {
+    const players = [player('A', 'Ana'), player('B', 'Bo')];
+    const round = mkRound(1, input({ nominations: [{ nominatorId: 'A', nomineeId: 'B', votes: 3, executed: true }] }), ['A', 'B']);
+    expect(botc.describeRound!(round, players)).toBe('☀️ Day 1 · Bo executed');
+  });
+});
+
+// ── Stats ─────────────────────────────────────────────────────────────────
+
+describe('botcStats', () => {
+  const games: Game[] = [
+    { id: 'g', type: 'botc', config: {}, playerIds: ['A', 'B', 'C'], status: 'finished', createdAt: 0, roundCount: 3 } as Game,
+  ];
+  // Night 1, Day 1 (B executed), Night 2 → Evil wins. A evil & alive; B good & dead; C good & alive.
+  const rounds: Round[] = [
+    mkRound(0, input({ states: { A: state({ team: 'evil' }), B: state(), C: state() } }), ['A', 'B', 'C']),
+    mkRound(1, input({ states: { A: state({ team: 'evil' }), B: state({ alive: false }), C: state() }, nominations: [{ nominatorId: 'C', nomineeId: 'B', votes: 2, executed: true }] }), ['A', 'B', 'C']),
+    mkRound(2, input({ states: { A: state({ team: 'evil' }), B: state({ alive: false }), C: state() }, result: 'evil' }), ['A', 'B', 'C']),
+  ];
+  const out = botcStats({ games, rounds, players: [], canonical: (id: ID) => id });
+
+  it('counts Good vs Evil wins globally', () => {
+    expect(out.global?.find((m) => m.key === 'botc_split')?.value).toBe('0–1');
+  });
+
+  it('reports average game length in phases', () => {
+    expect(out.global?.find((m) => m.key === 'botc_len')?.value).toBe('3 phases');
+  });
+
+  it('counts games on the Evil team', () => {
+    expect(out.perPlayer?.['A']?.find((m) => m.key === 'botc_evil')?.value).toBe('1');
+    expect(out.perPlayer?.['C']?.some((m) => m.key === 'botc_evil')).toBeFalsy();
+  });
+
+  it('counts executions and survival', () => {
+    expect(out.perPlayer?.['B']?.find((m) => m.key === 'botc_exec')?.value).toBe('1');
+    expect(out.perPlayer?.['B']?.find((m) => m.key === 'botc_survive')?.value).toBe('0%');
+    expect(out.perPlayer?.['C']?.find((m) => m.key === 'botc_survive')?.value).toBe('100%');
+  });
+
+  it('maps merged players to their canonical id', () => {
+    const merged = botcStats({
+      games,
+      rounds: [
+        mkRound(1, input({ nominations: [{ nominatorId: 'A', nomineeId: 'B2', votes: 2, executed: true }], states: { A: state(), B2: state({ alive: false }), C: state() } }), ['A', 'B2', 'C']),
+      ],
+      players: [],
+      canonical: (id: ID) => (id === 'B2' ? 'B' : id),
+    });
+    expect(merged.perPlayer?.['B']?.find((m) => m.key === 'botc_exec')?.value).toBe('1');
+  });
+});

--- a/src/lib/games/botc/index.ts
+++ b/src/lib/games/botc/index.ts
@@ -1,0 +1,79 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './BotcEditor.svelte';
+import * as logic from './logic';
+import type { BotcInput } from './logic';
+import { botcStats } from './stats';
+
+export type { BotcInput } from './logic';
+
+const ids = (ctx: RoundContext): ID[] => ctx.players.map((p) => p.id);
+
+export const botc: GameModule = {
+  id: 'botc',
+  name: 'Blood on the Clocktower',
+  tagline: 'Storyteller tracker for the town’s day & night',
+  emoji: '🕒',
+  keywords: ['social deduction', 'clocktower', 'botc', 'werewolf', 'mafia', 'storyteller', 'town'],
+  minPlayers: 5,
+  maxPlayers: 20,
+
+  configFields: [
+    {
+      key: 'script',
+      label: 'Script / edition (role reference)',
+      type: 'select',
+      default: 'tb',
+      options: logic.SCRIPTS.map((s) => ({ value: s.value, label: s.label })),
+      help: 'Sets the character list used to autocomplete roles — it never limits what you can type.',
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): BotcInput => {
+    const prevRound = ctx.rounds[ctx.roundIndex - 1];
+    const prev = prevRound ? (prevRound.input as BotcInput).states : undefined;
+    const states =
+      ctx.roundIndex === 0
+        ? logic.initialRoster(ids(ctx))
+        : logic.carryRoster(prev, ids(ctx));
+    return { states, nominations: [], result: null, note: '' };
+  },
+
+  validateRound: (input: BotcInput, ctx: RoundContext): string | null =>
+    logic.validate(input, ids(ctx)),
+
+  scoreRound: (input: BotcInput, ctx: RoundContext): Record<ID, number> =>
+    logic.scoreRound(input, ids(ctx)),
+
+  isFinished: (totals) => logic.isResolved(totals),
+
+  pickWinners: (totals) => logic.pickWinners(totals),
+
+  describeRound: (round: Round, players): string => {
+    const nameOf = (id: ID) => players.find((p) => p.id === id)?.name ?? '?';
+    return logic.describe(round.input as BotcInput, round.index, nameOf);
+  },
+
+  help: [
+    'A Storyteller’s tracker for the town’s day & night ritual — you run the game,',
+    'this just keeps the roster, deaths, votes, and the winner glanceable.',
+    '',
+    'Each round is one phase, alternating 🌙 Night → ☀️ Day:',
+    '• Night: the Demon and others act in secret. Mark who died.',
+    '• Day: the town talks, nominates, and votes. A nominee with votes ≥ half the',
+    '  living can go to the block; the most-voted above that line is executed.',
+    '',
+    'Death & the ghost vote: a dead player stays in the game and keeps ONE ghost',
+    'vote for the rest of it — mark it used once they spend it.',
+    '',
+    'Winning (character abilities can bend these — your word is final):',
+    '• Good wins when the Demon dies.',
+    '• Evil wins when only two players are left alive, or Good can no longer win.',
+    '',
+    'When it’s over, tap Good or Evil to record the winning team, then',
+    'Finish & record winner.',
+  ].join('\n'),
+
+  stats: botcStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/botc/logic.ts
+++ b/src/lib/games/botc/logic.ts
@@ -1,0 +1,281 @@
+import type { ID } from '../../types';
+
+/**
+ * Blood on the Clocktower — a Storyteller TRACKER, not a rules engine. This file
+ * holds the pure, Svelte-free core: phase math, roster carry-forward, the vote
+ * threshold, a light role reference, and how a recorded winner maps onto the
+ * point-oriented {@link import('../../types').GameModule} contract.
+ *
+ * The scoreless game is fitted to the contract by treating a recorded result as
+ * a one-off point award: every player on the winning team gets +1 the phase the
+ * Storyteller declares a winner, so cumulative totals become 1 (winning team) /
+ * 0 (everyone else) and `pickWinners` can return the whole team from totals alone.
+ */
+
+export type Team = 'good' | 'evil';
+export type PhaseKind = 'night' | 'day';
+
+/** One player's live state, snapshotted per phase so each round stands alone. */
+export interface PlayerState {
+  /** Free-text character name (autocompleted from the script, never enforced). */
+  role: string;
+  team: Team;
+  alive: boolean;
+  /** A dead player spends their single ghost vote once — tracked, never enforced. */
+  ghostUsed: boolean;
+}
+
+/** A single day-phase nomination and its vote tally. */
+export interface Nomination {
+  nominatorId: ID | null;
+  nomineeId: ID | null;
+  votes: number;
+  executed: boolean;
+}
+
+/** The full editable payload recorded for one phase (night or day). */
+export interface BotcInput {
+  /** Roster snapshot for this phase, keyed by player id. */
+  states: Record<ID, PlayerState>;
+  /** Day-phase nominations/votes (empty on nights). */
+  nominations: Nomination[];
+  /** Set on the deciding phase to record which team won. */
+  result: Team | null;
+  /** Optional Storyteller note for the phase. */
+  note: string;
+}
+
+// ── Phase math ────────────────────────────────────────────────────────────
+// Rounds alternate, starting on the first night: index 0 = Night 1, 1 = Day 1,
+// 2 = Night 2, 3 = Day 2, … so a round's kind + number come straight from index.
+
+export function phaseKind(index: number): PhaseKind {
+  return index % 2 === 0 ? 'night' : 'day';
+}
+
+export function phaseNumber(index: number): number {
+  return Math.floor(index / 2) + 1;
+}
+
+export function phaseLabel(index: number): string {
+  return `${phaseKind(index) === 'night' ? 'Night' : 'Day'} ${phaseNumber(index)}`;
+}
+
+export function phaseEmoji(index: number): string {
+  return phaseKind(index) === 'night' ? '🌙' : '☀️';
+}
+
+// ── Roster ──────────────────────────────────────────────────────────────────
+
+export function freshState(): PlayerState {
+  return { role: '', team: 'good', alive: true, ghostUsed: false };
+}
+
+/** A brand-new roster (Night 1): everyone alive, unassigned, presumed good. */
+export function initialRoster(playerIds: ID[]): Record<ID, PlayerState> {
+  return Object.fromEntries(playerIds.map((id) => [id, freshState()]));
+}
+
+/**
+ * Carry a roster forward into the next phase — roles, teams, alive/dead and
+ * ghost-vote status persist, so the Storyteller only edits what changed. New
+ * seats (defensive) start fresh; a cloned object keeps rounds independent.
+ */
+export function carryRoster(
+  prev: Record<ID, PlayerState> | undefined,
+  playerIds: ID[],
+): Record<ID, PlayerState> {
+  const out: Record<ID, PlayerState> = {};
+  for (const id of playerIds) {
+    const p = prev?.[id];
+    out[id] = p
+      ? { role: p.role, team: p.team, alive: p.alive, ghostUsed: p.ghostUsed }
+      : freshState();
+  }
+  return out;
+}
+
+export function aliveCount(states: Record<ID, PlayerState>): number {
+  return Object.values(states).filter((s) => s.alive).length;
+}
+
+export function teamCount(states: Record<ID, PlayerState>, team: Team): number {
+  return Object.values(states).filter((s) => s.team === team).length;
+}
+
+export function aliveTeamCount(states: Record<ID, PlayerState>, team: Team): number {
+  return Object.values(states).filter((s) => s.alive && s.team === team).length;
+}
+
+/**
+ * Votes needed to put a player on the block: a majority of the living. This is
+ * pure arithmetic the table already does aloud — a glance helper, not a rule.
+ */
+export function voteThreshold(alive: number): number {
+  return Math.ceil(Math.max(0, alive) / 2);
+}
+
+// ── Scoring / winners ─────────────────────────────────────────────────────
+
+/**
+ * Score a phase. Tracking phases are scoreless (0 for everyone); the phase that
+ * records a `result` awards +1 to each player on the winning team, so totals
+ * end at 1 (winners) / 0 (losers).
+ */
+export function scoreRound(input: BotcInput, playerIds: ID[]): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  const result = input.result;
+  for (const id of playerIds) {
+    const st = input.states?.[id];
+    out[id] = result && st && st.team === result ? 1 : 0;
+  }
+  return out;
+}
+
+/** The winning team = every id sharing the top total, once a winner exists. */
+export function pickWinners(totals: Record<ID, number>): ID[] {
+  const ids = Object.keys(totals);
+  if (ids.length === 0) return [];
+  const max = Math.max(...ids.map((id) => totals[id] ?? 0));
+  if (max <= 0) return [];
+  return ids.filter((id) => (totals[id] ?? 0) === max);
+}
+
+/** A winner has been recorded once any total crosses zero. */
+export function isResolved(totals: Record<ID, number>): boolean {
+  return Object.values(totals).some((t) => (t ?? 0) > 0);
+}
+
+// ── Validation ────────────────────────────────────────────────────────────
+
+export function validate(input: BotcInput, playerIds: ID[]): string | null {
+  for (const nom of input.nominations ?? []) {
+    if (!nom.nomineeId) return 'Pick who was nominated, or remove the empty nomination.';
+    if ((Number(nom.votes) || 0) < 0) return 'Votes can’t be negative.';
+  }
+  if (input.result) {
+    const winners = playerIds.some((id) => input.states?.[id]?.team === input.result);
+    if (!winners) {
+      return `Assign at least one player to the ${
+        input.result === 'good' ? 'Good' : 'Evil'
+      } team before recording their win.`;
+    }
+  }
+  return null;
+}
+
+// ── History summary ───────────────────────────────────────────────────────
+
+export function describe(
+  input: BotcInput,
+  index: number,
+  nameOf: (id: ID) => string,
+): string {
+  const label = phaseLabel(index);
+  const emoji = phaseEmoji(index);
+  if (input.result) {
+    return `🏁 ${label} · ${input.result === 'good' ? 'Good' : 'Evil'} wins`;
+  }
+  if (phaseKind(index) === 'day') {
+    const noms = input.nominations ?? [];
+    const executed = noms.filter((n) => n.executed && n.nomineeId);
+    if (executed.length) {
+      return `${emoji} ${label} · ${executed
+        .map((n) => nameOf(n.nomineeId as ID))
+        .join(', ')} executed`;
+    }
+    if (noms.length) {
+      return `${emoji} ${label} · ${noms.length} nomination${
+        noms.length === 1 ? '' : 's'
+      }, no execution`;
+    }
+    return `${emoji} ${label} · no nominations`;
+  }
+  const alive = aliveCount(input.states ?? {});
+  return `${emoji} ${label} · ${alive} alive`;
+}
+
+// ── Script / role reference (data only — no abilities encoded) ─────────────
+
+export type RoleType = 'townsfolk' | 'outsider' | 'minion' | 'demon';
+
+export interface RoleRef {
+  name: string;
+  type: RoleType;
+}
+
+/** Townsfolk & Outsiders are Good; Minions & the Demon are Evil. */
+export function teamOfType(type: RoleType): Team {
+  return type === 'minion' || type === 'demon' ? 'evil' : 'good';
+}
+
+function roles(
+  townsfolk: string[],
+  outsider: string[],
+  minion: string[],
+  demon: string[],
+): RoleRef[] {
+  return [
+    ...townsfolk.map((name) => ({ name, type: 'townsfolk' as const })),
+    ...outsider.map((name) => ({ name, type: 'outsider' as const })),
+    ...minion.map((name) => ({ name, type: 'minion' as const })),
+    ...demon.map((name) => ({ name, type: 'demon' as const })),
+  ];
+}
+
+export interface ScriptRef {
+  value: string;
+  label: string;
+  roles: RoleRef[];
+}
+
+/** The three official editions, plus a Custom fallback with no reference list. */
+export const SCRIPTS: ScriptRef[] = [
+  {
+    value: 'tb',
+    label: 'Trouble Brewing',
+    roles: roles(
+      ['Washerwoman', 'Librarian', 'Investigator', 'Chef', 'Empath', 'Fortune Teller', 'Undertaker', 'Monk', 'Ravenkeeper', 'Virgin', 'Slayer', 'Soldier', 'Mayor'],
+      ['Butler', 'Drunk', 'Recluse', 'Saint'],
+      ['Poisoner', 'Spy', 'Scarlet Woman', 'Baron'],
+      ['Imp'],
+    ),
+  },
+  {
+    value: 'bmr',
+    label: 'Bad Moon Rising',
+    roles: roles(
+      ['Grandmother', 'Sailor', 'Chambermaid', 'Exorcist', 'Innkeeper', 'Gambler', 'Gossip', 'Courtier', 'Professor', 'Minstrel', 'Tea Lady', 'Pacifist', 'Fool'],
+      ['Goon', 'Lunatic', 'Tinker', 'Moonchild'],
+      ['Godfather', "Devil's Advocate", 'Assassin', 'Mastermind'],
+      ['Zombuul', 'Pukka', 'Shabaloth', 'Po'],
+    ),
+  },
+  {
+    value: 'snv',
+    label: 'Sects & Violets',
+    roles: roles(
+      ['Clockmaker', 'Dreamer', 'Snake Charmer', 'Mathematician', 'Flowergirl', 'Town Crier', 'Oracle', 'Savant', 'Seamstress', 'Philosopher', 'Artist', 'Juggler', 'Sage'],
+      ['Mutant', 'Sweetheart', 'Barber', 'Klutz'],
+      ['Evil Twin', 'Witch', 'Cerenovus', 'Pit-Hag'],
+      ['Fang Gu', 'Vigormortis', 'No Dashii', 'Vortox'],
+    ),
+  },
+  { value: 'custom', label: 'Custom / homebrew', roles: [] },
+];
+
+export function scriptRef(value: string | undefined): ScriptRef {
+  return SCRIPTS.find((s) => s.value === value) ?? SCRIPTS[0];
+}
+
+export function rolesFor(script: string | undefined): RoleRef[] {
+  return scriptRef(script).roles;
+}
+
+/** Team a known role belongs to (case-insensitive), or null if off-script. */
+export function roleTeam(role: string, script: string | undefined): Team | null {
+  const key = role.trim().toLowerCase();
+  if (!key) return null;
+  const hit = rolesFor(script).find((r) => r.name.toLowerCase() === key);
+  return hit ? teamOfType(hit.type) : null;
+}

--- a/src/lib/games/botc/stats.ts
+++ b/src/lib/games/botc/stats.ts
@@ -1,0 +1,92 @@
+import type { ID, Round } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg, fmtPct } from '../../stats/format';
+import type { BotcInput } from './logic';
+
+interface BotcAgg {
+  games: number;
+  evil: number;
+  good: number;
+  executed: number;
+  survived: number;
+}
+
+/**
+ * Blood on the Clocktower stats over finished games. Reads each phase's recorded
+ * roster + nominations — pure, no abilities inferred. The winning team comes from
+ * the phase that carries a `result`; team/survival come from the final roster.
+ */
+export function botcStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const byGame = new Map<ID, Round[]>();
+  const gameIds = new Set(games.map((g) => g.id));
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const arr = byGame.get(r.gameId);
+    if (arr) arr.push(r);
+    else byGame.set(r.gameId, [r]);
+  }
+
+  const per = new Map<ID, BotcAgg>();
+  const agg = (id: ID): BotcAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { games: 0, evil: 0, good: 0, executed: 0, survived: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let goodWins = 0;
+  let evilWins = 0;
+  let totalPhases = 0;
+  let counted = 0;
+
+  for (const g of games) {
+    const gr = (byGame.get(g.id) ?? []).slice().sort((a, b) => a.index - b.index);
+    if (gr.length === 0) continue;
+    counted += 1;
+    totalPhases += gr.length;
+
+    const result = gr.map((r) => (r.input as BotcInput | undefined)?.result).find(Boolean) ?? null;
+    if (result === 'good') goodWins += 1;
+    else if (result === 'evil') evilWins += 1;
+
+    const finalStates = (gr[gr.length - 1].input as BotcInput | undefined)?.states ?? {};
+    for (const [pid, st] of Object.entries(finalStates)) {
+      const a = agg(canonical(pid));
+      a.games += 1;
+      if (st.team === 'evil') a.evil += 1;
+      else a.good += 1;
+      if (st.alive) a.survived += 1;
+    }
+
+    for (const r of gr) {
+      const noms = (r.input as BotcInput | undefined)?.nominations ?? [];
+      for (const nom of noms) {
+        if (nom.executed && nom.nomineeId) agg(canonical(nom.nomineeId)).executed += 1;
+      }
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.evil) metrics.push({ key: 'botc_evil', label: 'Games as Evil', value: `${a.evil}`, emoji: '😈' });
+    if (a.executed) metrics.push({ key: 'botc_exec', label: 'Times executed', value: `${a.executed}`, emoji: '⚰️' });
+    if (a.games) {
+      metrics.push({ key: 'botc_survive', label: 'Survived to the end', value: fmtPct(a.survived / a.games), emoji: '🕯️' });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (goodWins || evilWins) {
+    const lead = goodWins === evilWins ? 'Even' : goodWins > evilWins ? 'Good leads' : 'Evil leads';
+    global.push({ key: 'botc_split', label: 'Good vs Evil wins', value: `${goodWins}–${evilWins}`, sub: lead, emoji: '⚖️' });
+  }
+  if (counted) {
+    global.push({ key: 'botc_len', label: 'Avg game length', value: `${fmtAvg(totalPhases / counted)} phases`, emoji: '🕒' });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## 🕒 Blood on the Clocktower — Storyteller Tracker

Adds a new, **purely additive** game module (`src/lib/games/botc/` only) for **Blood on the Clocktower**, the day/night social-deduction game. This is a **practical Storyteller tracker for the table — not a rules engine.** It deliberately never encodes character abilities; the script is used only as a role reference.

### What it tracks
- **Roster snapshot each phase** — every player's character/role, **team (Good/Evil)**, **alive/dead** status, and whether their single **ghost vote** has been used.
- **Day/Night phase + counter** — round index `0 = Night 1`, `1 = Day 1`, `2 = Night 2`, … derived from `round.index`.
- **Per-day nominations** — nominee, nominator, vote tally (with a live **majority threshold** hint), and an **executed** flag.
- **Winning-team recorder** — record Good or Evil as the victor.

### Fitting the point-oriented `GameModule` contract
BotC is Good-vs-Evil, not points, so it's mapped cleanly onto the scoring contract:
- **Round = one phase.** Tracking phases score `0` for everyone.
- The phase where a **result** (`good` | `evil`) is recorded awards **+1 to each player on the winning team**, so totals become `1` (winners) / `0` (losers).
- **`pickWinners` returns the whole winning team** once a result is set, else `[]` — i.e. *pickWinners records the winning team*. `isFinished` flips true once any total > 0.

This mirrors the existing `explodingkittens` module's proven "+1 to the winner / `[]` until decided" pattern, so it fits the contract without contorting the shell.

### Config
- **`script`** — Trouble Brewing (default) · Bad Moon Rising · Sects & Violets · Custom. Used purely as a **role reference** (autocomplete datalist + team lookup); it does **not** drive any rules.
- Player count **5–20**.

### Design compliance
- App **chrome stays identical**; clocktower personality is in **emoji/copy only** (🕒 / 🌙 / ☀️).
- **Royal Violet** reserved for the shell's single primary action; **Crown Gold** for winners only.
- Depth via the **surface ramp**, `tabular-nums` on changing numbers, touch targets **≥46px**, **never state-by-color-alone** (alive/dead and team are always labeled with icon **and** text), and **`prefers-reduced-motion`** honored.

### Files
- `logic.ts` — pure phase/status/vote logic, thresholds, role reference, scoring, validation (no Svelte imports).
- `index.ts` — `export const botc: GameModule` (auto-discovered; `registry.ts` untouched).
- `BotcEditor.svelte` — the Storyteller UI (phase header, roster rows, nominations, result recorder).
- `stats.ts` — Good/Evil win split, average game length, per-player team/execution/survival stats.
- `botc.test.ts` — thorough tests for logic, module wiring, and stats.

### Verification
- ✅ `npm run check` — 0 errors, 0 warnings
- ✅ `npm test` — all tests pass (41 new botc tests)
- ✅ `npm run build` — production build succeeds
