### PR TITLE
Add Fluff (Liar's Dice / Perudo) dice game

### DIFF
--- a/src/lib/games/fluff/FluffEditor.svelte
+++ b/src/lib/games/fluff/FluffEditor.svelte
@@ -1,0 +1,261 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Segmented from '../../components/Segmented.svelte';
+  import { fluff } from './index';
+  import {
+    diceRemaining,
+    onesWild,
+    spotOnEnabled,
+    startDice,
+    type FluffInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: FluffInput; ctx: RoundContext } = $props();
+
+  const start = $derived(startDice(ctx.config));
+  const spotOn = $derived(spotOnEnabled(ctx.config));
+  const wild = $derived(onesWild(ctx.config));
+
+  // Dice each player still holds going into this challenge.
+  const remaining = $derived(
+    Object.fromEntries(ctx.players.map((p) => [p.id, diceRemaining(ctx.totals, p.id, start)])),
+  );
+  const inPlay = $derived(ctx.players.reduce((sum, p) => sum + remaining[p.id], 0));
+  const aliveCount = $derived(ctx.players.filter((p) => remaining[p.id] > 0).length);
+
+  let showHelp = $state(false);
+
+  function pick(id: string) {
+    if (remaining[id] <= 0) return;
+    input.playerId = input.playerId === id ? null : id;
+    // A freshly picked player at full dice can only lose one, never gain.
+    if (input.playerId && remaining[input.playerId] >= start && input.result === 'gain') {
+      input.result = 'lose';
+    }
+  }
+
+  const selName = $derived(ctx.players.find((p) => p.id === input.playerId)?.name ?? '');
+  const before = $derived(input.playerId ? remaining[input.playerId] : 0);
+  const after = $derived(
+    input.playerId
+      ? Math.max(0, Math.min(start, before + (input.result === 'gain' ? 1 : -1)))
+      : 0,
+  );
+  const othersAlive = $derived(aliveCount - (input.playerId ? 1 : 0));
+
+  // A single status line that co-signals with an emoji + words, never colour alone.
+  const status = $derived.by(() => {
+    if (!input.playerId) {
+      return {
+        tone: 'muted',
+        text: spotOn
+          ? 'Tap whoever lost the die this challenge — or won one back.'
+          : 'Tap whoever lost the die this challenge.',
+      };
+    }
+    if (input.result === 'gain') {
+      if (before >= start) {
+        return { tone: 'bad', text: `${selName} already has all ${start} dice.` };
+      }
+      return { tone: 'good', text: `${selName} wins a die back · ${before} → ${after} 🎲` };
+    }
+    if (othersAlive === 0) {
+      return { tone: 'bad', text: `Only ${selName} left — tap “Finish & record winner”. 🏆` };
+    }
+    if (after === 0) {
+      return othersAlive === 1
+        ? { tone: 'good', text: `${selName} is out — that’s game! Last cup standing wins. 🏆` }
+        : { tone: 'bad', text: `${selName} is knocked out! 💀 (${before} → 0)` };
+    }
+    return { tone: 'plain', text: `${selName} loses a die · ${before} → ${after}` };
+  });
+</script>
+
+<div class="stack">
+  <div class="row spread wrap" style="gap: 8px">
+    <span class="row wrap" style="gap: 6px">
+      <span class="pill">🎲 {inPlay} {inPlay === 1 ? 'die' : 'dice'} in play</span>
+      <span class="pill">{aliveCount} still in</span>
+    </span>
+    <span class="row" style="gap: 6px">
+      <span class="pill" title={wild ? 'Ones count as any face' : 'Ones are just ones'}>
+        {wild ? '⚀ ones wild' : '⚀ ones tame'}
+      </span>
+      <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+        Rules
+      </button>
+    </span>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{fluff.help}</pre>
+  {/if}
+
+  <div class="roster">
+    {#each ctx.players as p (p.id)}
+      {@const left = remaining[p.id]}
+      {@const out = left <= 0}
+      {@const chosen = input.playerId === p.id}
+      <button
+        type="button"
+        class="prow"
+        class:chosen
+        class:out
+        aria-pressed={chosen}
+        disabled={out}
+        onclick={() => pick(p.id)}
+      >
+        <span class="who">
+          <Avatar name={p.name} color={p.color} />
+          <span class="name" class:struck={out}>{p.name}</span>
+          {#if chosen}<span class="tag">{input.result === 'gain' ? '✓ won one back' : '✓ lost the die'}</span>{/if}
+        </span>
+        <span class="dice">
+          <span class="pips" aria-hidden="true">
+            {#each Array.from({ length: start }) as _, i (i)}
+              <span class="pip" class:filled={i < left}></span>
+            {/each}
+          </span>
+          <span class="count">{out ? 'OUT 💀' : left}</span>
+        </span>
+      </button>
+    {/each}
+  </div>
+
+  {#if spotOn && input.playerId}
+    <Segmented
+      label="What happened to {selName}"
+      bind:value={input.result}
+      options={[
+        { value: 'lose', label: '🎲➖ Lost a die' },
+        { value: 'gain', label: '🎲➕ Won one back' },
+      ]}
+    />
+  {/if}
+
+  <p class="status" class:score-good={status.tone === 'good'} class:score-bad={status.tone === 'bad'} class:muted={status.tone === 'muted'}>
+    {status.text}
+  </p>
+</div>
+
+<style>
+  .roster {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .prow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    width: 100%;
+    min-height: 46px;
+    padding: 10px 12px;
+    text-align: left;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    color: var(--text);
+    cursor: pointer;
+    font: inherit;
+    transition: background 0.15s ease, border-color 0.15s ease, transform 0.05s ease;
+  }
+  .prow:hover:not(:disabled) {
+    background: var(--surface-3);
+  }
+  .prow:active:not(:disabled) {
+    transform: translateY(1px);
+  }
+  .prow:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .prow.chosen {
+    border-color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 12%, var(--surface-2));
+    box-shadow: inset 0 0 0 1px var(--primary);
+  }
+  .prow.chosen:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--primary) 16%, var(--surface-2));
+  }
+  .prow.out {
+    cursor: default;
+    opacity: 0.55;
+  }
+  .who {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .name {
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .name.struck {
+    text-decoration: line-through;
+    text-decoration-thickness: 1px;
+  }
+  .tag {
+    flex: none;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--primary);
+    color: #fff;
+  }
+  .dice {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: none;
+  }
+  .pips {
+    display: inline-flex;
+    gap: 3px;
+  }
+  .pip {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    border: 1px solid currentColor;
+    opacity: 0.4;
+  }
+  .pip.filled {
+    background: currentColor;
+    opacity: 1;
+  }
+  .count {
+    min-width: 3.4em;
+    text-align: right;
+    white-space: nowrap;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .status {
+    margin: 2px 2px 0;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+  }
+  .status.score-good,
+  .status.score-bad {
+    font-weight: 700;
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/fluff/fluff.test.ts
+++ b/src/lib/games/fluff/fluff.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from 'vitest';
+import type { ID, Player, Round, RoundContext } from '../../types';
+import { computeTotals } from '../../scoring';
+import { fluff } from './index';
+import {
+  DEFAULT_START_DICE,
+  describeRound,
+  diceInPlay,
+  diceLost,
+  diceRemaining,
+  isAlive,
+  isFinished,
+  pickWinners,
+  scoreRound,
+  startDice,
+  survivors,
+  validateRound,
+  type FluffInput,
+  type FluffResult,
+} from './logic';
+
+const NAMES = ['Alice', 'Bob', 'Carol', 'Dave'];
+
+function mkPlayers(n: number): Player[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `p${i + 1}`,
+    name: NAMES[i] ?? `P${i + 1}`,
+    color: '#7c5cff',
+    createdAt: 0,
+  }));
+}
+
+function ctx(
+  players: Player[],
+  totals: Record<ID, number>,
+  config: Record<string, unknown> = {},
+): RoundContext {
+  return {
+    game: {} as never,
+    players,
+    config,
+    roundIndex: 0,
+    totals,
+    rounds: [],
+  };
+}
+
+function input(playerId: ID | null, result: FluffResult = 'lose'): FluffInput {
+  return { playerId, result };
+}
+
+/** Simulate a sequence of challenges, returning the running rounds + totals (dice lost). */
+function play(
+  players: Player[],
+  steps: FluffInput[],
+  config: Record<string, unknown> = {},
+): { rounds: Round[]; totals: Record<ID, number> } {
+  const ids = players.map((p) => p.id);
+  const rounds: Round[] = [];
+  let totals = computeTotals(rounds, ids);
+  for (const step of steps) {
+    const deltas = scoreRound(step, ctx(players, totals, config));
+    rounds.push({ input: step, deltas } as Round);
+    totals = computeTotals(rounds, ids);
+  }
+  return { rounds, totals };
+}
+
+describe('fluff / config helpers', () => {
+  it('defaults to 5 starting dice and clamps to 1–6', () => {
+    expect(startDice({})).toBe(DEFAULT_START_DICE);
+    expect(startDice({ startDice: 3 })).toBe(3);
+    expect(startDice({ startDice: 0 })).toBe(5);
+    expect(startDice({ startDice: 99 })).toBe(6);
+    expect(startDice({ startDice: 'nope' })).toBe(5);
+  });
+});
+
+describe('fluff / dice bookkeeping', () => {
+  it('derives remaining and lost from cumulative totals', () => {
+    const totals = { p1: 0, p2: 2, p3: 5 };
+    expect(diceRemaining(totals, 'p1', 5)).toBe(5);
+    expect(diceRemaining(totals, 'p2', 5)).toBe(3);
+    expect(diceRemaining(totals, 'p3', 5)).toBe(0);
+    expect(diceLost(totals, 'p2')).toBe(2);
+    expect(isAlive(totals, 'p3', 5)).toBe(false);
+    expect(isAlive(totals, 'p2', 5)).toBe(true);
+  });
+
+  it('clamps out-of-range totals defensively', () => {
+    expect(diceRemaining({ p1: -3 }, 'p1', 5)).toBe(5);
+    expect(diceRemaining({ p1: 8 }, 'p1', 5)).toBe(0);
+    expect(diceLost({ p1: -3 }, 'p1')).toBe(0);
+  });
+
+  it('counts survivors and dice in play', () => {
+    const totals = { p1: 4, p2: 0, p3: 5 }; // p1 has 1 die, p2 has 5, p3 is out
+    expect(survivors(totals, ['p1', 'p2', 'p3'], 5)).toEqual(['p1', 'p2']);
+    expect(diceInPlay(totals, ['p1', 'p2', 'p3'], 5)).toBe(6);
+  });
+});
+
+describe('fluff / scoreRound', () => {
+  it('docks one die from the challenge loser and no one else', () => {
+    const players = mkPlayers(3);
+    const deltas = scoreRound(input('p2', 'lose'), ctx(players, { p1: 0, p2: 0, p3: 0 }));
+    expect(deltas).toEqual({ p1: 0, p2: 1, p3: 0 });
+  });
+
+  it('returns a die on a spot-on gain', () => {
+    const players = mkPlayers(3);
+    const deltas = scoreRound(input('p3', 'gain'), ctx(players, { p1: 0, p2: 0, p3: 2 }));
+    expect(deltas).toEqual({ p1: 0, p2: 0, p3: -1 });
+  });
+
+  it('is a no-op when no player is selected', () => {
+    const players = mkPlayers(2);
+    expect(scoreRound(input(null), ctx(players, { p1: 0, p2: 0 }))).toEqual({ p1: 0, p2: 0 });
+  });
+
+  it('ignores an unknown player id', () => {
+    const players = mkPlayers(2);
+    expect(scoreRound(input('ghost'), ctx(players, { p1: 0, p2: 0 }))).toEqual({ p1: 0, p2: 0 });
+  });
+});
+
+describe('fluff / validateRound', () => {
+  const players = mkPlayers(3);
+
+  it('requires a selected player', () => {
+    expect(validateRound(input(null), ctx(players, { p1: 0, p2: 0, p3: 0 }))).toMatch(/Tap the player/);
+  });
+
+  it('rejects an unknown player', () => {
+    expect(validateRound(input('ghost'), ctx(players, { p1: 0, p2: 0, p3: 0 }))).toMatch(/still in the game/);
+  });
+
+  it('rejects taking a die from an eliminated player', () => {
+    const t = { p1: 0, p2: 0, p3: 5 };
+    expect(validateRound(input('p3', 'lose'), ctx(players, t))).toMatch(/already out/);
+  });
+
+  it('accepts a normal loss', () => {
+    expect(validateRound(input('p1', 'lose'), ctx(players, { p1: 1, p2: 0, p3: 0 }))).toBeNull();
+  });
+
+  it('refuses to eliminate the last player standing', () => {
+    // p2 and p3 are out; p1 is the only one left.
+    const t = { p1: 4, p2: 5, p3: 5 };
+    expect(validateRound(input('p1', 'lose'), ctx(players, t))).toMatch(/Only one player left/);
+  });
+
+  it('blocks spot-on gains unless enabled', () => {
+    const t = { p1: 2, p2: 0, p3: 0 };
+    expect(validateRound(input('p1', 'gain'), ctx(players, t))).toMatch(/turned off/);
+    expect(validateRound(input('p1', 'gain'), ctx(players, t, { spotOn: true }))).toBeNull();
+  });
+
+  it('will not let a player exceed their starting dice', () => {
+    const t = { p1: 0, p2: 0, p3: 0 };
+    expect(validateRound(input('p1', 'gain'), ctx(players, t, { spotOn: true }))).toMatch(/all 5 dice/);
+  });
+
+  it('cannot gain a die once eliminated', () => {
+    const t = { p1: 5, p2: 0, p3: 0 };
+    expect(validateRound(input('p1', 'gain'), ctx(players, t, { spotOn: true }))).toMatch(/already out/);
+  });
+
+  it('honours a custom starting-dice count', () => {
+    const t = { p1: 2, p2: 0, p3: 0 };
+    // With 3 starting dice, p1 has lost 2 → 1 left → gaining is fine.
+    expect(validateRound(input('p1', 'gain'), ctx(players, t, { spotOn: true, startDice: 3 }))).toBeNull();
+    // A third loss would take p1 to 0 (out), but that's a *lose*, still allowed here (others alive).
+    expect(validateRound(input('p1', 'lose'), ctx(players, t, { startDice: 3 }))).toBeNull();
+  });
+});
+
+describe('fluff / isFinished', () => {
+  it('is not finished at kickoff (everyone full)', () => {
+    expect(isFinished({ p1: 0, p2: 0, p3: 0 }, { config: {} })).toBe(false);
+  });
+
+  it('is not finished while two players hold dice', () => {
+    expect(isFinished({ p1: 5, p2: 3, p3: 2 }, { config: {} })).toBe(false);
+  });
+
+  it('is finished when only one player has dice left', () => {
+    expect(isFinished({ p1: 5, p2: 5, p3: 1 }, { config: {} })).toBe(true);
+  });
+
+  it('respects a custom starting-dice count', () => {
+    // start=3: p1 lost 3 (out), p2 lost 3 (out), p3 alive → finished.
+    expect(isFinished({ p1: 3, p2: 3, p3: 1 }, { config: { startDice: 3 } })).toBe(true);
+    expect(isFinished({ p1: 3, p2: 2, p3: 1 }, { config: { startDice: 3 } })).toBe(false);
+  });
+});
+
+describe('fluff / pickWinners', () => {
+  it('crowns the last cup standing', () => {
+    expect(pickWinners({ p1: 5, p2: 2, p3: 5 }, {})).toEqual(['p2']);
+  });
+
+  it('breaks a forced early finish toward the fewest dice lost', () => {
+    // Two still alive; p3 has lost fewer → sole leader wins.
+    expect(pickWinners({ p1: 5, p2: 3, p3: 1 }, {})).toEqual(['p3']);
+  });
+
+  it('can return a tie among equally-placed survivors', () => {
+    expect(pickWinners({ p1: 2, p2: 2, p3: 5 }, {}).sort()).toEqual(['p1', 'p2']);
+  });
+
+  it('falls back to fewest lost if somehow everyone is out', () => {
+    expect(pickWinners({ p1: 5, p2: 5, p3: 6 }, {})).toEqual(['p1', 'p2']);
+  });
+});
+
+describe('fluff / describeRound', () => {
+  const players = mkPlayers(2);
+  it('summarises a loss and a gain', () => {
+    expect(describeRound({ input: input('p1', 'lose') } as Round, players)).toBe('💀 Alice lost a die');
+    expect(describeRound({ input: input('p2', 'gain') } as Round, players)).toBe('🎲 Bob won a die back');
+  });
+  it('handles an empty round', () => {
+    expect(describeRound({ input: input(null) } as Round, players)).toBe('no change');
+  });
+});
+
+describe('fluff / full game simulation', () => {
+  it('tracks dice down to a single winner', () => {
+    const players = mkPlayers(3); // p1 Alice, p2 Bob, p3 Carol — 5 dice each
+    // Knock Carol all the way out (5 losses), then whittle Bob to zero (5 losses).
+    const steps: FluffInput[] = [
+      ...Array(5).fill(input('p3', 'lose')),
+      ...Array(5).fill(input('p2', 'lose')),
+    ];
+    const { totals } = play(players, steps);
+    expect(diceRemaining(totals, 'p1', 5)).toBe(5);
+    expect(diceRemaining(totals, 'p2', 5)).toBe(0);
+    expect(diceRemaining(totals, 'p3', 5)).toBe(0);
+    expect(isFinished(totals, { config: {} })).toBe(true);
+    expect(pickWinners(totals, {})).toEqual(['p1']);
+  });
+
+  it('lets a spot-on call claw a die back mid-game', () => {
+    const players = mkPlayers(2);
+    const cfg = { spotOn: true };
+    const { totals } = play(
+      players,
+      [input('p1', 'lose'), input('p1', 'lose'), input('p1', 'gain')],
+      cfg,
+    );
+    // Alice: 5 → 4 → 3 → 4
+    expect(diceRemaining(totals, 'p1', 5)).toBe(4);
+    expect(diceRemaining(totals, 'p2', 5)).toBe(5);
+    expect(isFinished(totals, { config: cfg })).toBe(false);
+  });
+
+  it('stays correct when an earlier round is deleted and the rest re-indexed', () => {
+    const players = mkPlayers(2);
+    const { rounds } = play(players, [
+      input('p1', 'lose'),
+      input('p2', 'lose'),
+      input('p1', 'lose'),
+    ]);
+    // Drop the first round (a p1 loss) and recompute — the ±1 deltas are position-free.
+    const trimmed = rounds.slice(1);
+    const totals = computeTotals(trimmed, ['p1', 'p2']);
+    expect(diceLost(totals, 'p1')).toBe(1); // was 2, minus the deleted loss
+    expect(diceLost(totals, 'p2')).toBe(1);
+    expect(diceRemaining(totals, 'p1', 5)).toBe(4);
+  });
+});
+
+describe('fluff / module wiring', () => {
+  it('exposes the expected identity and bounds', () => {
+    expect(fluff.id).toBe('fluff');
+    expect(fluff.lowerIsBetter).toBe(true);
+    expect(fluff.minPlayers).toBe(2);
+    expect(fluff.maxPlayers).toBeGreaterThanOrEqual(fluff.minPlayers);
+    expect(typeof fluff.help).toBe('string');
+  });
+
+  it('creates a blank round input', () => {
+    const players = mkPlayers(2);
+    expect(fluff.createRoundInput(ctx(players, { p1: 0, p2: 0 }))).toEqual({
+      playerId: null,
+      result: 'lose',
+    });
+  });
+
+  it('wires isFinished / pickWinners through the module', () => {
+    const totals = { p1: 5, p2: 1 };
+    expect(fluff.isFinished!(totals, { config: {}, roundCount: 9, playerCount: 2 })).toBe(true);
+    expect(fluff.pickWinners!(totals, {})).toEqual(['p2']);
+  });
+});

--- a/src/lib/games/fluff/index.ts
+++ b/src/lib/games/fluff/index.ts
@@ -1,0 +1,87 @@
+import type { GameModule, Round, RoundContext } from '../../types';
+import Editor from './FluffEditor.svelte';
+import { fluffStats } from './stats';
+import {
+  describeRound,
+  isFinished,
+  pickWinners,
+  scoreRound,
+  validateRound,
+  type FluffInput,
+} from './logic';
+
+export type { FluffInput, FluffResult } from './logic';
+
+export const fluff: GameModule = {
+  id: 'fluff',
+  name: 'Fluff',
+  tagline: 'Bluff your bids, keep your dice.',
+  emoji: '🎲',
+  keywords: ["liar's dice", 'perudo', 'dudo', 'bluffing', 'dice', 'bidding', 'elimination'],
+  minPlayers: 2,
+  maxPlayers: 8,
+  // Fewest dice lost leads — the last cup standing wins.
+  lowerIsBetter: true,
+
+  configFields: [
+    {
+      key: 'startDice',
+      label: 'Dice per player to start',
+      type: 'number',
+      default: 5,
+      min: 1,
+      max: 6,
+      help: 'Everyone begins with this many dice. Lose your last one and you’re out.',
+    },
+    {
+      key: 'onesWild',
+      label: 'Ones are wild',
+      type: 'boolean',
+      default: true,
+      help: 'Ones count as every face when the dice are revealed (except during a Palifico round).',
+    },
+    {
+      key: 'spotOn',
+      label: 'Allow “spot-on” calls',
+      type: 'boolean',
+      default: false,
+      help: 'Call the exact count and, if you nail it, win a die back instead of losing one.',
+    },
+  ],
+
+  createRoundInput: (_ctx: RoundContext): FluffInput => ({ playerId: null, result: 'lose' }),
+
+  validateRound,
+  scoreRound,
+
+  isFinished: (totals, info) => isFinished(totals, info),
+  pickWinners,
+
+  describeRound: (round: Round, players): string => describeRound(round, players),
+
+  help: [
+    '🎲 Fluff — a.k.a. Liar’s Dice / Perudo. Bluff, bid, and call. Last cup standing wins.',
+    '',
+    'Each player shakes their dice under a cup and peeks in secret.',
+    'On your turn, raise the bid — a quantity and a face across ALL dice on the table',
+    '(e.g. “four 5s”) — by upping the quantity, the face, or both…',
+    '…or call “Fluff!” if you think the last bid is a bluff.',
+    '',
+    'When someone calls, every cup lifts and you count that face:',
+    '• Bid was too high (a bluff) → the bidder loses a die.',
+    '• Bid was right or low → the caller loses a die.',
+    '',
+    'Lose your last die and you’re knocked out. Play until one player remains.',
+    '',
+    'Ones are wild — they count as any face (toggle in setup).',
+    'Spot-on (optional): nail the exact count and win a die back instead.',
+    'Palifico: the first time a player drops to one die, that round fixes a single',
+    'face and ones aren’t wild.',
+    '',
+    'This tracker keeps the dice count: tap whoever lost the die each challenge.',
+  ].join('\n'),
+
+  stats: fluffStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/fluff/logic.ts
+++ b/src/lib/games/fluff/logic.ts
@@ -1,0 +1,143 @@
+import type { ID, Round, RoundContext } from '../../types';
+
+/**
+ * Fluff — the bluffing dice game in the Liar's Dice / Perudo family. Pure, Svelte-free
+ * logic so it can be unit-tested (see `fluff.test.ts`) without importing the editor.
+ *
+ * ## The tracker model
+ * Fluff is an *elimination* game: every player starts with a cup of dice; each challenge
+ * resolves with exactly one player being wrong and **losing a die** (or, with the
+ * spot-on variant, a correct exact-caller **regaining** one). A player is out at zero
+ * dice; the **last player standing wins**.
+ *
+ * We map that onto the generic score engine by making each recorded round one challenge
+ * and letting `totals[id]` accumulate **dice lost** (so `lowerIsBetter` — fewest lost
+ * leads). Dice *remaining* is derived as `startDice − lost`. Deltas are a position-free
+ * ±1, so the running totals stay correct even when a round is deleted and the rest are
+ * re-indexed (the engine re-indexes without re-scoring).
+ */
+
+export type FluffResult = 'lose' | 'gain';
+
+export interface FluffInput {
+  /** The player affected by this challenge — the one who lost (or, spot-on, regained) a die. */
+  playerId: ID | null;
+  /** `'lose'` = down a die (a busted bid or bad call); `'gain'` = up a die (a correct spot-on call). */
+  result: FluffResult;
+}
+
+export const DEFAULT_START_DICE = 5;
+
+/** Dice each player starts with, from config (defaults to 5, clamped to a sane 1–6). */
+export function startDice(config: Record<string, unknown>): number {
+  const n = Math.floor(Number(config.startDice));
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_START_DICE;
+  return Math.min(6, n);
+}
+
+/** Whether "ones are wild" is on (flavor/house-rule — reflected in copy & help, not scoring). */
+export function onesWild(config: Record<string, unknown>): boolean {
+  return config.onesWild !== false;
+}
+
+/** Whether "spot-on" (exact) calls are enabled — a correct exact call lets a player regain a die. */
+export function spotOnEnabled(config: Record<string, unknown>): boolean {
+  return config.spotOn === true;
+}
+
+/** Cumulative dice a player has lost so far (never negative). */
+export function diceLost(totals: Record<ID, number>, id: ID): number {
+  return Math.max(0, Number(totals[id]) || 0);
+}
+
+/** Dice a player still has in their cup, clamped to `[0, start]`. */
+export function diceRemaining(totals: Record<ID, number>, id: ID, start: number): number {
+  return Math.max(0, Math.min(start, start - diceLost(totals, id)));
+}
+
+/** Still in the game (has at least one die). */
+export function isAlive(totals: Record<ID, number>, id: ID, start: number): boolean {
+  return diceRemaining(totals, id, start) > 0;
+}
+
+/** Ids of every player who still has dice. */
+export function survivors(totals: Record<ID, number>, ids: ID[], start: number): ID[] {
+  return ids.filter((id) => diceRemaining(totals, id, start) > 0);
+}
+
+/** Total dice still on the table across everyone still playing. */
+export function diceInPlay(totals: Record<ID, number>, ids: ID[], start: number): number {
+  return ids.reduce((sum, id) => sum + diceRemaining(totals, id, start), 0);
+}
+
+/**
+ * Per-player point deltas for one challenge. A challenge touches exactly one player:
+ * `lose` costs a die (+1 lost), a spot-on `gain` returns one (−1 lost). Everyone else 0.
+ */
+export function scoreRound(input: FluffInput, ctx: RoundContext): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const p of ctx.players) out[p.id] = 0;
+  const id = input.playerId;
+  if (id && id in out) {
+    out[id] = input.result === 'gain' ? -1 : 1;
+  }
+  return out;
+}
+
+/** Null when the round is valid, otherwise a friendly, specific error. */
+export function validateRound(input: FluffInput, ctx: RoundContext): string | null {
+  const start = startDice(ctx.config);
+  const id = input.playerId;
+  if (!id) return 'Tap the player who lost the challenge.';
+
+  const player = ctx.players.find((p) => p.id === id);
+  if (!player) return 'Pick a player who is still in the game.';
+
+  const remaining = diceRemaining(ctx.totals, id, start);
+  if (remaining <= 0) return `${player.name} is already out.`;
+
+  if (input.result === 'gain') {
+    if (!spotOnEnabled(ctx.config)) return 'Spot-on calls are turned off for this game.';
+    if (remaining >= start) return `${player.name} already has all ${start} dice.`;
+  } else {
+    // Refuse to empty the table: once one player is left, the game is won.
+    const othersAlive = ctx.players.some(
+      (p) => p.id !== id && diceRemaining(ctx.totals, p.id, start) > 0,
+    );
+    if (!othersAlive) return 'Only one player left — tap “Finish & record winner”.';
+  }
+  return null;
+}
+
+/** The game ends when at most one player still has dice. */
+export function isFinished(
+  totals: Record<ID, number>,
+  info: { config: Record<string, unknown> },
+): boolean {
+  const start = startDice(info.config);
+  const ids = Object.keys(totals);
+  if (ids.length === 0) return false;
+  return survivors(totals, ids, start).length <= 1;
+}
+
+/**
+ * The winner is the last player standing. If forced to finish early (more than one still
+ * alive), the leader(s) — the player(s) with the fewest dice lost — take it.
+ */
+export function pickWinners(totals: Record<ID, number>, config: Record<string, unknown>): ID[] {
+  const start = startDice(config);
+  const ids = Object.keys(totals);
+  if (ids.length === 0) return [];
+  const alive = survivors(totals, ids, start);
+  const pool = alive.length ? alive : ids;
+  const fewest = Math.min(...pool.map((id) => diceLost(totals, id)));
+  return pool.filter((id) => diceLost(totals, id) === fewest);
+}
+
+/** One-line summary of a recorded challenge for the history table. */
+export function describeRound(round: Round, players: { id: ID; name: string }[]): string {
+  const input = round.input as FluffInput | undefined;
+  if (!input || !input.playerId) return 'no change';
+  const name = players.find((p) => p.id === input.playerId)?.name ?? '?';
+  return input.result === 'gain' ? `🎲 ${name} won a die back` : `💀 ${name} lost a die`;
+}

--- a/src/lib/games/fluff/stats.ts
+++ b/src/lib/games/fluff/stats.ts
@@ -1,0 +1,63 @@
+import type { ID } from '../../types';
+import type { FluffInput } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt } from '../../stats/format';
+
+interface FluffAgg {
+  lost: number;
+  gained: number;
+}
+
+/**
+ * Fluff stats, derived purely from each recorded challenge. Every round names the one
+ * player who lost (or, spot-on, regained) a die, so we can tally who bleeds dice and who
+ * claws them back. Pure — no Svelte — so it's independently unit-testable and safe for
+ * the stats engine to import.
+ */
+export function fluffStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, FluffAgg>();
+  const get = (id: ID): FluffAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { lost: 0, gained: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let challenges = 0;
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as FluffInput | undefined;
+    if (!input?.playerId) continue;
+    challenges += 1;
+    const a = get(canonical(input.playerId));
+    if (input.result === 'gain') a.gained += 1;
+    else a.lost += 1;
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.lost) {
+      metrics.push({ key: 'fluff_lost', label: 'Dice lost', value: fmtInt(a.lost), emoji: '💀' });
+    }
+    if (a.gained) {
+      metrics.push({ key: 'fluff_won', label: 'Dice won back', value: fmtInt(a.gained), emoji: '🎲' });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (challenges) {
+    global.push({
+      key: 'fluff_calls',
+      label: 'Challenges called',
+      value: fmtInt(challenges),
+      emoji: '🗣️',
+    });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
﻿## 🎲 Fluff — a bluffing dice tracker

**Fluff** is the common UK pub name for the **Liar's Dice / Perudo** family of bluffing dice games. This PR adds it as a first-class elimination tracker in `src/lib/games/fluff/`.

### The game (research)
Each player hides a cup of dice (5 to start). On your turn you either **raise the bid** — a claim about how many dice show a face across *everyone's* hidden dice (e.g. "six fives") — or you **call/challenge** the previous bid. When a bid is called, all cups lift:

- If the bid was a bluff, the **bidder loses a die**.
- If the bid was good, the **caller loses a die**.
- Lose your last die and you're **eliminated**. **Last cup standing wins.**

Common house rules, surfaced as config:
- **Ones wild** — ones count as any face (on by default).
- **Spot-on / exact call** — if a caller nails the exact count, they *win a die back* instead (optional, off by default).
- **Palifico** (a player down to 1 die triggers a fixed-face, no-wild round) is described in the in-app Rules help.

### Tracker model
Score King re-indexes rounds when one is deleted **without re-scoring**, so per-round deltas must be position-independent. Rather than store "dice remaining" (which needs a seed), each round records **one challenge outcome** and totals accumulate **dice _lost_**:

- `lose` → +1 lost · `gain` (spot-on) → −1 lost
- `remaining = startDice − lost` is derived and always correct, even after deletes.
- `lowerIsBetter: true`, so the scoreboard's rank-1 (fewest lost = most dice) earns the crown.
- `isFinished` when ≤1 player still has dice · `pickWinners` = last cup(s) standing.

### Config
- **Starting dice** per player (default **5**, 1–6)
- **Ones wild** toggle (flavor)
- **Spot-on** toggle (enables winning a die back)

### Design
Chrome is untouched; personality comes from 🎲 copy and emoji only. The editor is a one-handed, tap-**who-lost** roster with live **dice pips**, a subtle violet selected-state (border + tint + badge — no second competing violet fill), an eliminated/OUT 💀 treatment that never relies on color alone, `tabular-nums` counts, ≥46px targets, and a co-signaled knockout/last-standing status line. Spot-on rounds reveal a lose/gain `Segmented`.

### Verification
- ✅ `npm run check` — 0 errors, 0 warnings
- ✅ `npm test` — all green (33 dedicated Fluff tests: dice bookkeeping, elimination, last-standing, validation, a full-game sim, and delete/re-index robustness)
- ✅ `npm run build`

Purely additive — only `src/lib/games/fluff/` (registry auto-discovers the module).
