### PR TITLE
Add Avalon (The Resistance) hidden-role quest tracker

### DIFF
--- a/src/lib/games/avalon/AvalonEditor.svelte
+++ b/src/lib/games/avalon/AvalonEditor.svelte
@@ -1,0 +1,497 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import {
+    MAX_QUESTS,
+    clinch,
+    decidedBefore,
+    expectedWinnerCount,
+    outcomeOf,
+    roleList,
+    roleSetup,
+    tallyBefore,
+    winningSide,
+    type AvalonInput,
+    type Outcome,
+    type Side,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: AvalonInput; ctx: RoundContext } = $props();
+
+  let showRoles = $state(false);
+
+  const players = $derived(ctx.players);
+  const playerCount = $derived(players.length);
+  const setup = $derived(roleSetup(playerCount));
+  const cfg = $derived({
+    percival: !!ctx.config.percival,
+    morgana: !!ctx.config.morgana,
+    mordred: !!ctx.config.mordred,
+    oberon: !!ctx.config.oberon,
+  });
+  const roles = $derived(roleList(playerCount, cfg));
+
+  const before = $derived(tallyBefore(ctx.rounds, ctx.roundIndex, setup));
+  const decided = $derived(decidedBefore(before));
+  const questNo = $derived(ctx.roundIndex + 1);
+  const twoFail = $derived(setup.twoFailQuests[ctx.roundIndex] ?? false);
+  const requiredFails = $derived(twoFail ? 2 : 1);
+  const suggestedTeam = $derived(
+    setup.questTeams[ctx.roundIndex] ?? setup.questTeams[MAX_QUESTS - 1] ?? 3,
+  );
+
+  const outcome = $derived<Outcome>(outcomeOf(input, twoFail));
+  const clinchedBy = $derived<Side | null>(decided ? null : clinch(before, outcome));
+  const sideKnown = $derived(
+    clinchedBy === 'evil' || (clinchedBy === 'good' && input.assassinFoundMerlin !== null),
+  );
+  const finalSide = $derived<Side | null>(
+    !clinchedBy ? null : sideKnown ? winningSide(clinchedBy, input.assassinFoundMerlin) : null,
+  );
+  const expectedWinners = $derived(finalSide ? expectedWinnerCount(setup, finalSide) : 0);
+
+  type PipState = Outcome | 'current' | 'future';
+  const pips = $derived.by(() => {
+    const list: { n: number; state: PipState }[] = [];
+    for (let i = 0; i < MAX_QUESTS; i++) {
+      let state: PipState = 'future';
+      if (i === ctx.roundIndex) {
+        state = 'current';
+      } else {
+        const r = ctx.rounds.find((x) => x.index === i);
+        const inp = r?.input as AvalonInput | undefined;
+        if (r && inp) state = outcomeOf(inp, setup.twoFailQuests[i] ?? false);
+      }
+      list.push({ n: i + 1, state });
+    }
+    return list;
+  });
+
+  // Keep the fail count within the team once the team size shrinks.
+  $effect(() => {
+    const ts = Number(input.teamSize) || 0;
+    if ((Number(input.fails) || 0) > ts) input.fails = ts;
+  });
+
+  // Reset resolution when it no longer applies, and drop stale winners whenever the
+  // winning side changes — but never on first mount, so editing a saved clinch keeps
+  // its recorded team.
+  let primed = false;
+  let lastSide: Side | null = null;
+  $effect(() => {
+    const fs = finalSide;
+    if (clinchedBy !== 'good' && input.assassinFoundMerlin !== null) {
+      input.assassinFoundMerlin = null;
+    }
+    if (!primed) {
+      primed = true;
+      lastSide = fs;
+      return;
+    }
+    if (fs !== lastSide) {
+      lastSide = fs;
+      if (input.winners.length) input.winners = [];
+    }
+  });
+
+  function markSuccess() {
+    input.fails = 0;
+  }
+  function markFail() {
+    if ((Number(input.fails) || 0) < requiredFails) input.fails = requiredFails;
+  }
+  function setAssassin(found: boolean) {
+    input.assassinFoundMerlin = found;
+    input.winners = [];
+  }
+  function toggleWinner(id: string) {
+    input.winners = input.winners.includes(id)
+      ? input.winners.filter((x) => x !== id)
+      : [...input.winners, id];
+  }
+</script>
+
+<div class="stack">
+  <div class="panel track">
+    <div class="row spread">
+      <span class="muted small">Quest track</span>
+      <span class="tally tnum">
+        <span class="score-good">🛡️ {before.successes}</span>
+        <span class="muted">–</span>
+        <span class="score-bad">{before.fails} 🗡️</span>
+      </span>
+    </div>
+    <div class="pips">
+      {#each pips as p (p.n)}
+        <div
+          class="pip"
+          class:current={p.state === 'current'}
+          class:success={p.state === 'success'}
+          class:fail={p.state === 'fail'}
+        >
+          <span class="pn tnum">Q{p.n}</span>
+          <span class="pmark" aria-hidden="true">
+            {#if p.state === 'success'}✓{:else if p.state === 'fail'}✗{:else if p.state === 'current'}●{:else}·{/if}
+          </span>
+        </div>
+      {/each}
+    </div>
+  </div>
+
+  <div class="panel">
+    <button class="rowbtn" type="button" onclick={() => (showRoles = !showRoles)} aria-expanded={showRoles}>
+      <span class="row" style="gap: 8px">
+        <span aria-hidden="true">🎭</span>
+        <span><strong>{playerCount} players</strong> · 🛡️ {setup.good} Good · 🗡️ {setup.evil} Evil</span>
+      </span>
+      <span class="muted small">{showRoles ? 'Hide' : 'Roles'}</span>
+    </button>
+    {#if showRoles}
+      <div class="roles">
+        {#each roles as r (r.name + r.emoji)}
+          <span class="pill role" class:good={r.side === 'good'} class:evil={r.side === 'evil'}>
+            {r.emoji} {r.name}{#if r.note}<span class="muted"> · {r.note}</span>{/if}
+          </span>
+        {/each}
+        <p class="muted small teams">
+          Team sizes by quest: {setup.questTeams.join(' · ')}{#if twoFail || setup.twoFailQuests.some(Boolean)} · Quest 4 needs 2 fails{/if}
+        </p>
+      </div>
+    {/if}
+  </div>
+
+  {#if decided}
+    <div class="panel">
+      <p class="done">
+        This game is already decided — three quests have gone to one side. Tap <strong>Finish</strong> to record the result.
+      </p>
+    </div>
+  {:else}
+    <div class="panel entry">
+      <div class="row spread">
+        <strong>Quest {questNo}</strong>
+        <span class="muted small">Suggested team {suggestedTeam}{#if twoFail} · needs 2 fails{/if}</span>
+      </div>
+
+      <div class="row spread field">
+        <span>On the quest</span>
+        <Stepper bind:value={input.teamSize} min={2} max={playerCount} />
+      </div>
+
+      <div class="otoggles">
+        <button
+          type="button"
+          class="otoggle success"
+          class:on={outcome === 'success'}
+          aria-pressed={outcome === 'success'}
+          onclick={markSuccess}
+        >
+          <span class="oi score-good" aria-hidden="true">✓</span> Succeeded
+        </button>
+        <button
+          type="button"
+          class="otoggle fail"
+          class:on={outcome === 'fail'}
+          aria-pressed={outcome === 'fail'}
+          onclick={markFail}
+        >
+          <span class="oi score-bad" aria-hidden="true">✗</span> Failed
+        </button>
+      </div>
+
+      {#if outcome === 'fail'}
+        <div class="row spread field">
+          <span>Fail cards revealed</span>
+          <Stepper bind:value={input.fails} min={requiredFails} max={input.teamSize} />
+        </div>
+      {:else if twoFail}
+        <p class="muted small hint">On Quest 4 a single Fail still succeeds — it takes two.</p>
+      {/if}
+    </div>
+
+    {#if clinchedBy}
+      <div class="panel resolve">
+        {#if clinchedBy === 'good'}
+          <p class="rhead">🛡️ Good completed three quests! The Assassin gets one shot at Merlin.</p>
+          <div class="atoggles">
+            <button
+              type="button"
+              class="toggle"
+              class:on={input.assassinFoundMerlin === false}
+              aria-pressed={input.assassinFoundMerlin === false}
+              onclick={() => setAssassin(false)}
+            >
+              🎯 Missed
+            </button>
+            <button
+              type="button"
+              class="toggle"
+              class:on={input.assassinFoundMerlin === true}
+              aria-pressed={input.assassinFoundMerlin === true}
+              onclick={() => setAssassin(true)}
+            >
+              🗡️ Found Merlin
+            </button>
+          </div>
+        {:else}
+          <p class="rhead">🗡️ Evil sank three quests — the Minions of Mordred win.</p>
+        {/if}
+
+        {#if finalSide}
+          <div class="banner" class:good={finalSide === 'good'} class:evil={finalSide === 'evil'}>
+            {#if finalSide === 'good'}
+              🛡️ Good wins — tap the {expectedWinners} loyal servants (Merlin included).
+            {:else if clinchedBy === 'good'}
+              🗡️ Evil steals it — the Assassin found Merlin. Tap the {expectedWinners} minions.
+            {:else}
+              🗡️ Evil wins — tap the {expectedWinners} minions of Mordred.
+            {/if}
+          </div>
+
+          <div class="row spread">
+            <span class="muted small">Winning team</span>
+            <span class="pill tnum" class:score-good={input.winners.length === expectedWinners}>
+              {input.winners.length}/{expectedWinners}
+            </span>
+          </div>
+
+          <div class="chips">
+            {#each players as p (p.id)}
+              <button
+                type="button"
+                class="chip"
+                class:on={input.winners.includes(p.id)}
+                aria-pressed={input.winners.includes(p.id)}
+                onclick={() => toggleWinner(p.id)}
+              >
+                <Avatar name={p.name} color={p.color} size={26} />
+                <span class="cn">{p.name}</span>
+                {#if input.winners.includes(p.id)}<span class="ck" aria-hidden="true">✓</span>{/if}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .panel {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+  }
+  .small {
+    font-size: 0.82rem;
+  }
+  .tnum {
+    font-variant-numeric: tabular-nums;
+  }
+  .track {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .tally {
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
+    font-weight: 800;
+  }
+  .pips {
+    display: flex;
+    gap: 8px;
+  }
+  .pip {
+    flex: 1 1 0;
+    min-height: 46px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    color: var(--muted);
+  }
+  .pip .pn {
+    font-size: 0.7rem;
+  }
+  .pip .pmark {
+    font-size: 1.05rem;
+    font-weight: 800;
+    line-height: 1;
+  }
+  .pip.success {
+    border-color: var(--good);
+    color: var(--good);
+    background: color-mix(in srgb, var(--good) 12%, var(--surface));
+  }
+  .pip.fail {
+    border-color: var(--bad);
+    color: var(--bad);
+    background: color-mix(in srgb, var(--bad) 12%, var(--surface));
+  }
+  .pip.current {
+    border-color: var(--primary);
+    color: var(--text);
+    box-shadow: inset 0 0 0 1px var(--primary);
+  }
+
+  .rowbtn {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 46px;
+    background: transparent;
+    border: 0;
+    color: var(--text);
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+    padding: 0;
+  }
+  .roles {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 10px;
+  }
+  .role.good {
+    border-color: color-mix(in srgb, var(--good) 45%, var(--border));
+  }
+  .role.evil {
+    border-color: color-mix(in srgb, var(--bad) 45%, var(--border));
+  }
+  .teams {
+    width: 100%;
+    margin: 8px 0 0;
+  }
+
+  .entry {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .field {
+    min-height: 46px;
+  }
+  .field > span {
+    color: var(--muted);
+  }
+  .hint {
+    margin: 0;
+  }
+
+  .otoggles {
+    display: flex;
+    gap: 8px;
+  }
+  .otoggle {
+    flex: 1 1 0;
+    min-height: 46px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+  .otoggle .oi {
+    font-weight: 900;
+  }
+  .otoggle.success.on {
+    border-color: var(--good);
+    background: color-mix(in srgb, var(--good) 16%, var(--surface));
+  }
+  .otoggle.fail.on {
+    border-color: var(--bad);
+    background: color-mix(in srgb, var(--bad) 16%, var(--surface));
+  }
+
+  .resolve {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .rhead {
+    margin: 0;
+    font-weight: 700;
+  }
+  .atoggles {
+    display: flex;
+    gap: 8px;
+  }
+  .toggle {
+    flex: 1 1 0;
+    min-height: 46px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+  }
+  .toggle.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+
+  .banner {
+    border-radius: 10px;
+    padding: 10px 12px;
+    font-weight: 700;
+    border: 1px solid var(--border);
+    background: var(--surface);
+  }
+  .banner.good {
+    border-color: var(--good);
+    background: color-mix(in srgb, var(--good) 12%, var(--surface));
+  }
+  .banner.evil {
+    border-color: var(--bad);
+    background: color-mix(in srgb, var(--bad) 12%, var(--surface));
+  }
+
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 6px 14px 6px 6px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 600;
+  }
+  .chip.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .chip .ck {
+    font-weight: 900;
+  }
+
+  .done {
+    margin: 0;
+  }
+</style>

--- a/src/lib/games/avalon/avalon.test.ts
+++ b/src/lib/games/avalon/avalon.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it } from 'vitest';
+import type { ID, Round } from '../../types';
+import {
+  MAX_PLAYERS,
+  MIN_PLAYERS,
+  clampPlayers,
+  clinch,
+  decidedBefore,
+  describeAvalon,
+  expectedWinnerCount,
+  isResolved,
+  outcomeOf,
+  pickAvalonWinners,
+  roleList,
+  roleSetup,
+  scoreAvalon,
+  tallyBefore,
+  validateAvalon,
+  winningSide,
+  type AvalonInput,
+  type RolesConfig,
+} from './logic';
+
+function inp(partial: Partial<AvalonInput> = {}): AvalonInput {
+  return { fails: 0, teamSize: 3, assassinFoundMerlin: null, winners: [], ...partial };
+}
+
+function mkRound(index: number, input: AvalonInput): Round {
+  return { id: `r${index}`, gameId: 'g', index, input, deltas: {}, createdAt: 0 };
+}
+
+const seats = (n: number): ID[] => Array.from({ length: n }, (_, i) => `p${i + 1}`);
+
+const noRoles: RolesConfig = { percival: false, morgana: false, mordred: false, oberon: false };
+
+describe('clampPlayers', () => {
+  it('clamps to the 5–10 range', () => {
+    expect(clampPlayers(3)).toBe(MIN_PLAYERS);
+    expect(clampPlayers(11)).toBe(MAX_PLAYERS);
+    expect(clampPlayers(7)).toBe(7);
+  });
+  it('rounds and tolerates junk', () => {
+    expect(clampPlayers(7.4)).toBe(7);
+    expect(clampPlayers(NaN)).toBe(MIN_PLAYERS);
+  });
+});
+
+describe('roleSetup', () => {
+  it('splits Good/Evil by the standard table', () => {
+    expect([roleSetup(5).good, roleSetup(5).evil]).toEqual([3, 2]);
+    expect([roleSetup(6).good, roleSetup(6).evil]).toEqual([4, 2]);
+    expect([roleSetup(7).good, roleSetup(7).evil]).toEqual([4, 3]);
+    expect([roleSetup(8).good, roleSetup(8).evil]).toEqual([5, 3]);
+    expect([roleSetup(9).good, roleSetup(9).evil]).toEqual([6, 3]);
+    expect([roleSetup(10).good, roleSetup(10).evil]).toEqual([6, 4]);
+  });
+
+  it('good + evil always equals the (clamped) player count', () => {
+    for (let n = MIN_PLAYERS; n <= MAX_PLAYERS; n++) {
+      const s = roleSetup(n);
+      expect(s.good + s.evil).toBe(n);
+      expect(s.players).toBe(n);
+    }
+  });
+
+  it('provides five quest team sizes', () => {
+    expect(roleSetup(5).questTeams).toEqual([2, 3, 2, 3, 3]);
+    expect(roleSetup(7).questTeams).toEqual([2, 3, 3, 4, 4]);
+    expect(roleSetup(10).questTeams).toEqual([3, 4, 4, 5, 5]);
+    for (let n = MIN_PLAYERS; n <= MAX_PLAYERS; n++) {
+      expect(roleSetup(n).questTeams).toHaveLength(5);
+    }
+  });
+
+  it('marks Quest 4 as the two-fail quest only at 7+ players', () => {
+    expect(roleSetup(5).twoFailQuests).toEqual([false, false, false, false, false]);
+    expect(roleSetup(6).twoFailQuests[3]).toBe(false);
+    expect(roleSetup(7).twoFailQuests).toEqual([false, false, false, true, false]);
+    expect(roleSetup(10).twoFailQuests[3]).toBe(true);
+  });
+
+  it('clamps out-of-range counts', () => {
+    expect(roleSetup(4).players).toBe(5);
+    expect(roleSetup(99).players).toBe(10);
+  });
+});
+
+describe('roleList', () => {
+  it('always seats exactly the Good and Evil counts', () => {
+    for (let n = MIN_PLAYERS; n <= MAX_PLAYERS; n++) {
+      const list = roleList(n, noRoles);
+      const setup = roleSetup(n);
+      expect(list).toHaveLength(n);
+      expect(list.filter((r) => r.side === 'good')).toHaveLength(setup.good);
+      expect(list.filter((r) => r.side === 'evil')).toHaveLength(setup.evil);
+    }
+  });
+
+  it('always includes Merlin and the Assassin', () => {
+    const list = roleList(5, noRoles);
+    expect(list.some((r) => r.name === 'Merlin')).toBe(true);
+    expect(list.some((r) => r.name === 'Assassin')).toBe(true);
+  });
+
+  it('adds optional roles without changing head counts', () => {
+    // 10 players => 4 Evil seats, enough to fit Assassin + Morgana + Mordred + Oberon.
+    const cfg: RolesConfig = { percival: true, morgana: true, mordred: true, oberon: true };
+    const list = roleList(10, cfg);
+    const setup = roleSetup(10);
+    expect(list.filter((r) => r.side === 'good')).toHaveLength(setup.good);
+    expect(list.filter((r) => r.side === 'evil')).toHaveLength(setup.evil);
+    expect(list.some((r) => r.name === 'Percival')).toBe(true);
+    expect(list.some((r) => r.name === 'Morgana')).toBe(true);
+    expect(list.some((r) => r.name === 'Mordred')).toBe(true);
+    expect(list.some((r) => r.name === 'Oberon')).toBe(true);
+  });
+
+  it('never exceeds the Evil count even with every Evil toggle on', () => {
+    // 5 players => only 2 Evil seats; Assassin + Morgana + Mordred + Oberon must be trimmed.
+    const cfg: RolesConfig = { percival: false, morgana: true, mordred: true, oberon: true };
+    const list = roleList(5, cfg);
+    expect(list.filter((r) => r.side === 'evil')).toHaveLength(2);
+    expect(list.filter((r) => r.side === 'good')).toHaveLength(3);
+  });
+});
+
+describe('outcomeOf', () => {
+  it('treats a single Fail as a failed quest normally', () => {
+    expect(outcomeOf({ fails: 0 }, false)).toBe('success');
+    expect(outcomeOf({ fails: 1 }, false)).toBe('fail');
+    expect(outcomeOf({ fails: 3 }, false)).toBe('fail');
+  });
+  it('requires two Fails on the two-fail quest', () => {
+    expect(outcomeOf({ fails: 1 }, true)).toBe('success');
+    expect(outcomeOf({ fails: 2 }, true)).toBe('fail');
+  });
+});
+
+describe('tallyBefore', () => {
+  it('counts only quests before the given index', () => {
+    const setup = roleSetup(5);
+    const rounds = [
+      mkRound(0, inp({ fails: 0 })), // success
+      mkRound(1, inp({ fails: 1 })), // fail
+      mkRound(2, inp({ fails: 0 })), // success (ignored when index=2)
+    ];
+    expect(tallyBefore(rounds, 2, setup)).toEqual({ successes: 1, fails: 1 });
+    expect(tallyBefore(rounds, 3, setup)).toEqual({ successes: 2, fails: 1 });
+    expect(tallyBefore(rounds, 0, setup)).toEqual({ successes: 0, fails: 0 });
+  });
+
+  it('honors the two-fail quest when tallying', () => {
+    const setup = roleSetup(7); // Quest 4 (index 3) is two-fail
+    const rounds = [mkRound(3, inp({ fails: 1, teamSize: 4 }))];
+    expect(tallyBefore(rounds, 4, setup)).toEqual({ successes: 1, fails: 0 });
+    const rounds2 = [mkRound(3, inp({ fails: 2, teamSize: 4 }))];
+    expect(tallyBefore(rounds2, 4, setup)).toEqual({ successes: 0, fails: 1 });
+  });
+});
+
+describe('clinch', () => {
+  it('flags Good on the third success', () => {
+    expect(clinch({ successes: 2, fails: 0 }, 'success')).toBe('good');
+    expect(clinch({ successes: 1, fails: 2 }, 'success')).toBeNull();
+  });
+  it('flags Evil on the third fail', () => {
+    expect(clinch({ successes: 0, fails: 2 }, 'fail')).toBe('evil');
+    expect(clinch({ successes: 2, fails: 1 }, 'fail')).toBeNull();
+  });
+});
+
+describe('winningSide', () => {
+  it('keeps the win for Good when the Assassin misses', () => {
+    expect(winningSide('good', false)).toBe('good');
+    expect(winningSide('good', null)).toBe('good');
+  });
+  it('lets Evil steal a Good clinch when the Assassin finds Merlin', () => {
+    expect(winningSide('good', true)).toBe('evil');
+  });
+  it('always gives an Evil clinch to Evil', () => {
+    expect(winningSide('evil', null)).toBe('evil');
+    expect(winningSide('evil', true)).toBe('evil');
+  });
+});
+
+describe('decidedBefore & expectedWinnerCount', () => {
+  it('detects a game already decided', () => {
+    expect(decidedBefore({ successes: 3, fails: 0 })).toBe(true);
+    expect(decidedBefore({ successes: 0, fails: 3 })).toBe(true);
+    expect(decidedBefore({ successes: 2, fails: 2 })).toBe(false);
+  });
+  it('maps a side to its seat count', () => {
+    const setup = roleSetup(7);
+    expect(expectedWinnerCount(setup, 'good')).toBe(4);
+    expect(expectedWinnerCount(setup, 'evil')).toBe(3);
+  });
+});
+
+describe('validateAvalon', () => {
+  it('rejects out-of-range player counts', () => {
+    expect(validateAvalon(inp(), [], 0, seats(4))).toMatch(/5–10 players/);
+    expect(validateAvalon(inp(), [], 0, seats(11))).toMatch(/5–10 players/);
+  });
+
+  it('blocks adding a quest once a side already reached three', () => {
+    const rounds = [
+      mkRound(0, inp({ fails: 0 })),
+      mkRound(1, inp({ fails: 0 })),
+      mkRound(2, inp({ fails: 0 })),
+    ];
+    expect(validateAvalon(inp(), rounds, 3, seats(5))).toMatch(/already decided/);
+  });
+
+  it('validates team size and fail bounds', () => {
+    expect(validateAvalon(inp({ teamSize: 1 }), [], 0, seats(5))).toMatch(/team size/);
+    expect(validateAvalon(inp({ teamSize: 6 }), [], 0, seats(5))).toMatch(/team size/);
+    expect(validateAvalon(inp({ teamSize: 3, fails: 4 }), [], 0, seats(5))).toMatch(/fails/);
+  });
+
+  it('is happy with an ordinary non-clinching quest', () => {
+    expect(validateAvalon(inp({ teamSize: 2, fails: 0 }), [], 0, seats(5))).toBeNull();
+    expect(validateAvalon(inp({ teamSize: 2, fails: 1 }), [], 0, seats(5))).toBeNull();
+  });
+
+  it('requires the Assassin guess when Good clinches', () => {
+    const rounds = [mkRound(0, inp({ fails: 0 })), mkRound(1, inp({ fails: 0 }))];
+    const draft = inp({ teamSize: 2, fails: 0, assassinFoundMerlin: null });
+    expect(validateAvalon(draft, rounds, 2, seats(5))).toMatch(/Assassin/);
+  });
+
+  it('requires the correct number of winners at the clinch', () => {
+    const rounds = [mkRound(0, inp({ fails: 0 })), mkRound(1, inp({ fails: 0 }))];
+    // Good clinch, Assassin missed => 3 Good winners needed.
+    const draft = inp({ teamSize: 2, fails: 0, assassinFoundMerlin: false, winners: ['p1'] });
+    expect(validateAvalon(draft, rounds, 2, seats(5))).toMatch(/3 Good/);
+    const ok = inp({
+      teamSize: 2,
+      fails: 0,
+      assassinFoundMerlin: false,
+      winners: ['p1', 'p2', 'p3'],
+    });
+    expect(validateAvalon(ok, rounds, 2, seats(5))).toBeNull();
+  });
+
+  it('needs the Evil team recorded when Evil clinches (no Assassin step)', () => {
+    const rounds = [mkRound(0, inp({ fails: 1 })), mkRound(1, inp({ fails: 1 }))];
+    const draft = inp({ teamSize: 3, fails: 1, winners: ['p1', 'p2'] }); // 2 Evil at 5p
+    expect(validateAvalon(draft, rounds, 2, seats(5))).toBeNull();
+    const wrong = inp({ teamSize: 3, fails: 1, winners: ['p1'] });
+    expect(validateAvalon(wrong, rounds, 2, seats(5))).toMatch(/2 Evil/);
+  });
+
+  it('rejects winners who are not seated, and duplicates', () => {
+    const rounds = [mkRound(0, inp({ fails: 0 })), mkRound(1, inp({ fails: 0 }))];
+    const outsider = inp({
+      teamSize: 2,
+      fails: 0,
+      assassinFoundMerlin: false,
+      winners: ['p1', 'p2', 'zzz'],
+    });
+    expect(validateAvalon(outsider, rounds, 2, seats(5))).toMatch(/not in this game/);
+    const dupe = inp({
+      teamSize: 2,
+      fails: 0,
+      assassinFoundMerlin: false,
+      winners: ['p1', 'p1', 'p2'],
+    });
+    expect(validateAvalon(dupe, rounds, 2, seats(5))).toMatch(/twice/);
+  });
+});
+
+describe('scoreAvalon', () => {
+  it('scores every player zero on a non-clinching quest', () => {
+    const deltas = scoreAvalon(inp({ fails: 1, teamSize: 3 }), [], 0, seats(5));
+    expect(Object.values(deltas)).toEqual([0, 0, 0, 0, 0]);
+  });
+
+  it('marks the winning side 1 and everyone else 0 at a Good clinch', () => {
+    const rounds = [mkRound(0, inp({ fails: 0 })), mkRound(1, inp({ fails: 0 }))];
+    const draft = inp({
+      teamSize: 2,
+      fails: 0,
+      assassinFoundMerlin: false,
+      winners: ['p1', 'p2', 'p3'],
+    });
+    const deltas = scoreAvalon(draft, rounds, 2, seats(5));
+    expect(deltas).toEqual({ p1: 1, p2: 1, p3: 1, p4: 0, p5: 0 });
+  });
+
+  it('credits the Evil team when the Assassin steals the win', () => {
+    const rounds = [mkRound(0, inp({ fails: 0 })), mkRound(1, inp({ fails: 0 }))];
+    // Good reached 3 quests, but Assassin found Merlin => the 2 Evil players win.
+    const draft = inp({
+      teamSize: 2,
+      fails: 0,
+      assassinFoundMerlin: true,
+      winners: ['p4', 'p5'],
+    });
+    const deltas = scoreAvalon(draft, rounds, 2, seats(5));
+    expect(deltas).toEqual({ p1: 0, p2: 0, p3: 0, p4: 1, p5: 1 });
+    expect(pickAvalonWinners(deltas)).toEqual(['p4', 'p5']);
+  });
+});
+
+describe('isResolved & pickAvalonWinners', () => {
+  it('is unresolved while every total is zero', () => {
+    expect(isResolved({ p1: 0, p2: 0 })).toBe(false);
+    expect(pickAvalonWinners({ p1: 0, p2: 0 })).toEqual([]);
+  });
+  it('resolves once a positive total exists', () => {
+    expect(isResolved({ p1: 1, p2: 0 })).toBe(true);
+    expect(pickAvalonWinners({ p1: 1, p2: 0, p3: 1 })).toEqual(['p1', 'p3']);
+  });
+});
+
+describe('describeAvalon', () => {
+  it('summarizes a plain success and a plain fail', () => {
+    expect(describeAvalon(mkRound(0, inp({ fails: 0 })), 5)).toBe('Quest 1 ✓ succeeded');
+    expect(describeAvalon(mkRound(1, inp({ fails: 1 })), 5)).toBe('Quest 2 ✗ failed · 1 fail');
+    expect(describeAvalon(mkRound(1, inp({ fails: 2 })), 5)).toBe('Quest 2 ✗ failed · 2 fails');
+  });
+
+  it('narrates a Good victory finale', () => {
+    const r = mkRound(2, inp({ fails: 0, assassinFoundMerlin: false, winners: ['p1', 'p2', 'p3'] }));
+    expect(describeAvalon(r, 5)).toContain('🛡️ Good prevails');
+  });
+
+  it('narrates the Assassin stealing the win', () => {
+    const r = mkRound(2, inp({ fails: 0, assassinFoundMerlin: true, winners: ['p4', 'p5'] }));
+    expect(describeAvalon(r, 5)).toContain('Evil steals it');
+  });
+
+  it('narrates an Evil quest-fail victory', () => {
+    const r = mkRound(2, inp({ fails: 1, winners: ['p4', 'p5'] }));
+    expect(describeAvalon(r, 5)).toContain('🗡️ Evil triumphs');
+  });
+
+  it('handles a round with no recorded input', () => {
+    const r: Round = { id: 'x', gameId: 'g', index: 0, input: undefined, deltas: {}, createdAt: 0 };
+    expect(describeAvalon(r, 5)).toBe('Quest 1');
+  });
+});

--- a/src/lib/games/avalon/index.ts
+++ b/src/lib/games/avalon/index.ts
@@ -1,0 +1,106 @@
+import type { GameModule, RoundContext } from '../../types';
+import Editor from './AvalonEditor.svelte';
+import { avalonStats } from './stats';
+import {
+  MAX_PLAYERS,
+  MAX_QUESTS,
+  MIN_PLAYERS,
+  describeAvalon,
+  isResolved,
+  pickAvalonWinners,
+  roleSetup,
+  scoreAvalon,
+  validateAvalon,
+  type AvalonInput,
+} from './logic';
+
+export type { AvalonInput } from './logic';
+
+const seatIds = (ctx: RoundContext) => ctx.players.map((p) => p.id);
+
+export const avalon: GameModule = {
+  id: 'avalon',
+  name: 'Avalon',
+  tagline: 'Loyal servants vs. minions of Mordred',
+  emoji: '⚔️',
+  keywords: [
+    'the resistance',
+    'social deduction',
+    'hidden roles',
+    'merlin',
+    'assassin',
+    'teams',
+    'party',
+  ],
+  minPlayers: MIN_PLAYERS,
+  maxPlayers: MAX_PLAYERS,
+  teams: true,
+  configFields: [
+    {
+      key: 'percival',
+      label: 'Percival (Good)',
+      type: 'boolean',
+      default: false,
+      help: 'Sees Merlin & Morgana — but can’t tell them apart.',
+    },
+    {
+      key: 'morgana',
+      label: 'Morgana (Evil)',
+      type: 'boolean',
+      default: false,
+      help: 'Appears as Merlin to Percival.',
+    },
+    {
+      key: 'mordred',
+      label: 'Mordred (Evil)',
+      type: 'boolean',
+      default: false,
+      help: 'Hidden from Merlin — Good flies blind on one minion.',
+    },
+    {
+      key: 'oberon',
+      label: 'Oberon (Evil)',
+      type: 'boolean',
+      default: false,
+      help: 'Unknown even to his fellow minions.',
+    },
+  ],
+
+  maxRounds: () => MAX_QUESTS,
+
+  createRoundInput: (ctx: RoundContext): AvalonInput => {
+    const setup = roleSetup(ctx.players.length);
+    const teamSize = setup.questTeams[ctx.roundIndex] ?? setup.questTeams[MAX_QUESTS - 1] ?? 3;
+    return { fails: 0, teamSize, assassinFoundMerlin: null, winners: [] };
+  },
+
+  validateRound: (input: AvalonInput, ctx: RoundContext) =>
+    validateAvalon(input, ctx.rounds, ctx.roundIndex, seatIds(ctx)),
+
+  scoreRound: (input: AvalonInput, ctx: RoundContext) =>
+    scoreAvalon(input, ctx.rounds, ctx.roundIndex, seatIds(ctx)),
+
+  isFinished: (totals) => isResolved(totals),
+
+  pickWinners: (totals) => pickAvalonWinners(totals),
+
+  describeRound: (round, players) => describeAvalon(round, players.length),
+
+  help: [
+    'A hidden-role duel: 🛡️ Good (Loyal Servants of Arthur, incl. Merlin & Percival) vs.',
+    '🗡️ Evil (Minions of Mordred, incl. Morgana, Mordred, Oberon & the Assassin).',
+    '',
+    'Each round a leader sends a team on a QUEST. On its mission the team plays secret',
+    'Success/Fail cards — any single Fail sinks the quest (Quest 4 needs TWO Fails at 7+ players).',
+    'Record how many Fails were revealed; the tracker marks the quest ✓ or ✗.',
+    '',
+    '🛡️ Good wins by succeeding 3 quests — then the Assassin may name Merlin: if correct,',
+    '🗡️ Evil steals the win. Evil wins outright by failing 3 quests.',
+    '',
+    'At the clinch, tap everyone on the winning side to record the result.',
+  ].join('\n'),
+
+  stats: avalonStats,
+
+  RoundEditor: Editor,
+};

--- a/src/lib/games/avalon/logic.ts
+++ b/src/lib/games/avalon/logic.ts
@@ -1,0 +1,282 @@
+import type { ID, Round } from '../../types';
+
+/**
+ * Pure Avalon (The Resistance: Avalon) tracker logic — no Svelte, no I/O — so it can be
+ * exercised directly by `avalon.test.ts` and imported by both `index.ts` and the editor.
+ *
+ * ── Modeling a scoreless, hidden-role team game inside the point-oriented GameModule ──
+ * A *round is a QUEST*. The quest phase runs until one side reaches three quests: Good by
+ * three Successes, Evil by three Fails (min 3, max 5 quests). Because roles are secret
+ * during play, quest rounds carry **no per-player points** — the live "scoreboard" is the
+ * quest track (Good n – Evil n), derived from the round inputs here.
+ *
+ * The **clinching quest** (the one that takes a side to three) folds in the game's
+ * *resolution*: if Good reaches three, the Assassin may name Merlin (stealing the win for
+ * Evil); then the seat-holder records the **members of the winning side**. Only that round
+ * scores — each winning-side player gets `1`, everyone else `0` — so `pickWinners` is simply
+ * "everyone with a positive total". That stays unambiguous even for the assassination steal,
+ * where Good won more quests yet Evil wins. Quest tallies and the finale are narrated in
+ * `describeAvalon` rather than encoded as points.
+ */
+
+export type Side = 'good' | 'evil';
+export type Outcome = 'success' | 'fail';
+
+/** The draft recorded for one quest (round). Resolution fields matter only on the clinching quest. */
+export interface AvalonInput {
+  /** Number of Fail cards revealed on this quest (0 = a clean success). */
+  fails: number;
+  /** How many players were sent on the quest. */
+  teamSize: number;
+  /** Resolution: when Good reaches three quests, did the Assassin find Merlin? Else `null`. */
+  assassinFoundMerlin: boolean | null;
+  /** Resolution: the members of the winning side (drives `pickWinners`). */
+  winners: ID[];
+}
+
+/** Optional-role toggles (reference only — they never change the Good/Evil head counts). */
+export interface RolesConfig {
+  percival: boolean;
+  morgana: boolean;
+  mordred: boolean;
+  oberon: boolean;
+}
+
+export interface Tally {
+  successes: number;
+  fails: number;
+}
+
+export interface RoleSetup {
+  players: number;
+  good: number;
+  evil: number;
+  /** Required team size per quest — index 0 = Quest 1 … index 4 = Quest 5. */
+  questTeams: number[];
+  /** Quests that need TWO Fail cards to fail (Quest 4 with 7+ players). */
+  twoFailQuests: boolean[];
+}
+
+export interface RoleLine {
+  side: Side;
+  name: string;
+  emoji: string;
+  note?: string;
+}
+
+export const MIN_PLAYERS = 5;
+export const MAX_PLAYERS = 10;
+export const MAX_QUESTS = 5;
+/** Quests a side must win to end the quest phase. */
+export const QUESTS_TO_WIN = 3;
+
+/** Evil (Minions of Mordred) head count by player count; the rest are Good. */
+const EVIL_BY_COUNT: Record<number, number> = { 5: 2, 6: 2, 7: 3, 8: 3, 9: 3, 10: 4 };
+
+/** Standard quest team sizes by player count (Quest 1 … Quest 5). */
+const QUEST_TEAMS: Record<number, number[]> = {
+  5: [2, 3, 2, 3, 3],
+  6: [2, 3, 4, 3, 4],
+  7: [2, 3, 3, 4, 4],
+  8: [3, 4, 4, 5, 5],
+  9: [3, 4, 4, 5, 5],
+  10: [3, 4, 4, 5, 5],
+};
+
+export function clampPlayers(n: number): number {
+  const v = Math.round(Number(n) || 0);
+  return Math.max(MIN_PLAYERS, Math.min(MAX_PLAYERS, v));
+}
+
+/** Role composition + quest table for a given player count (clamped to 5–10). */
+export function roleSetup(playerCount: number): RoleSetup {
+  const players = clampPlayers(playerCount);
+  const evil = EVIL_BY_COUNT[players];
+  const questTeams = QUEST_TEAMS[players].slice();
+  // Only Quest 4 (index 3) needs two Fails, and only in games of 7+.
+  const twoFailQuests = [false, false, false, players >= 7, false];
+  return { players, good: players - evil, evil, questTeams, twoFailQuests };
+}
+
+/** The full role line-up for the reference sheet, honoring the optional-role toggles. */
+export function roleList(playerCount: number, cfg: RolesConfig): RoleLine[] {
+  const { good, evil } = roleSetup(playerCount);
+
+  const goodRoles: RoleLine[] = [{ side: 'good', name: 'Merlin', emoji: '🧙', note: 'knows Evil' }];
+  if (cfg.percival) {
+    goodRoles.push({ side: 'good', name: 'Percival', emoji: '🔎', note: 'sees Merlin & Morgana' });
+  }
+  for (let i = goodRoles.length; i < good; i++) {
+    goodRoles.push({ side: 'good', name: 'Loyal Servant of Arthur', emoji: '⚜️' });
+  }
+
+  const evilRoles: RoleLine[] = [
+    { side: 'evil', name: 'Assassin', emoji: '🗡️', note: 'may name Merlin if Good wins' },
+  ];
+  if (cfg.morgana) evilRoles.push({ side: 'evil', name: 'Morgana', emoji: '🎭', note: 'appears as Merlin' });
+  if (cfg.mordred) evilRoles.push({ side: 'evil', name: 'Mordred', emoji: '🕶️', note: 'hidden from Merlin' });
+  if (cfg.oberon) evilRoles.push({ side: 'evil', name: 'Oberon', emoji: '👁️', note: 'unknown to fellow Evil' });
+  for (let i = evilRoles.length; i < evil; i++) {
+    evilRoles.push({ side: 'evil', name: 'Minion of Mordred', emoji: '😈' });
+  }
+
+  // Trim if optional roles ever exceed the head count (defensive; toggles don't add seats).
+  return [...goodRoles.slice(0, good), ...evilRoles.slice(0, evil)];
+}
+
+/** A quest fails once enough Fail cards appear (two are needed on the 7+ player Quest 4). */
+export function outcomeOf(input: Pick<AvalonInput, 'fails'>, twoFail: boolean): Outcome {
+  const fails = Number(input.fails) || 0;
+  return fails >= (twoFail ? 2 : 1) ? 'fail' : 'success';
+}
+
+/** Successes/fails recorded across the quests *before* `roundIndex` (the ones that count so far). */
+export function tallyBefore(rounds: Round[], roundIndex: number, setup: RoleSetup): Tally {
+  let successes = 0;
+  let fails = 0;
+  for (const r of rounds) {
+    if (r.index >= roundIndex) continue;
+    const inp = r.input as AvalonInput | undefined;
+    if (!inp) continue;
+    const twoFail = setup.twoFailQuests[r.index] ?? false;
+    if (outcomeOf(inp, twoFail) === 'fail') fails++;
+    else successes++;
+  }
+  return { successes, fails };
+}
+
+/** Which side (if any) reaches three quests once `outcome` is applied to `before`. */
+export function clinch(before: Tally, outcome: Outcome): Side | null {
+  if (outcome === 'success' && before.successes + 1 >= QUESTS_TO_WIN) return 'good';
+  if (outcome === 'fail' && before.fails + 1 >= QUESTS_TO_WIN) return 'evil';
+  return null;
+}
+
+/** The final winner: Evil steals a Good clinch iff the Assassin found Merlin. */
+export function winningSide(clinchedBy: Side, assassinFoundMerlin: boolean | null): Side {
+  if (clinchedBy === 'good') return assassinFoundMerlin ? 'evil' : 'good';
+  return 'evil';
+}
+
+/** True when a side already reached three quests before this round (game over). */
+export function decidedBefore(before: Tally): boolean {
+  return before.successes >= QUESTS_TO_WIN || before.fails >= QUESTS_TO_WIN;
+}
+
+/** How many players sit on the given side (= how many winners to record). */
+export function expectedWinnerCount(setup: RoleSetup, side: Side): number {
+  return side === 'good' ? setup.good : setup.evil;
+}
+
+/** Validate one quest draft. Returns `null` when valid, else a human-readable message. */
+export function validateAvalon(
+  input: AvalonInput,
+  rounds: Round[],
+  roundIndex: number,
+  playerIds: ID[],
+): string | null {
+  const n = playerIds.length;
+  if (n < MIN_PLAYERS || n > MAX_PLAYERS) {
+    return `Avalon needs ${MIN_PLAYERS}–${MAX_PLAYERS} players (currently ${n}).`;
+  }
+  const setup = roleSetup(n);
+  const before = tallyBefore(rounds, roundIndex, setup);
+  if (decidedBefore(before)) {
+    return 'This game is already decided — three quests have gone to one side.';
+  }
+  const questNo = roundIndex + 1;
+  if (questNo > MAX_QUESTS) return `Avalon is at most ${MAX_QUESTS} quests.`;
+
+  const teamSize = Number(input.teamSize) || 0;
+  if (teamSize < 2 || teamSize > n) {
+    return `Quest ${questNo}: team size must be between 2 and ${n}.`;
+  }
+  const fails = Number(input.fails) || 0;
+  if (fails < 0 || fails > teamSize) {
+    return `Quest ${questNo}: fails must be between 0 and the team size (${teamSize}).`;
+  }
+
+  const twoFail = setup.twoFailQuests[roundIndex] ?? false;
+  const clinchedBy = clinch(before, outcomeOf(input, twoFail));
+  if (clinchedBy) {
+    if (
+      clinchedBy === 'good' &&
+      (input.assassinFoundMerlin === null || input.assassinFoundMerlin === undefined)
+    ) {
+      return 'Good reached three quests — record the Assassin’s guess at Merlin.';
+    }
+    const side = winningSide(clinchedBy, input.assassinFoundMerlin);
+    const seats = new Set(playerIds);
+    const winners = input.winners ?? [];
+    for (const w of winners) {
+      if (!seats.has(w)) return 'The winning team includes someone who is not in this game.';
+    }
+    if (new Set(winners).size !== winners.length) {
+      return 'A player is listed twice on the winning team.';
+    }
+    const need = expectedWinnerCount(setup, side);
+    if (winners.length !== need) {
+      const label = side === 'good' ? 'Good' : 'Evil';
+      return `Tap the ${need} ${label} player${need === 1 ? '' : 's'} on the winning team (${winners.length}/${need}).`;
+    }
+  }
+  return null;
+}
+
+/** Per-player deltas: `0` for every quest until the clinching one, which marks the winners `1`. */
+export function scoreAvalon(
+  input: AvalonInput,
+  rounds: Round[],
+  roundIndex: number,
+  playerIds: ID[],
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) out[id] = 0;
+
+  const setup = roleSetup(playerIds.length);
+  const before = tallyBefore(rounds, roundIndex, setup);
+  const twoFail = setup.twoFailQuests[roundIndex] ?? false;
+  if (!clinch(before, outcomeOf(input, twoFail))) return out;
+
+  const winners = new Set(input.winners ?? []);
+  for (const id of playerIds) out[id] = winners.has(id) ? 1 : 0;
+  return out;
+}
+
+/** The game is finished once a resolution has been recorded (someone has a positive total). */
+export function isResolved(totals: Record<ID, number>): boolean {
+  return Object.values(totals).some((v) => (Number(v) || 0) > 0);
+}
+
+/** Winners = everyone on the recorded winning side. */
+export function pickAvalonWinners(totals: Record<ID, number>): ID[] {
+  return Object.keys(totals).filter((id) => (Number(totals[id]) || 0) > 0);
+}
+
+/** One-line history summary for a quest, narrating the finale on the clinching round. */
+export function describeAvalon(round: Round, playerCount: number): string {
+  const inp = round.input as AvalonInput | undefined;
+  const qn = round.index + 1;
+  if (!inp) return `Quest ${qn}`;
+
+  const setup = roleSetup(playerCount);
+  const twoFail = setup.twoFailQuests[round.index] ?? false;
+  const outcome = outcomeOf(inp, twoFail);
+  const fails = Number(inp.fails) || 0;
+  const base =
+    outcome === 'success'
+      ? `Quest ${qn} ✓ succeeded`
+      : `Quest ${qn} ✗ failed · ${fails} fail${fails === 1 ? '' : 's'}`;
+
+  const winners = inp.winners ?? [];
+  if (winners.length) {
+    const clinchedBy: Side = outcome === 'fail' ? 'evil' : 'good';
+    const side = winningSide(clinchedBy, inp.assassinFoundMerlin);
+    let finale: string;
+    if (side === 'good') finale = '🛡️ Good prevails';
+    else if (clinchedBy === 'good') finale = '🗡️ Evil steals it — Assassin found Merlin';
+    else finale = '🗡️ Evil triumphs';
+    return `${base} · ${finale}`;
+  }
+  return base;
+}

--- a/src/lib/games/avalon/stats.ts
+++ b/src/lib/games/avalon/stats.ts
@@ -1,0 +1,152 @@
+import type { ID, Round } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtPct } from '../../stats/format';
+import { outcomeOf, roleSetup, winningSide, type AvalonInput, type Side } from './logic';
+
+interface Agg {
+  goodGames: number;
+  goodWins: number;
+  evilGames: number;
+  evilWins: number;
+}
+
+interface Resolution {
+  winners: Set<ID>;
+  side: Side;
+  assassinated: boolean;
+}
+
+/**
+ * Avalon stats, derived purely from each finished game's recorded quests. Roles are secret
+ * during play, but a finished game's *winning side* (recorded at the clinch) plus the seat
+ * list fully partitions the table: winners sat on the winning side, everyone else on the
+ * other — so per-player Good/Evil win rates fall out without ever storing a role. Pure and
+ * unit-testable; mirrors the module's own `logic.ts`.
+ */
+export function avalonStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const roundsByGame = new Map<ID, Round[]>();
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const arr = roundsByGame.get(r.gameId);
+    if (arr) arr.push(r);
+    else roundsByGame.set(r.gameId, [r]);
+  }
+
+  const per = new Map<ID, Agg>();
+  const get = (id: ID): Agg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { goodGames: 0, goodWins: 0, evilGames: 0, evilWins: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let questsPlayed = 0;
+  let questFails = 0;
+  let assassinations = 0;
+  let resolvedGames = 0;
+
+  for (const g of games) {
+    const grounds = (roundsByGame.get(g.id) ?? []).slice().sort((a, b) => a.index - b.index);
+    const setup = roleSetup(g.playerIds.length);
+
+    let resolution: Resolution | null = null;
+    for (const r of grounds) {
+      const inp = r.input as AvalonInput | undefined;
+      if (!inp) continue;
+      const twoFail = setup.twoFailQuests[r.index] ?? false;
+      const outcome = outcomeOf(inp, twoFail);
+      questsPlayed += 1;
+      if (outcome === 'fail') questFails += 1;
+
+      const winners = inp.winners ?? [];
+      if (winners.length) {
+        const clinchedBy: Side = outcome === 'fail' ? 'evil' : 'good';
+        const side = winningSide(clinchedBy, inp.assassinFoundMerlin);
+        resolution = {
+          winners: new Set(winners.map(canonical)),
+          side,
+          assassinated: clinchedBy === 'good' && side === 'evil',
+        };
+      }
+    }
+
+    if (!resolution) continue;
+    resolvedGames += 1;
+    if (resolution.assassinated) assassinations += 1;
+
+    const other: Side = resolution.side === 'good' ? 'evil' : 'good';
+    for (const raw of g.playerIds) {
+      const id = canonical(raw);
+      const won = resolution.winners.has(id);
+      const side = won ? resolution.side : other;
+      const a = get(id);
+      if (side === 'good') {
+        a.goodGames += 1;
+        if (won) a.goodWins += 1;
+      } else {
+        a.evilGames += 1;
+        if (won) a.evilWins += 1;
+      }
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.goodGames) {
+      metrics.push({
+        key: 'av_good',
+        label: 'Win rate as Good',
+        value: fmtPct(a.goodWins / a.goodGames),
+        sub: `${a.goodWins}/${a.goodGames}`,
+        emoji: '🛡️',
+      });
+    }
+    if (a.evilGames) {
+      metrics.push({
+        key: 'av_evil',
+        label: 'Win rate as Evil',
+        value: fmtPct(a.evilWins / a.evilGames),
+        sub: `${a.evilWins}/${a.evilGames}`,
+        emoji: '🗡️',
+      });
+    }
+    const total = a.goodGames + a.evilGames;
+    if (total) {
+      metrics.push({
+        key: 'av_loyalty',
+        label: 'Dealt to Good',
+        value: fmtPct(a.goodGames / total),
+        sub: `${a.goodGames}/${total}`,
+        emoji: '⚜️',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (questsPlayed) {
+    global.push({ key: 'av_quests', label: 'Quests undertaken', value: `${questsPlayed}`, emoji: '🗺️' });
+    global.push({
+      key: 'av_fails',
+      label: 'Quests failed',
+      value: fmtPct(questFails / questsPlayed),
+      sub: `${questFails}/${questsPlayed}`,
+      emoji: '💥',
+    });
+  }
+  if (resolvedGames) {
+    global.push({
+      key: 'av_assassin',
+      label: 'Merlin assassinated',
+      value: fmtPct(assassinations / resolvedGames),
+      sub: `${assassinations}/${resolvedGames}`,
+      emoji: '🗡️',
+    });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## ⚔️ Avalon — The Resistance: Avalon

Adds a first-class **scoreless** tracker for the hidden-role social deduction game, living entirely in `src/lib/games/avalon/`. The registry auto-discovers it — no shared files touched.

### Modeling a scoreless team game inside a point-oriented contract
`GameModule` is point-oriented, so the module uses a clean representation:

- **A round is a QUEST.** The quest phase runs until one side reaches 3 — Good by 3 successes, Evil by 3 fails (min 3, max 5 quests). Quest rounds carry **no per-player points**; the live board is the Good–Evil quest track derived from round inputs.
- **Resolution folds into the clinching quest.** When a quest takes a side to 3, the editor reveals the finale: if **Good** clinched, the **Assassin** may name Merlin (stealing the win for Evil); then the seat-holder taps the **members of the winning side**.
- **Only the clinch scores:** each winning-side player gets `1`, everyone else `0`. So `pickWinners` = "everyone with a positive total" — unambiguous even for the assassination steal, where Good won more quests yet **Evil** wins.
- `isFinished` = a resolution has been recorded (some total > 0). `describeRound` narrates each quest and the finale (`Quest 3 ✓ succeeded`, `🗡️ Evil steals it — Assassin found Merlin`). `maxRounds = 5`.

### Role & quest setup by player count (`logic.ts`, pure/tested)
- Evil head count: 5→2, 6→2, 7→3, 8→3, 9→3, 10→4 (rest Good).
- Quest team sizes per count, and **Quest 4 needs two Fails at 7+ players** (the tracker derives ✓/✗ from the fail count accordingly).
- **Config toggles** (reference only, never change head counts): Percival, Morgana, Mordred, Oberon — surfaced in a collapsible in-editor roster.

### Design
Chrome unchanged; personality via emoji/copy only (🛡️ Good / 🗡️ Evil). Success/fail use `score-good`/`score-bad` (never colour alone — always paired with ✓/✗ + text). No Crown Gold anywhere (reserved for leader/winner). Depth via the surface ramp; violet used only for selection toggle states (precedented by Hearts). Reuses `Avatar` + `Stepper`; touch targets ≥46px; `tabular-nums` on changing numbers; honours reduced-motion via the global rules.

### Files (all new)
`logic.ts` · `index.ts` · `AvalonEditor.svelte` · `stats.ts` · `avalon.test.ts`

### Verification
- `npm run check` → 0 errors, 0 warnings
- `npm test` → 115 passed (40 new Avalon tests + existing suite)
- `npm run build` → success

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
