### PR TITLE
Add Two Rooms and a Boom tracker

### DIFF
--- a/src/lib/games/tworooms/TwoRoomsEditor.svelte
+++ b/src/lib/games/tworooms/TwoRoomsEditor.svelte
@@ -1,0 +1,310 @@
+<script lang="ts">
+  import type { ID, RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import {
+    isFinalRound,
+    roleBreakdown,
+    suggestedMinutes,
+    type Team,
+    type TwoRoomsInput,
+  } from './logic';
+  import { tworooms } from './index';
+
+  let { input = $bindable(), ctx }: { input: TwoRoomsInput; ctx: RoundContext } = $props();
+
+  const isFinal = $derived(isFinalRound(ctx.roundIndex, ctx.config));
+  const minutes = $derived(suggestedMinutes(ctx.roundIndex, ctx.config));
+  const roles = $derived(roleBreakdown(ctx.players.length));
+  const maxHostages = $derived(Math.max(1, ctx.players.length));
+  const winner = $derived(input.reveal.winner);
+
+  let showRoles = $state(false);
+  let showRules = $state(false);
+
+  const rooms: (1 | 2)[] = [1, 2];
+
+  function setLeader(room: 1 | 2, id: ID) {
+    if (room === 1) input.leader1 = input.leader1 === id ? null : id;
+    else input.leader2 = input.leader2 === id ? null : id;
+  }
+
+  function setWinner(team: Team) {
+    input.reveal.winner = team;
+  }
+
+  function toggleWinnerMember(id: ID) {
+    const has = input.reveal.winners.includes(id);
+    input.reveal.winners = has
+      ? input.reveal.winners.filter((x) => x !== id)
+      : [...input.reveal.winners, id];
+  }
+
+  function setPresident(id: ID) {
+    input.reveal.president = input.reveal.president === id ? null : id;
+  }
+  function setBomber(id: ID) {
+    input.reveal.bomber = input.reveal.bomber === id ? null : id;
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="pill">⏱ <span class="tnum">{minutes}</span> min{isFinal ? ' · final round' : ''}</span>
+    <span class="row" style="gap: 8px">
+      <button type="button" class="btn small ghost" aria-pressed={showRoles} onclick={() => (showRoles = !showRoles)}>
+        🎭 Roles
+      </button>
+      <button type="button" class="btn small ghost" aria-pressed={showRules} onclick={() => (showRules = !showRules)}>
+        Rules
+      </button>
+    </span>
+  </div>
+
+  {#if showRoles}
+    <div class="ref">
+      <div class="row spread">
+        <strong>Deal for {roles.players} players</strong>
+        <span class="muted small">Blue {roles.blueTotal} · Red {roles.redTotal}</span>
+      </div>
+      <ul class="reflist">
+        <li>🏛️ President <span class="tnum">×{roles.president}</span> <span class="muted">(Blue)</span></li>
+        <li>💣 Bomber <span class="tnum">×{roles.bomber}</span> <span class="muted">(Red)</span></li>
+        <li>🔵 Blue Team card <span class="tnum">×{roles.blueTeam}</span></li>
+        <li>🔴 Red Team card <span class="tnum">×{roles.redTeam}</span></li>
+        {#if roles.gambler}
+          <li>🃏 Gambler <span class="tnum">×{roles.gambler}</span> <span class="muted">(odd table)</span></li>
+        {/if}
+      </ul>
+      {#if ctx.config.advancedRoles}
+        <div class="muted small">Advanced game: swap in colored roles for some Blue/Red cards as you like.</div>
+      {/if}
+    </div>
+  {/if}
+
+  {#if showRules}
+    <pre class="rules">{tworooms.help}</pre>
+  {/if}
+
+  {#each rooms as room (room)}
+    <div class="room">
+      <div class="row spread">
+        <strong>Room {room}</strong>
+        <span class="pill">➡️ sends <span class="tnum">{room === 1 ? input.sent1 : input.sent2}</span></span>
+      </div>
+
+      <div class="fieldlabel">Leader <span class="muted">(optional)</span></div>
+      <div class="chips">
+        {#each ctx.players as p (p.id)}
+          {@const on = (room === 1 ? input.leader1 : input.leader2) === p.id}
+          <button type="button" class="chip" class:on aria-pressed={on} onclick={() => setLeader(room, p.id)}>
+            <Avatar name={p.name} color={p.color} size={22} />
+            <span>{p.name}</span>
+            {#if on}<span class="tag">📢 Leader</span>{/if}
+          </button>
+        {/each}
+      </div>
+
+      <div class="row spread hostrow">
+        <span>Hostages sent to Room {room === 1 ? 2 : 1}</span>
+        {#if room === 1}
+          <Stepper bind:value={input.sent1} min={0} max={maxHostages} />
+        {:else}
+          <Stepper bind:value={input.sent2} min={0} max={maxHostages} />
+        {/if}
+      </div>
+    </div>
+  {/each}
+
+  {#if isFinal}
+    <div class="reveal">
+      <div class="revhead">🎭 The Reveal</div>
+      <p class="muted revlede">Everyone flips their card. Did the Bomber end up in the President's room?</p>
+
+      <div class="picks">
+        <button type="button" class="pick" class:on={winner === 'red'} aria-pressed={winner === 'red'} onclick={() => setWinner('red')}>
+          <span class="pickmain">💥 Same room</span>
+          <span class="picksub">🔴 Red Team wins</span>
+        </button>
+        <button type="button" class="pick" class:on={winner === 'blue'} aria-pressed={winner === 'blue'} onclick={() => setWinner('blue')}>
+          <span class="pickmain">🕊️ Kept apart</span>
+          <span class="picksub">🔵 Blue Team wins</span>
+        </button>
+      </div>
+
+      {#if winner}
+        <div class="fieldlabel winlabel">
+          Tap everyone on the winning {winner === 'red' ? '🔴 Red Team' : '🔵 Blue Team'}
+          <span class="muted">· {input.reveal.winners.length} of ~{winner === 'red' ? roles.redTotal : roles.blueTotal}</span>
+        </div>
+        <div class="chips">
+          {#each ctx.players as p (p.id)}
+            {@const on = input.reveal.winners.includes(p.id)}
+            <button type="button" class="chip win" class:on aria-pressed={on} onclick={() => toggleWinnerMember(p.id)}>
+              <Avatar name={p.name} color={p.color} size={22} />
+              <span>{p.name}</span>
+              {#if on}<span class="tag">🏆</span>{/if}
+            </button>
+          {/each}
+        </div>
+
+        <details class="who">
+          <summary>Note the President &amp; Bomber <span class="muted">(optional)</span></summary>
+          <div class="fieldlabel">🏛️ President</div>
+          <div class="chips">
+            {#each ctx.players as p (p.id)}
+              {@const on = input.reveal.president === p.id}
+              <button type="button" class="chip" class:on aria-pressed={on} onclick={() => setPresident(p.id)}>
+                <Avatar name={p.name} color={p.color} size={22} /><span>{p.name}</span>
+              </button>
+            {/each}
+          </div>
+          <div class="fieldlabel">💣 Bomber</div>
+          <div class="chips">
+            {#each ctx.players as p (p.id)}
+              {@const on = input.reveal.bomber === p.id}
+              <button type="button" class="chip" class:on aria-pressed={on} onclick={() => setBomber(p.id)}>
+                <Avatar name={p.name} color={p.color} size={22} /><span>{p.name}</span>
+              </button>
+            {/each}
+          </div>
+        </details>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .tnum {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+  }
+  .small {
+    font-size: 0.8rem;
+  }
+  .room,
+  .ref,
+  .reveal {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .fieldlabel {
+    margin: 0;
+  }
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 44px;
+    padding: 6px 12px 6px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 600;
+  }
+  .chip.on {
+    border-color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 18%, var(--surface));
+  }
+  .chip .tag {
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: var(--muted);
+  }
+  .hostrow {
+    gap: 10px;
+  }
+  .reflist {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .reflist li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .rules {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+  .revhead {
+    font-weight: 800;
+    font-size: 1.05rem;
+  }
+  .revlede {
+    margin: 0;
+  }
+  .picks {
+    display: flex;
+    gap: 10px;
+  }
+  .pick {
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    min-height: 60px;
+    padding: 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    text-align: center;
+  }
+  .pick .pickmain {
+    font-weight: 700;
+  }
+  .pick .picksub {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .pick.on {
+    border-color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 16%, var(--surface));
+  }
+  .pick.on .picksub {
+    color: var(--text);
+  }
+  .winlabel {
+    margin-top: 2px;
+  }
+  .who {
+    margin-top: 2px;
+  }
+  .who summary {
+    cursor: pointer;
+    color: var(--muted);
+    font-size: 0.9rem;
+    min-height: 32px;
+    display: flex;
+    align-items: center;
+  }
+  .who .fieldlabel {
+    margin-top: 8px;
+  }
+</style>

--- a/src/lib/games/tworooms/index.ts
+++ b/src/lib/games/tworooms/index.ts
@@ -1,0 +1,113 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import Editor from './TwoRoomsEditor.svelte';
+import { twoRoomsStats } from './stats';
+import {
+  DEFAULT_ROUNDS,
+  MAX_PLAYERS,
+  MAX_ROUNDS,
+  MIN_PLAYERS,
+  MIN_ROUNDS,
+  createInput,
+  describe,
+  pickWinners as pickWinnersLogic,
+  roundCount,
+  score,
+  suggestedHostages,
+  validate,
+  type TwoRoomsInput,
+} from './logic';
+
+export type { TwoRoomsInput } from './logic';
+
+const ids = (ctx: RoundContext): ID[] => ctx.players.map((p) => p.id);
+
+export const tworooms: GameModule = {
+  id: 'tworooms',
+  name: 'Two Rooms and a Boom',
+  tagline: 'Blue’s President vs Red’s Bomber — two rooms, one boom',
+  emoji: '💣',
+  keywords: [
+    'social deduction',
+    'hidden role',
+    'party',
+    'team',
+    'president',
+    'bomber',
+    'spy',
+    'werewolf',
+    'two rooms',
+  ],
+  minPlayers: MIN_PLAYERS,
+  maxPlayers: MAX_PLAYERS,
+  teams: true,
+  configFields: [
+    {
+      key: 'rounds',
+      label: 'Number of rounds',
+      type: 'number',
+      default: DEFAULT_ROUNDS,
+      min: MIN_ROUNDS,
+      max: MAX_ROUNDS,
+      help: 'Each round is a minute shorter than the last, down to a one-minute finish. The Reveal rides on the final round.',
+    },
+    {
+      key: 'advancedRoles',
+      label: 'Playing with advanced character cards',
+      type: 'boolean',
+      default: false,
+      help: 'Adds colored roles beyond the President & Bomber. Deal those by hand — the tracker still records leaders, hostages, and the winning team.',
+    },
+  ],
+
+  maxRounds: (config) => roundCount(config),
+
+  createRoundInput: (ctx: RoundContext): TwoRoomsInput => {
+    const input = createInput();
+    // Pre-fill the steppers with the official suggestion so a room usually just
+    // confirms; the last round always trades one hostage.
+    const h = suggestedHostages(ctx.players.length, ctx.roundIndex, ctx.config);
+    input.sent1 = h;
+    input.sent2 = h;
+    return input;
+  },
+
+  validateRound: (input: TwoRoomsInput, ctx: RoundContext): string | null =>
+    validate(input, ctx.roundIndex, ctx.config, ids(ctx)),
+
+  scoreRound: (input: TwoRoomsInput, ctx: RoundContext): Record<ID, number> =>
+    score(input, ctx.roundIndex, ctx.config, ids(ctx)),
+
+  /**
+   * Scoreless team game: the reveal round tags each winner with +1, so the top
+   * total is exactly the winning team. Returns [] while undecided (all zero).
+   */
+  pickWinners: (totals) => pickWinnersLogic(totals),
+
+  describeRound: (round: Round, players): string =>
+    describe(round.input as TwoRoomsInput, (id) => players.find((p) => p.id === id)?.name ?? '?'),
+
+  help: [
+    '💣 Two teams, two rooms, one bomb.',
+    'Blue Team has the President. Red Team has the Bomber.',
+    '',
+    'Split the group evenly across two rooms and deal one secret character card each.',
+    'Play a set number of timed rounds (each a minute shorter than the last). Each room',
+    'appoints a Leader; at the end of the round the Leaders trade hostages between rooms.',
+    '',
+    'Hostages traded per round (per room):',
+    '• 6–10 players: 1 · 1 · 1',
+    '• 11–21 players: 2 · 1 · 1',
+    '• 22+ players: 3 · 2 · 1',
+    'The final round always trades a single hostage.',
+    '',
+    'After the last exchange, everyone reveals their card:',
+    '• Bomber in the President’s room → 💥 RED Team wins.',
+    '• Otherwise → 🕊️ BLUE Team wins.',
+    '',
+    'Odd number of players? Add the Gambler (grey) to even the deck.',
+  ].join('\n'),
+
+  stats: twoRoomsStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/tworooms/logic.ts
+++ b/src/lib/games/tworooms/logic.ts
@@ -1,0 +1,236 @@
+import type { ID } from '../../types';
+
+/**
+ * Two Rooms and a Boom — a scoreless, hidden-role team game modeled onto the
+ * point-oriented {@link import('../../types').GameModule} contract.
+ *
+ * The timeline is the game's physical ROUNDS: each records the two room leaders
+ * and how many hostages each room sent. Those rounds score nothing. The FINAL
+ * round also carries the Reveal — the winning team and who was on it — which is
+ * the only round that scores (each winner +1), so `pickWinners` reads the
+ * winning team straight out of the totals. Everything here is pure and
+ * Svelte-free so `tworooms.test.ts` can exercise the real rules.
+ */
+
+export type Team = 'blue' | 'red';
+
+export interface TwoRoomsReveal {
+  /**
+   * Winning team. 'red' when the Bomber ended in the President's room (the Bomber
+   * "caught" the President); otherwise 'blue'. null until the reveal is recorded.
+   */
+  winner: Team | null;
+  /** Players revealed to be on the winning team — each one earns the win. */
+  winners: ID[];
+  /** Who held the President card (Blue). Optional, for flavor + stats. */
+  president: ID | null;
+  /** Who held the Bomber card (Red). Optional, for flavor + stats. */
+  bomber: ID | null;
+}
+
+export interface TwoRoomsInput {
+  /** Leader of Room 1 this round (a player id), or null when unrecorded. */
+  leader1: ID | null;
+  /** Leader of Room 2 this round. */
+  leader2: ID | null;
+  /** Hostages Room 1 sent to Room 2 at the end of the round. */
+  sent1: number;
+  /** Hostages Room 2 sent to Room 1. */
+  sent2: number;
+  /** The final reveal — only meaningful on (and validated for) the last round. */
+  reveal: TwoRoomsReveal;
+}
+
+export const MIN_PLAYERS = 6;
+export const MAX_PLAYERS = 30;
+export const MIN_ROUNDS = 3;
+export const MAX_ROUNDS = 5;
+export const DEFAULT_ROUNDS = 3;
+
+/** The configured number of rounds, clamped to the supported 3–5 range. */
+export function roundCount(config: Record<string, unknown> | undefined): number {
+  const n = Math.round(Number(config?.rounds));
+  if (!Number.isFinite(n)) return DEFAULT_ROUNDS;
+  return Math.min(MAX_ROUNDS, Math.max(MIN_ROUNDS, n));
+}
+
+/** True when this 0-based round is the last one — the round that records the reveal. */
+export function isFinalRound(roundIndex: number, config: Record<string, unknown> | undefined): boolean {
+  return roundIndex >= roundCount(config) - 1;
+}
+
+/**
+ * Suggested round length in minutes. Rounds count down to a tense one-minute
+ * finish (3-round game → 3, 2, 1; a 5-round game → 5, 4, 3, 2, 1).
+ */
+export function suggestedMinutes(roundIndex: number, config: Record<string, unknown> | undefined): number {
+  return Math.max(1, roundCount(config) - roundIndex);
+}
+
+/**
+ * Suggested hostages a room sends this round, following the official chart:
+ *   6–10 players → 1 / 1 / 1,  11–21 → 2 / 1 / 1,  22+ → 3 / 2 / 1.
+ * The final round always trades a single hostage; the opening round scales with
+ * the crowd; middle rounds sit in between (generalized so 4–5 round games taper).
+ */
+export function suggestedHostages(
+  playerCount: number,
+  roundIndex: number,
+  config: Record<string, unknown> | undefined,
+): number {
+  const rounds = roundCount(config);
+  if (roundIndex >= rounds - 1) return 1;
+  const opening = playerCount >= 22 ? 3 : playerCount >= 11 ? 2 : 1;
+  if (roundIndex === 0) return opening;
+  return playerCount >= 22 ? 2 : 1;
+}
+
+export interface RoleBreakdown {
+  players: number;
+  /** Always 1 — the Blue Team's President. */
+  president: number;
+  /** Always 1 — the Red Team's Bomber. */
+  bomber: number;
+  /** Plain Blue cards (does not include the President). */
+  blueTeam: number;
+  /** Plain Red cards (does not include the Bomber). */
+  redTeam: number;
+  /** 1 when the count is odd — the grey/independent Gambler is added. */
+  gambler: number;
+  /** Blue side total, including the President. */
+  blueTotal: number;
+  /** Red side total, including the Bomber. */
+  redTotal: number;
+}
+
+/**
+ * The character deck for `players`: President (Blue) + Bomber (Red) + an equal
+ * number of plain Blue/Red cards, plus a Gambler when the count is odd (the
+ * rulebook's tie-breaker for odd tables).
+ */
+export function roleBreakdown(players: number): RoleBreakdown {
+  const p = Math.max(0, Math.floor(Number(players) || 0));
+  const leaders = p >= 2 ? 1 : 0;
+  const gambler = p % 2 === 1 ? 1 : 0;
+  const rest = Math.max(0, p - 2 * leaders - gambler);
+  const half = Math.floor(rest / 2);
+  return {
+    players: p,
+    president: leaders,
+    bomber: leaders,
+    blueTeam: half,
+    redTeam: half,
+    gambler,
+    blueTotal: leaders + half,
+    redTotal: leaders + half,
+  };
+}
+
+/** A fresh, empty round draft. */
+export function createInput(): TwoRoomsInput {
+  return {
+    leader1: null,
+    leader2: null,
+    sent1: 0,
+    sent2: 0,
+    reveal: { winner: null, winners: [], president: null, bomber: null },
+  };
+}
+
+/** Human label for a team. */
+export function teamLabel(team: Team): string {
+  return team === 'red' ? 'Red Team' : 'Blue Team';
+}
+
+/** Return null when the round is valid, otherwise a human-readable error. */
+export function validate(
+  input: TwoRoomsInput,
+  roundIndex: number,
+  config: Record<string, unknown> | undefined,
+  playerIds: ID[],
+): string | null {
+  if (!input) return 'Round data is missing.';
+  if ((Number(input.sent1) || 0) < 0 || (Number(input.sent2) || 0) < 0) {
+    return 'Hostage counts can’t be negative.';
+  }
+  if (input.leader1 && input.leader2 && input.leader1 === input.leader2) {
+    return 'Each room needs its own leader — one player can’t lead both rooms.';
+  }
+  if (isFinalRound(roundIndex, config)) {
+    const r = input.reveal;
+    if (!r || (r.winner !== 'blue' && r.winner !== 'red')) {
+      return 'Reveal time: did the Bomber end up in the President’s room?';
+    }
+    if (!Array.isArray(r.winners) || r.winners.length === 0) {
+      return `Tap everyone on the winning ${teamLabel(r.winner)}.`;
+    }
+    const known = new Set(playerIds);
+    if (r.winners.some((id) => !known.has(id))) {
+      return 'A selected winner isn’t in this game.';
+    }
+    if (r.president && !known.has(r.president)) return 'The President isn’t in this game.';
+    if (r.bomber && !known.has(r.bomber)) return 'The Bomber isn’t in this game.';
+  }
+  return null;
+}
+
+/**
+ * Per-player deltas. Exchange rounds score nothing (the game is scoreless until
+ * the reveal). The final round awards +1 to each player on the winning team, so
+ * the totals encode exactly one thing: who won.
+ */
+export function score(
+  input: TwoRoomsInput,
+  roundIndex: number,
+  config: Record<string, unknown> | undefined,
+  playerIds: ID[],
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) out[id] = 0;
+  if (isFinalRound(roundIndex, config) && input?.reveal?.winner) {
+    const winners = new Set(input.reveal.winners ?? []);
+    for (const id of playerIds) out[id] = winners.has(id) ? 1 : 0;
+  }
+  return out;
+}
+
+/**
+ * The winning team from accumulated totals: everyone tied at the top total,
+ * provided it's above zero. Returns [] while the game is undecided (all zero) so
+ * a scoreless, unrevealed game reports no winner instead of a full-table tie.
+ */
+export function pickWinners(totals: Record<ID, number>): ID[] {
+  const ids = Object.keys(totals);
+  let max = 0;
+  for (const id of ids) max = Math.max(max, Number(totals[id]) || 0);
+  if (max <= 0) return [];
+  return ids.filter((id) => (Number(totals[id]) || 0) === max);
+}
+
+/**
+ * A one-line summary for the history log. Detects the reveal by its recorded
+ * winner (describeRound has no config), so exchange rounds read as swaps and the
+ * final round reads as the boom.
+ */
+export function describe(input: TwoRoomsInput, nameOf: (id: ID | null) => string): string {
+  const r = input?.reveal;
+  if (r && (r.winner === 'red' || r.winner === 'blue')) {
+    if (r.winner === 'red') {
+      const who =
+        r.bomber && r.president
+          ? `${nameOf(r.bomber)} caught ${nameOf(r.president)}`
+          : 'the Bomber caught the President';
+      return `💥 Red Team wins — ${who}`;
+    }
+    const who = r.president ? `${nameOf(r.president)} escaped the Bomber` : 'the Bomber was contained';
+    return `🕊️ Blue Team wins — ${who}`;
+  }
+  const a = Number(input?.sent1) || 0;
+  const b = Number(input?.sent2) || 0;
+  if (input?.leader1 || input?.leader2) {
+    const l1 = input.leader1 ? nameOf(input.leader1) : 'Room 1';
+    const l2 = input.leader2 ? nameOf(input.leader2) : 'Room 2';
+    return `🔁 ${l1} sent ${a} · ${l2} sent ${b}`;
+  }
+  return `🔁 Hostage swap — ${a} ⇄ ${b}`;
+}

--- a/src/lib/games/tworooms/stats.ts
+++ b/src/lib/games/tworooms/stats.ts
@@ -1,0 +1,91 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt } from '../../stats/format';
+import type { TwoRoomsInput } from './logic';
+
+interface TwoRoomsAgg {
+  /** Rounds this player held a room's Leader card. */
+  roomsLed: number;
+  /** Games this player was the President. */
+  presidencies: number;
+  /** Games this player was the Bomber. */
+  bombings: number;
+  /** Games this player was the Bomber AND Red won (the bomb landed). */
+  bombsLanded: number;
+}
+
+/**
+ * Two Rooms and a Boom stats from each round's recorded leaders + reveal. Pure,
+ * no I/O — mirrors the module's own scoring. The generic engine already tracks
+ * wins from the winning team, so this surfaces the flavor it can't: who wore the
+ * President and Bomber hats, who kept getting handed the Leader card, and how
+ * often the Bomber actually caught the President.
+ */
+export function twoRoomsStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, TwoRoomsAgg>();
+  const get = (id: ID): TwoRoomsAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { roomsLed: 0, presidencies: 0, bombings: 0, bombsLanded: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let redWins = 0;
+  let blueWins = 0;
+  let hostages = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as TwoRoomsInput | undefined;
+    if (!input) continue;
+
+    hostages += (Number(input.sent1) || 0) + (Number(input.sent2) || 0);
+    if (input.leader1) get(canonical(input.leader1)).roomsLed += 1;
+    if (input.leader2) get(canonical(input.leader2)).roomsLed += 1;
+
+    const reveal = input.reveal;
+    if (reveal && (reveal.winner === 'red' || reveal.winner === 'blue')) {
+      if (reveal.winner === 'red') redWins += 1;
+      else blueWins += 1;
+
+      const president = reveal.president ? canonical(reveal.president) : null;
+      const bomber = reveal.bomber ? canonical(reveal.bomber) : null;
+      if (president) get(president).presidencies += 1;
+      if (bomber) {
+        const a = get(bomber);
+        a.bombings += 1;
+        if (reveal.winner === 'red') a.bombsLanded += 1;
+      }
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.presidencies) {
+      metrics.push({ key: 'tr_pres', label: 'President', value: fmtInt(a.presidencies), emoji: '🏛️' });
+    }
+    if (a.bombings) {
+      const sub = a.bombsLanded ? `${fmtInt(a.bombsLanded)} landed` : undefined;
+      metrics.push({ key: 'tr_bomb', label: 'Bomber', value: fmtInt(a.bombings), sub, emoji: '💣' });
+    }
+    if (a.roomsLed) {
+      metrics.push({ key: 'tr_led', label: 'Rooms led', value: fmtInt(a.roomsLed), emoji: '📢' });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (redWins || blueWins) {
+    global.push({ key: 'tr_red', label: 'Red Team wins', value: fmtInt(redWins), emoji: '💥' });
+    global.push({ key: 'tr_blue', label: 'Blue Team wins', value: fmtInt(blueWins), emoji: '🕊️' });
+  }
+  if (hostages) {
+    global.push({ key: 'tr_hostages', label: 'Hostages traded', value: fmtInt(hostages), emoji: '🔁' });
+  }
+
+  return { perPlayer, global };
+}

--- a/src/lib/games/tworooms/tworooms.test.ts
+++ b/src/lib/games/tworooms/tworooms.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_ROUNDS,
+  MAX_ROUNDS,
+  MIN_ROUNDS,
+  createInput,
+  describe as describeRound,
+  isFinalRound,
+  pickWinners,
+  roleBreakdown,
+  roundCount,
+  score,
+  suggestedHostages,
+  suggestedMinutes,
+  teamLabel,
+  validate,
+  type TwoRoomsInput,
+} from './logic';
+
+/** A fresh input with a few overrides applied. */
+function make(overrides: Partial<TwoRoomsInput> = {}): TwoRoomsInput {
+  return { ...createInput(), ...overrides };
+}
+const cfg = (rounds: number) => ({ rounds });
+const nameOf = (id: string | null) => (id ? id.toUpperCase() : '');
+
+describe('roundCount', () => {
+  it('defaults to 3 when unset or non-numeric', () => {
+    expect(roundCount(undefined)).toBe(DEFAULT_ROUNDS);
+    expect(roundCount({})).toBe(DEFAULT_ROUNDS);
+    expect(roundCount({ rounds: 'nope' })).toBe(DEFAULT_ROUNDS);
+  });
+
+  it('clamps to the supported 3–5 range', () => {
+    expect(roundCount({ rounds: 1 })).toBe(MIN_ROUNDS);
+    expect(roundCount({ rounds: 3 })).toBe(3);
+    expect(roundCount({ rounds: 4 })).toBe(4);
+    expect(roundCount({ rounds: 5 })).toBe(5);
+    expect(roundCount({ rounds: 9 })).toBe(MAX_ROUNDS);
+  });
+
+  it('rounds fractional configs', () => {
+    expect(roundCount({ rounds: 3.4 })).toBe(3);
+    expect(roundCount({ rounds: 4.6 })).toBe(5);
+  });
+});
+
+describe('isFinalRound', () => {
+  it('marks only the last round for a 3-round game', () => {
+    expect(isFinalRound(0, cfg(3))).toBe(false);
+    expect(isFinalRound(1, cfg(3))).toBe(false);
+    expect(isFinalRound(2, cfg(3))).toBe(true);
+  });
+
+  it('tracks the configured count and treats overshoot as final', () => {
+    expect(isFinalRound(3, cfg(5))).toBe(false);
+    expect(isFinalRound(4, cfg(5))).toBe(true);
+    expect(isFinalRound(9, cfg(3))).toBe(true);
+  });
+});
+
+describe('suggestedMinutes', () => {
+  it('counts down to a one-minute finish', () => {
+    expect([0, 1, 2].map((i) => suggestedMinutes(i, cfg(3)))).toEqual([3, 2, 1]);
+    expect([0, 1, 2, 3, 4].map((i) => suggestedMinutes(i, cfg(5)))).toEqual([5, 4, 3, 2, 1]);
+  });
+
+  it('never drops below one minute', () => {
+    expect(suggestedMinutes(7, cfg(3))).toBe(1);
+  });
+});
+
+describe('suggestedHostages (official chart)', () => {
+  it('6–10 players trade one each round', () => {
+    expect([0, 1, 2].map((i) => suggestedHostages(8, i, cfg(3)))).toEqual([1, 1, 1]);
+  });
+
+  it('11–21 players open with two, then one', () => {
+    expect([0, 1, 2].map((i) => suggestedHostages(16, i, cfg(3)))).toEqual([2, 1, 1]);
+  });
+
+  it('22+ players run 3 / 2 / 1', () => {
+    expect([0, 1, 2].map((i) => suggestedHostages(24, i, cfg(3)))).toEqual([3, 2, 1]);
+  });
+
+  it('always trades a single hostage on the final round', () => {
+    expect(suggestedHostages(24, 4, cfg(5))).toBe(1);
+    expect(suggestedHostages(8, 2, cfg(3))).toBe(1);
+  });
+
+  it('tapers sanely for longer games', () => {
+    expect([0, 1, 2, 3, 4].map((i) => suggestedHostages(24, i, cfg(5)))).toEqual([3, 2, 2, 2, 1]);
+  });
+});
+
+describe('roleBreakdown', () => {
+  it('splits an even table evenly with President + Bomber', () => {
+    const r = roleBreakdown(6);
+    expect(r).toMatchObject({ president: 1, bomber: 1, blueTeam: 2, redTeam: 2, gambler: 0 });
+    expect(r.blueTotal).toBe(3);
+    expect(r.redTotal).toBe(3);
+    expect(r.blueTotal + r.redTotal).toBe(6);
+  });
+
+  it('adds a Gambler for an odd table', () => {
+    const r = roleBreakdown(7);
+    expect(r.gambler).toBe(1);
+    expect(r.blueTeam).toBe(2);
+    expect(r.redTeam).toBe(2);
+    expect(r.blueTotal + r.redTotal + r.gambler).toBe(7);
+  });
+
+  it('handles the minimum even split', () => {
+    const r = roleBreakdown(2);
+    expect(r).toMatchObject({ president: 1, bomber: 1, blueTeam: 0, redTeam: 0, gambler: 0 });
+  });
+
+  it('degrades gracefully below two players', () => {
+    expect(roleBreakdown(0)).toMatchObject({ president: 0, bomber: 0, blueTotal: 0, redTotal: 0 });
+    expect(roleBreakdown(1).gambler).toBe(1);
+  });
+
+  it('always accounts for every player', () => {
+    for (let n = 2; n <= 30; n++) {
+      const r = roleBreakdown(n);
+      expect(r.blueTotal + r.redTotal + r.gambler).toBe(n);
+    }
+  });
+});
+
+describe('createInput', () => {
+  it('starts empty and scoreless', () => {
+    const input = createInput();
+    expect(input).toEqual({
+      leader1: null,
+      leader2: null,
+      sent1: 0,
+      sent2: 0,
+      reveal: { winner: null, winners: [], president: null, bomber: null },
+    });
+  });
+});
+
+describe('validate', () => {
+  const ids = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+  it('accepts a plain exchange round', () => {
+    expect(validate(make({ sent1: 2, sent2: 1 }), 0, cfg(3), ids)).toBeNull();
+  });
+
+  it('rejects negative hostage counts', () => {
+    expect(validate(make({ sent1: -1 }), 0, cfg(3), ids)).toMatch(/negative/i);
+  });
+
+  it('rejects one player leading both rooms', () => {
+    expect(validate(make({ leader1: 'a', leader2: 'a' }), 0, cfg(3), ids)).toMatch(/both rooms/i);
+  });
+
+  it('allows distinct leaders per room', () => {
+    expect(validate(make({ leader1: 'a', leader2: 'b' }), 0, cfg(3), ids)).toBeNull();
+  });
+
+  it('requires the reveal on the final round', () => {
+    expect(validate(make(), 2, cfg(3), ids)).toMatch(/Reveal time/i);
+  });
+
+  it('requires at least one winner once a team is chosen', () => {
+    const input = make();
+    input.reveal.winner = 'red';
+    expect(validate(input, 2, cfg(3), ids)).toMatch(/winning Red Team/i);
+  });
+
+  it('rejects winners who are not in the game', () => {
+    const input = make();
+    input.reveal.winner = 'blue';
+    input.reveal.winners = ['zzz'];
+    expect(validate(input, 2, cfg(3), ids)).toMatch(/isn’t in this game/i);
+  });
+
+  it('rejects an unknown President or Bomber', () => {
+    const input = make();
+    input.reveal = { winner: 'blue', winners: ['a'], president: 'zzz', bomber: null };
+    expect(validate(input, 2, cfg(3), ids)).toMatch(/President isn’t/i);
+  });
+
+  it('accepts a complete reveal', () => {
+    const input = make({ sent1: 1, sent2: 1 });
+    input.reveal = { winner: 'red', winners: ['a', 'b', 'c'], president: 'd', bomber: 'a' };
+    expect(validate(input, 2, cfg(3), ids)).toBeNull();
+  });
+
+  it('does not demand a reveal on non-final rounds', () => {
+    expect(validate(make(), 0, cfg(3), ids)).toBeNull();
+    expect(validate(make(), 1, cfg(3), ids)).toBeNull();
+  });
+});
+
+describe('score', () => {
+  const ids = ['a', 'b', 'c', 'd'];
+
+  it('scores nothing on exchange rounds', () => {
+    const out = score(make({ sent1: 3, sent2: 2, leader1: 'a' }), 0, cfg(3), ids);
+    expect(out).toEqual({ a: 0, b: 0, c: 0, d: 0 });
+  });
+
+  it('awards +1 to each winner on the reveal round', () => {
+    const input = make();
+    input.reveal = { winner: 'red', winners: ['a', 'c'], president: 'b', bomber: 'a' };
+    expect(score(input, 2, cfg(3), ids)).toEqual({ a: 1, b: 0, c: 1, d: 0 });
+  });
+
+  it('ignores a reveal recorded on a non-final round', () => {
+    const input = make();
+    input.reveal = { winner: 'red', winners: ['a', 'c'], president: null, bomber: null };
+    expect(score(input, 0, cfg(3), ids)).toEqual({ a: 0, b: 0, c: 0, d: 0 });
+  });
+
+  it('scores zero when the final round has no recorded winner', () => {
+    expect(score(make(), 2, cfg(3), ids)).toEqual({ a: 0, b: 0, c: 0, d: 0 });
+  });
+});
+
+describe('pickWinners', () => {
+  it('reports no winner while the game is scoreless', () => {
+    expect(pickWinners({ a: 0, b: 0, c: 0 })).toEqual([]);
+  });
+
+  it('returns exactly the winning team', () => {
+    expect(pickWinners({ a: 1, b: 0, c: 1, d: 0 }).sort()).toEqual(['a', 'c']);
+  });
+
+  it('handles an empty table', () => {
+    expect(pickWinners({})).toEqual([]);
+  });
+
+  it('lines up with score() end to end', () => {
+    const ids = ['a', 'b', 'c', 'd'];
+    const input = make();
+    input.reveal = { winner: 'blue', winners: ['b', 'd'], president: 'b', bomber: 'a' };
+    const totals = score(input, 2, cfg(3), ids);
+    expect(pickWinners(totals).sort()).toEqual(['b', 'd']);
+  });
+});
+
+describe('describe', () => {
+  it('summarizes a bare hostage swap', () => {
+    expect(describeRound(make({ sent1: 2, sent2: 1 }), nameOf)).toBe('🔁 Hostage swap — 2 ⇄ 1');
+  });
+
+  it('names the leaders when recorded', () => {
+    const input = make({ sent1: 1, sent2: 2, leader1: 'ana', leader2: 'ben' });
+    expect(describeRound(input, nameOf)).toBe('🔁 ANA sent 1 · BEN sent 2');
+  });
+
+  it('celebrates a Red win with the caught pair', () => {
+    const input = make();
+    input.reveal = { winner: 'red', winners: ['a'], president: 'pat', bomber: 'bo' };
+    expect(describeRound(input, nameOf)).toBe('💥 Red Team wins — BO caught PAT');
+  });
+
+  it('celebrates a Blue win', () => {
+    const input = make();
+    input.reveal = { winner: 'blue', winners: ['a'], president: 'pat', bomber: null };
+    expect(describeRound(input, nameOf)).toBe('🕊️ Blue Team wins — PAT escaped the Bomber');
+  });
+
+  it('falls back to generic reveal copy without named roles', () => {
+    const input = make();
+    input.reveal = { winner: 'red', winners: ['a'], president: null, bomber: null };
+    expect(describeRound(input, nameOf)).toBe('💥 Red Team wins — the Bomber caught the President');
+  });
+});
+
+describe('teamLabel', () => {
+  it('labels both teams by name, never colour alone', () => {
+    expect(teamLabel('red')).toBe('Red Team');
+    expect(teamLabel('blue')).toBe('Blue Team');
+  });
+});


### PR DESCRIPTION
﻿## Two Rooms and a Boom

Adds a first-class tracker for **Two Rooms and a Boom** — a scoreless, hidden-role social-deduction party game (Blue Team's **President** vs Red Team's **Bomber**, played across two physical rooms over timed rounds with hostage exchanges). At the final reveal: **Bomber in the President's room -> Red wins; otherwise -> Blue wins.**

Purely additive: everything lives under `src/lib/games/tworooms/`. No shared files touched — the registry auto-discovers the folder's `index.ts`.

### Modeling a scoreless team game onto the point-oriented GameModule
- **Rounds are the timeline.** Each round records the two room **Leaders** and how many **hostages** each room sent. Exchange rounds score **0** for everyone.
- **The final round carries the Reveal** — the winning team plus who was on it. It's the only round that scores: **+1 to each winner**, so accumulated totals encode exactly one fact: who won.
- **pickWinners** returns everyone tied at the top total when it's > 0, and **[]** while undecided (all-zero), so an unrevealed game reports no winner instead of a full-table tie.
- **maxRounds** = the configured round count, so the shell's "Round N of N" header stays accurate with the reveal riding on the last round.
- describeRound detects the reveal from reveal.winner, so history reads exchange rounds as swaps and the finale as the boom.

### Config
- **Number of rounds** (3-5, default 3). Each round is suggested a minute shorter than the last, down to a one-minute finish.
- **Advanced character cards** (toggle) — the tracker still records leaders, hostages, and the winning team.

The editor seeds the steppers with the **official hostage chart** (6-10 -> 1/1/1, 11-21 -> 2/1/1, 22+ -> 3/2/1; final round always 1) and shows a per-player-count **role reference** (President, Bomber, Blue/Red cards, Gambler on odd tables).

### Design (per DESIGN.md)
- Chrome unchanged; personality via emoji/copy only. Royal Violet for selected states; **Crown Gold reserved for leader/winner** (not used inside the editor).
- **Never state-by-colour-alone** — teams always labelled "Red Team"/"Blue Team" with emoji, never a painted region.
- Touch targets >= 44-60px, tabular-nums on every changing number, depth via the surface ramp, motion left to global prefers-reduced-motion.

### Stats
Per-player Presidents / Bombers (with bombs landed) / rooms led, plus global Red-vs-Blue wins and hostages traded.

### Verification — all green
- npm run check -> 0 errors, 0 warnings
- npm test -> all suites pass (adds thorough tworooms.test.ts)
- npm run build -> success

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
