### PR TITLE
Add Volleyball game module

### DIFF
--- a/src/lib/games/volleyball/VolleyballEditor.svelte
+++ b/src/lib/games/volleyball/VolleyballEditor.svelte
@@ -1,0 +1,342 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import type { VolleyballInput } from './index';
+  import { isDecidingSet, readConfig, setWinner, targetForSet, type Side } from './logic';
+
+  let { input = $bindable(), ctx }: { input: VolleyballInput; ctx: RoundContext } = $props();
+
+  const cfg = $derived(readConfig(ctx.config));
+  const pa = $derived(ctx.players[0]);
+  const pb = $derived(ctx.players[1]);
+
+  // Sets won so far (the running match score) come from the totals-before-this-round.
+  const setsA = $derived(Number(ctx.totals[pa?.id]) || 0);
+  const setsB = $derived(Number(ctx.totals[pb?.id]) || 0);
+  const setNumber = $derived(setsA + setsB + 1);
+  const deciding = $derived(isDecidingSet(setsA, setsB, cfg.setsToWin));
+  const target = $derived(targetForSet(cfg, setsA, setsB));
+
+  const ptsA = $derived(Number(input.points[pa?.id]) || 0);
+  const ptsB = $derived(Number(input.points[pb?.id]) || 0);
+  const result = $derived(setWinner(ptsA, ptsB, target, cfg.winBy2, cfg.hardCap));
+
+  function bump(id: string, delta: number) {
+    input.points[id] = Math.max(0, (Number(input.points[id]) || 0) + delta);
+  }
+  function onType(id: string, value: string) {
+    const n = Math.floor(Number(value));
+    input.points[id] = Number.isFinite(n) && n > 0 ? n : 0;
+  }
+
+  /** Would one more point here win the set — and would that win the match? */
+  function pointKind(side: Side): 'match' | 'set' | null {
+    if (result) return null;
+    const na = side === 'a' ? ptsA + 1 : ptsA;
+    const nb = side === 'b' ? ptsB + 1 : ptsB;
+    if (setWinner(na, nb, target, cfg.winBy2, cfg.hardCap) !== side) return null;
+    const setsAfter = (side === 'a' ? setsA : setsB) + 1;
+    return setsAfter >= cfg.setsToWin ? 'match' : 'set';
+  }
+
+  const kindA = $derived(pointKind('a'));
+  const kindB = $derived(pointKind('b'));
+  const deuce = $derived(!result && cfg.winBy2 && ptsA >= target - 1 && ptsB >= target - 1);
+
+  const sideList = $derived([
+    { side: 'a' as Side, player: pa, sets: setsA, points: ptsA, won: result === 'a', kind: kindA },
+    { side: 'b' as Side, player: pb, sets: setsB, points: ptsB, won: result === 'b', kind: kindB },
+  ]);
+
+  const status = $derived.by(() => {
+    if (result) {
+      const w = result === 'a' ? pa : pb;
+      const hi = Math.max(ptsA, ptsB);
+      const lo = Math.min(ptsA, ptsB);
+      return { emoji: '✅', text: `${w?.name ?? 'Winner'} takes the set ${hi}–${lo}`, tone: 'good' };
+    }
+    if (kindA || kindB) {
+      const side = kindA ? pa : pb;
+      const kind = kindA ?? kindB;
+      return {
+        emoji: kind === 'match' ? '🏆' : '🎯',
+        text: `${kind === 'match' ? 'Match point' : 'Set point'} — ${side?.name ?? ''}`,
+        tone: 'warn',
+      };
+    }
+    if (deuce) return { emoji: '🔁', text: 'Deuce — must win by two', tone: 'muted' };
+    return {
+      emoji: '🏐',
+      text: `Rally to ${target}${cfg.winBy2 ? ', win by two' : ''}`,
+      tone: 'muted',
+    };
+  });
+</script>
+
+<div class="stack">
+  <div class="row spread meta">
+    <span class="pill">🏐 Set {setNumber} · to {target}</span>
+    {#if deciding}
+      <span class="pill decider">⭐ Deciding set</span>
+    {:else}
+      <span class="pill">Best of {cfg.setsToWin * 2 - 1}</span>
+    {/if}
+  </div>
+
+  <p
+    class="status"
+    class:good={status.tone === 'good'}
+    class:warn={status.tone === 'warn'}
+    aria-live="polite"
+  >
+    <span aria-hidden="true">{status.emoji}</span>
+    <span>{status.text}</span>
+  </p>
+
+  <div class="sides">
+    {#each sideList as s (s.player?.id)}
+      <div class="side" class:won={s.won}>
+        <div class="shead">
+          <span class="who">
+            <Avatar name={s.player?.name ?? '?'} color={s.player?.color ?? '#7c5cff'} />
+            <strong class="nm">{s.player?.name ?? '—'}</strong>
+          </span>
+          <span class="pips" role="img" aria-label={`${s.sets} of ${cfg.setsToWin} sets won`}>
+            {#each Array(cfg.setsToWin) as _, i (i)}
+              <span class="pip" class:on={i < s.sets}></span>
+            {/each}
+          </span>
+        </div>
+
+        <label class="scorewrap">
+          <span class="sr-only">{s.player?.name} points this set</span>
+          <input
+            class="score"
+            class:score-good={s.won}
+            type="number"
+            inputmode="numeric"
+            min="0"
+            value={s.points}
+            oninput={(e) => onType(s.player?.id, e.currentTarget.value)}
+          />
+        </label>
+
+        <div class="ctrls">
+          <button
+            type="button"
+            class="minus"
+            onclick={() => bump(s.player?.id, -1)}
+            disabled={s.points <= 0}
+            aria-label={`Take a point back from ${s.player?.name}`}
+          >
+            −1
+          </button>
+          <button
+            type="button"
+            class="plus"
+            class:pt={!!s.kind}
+            onclick={() => bump(s.player?.id, 1)}
+            aria-label={`Add a point for ${s.player?.name}`}
+          >
+            <span class="big">+1</span>
+            {#if s.kind}<span class="ptlabel">{s.kind === 'match' ? 'match pt' : 'set pt'}</span>{/if}
+          </button>
+        </div>
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .meta {
+    align-items: center;
+  }
+  .pill.decider {
+    color: var(--text);
+    border-color: color-mix(in srgb, var(--text) 22%, var(--border));
+  }
+
+  .status {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin: 0;
+    padding: 10px 12px;
+    text-align: center;
+    font-weight: 700;
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    color: var(--muted);
+  }
+  .status.good {
+    color: var(--good);
+    border-color: color-mix(in srgb, var(--good) 45%, var(--border));
+    background: color-mix(in srgb, var(--good) 12%, var(--surface-2));
+  }
+  .status.warn {
+    color: var(--warn);
+    border-color: color-mix(in srgb, var(--warn) 45%, var(--border));
+    background: color-mix(in srgb, var(--warn) 12%, var(--surface-2));
+  }
+
+  .sides {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+  }
+
+  .side {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .side.won {
+    border-color: color-mix(in srgb, var(--good) 55%, var(--border));
+  }
+
+  .shead {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    min-height: 30px;
+  }
+  .who {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .nm {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .pips {
+    display: inline-flex;
+    gap: 4px;
+    flex: none;
+  }
+  .pip {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    border: 1.5px solid var(--muted);
+    box-sizing: border-box;
+  }
+  .pip.on {
+    background: var(--text);
+    border-color: var(--text);
+  }
+
+  .scorewrap {
+    display: block;
+    margin: 0;
+  }
+  .score {
+    width: 100%;
+    height: 84px;
+    padding: 0 8px;
+    text-align: center;
+    font-size: 3rem;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    appearance: textfield;
+    -moz-appearance: textfield;
+  }
+  .score::-webkit-outer-spin-button,
+  .score::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    appearance: none;
+    margin: 0;
+  }
+
+  .ctrls {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+  }
+  .minus,
+  .plus {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+    transition:
+      transform 0.05s ease,
+      background 0.15s ease,
+      border-color 0.15s ease;
+  }
+  .minus {
+    flex: none;
+    width: 56px;
+    min-height: 56px;
+    font-size: 1.2rem;
+  }
+  .minus:hover {
+    background: var(--surface-2);
+  }
+  .minus:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  /* The +1 is the courtside hero: large, thumb-friendly. It stays a neutral
+     raised control so the screen keeps a single Royal Violet primary (Save). */
+  .plus {
+    flex: 1;
+    min-height: 56px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1px;
+    background: var(--surface-3);
+  }
+  .plus:hover {
+    border-color: var(--primary);
+  }
+  .plus:active {
+    transform: translateY(1px);
+  }
+  .plus .big {
+    font-size: 1.35rem;
+  }
+  .plus.pt {
+    border-color: color-mix(in srgb, var(--warn) 55%, var(--border));
+  }
+  .ptlabel {
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--warn);
+  }
+
+  .minus:focus-visible,
+  .plus:focus-visible,
+  .score:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+
+  @media (max-width: 360px) {
+    .score {
+      font-size: 2.5rem;
+    }
+  }
+</style>

--- a/src/lib/games/volleyball/index.ts
+++ b/src/lib/games/volleyball/index.ts
@@ -1,0 +1,145 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './VolleyballEditor.svelte';
+import { volleyballStats } from './stats';
+import {
+  maxSets,
+  readConfig,
+  setWinner,
+  targetForSet,
+  validateSetScore,
+} from './logic';
+
+/**
+ * One set's final points, keyed by side (player) id. A volleyball match is
+ * modelled as a sequence of sets: each round is a set, and the module banks a
+ * "set won" (+1) to whoever took it, so a side's running total is its sets won —
+ * exactly the number the big scoreboard should show. The match ends the moment a
+ * side reaches the sets it needs (best-of-5 → 3, best-of-3 → 2).
+ */
+export interface VolleyballInput {
+  points: Record<ID, number>;
+}
+
+/** The two sides, in board order. Volleyball is always exactly two. */
+function sides(ctx: RoundContext): [ID, ID] {
+  return [ctx.players[0]?.id, ctx.players[1]?.id];
+}
+
+export const volleyball: GameModule = {
+  id: 'volleyball',
+  name: 'Volleyball',
+  tagline: 'Rally scoring, win by two, best of five',
+  emoji: '🏐',
+  keywords: ['volleyball', 'sets', 'rally', 'net', 'sport', 'beach', 'indoor', 'spike', 'match'],
+  minPlayers: 2,
+  maxPlayers: 2,
+  teams: true,
+  configFields: [
+    {
+      key: 'format',
+      label: 'Match length',
+      type: 'select',
+      default: 'bo5',
+      options: [
+        { value: 'bo5', label: 'Best of 5 (first to 3 sets)' },
+        { value: 'bo3', label: 'Best of 3 (first to 2 sets)' },
+      ],
+    },
+    { key: 'pointsPerSet', label: 'Points to win a set', type: 'number', default: 25, min: 1 },
+    {
+      key: 'decidingSetPoints',
+      label: 'Points to win the deciding set',
+      type: 'number',
+      default: 15,
+      min: 1,
+      help: 'The final set (2–2 in a best-of-5, 1–1 in a best-of-3) is played to this shorter target.',
+    },
+    { key: 'winBy2', label: 'Win a set by two', type: 'boolean', default: true },
+    {
+      key: 'hardCap',
+      label: 'Hard cap (0 = play it out)',
+      type: 'number',
+      default: 0,
+      min: 0,
+      help: 'Score where win-by-two stops and the first side to the cap takes the set (e.g. 27). 0 keeps playing until a two-point lead.',
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): VolleyballInput => ({
+    points: Object.fromEntries(ctx.players.map((p) => [p.id, 0])),
+  }),
+
+  validateRound: (input: VolleyballInput, ctx: RoundContext): string | null => {
+    if (ctx.players.length !== 2) return 'Volleyball is played by exactly two sides.';
+    const cfg = readConfig(ctx.config);
+    const [a, b] = sides(ctx);
+    const setsA = Number(ctx.totals[a]) || 0;
+    const setsB = Number(ctx.totals[b]) || 0;
+    if (setsA >= cfg.setsToWin || setsB >= cfg.setsToWin) {
+      return 'The match is already won — no more sets to play.';
+    }
+    const target = targetForSet(cfg, setsA, setsB);
+    return validateSetScore(
+      Number(input.points[a]) || 0,
+      Number(input.points[b]) || 0,
+      target,
+      cfg.winBy2,
+      cfg.hardCap,
+    );
+  },
+
+  scoreRound: (input: VolleyballInput, ctx: RoundContext): Record<ID, number> => {
+    const cfg = readConfig(ctx.config);
+    const [a, b] = sides(ctx);
+    const setsA = Number(ctx.totals[a]) || 0;
+    const setsB = Number(ctx.totals[b]) || 0;
+    const target = targetForSet(cfg, setsA, setsB);
+    const winner = setWinner(
+      Number(input.points[a]) || 0,
+      Number(input.points[b]) || 0,
+      target,
+      cfg.winBy2,
+      cfg.hardCap,
+    );
+    return { [a]: winner === 'a' ? 1 : 0, [b]: winner === 'b' ? 1 : 0 };
+  },
+
+  // A match can't run longer than best-of allows (5 sets in a best-of-5).
+  maxRounds: (config) => maxSets(readConfig(config)),
+
+  // Finished the instant a side has banked the sets it needs.
+  isFinished: (totals, { config }) => {
+    const cfg = readConfig(config);
+    return Object.values(totals).some((t) => (Number(t) || 0) >= cfg.setsToWin);
+  },
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as VolleyballInput;
+    const [pa, pb] = players;
+    if (!pa || !pb) return '';
+    const a = Number(input.points[pa.id]) || 0;
+    const b = Number(input.points[pb.id]) || 0;
+    const winner = a > b ? pa : b > a ? pb : null;
+    return `${a}–${b}${winner ? ` · ${winner.name}` : ''}`;
+  },
+
+  help: [
+    'Rally scoring: every serve wins a point for one side.',
+    'A set is played to 25 and must be won by two, so a tight set runs on',
+    '(25–23, 26–24, 30–28…) until a side leads by two.',
+    '',
+    'The match is best of 5 — first side to win 3 sets takes it (or best of 3,',
+    'first to 2). If it reaches a deciding set (2–2, or 1–1), that set is played',
+    'to 15, still win by two.',
+    '',
+    'Optional hard cap: set a ceiling (e.g. 27) where win-by-two stops and the',
+    'first side to the cap wins the set.',
+    '',
+    'Enter each set’s final score as it ends; the board tracks sets won and calls',
+    'the match at set point.',
+  ].join('\n'),
+
+  stats: volleyballStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/volleyball/logic.ts
+++ b/src/lib/games/volleyball/logic.ts
@@ -1,0 +1,193 @@
+/**
+ * Pure volleyball set/match logic — no Svelte, no app imports. Everything the
+ * module needs to score a rally-scored match lives here so `*.test.ts` can
+ * exercise the real rules (win-by-2, deuce, the deciding set, best-of formats,
+ * an optional hard cap) without pulling in the editor.
+ *
+ * A volleyball match is a race to win sets. Each set is rally-scored (a point on
+ * every serve) to a target — 25 for a normal set, 15 for the deciding set — and
+ * you must win by two, so a tight set climbs past the target (26–24, 30–28…)
+ * until someone leads by two. The match is best-of-5 (first to 3 sets) or
+ * best-of-3 (first to 2). We model each *set* as a round: the round records both
+ * sides' final points, and the module banks one "set won" to the winner, so a
+ * side's running total is simply the sets it has taken.
+ */
+
+export type Side = 'a' | 'b';
+
+export interface VolleyConfig {
+  /** Points to win a normal set (rally scoring). */
+  pointsPerSet: number;
+  /** Points to win the deciding set (the tiebreak set is shorter). */
+  decidingSetPoints: number;
+  /** Must a set be won by a two-point margin? */
+  winBy2: boolean;
+  /** Sets needed to win the match — 3 = best of 5, 2 = best of 3. */
+  setsToWin: number;
+  /** Score at which win-by-two stops (first to the cap takes the set). 0 = no cap. */
+  hardCap: number;
+}
+
+export const DEFAULTS: VolleyConfig = {
+  pointsPerSet: 25,
+  decidingSetPoints: 15,
+  winBy2: true,
+  setsToWin: 3,
+  hardCap: 0,
+};
+
+/** Coerce a stored config record into a safe, fully-populated {@link VolleyConfig}. */
+export function readConfig(config: Record<string, unknown> | undefined): VolleyConfig {
+  const cfg = config ?? {};
+  const posInt = (v: unknown, fallback: number): number => {
+    const n = Math.floor(Number(v));
+    return Number.isFinite(n) && n > 0 ? n : fallback;
+  };
+
+  // `format` is the friendly control; `setsToWin` is honoured as a direct escape hatch.
+  let setsToWin: number;
+  if (cfg.format === 'bo3') setsToWin = 2;
+  else if (cfg.format === 'bo5') setsToWin = 3;
+  else setsToWin = posInt(cfg.setsToWin, DEFAULTS.setsToWin);
+
+  const capRaw = Math.floor(Number(cfg.hardCap));
+  const hardCap = Number.isFinite(capRaw) && capRaw > 0 ? capRaw : 0;
+
+  return {
+    pointsPerSet: posInt(cfg.pointsPerSet, DEFAULTS.pointsPerSet),
+    decidingSetPoints: posInt(cfg.decidingSetPoints, DEFAULTS.decidingSetPoints),
+    winBy2: cfg.winBy2 !== false,
+    setsToWin,
+    hardCap,
+  };
+}
+
+/** Total sets that can possibly be played in the match (e.g. best-of-5 → 5). */
+export function maxSets(cfg: VolleyConfig): number {
+  return cfg.setsToWin * 2 - 1;
+}
+
+/**
+ * Is the upcoming set the deciding set? That's the moment the match is level with
+ * each side one win short — 2–2 in a best-of-5, 1–1 in a best-of-3 — so the final
+ * set is played to the (shorter) deciding target.
+ */
+export function isDecidingSet(setsA: number, setsB: number, setsToWin: number): boolean {
+  return setsA === setsToWin - 1 && setsB === setsToWin - 1;
+}
+
+/** Target points for the set about to be played, given the sets won so far. */
+export function targetForSet(cfg: VolleyConfig, setsA: number, setsB: number): number {
+  return isDecidingSet(setsA, setsB, cfg.setsToWin) ? cfg.decidingSetPoints : cfg.pointsPerSet;
+}
+
+/** A cap only bites when it sits above the target; otherwise there's nothing to cap. */
+function effectiveCap(target: number, hardCap: number): number {
+  return hardCap > target ? hardCap : 0;
+}
+
+/**
+ * Who has won this set, or `null` while it's still live (or a tie, which can't be
+ * a final score). Encodes rally scoring: reach the target and lead by two — unless
+ * a hard cap is set, where the first side to the cap takes it by a single point.
+ */
+export function setWinner(
+  a: number,
+  b: number,
+  target: number,
+  winBy2: boolean,
+  hardCap = 0,
+): Side | null {
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
+  if (a < 0 || b < 0) return null;
+  if (a === b) return null; // level: nobody has won
+
+  const hi = Math.max(a, b);
+  const lo = Math.min(a, b);
+  if (hi < target) return null; // target not reached yet
+
+  const lead = hi - lo;
+  const cap = effectiveCap(target, hardCap);
+  const capReached = cap > 0 && hi >= cap;
+  const won = capReached ? lead >= 1 : winBy2 ? lead >= 2 : lead >= 1;
+  if (!won) return null;
+
+  return a > b ? 'a' : 'b';
+}
+
+/**
+ * Validate a *final* set score. Returns an error string, or `null` when the score
+ * is a legal end-of-set: someone has won, and the set stopped at the earliest
+ * winning point (you can't overshoot, since a set ends the instant it's decided).
+ */
+export function validateSetScore(
+  a: number,
+  b: number,
+  target: number,
+  winBy2: boolean,
+  hardCap = 0,
+): string | null {
+  if (!Number.isInteger(a) || !Number.isInteger(b)) {
+    return 'Enter whole point totals for each side.';
+  }
+  if (a < 0 || b < 0) return 'Points can’t be negative.';
+
+  const winner = setWinner(a, b, target, winBy2, hardCap);
+  if (!winner) {
+    const tail = winBy2 ? ', win by two' : '';
+    return `That set isn’t over — first to ${target}${tail}.`;
+  }
+
+  // Undo the winner's final point: the set must have still been live a rally ago.
+  const prevA = winner === 'a' ? a - 1 : a;
+  const prevB = winner === 'b' ? b - 1 : b;
+  if (setWinner(prevA, prevB, target, winBy2, hardCap)) {
+    return 'That final score isn’t reachable — a set ends the moment it’s won.';
+  }
+  return null;
+}
+
+export interface SetScore {
+  a: number;
+  b: number;
+}
+
+export interface MatchState {
+  /** Sets won by each side (only completed, legal sets are counted). */
+  setsA: number;
+  setsB: number;
+  /** Has a side reached `setsToWin`? */
+  decided: boolean;
+  /** Match winner once decided. */
+  winner: Side | null;
+  /** Target points for the *next* set to be played. */
+  nextTarget: number;
+  /** Is that next set the deciding set? */
+  nextDeciding: boolean;
+}
+
+/**
+ * Fold a sequence of set scores into the match standing. Sets are counted in
+ * order (so the deciding-set target is applied at the right moment) and counting
+ * stops once the match is won — trailing sets can't happen in a real match.
+ */
+export function matchState(sets: SetScore[], cfg: VolleyConfig): MatchState {
+  let setsA = 0;
+  let setsB = 0;
+  for (const set of sets) {
+    if (setsA >= cfg.setsToWin || setsB >= cfg.setsToWin) break;
+    const target = targetForSet(cfg, setsA, setsB);
+    const winner = setWinner(set.a, set.b, target, cfg.winBy2, cfg.hardCap);
+    if (winner === 'a') setsA += 1;
+    else if (winner === 'b') setsB += 1;
+  }
+  const decided = setsA >= cfg.setsToWin || setsB >= cfg.setsToWin;
+  return {
+    setsA,
+    setsB,
+    decided,
+    winner: decided ? (setsA > setsB ? 'a' : 'b') : null,
+    nextDeciding: isDecidingSet(setsA, setsB, cfg.setsToWin),
+    nextTarget: targetForSet(cfg, setsA, setsB),
+  };
+}

--- a/src/lib/games/volleyball/stats.ts
+++ b/src/lib/games/volleyball/stats.ts
@@ -1,0 +1,135 @@
+import type { ID } from '../../types';
+import type { VolleyballInput } from './index';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt } from '../../stats/format';
+import { matchState, readConfig, setWinner, targetForSet, type SetScore } from './logic';
+
+interface SideAgg {
+  setsWon: number;
+  setsPlayed: number;
+  pointsFor: number;
+  deuceSets: number; // sets pushed past the target by the win-by-two rule
+  matchesWon: number;
+  sweeps: number; // matches won without dropping a set
+}
+
+/**
+ * Volleyball stats, rebuilt from each game's recorded set scores. Pure and
+ * config-aware: we replay every game's sets with its own rules (deciding-set
+ * target, win-by-two, cap) so sets won, deuce battles and sweeps are exact —
+ * mirroring how the module itself scores a set.
+ */
+export function volleyballStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const byGame = new Map<ID, typeof rounds>();
+  for (const r of rounds) {
+    const list = byGame.get(r.gameId);
+    if (list) list.push(r);
+    else byGame.set(r.gameId, [r]);
+  }
+
+  const per = new Map<ID, SideAgg>();
+  const get = (id: ID): SideAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { setsWon: 0, setsPlayed: 0, pointsFor: 0, deuceSets: 0, matchesWon: 0, sweeps: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let biggestSet: { hi: number; lo: number } | null = null;
+
+  for (const game of games) {
+    const [rawA, rawB] = game.playerIds;
+    if (!rawA || !rawB) continue;
+    const idA = canonical(rawA);
+    const idB = canonical(rawB);
+    const cfg = readConfig(game.config);
+
+    const gameRounds = (byGame.get(game.id) ?? []).slice().sort((x, y) => x.index - y.index);
+    const setScores: SetScore[] = [];
+
+    let setsA = 0;
+    let setsB = 0;
+    for (const r of gameRounds) {
+      const input = r.input as VolleyballInput | undefined;
+      if (!input?.points) continue;
+      const a = Number(input.points[rawA]) || 0;
+      const b = Number(input.points[rawB]) || 0;
+      const target = targetForSet(cfg, setsA, setsB);
+      const winner = setWinner(a, b, target, cfg.winBy2, cfg.hardCap);
+      if (!winner) continue;
+
+      setScores.push({ a, b });
+      const aggA = get(idA);
+      const aggB = get(idB);
+      aggA.setsPlayed += 1;
+      aggB.setsPlayed += 1;
+      aggA.pointsFor += a;
+      aggB.pointsFor += b;
+      if (winner === 'a') {
+        aggA.setsWon += 1;
+        setsA += 1;
+      } else {
+        aggB.setsWon += 1;
+        setsB += 1;
+      }
+
+      // A "deuce" set is one dragged past its target by the win-by-two rule.
+      if (Math.max(a, b) > target) {
+        aggA.deuceSets += 1;
+        aggB.deuceSets += 1;
+      }
+
+      const hi = Math.max(a, b);
+      const lo = Math.min(a, b);
+      if (!biggestSet || lo > biggestSet.lo || (lo === biggestSet.lo && hi > biggestSet.hi)) {
+        biggestSet = { hi, lo };
+      }
+    }
+
+    const state = matchState(setScores, cfg);
+    if (state.decided && state.winner) {
+      const winnerId = state.winner === 'a' ? idA : idB;
+      const loserSets = state.winner === 'a' ? state.setsB : state.setsA;
+      const agg = get(winnerId);
+      agg.matchesWon += 1;
+      if (loserSets === 0) agg.sweeps += 1;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let totalSets = 0;
+  let totalDeuce = 0;
+  for (const [id, a] of per) {
+    totalSets += a.setsWon;
+    totalDeuce += a.deuceSets;
+    const metrics: Metric[] = [];
+    if (a.setsWon) metrics.push({ key: 'v_sets', label: 'Sets won', value: `${a.setsWon}`, emoji: '🏐' });
+    if (a.pointsFor) {
+      metrics.push({ key: 'v_points', label: 'Points scored', value: fmtInt(a.pointsFor), emoji: '🔥' });
+    }
+    if (a.deuceSets) {
+      metrics.push({ key: 'v_deuce', label: 'Deuce sets', value: `${a.deuceSets}`, emoji: '😤' });
+    }
+    if (a.sweeps) metrics.push({ key: 'v_sweep', label: 'Sweeps', value: `${a.sweeps}`, emoji: '🧹' });
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totalSets) global.push({ key: 'v_sets_all', label: 'Sets played', value: `${totalSets}`, emoji: '🏐' });
+  if (totalDeuce) {
+    // Each deuce set is counted once per side above; halve for the true set count.
+    global.push({ key: 'v_deuce_all', label: 'Deuce sets', value: `${Math.round(totalDeuce / 2)}`, emoji: '😤' });
+  }
+  if (biggestSet) {
+    global.push({
+      key: 'v_biggest',
+      label: 'Longest set',
+      value: `${biggestSet.hi}–${biggestSet.lo}`,
+      emoji: '⚔️',
+    });
+  }
+
+  return { perPlayer, global };
+}

--- a/src/lib/games/volleyball/volleyball.test.ts
+++ b/src/lib/games/volleyball/volleyball.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULTS,
+  isDecidingSet,
+  matchState,
+  maxSets,
+  readConfig,
+  setWinner,
+  targetForSet,
+  validateSetScore,
+  type SetScore,
+  type VolleyConfig,
+} from './logic';
+
+const bo5: VolleyConfig = { ...DEFAULTS };
+const bo3: VolleyConfig = { ...DEFAULTS, setsToWin: 2 };
+
+describe('setWinner — rally scoring & win by two', () => {
+  it('awards a set at the target with a two-point lead', () => {
+    expect(setWinner(25, 23, 25, true)).toBe('a');
+    expect(setWinner(23, 25, 25, true)).toBe('b');
+    expect(setWinner(25, 0, 25, true)).toBe('a');
+  });
+
+  it('is not over at the target without a two-point lead', () => {
+    expect(setWinner(25, 24, 25, true)).toBeNull();
+    expect(setWinner(24, 24, 25, true)).toBeNull();
+  });
+
+  it('keeps a deuce set going until someone leads by two', () => {
+    expect(setWinner(26, 24, 25, true)).toBe('a');
+    expect(setWinner(24, 26, 25, true)).toBe('b');
+    expect(setWinner(26, 25, 25, true)).toBeNull();
+    expect(setWinner(30, 28, 25, true)).toBe('a');
+  });
+
+  it('needs the target to be reached first', () => {
+    expect(setWinner(20, 15, 25, true)).toBeNull();
+    expect(setWinner(10, 2, 25, true)).toBeNull();
+  });
+
+  it('rejects a tie as a winner', () => {
+    expect(setWinner(25, 25, 25, true)).toBeNull();
+    expect(setWinner(0, 0, 25, true)).toBeNull();
+  });
+
+  it('honours a one-point win when win-by-two is off', () => {
+    expect(setWinner(25, 24, 25, false)).toBe('a');
+    expect(setWinner(25, 23, 25, false)).toBe('a');
+    expect(setWinner(24, 23, 25, false)).toBeNull();
+  });
+
+  it('scores the shorter deciding-set target', () => {
+    expect(setWinner(15, 13, 15, true)).toBe('a');
+    expect(setWinner(15, 14, 15, true)).toBeNull();
+    expect(setWinner(16, 14, 15, true)).toBe('a');
+  });
+});
+
+describe('setWinner — hard cap', () => {
+  it('lets the first side to the cap win by one', () => {
+    expect(setWinner(27, 26, 25, true, 27)).toBe('a');
+    expect(setWinner(26, 27, 25, true, 27)).toBe('b');
+  });
+
+  it('still needs two before the cap is reached', () => {
+    expect(setWinner(26, 25, 25, true, 27)).toBeNull();
+    expect(setWinner(27, 25, 25, true, 27)).toBe('a');
+  });
+
+  it('ignores a cap that is not above the target', () => {
+    expect(setWinner(25, 24, 25, true, 25)).toBeNull();
+    expect(setWinner(25, 24, 25, true, 10)).toBeNull();
+  });
+});
+
+describe('validateSetScore — only legal final scores pass', () => {
+  it('accepts clean and deuce finals', () => {
+    expect(validateSetScore(25, 23, 25, true)).toBeNull();
+    expect(validateSetScore(25, 0, 25, true)).toBeNull();
+    expect(validateSetScore(26, 24, 25, true)).toBeNull();
+    expect(validateSetScore(27, 25, 25, true)).toBeNull();
+    expect(validateSetScore(30, 28, 25, true)).toBeNull();
+  });
+
+  it('rejects a set that is not over yet', () => {
+    expect(validateSetScore(25, 24, 25, true)).toMatch(/isn.t over/i);
+    expect(validateSetScore(20, 18, 25, true)).toMatch(/isn.t over/i);
+    expect(validateSetScore(25, 25, 25, true)).toMatch(/isn.t over/i);
+  });
+
+  it('rejects an unreachable (overshot) score', () => {
+    // A set ends at 25–20; you can't play on to 26–20.
+    expect(validateSetScore(26, 20, 25, true)).toMatch(/isn.t reachable/i);
+    expect(validateSetScore(28, 24, 25, true)).toMatch(/isn.t reachable/i);
+  });
+
+  it('rejects negative and non-integer scores', () => {
+    expect(validateSetScore(-1, 25, 25, true)).toMatch(/negative/i);
+    expect(validateSetScore(25.5, 20, 25, true)).toMatch(/whole/i);
+  });
+
+  it('validates against the deciding-set target', () => {
+    expect(validateSetScore(15, 12, 15, true)).toBeNull();
+    expect(validateSetScore(15, 14, 15, true)).toMatch(/isn.t over/i);
+    expect(validateSetScore(17, 15, 15, true)).toBeNull();
+  });
+
+  it('respects the hard cap boundary', () => {
+    expect(validateSetScore(27, 26, 25, true, 27)).toBeNull();
+    expect(validateSetScore(28, 26, 25, true, 27)).toMatch(/isn.t reachable/i);
+  });
+});
+
+describe('deciding set & targets', () => {
+  it('detects the deciding set only when level one short', () => {
+    expect(isDecidingSet(2, 2, 3)).toBe(true);
+    expect(isDecidingSet(2, 1, 3)).toBe(false);
+    expect(isDecidingSet(1, 1, 2)).toBe(true);
+    expect(isDecidingSet(0, 0, 2)).toBe(false);
+  });
+
+  it('uses the deciding target for the final set, the normal one otherwise', () => {
+    expect(targetForSet(bo5, 0, 0)).toBe(25);
+    expect(targetForSet(bo5, 2, 1)).toBe(25);
+    expect(targetForSet(bo5, 2, 2)).toBe(15);
+    expect(targetForSet(bo3, 1, 1)).toBe(15);
+  });
+
+  it('reports the maximum sets for a format', () => {
+    expect(maxSets(bo5)).toBe(5);
+    expect(maxSets(bo3)).toBe(3);
+  });
+});
+
+describe('matchState — folding sets into a result', () => {
+  it('calls a best-of-5 match at three sets', () => {
+    const sets: SetScore[] = [
+      { a: 25, b: 20 },
+      { a: 22, b: 25 },
+      { a: 25, b: 18 },
+      { a: 25, b: 22 },
+    ];
+    const s = matchState(sets, bo5);
+    expect(s.setsA).toBe(3);
+    expect(s.setsB).toBe(1);
+    expect(s.decided).toBe(true);
+    expect(s.winner).toBe('a');
+  });
+
+  it('plays a deciding fifth set to 15', () => {
+    const sets: SetScore[] = [
+      { a: 25, b: 20 },
+      { a: 20, b: 25 },
+      { a: 25, b: 23 },
+      { a: 23, b: 25 },
+      { a: 15, b: 12 }, // deciding set, shorter target
+    ];
+    const s = matchState(sets, bo5);
+    expect(s.setsA).toBe(3);
+    expect(s.setsB).toBe(2);
+    expect(s.winner).toBe('a');
+  });
+
+  it('a 15–12 fifth set would NOT count under normal-set rules (proves target switch)', () => {
+    // Same five sets but forced to a 25-point target everywhere: the fifth set
+    // (15–12) never reaches 25, so the match stays level and undecided.
+    const alwaysLong: VolleyConfig = { ...bo5, decidingSetPoints: 25 };
+    const sets: SetScore[] = [
+      { a: 25, b: 20 },
+      { a: 20, b: 25 },
+      { a: 25, b: 23 },
+      { a: 23, b: 25 },
+      { a: 15, b: 12 },
+    ];
+    const s = matchState(sets, alwaysLong);
+    expect(s.setsA).toBe(2);
+    expect(s.setsB).toBe(2);
+    expect(s.decided).toBe(false);
+  });
+
+  it('sweeps a best-of-3 at two sets', () => {
+    const s = matchState([{ a: 25, b: 20 }, { a: 25, b: 18 }], bo3);
+    expect(s.setsA).toBe(2);
+    expect(s.setsB).toBe(0);
+    expect(s.decided).toBe(true);
+    expect(s.winner).toBe('a');
+  });
+
+  it('stops counting once the match is already won', () => {
+    const sets: SetScore[] = [
+      { a: 25, b: 10 },
+      { a: 25, b: 10 },
+      { a: 25, b: 10 },
+      { a: 25, b: 10 }, // impossible trailing set — must be ignored
+    ];
+    const s = matchState(sets, bo5);
+    expect(s.setsA).toBe(3);
+    expect(s.setsB).toBe(0);
+  });
+
+  it('surfaces the next target/deciding flags mid-match', () => {
+    const s = matchState([{ a: 25, b: 20 }, { a: 20, b: 25 }, { a: 25, b: 23 }, { a: 22, b: 25 }], bo5);
+    expect(s.setsA).toBe(2);
+    expect(s.setsB).toBe(2);
+    expect(s.nextDeciding).toBe(true);
+    expect(s.nextTarget).toBe(15);
+  });
+
+  it('ignores incomplete sets when folding', () => {
+    const s = matchState([{ a: 25, b: 20 }, { a: 24, b: 24 }], bo5);
+    expect(s.setsA).toBe(1);
+    expect(s.setsB).toBe(0);
+    expect(s.decided).toBe(false);
+  });
+});
+
+describe('readConfig — safe coercion & formats', () => {
+  it('maps best-of formats to sets-to-win', () => {
+    expect(readConfig({ format: 'bo5' }).setsToWin).toBe(3);
+    expect(readConfig({ format: 'bo3' }).setsToWin).toBe(2);
+  });
+
+  it('fills sensible defaults', () => {
+    const c = readConfig(undefined);
+    expect(c).toEqual(DEFAULTS);
+    expect(readConfig({}).pointsPerSet).toBe(25);
+    expect(readConfig({}).decidingSetPoints).toBe(15);
+  });
+
+  it('respects win-by-two toggle and custom targets', () => {
+    expect(readConfig({ winBy2: false }).winBy2).toBe(false);
+    expect(readConfig({ winBy2: true }).winBy2).toBe(true);
+    expect(readConfig({ pointsPerSet: 21, decidingSetPoints: 11 })).toMatchObject({
+      pointsPerSet: 21,
+      decidingSetPoints: 11,
+    });
+  });
+
+  it('coerces junk to defaults and floors the cap', () => {
+    expect(readConfig({ pointsPerSet: -5 }).pointsPerSet).toBe(25);
+    expect(readConfig({ pointsPerSet: 'nonsense' }).pointsPerSet).toBe(25);
+    expect(readConfig({ hardCap: 0 }).hardCap).toBe(0);
+    expect(readConfig({ hardCap: 27.9 }).hardCap).toBe(27);
+    expect(readConfig({ hardCap: -3 }).hardCap).toBe(0);
+  });
+});


### PR DESCRIPTION
## 🏐 Volleyball

A live, courtside **rally-scoring match scorer** for two sides (teams). Purely additive — everything lives under `src/lib/games/volleyball/` and the registry auto-discovers it. No shared files touched.

### How it's scored
- **Rally scoring:** every serve wins a point for one side.
- **Sets to 25, win by two:** a tight set climbs past the target (25–23, 26–24, 30–28…) until a side leads by two.
- **Match = best of 5** (first to **3** sets) or **best of 3** (first to **2**).
- **Deciding set is shorter:** at 2–2 (or 1–1 in a best-of-3) the final set is played to **15**, still win by two.
- **Optional hard cap:** set a ceiling (e.g. 27) where win-by-two stops and the first side to the cap takes the set.

### The model (sets as rounds)
Each **round is one SET**. The round records both sides' final points; `scoreRound` banks **+1 to the set winner** (0 to the loser), so a side's running **total = sets won** — exactly the number shown on the big scoreboard. `isFinished` fires the instant a side reaches the sets it needs; the default winner pick (highest total) crowns the match winner. `maxRounds` caps the match at `2·setsToWin − 1` sets.

### Config
| Field | Default |
|---|---|
| Match length (Best of 5 / Best of 3) | Best of 5 |
| Points to win a set | 25 |
| Points to win the deciding set | 15 |
| Win a set by two | on |
| Hard cap (0 = play it out) | 0 |

### Files
- `logic.ts` — pure, Svelte-free set/match rules: `setWinner`, `validateSetScore` (no-overshoot: rejects unreachable finals like 26–20), `matchState`, `isDecidingSet`/`targetForSet`, `readConfig`.
- `index.ts` — `export const volleyball: GameModule` (config, validate/score/describe, `isFinished`, `maxRounds`, stats hook).
- `VolleyballEditor.svelte` — courtside set entry: big `tabular-nums` scores, large +1 / −1 taps, live set/match-point + deuce status, set pips, `SET PT`/`MATCH PT` hints on the winning tap.
- `stats.ts` — per-side sets won, points, deuce sets, sweeps; global sets played, deuce sets, longest set.
- `volleyball.test.ts` — 30 tests (win-by-2, deuce, hard cap, deciding-set target switch, best-of formats, match completion, overshoot validation, config coercion).

### Design adherence
Chrome unchanged — personality via 🏐 emoji/copy only. **Single Royal Violet primary** preserved (the +1 is a neutral raised control; Save stays the one violet action). **Crown Gold reserved for the winner** via the shared shell (removed from the deciding-set pill). `tabular-nums` on every changing number, touch targets ≥46px (+1/−1 = 56px, score field 84px), never state-by-color-alone (emoji + labels + filled/hollow pips + aria-labels), reduced-motion honored globally.

### Verification
- `npm run check` → 0 errors, 0 warnings
- `npm test` → **105 passed** (30 new)
- `npm run build` → success
- Manual courtside playthrough in the dev server: default → deuce (24–24) → set point (with badge) → set saved → scoreboard/pips update → match clinched 3–0 with the winner crowned.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
