### PR TITLE
Add game-by-game presets (saved lineup + rules)

### DIFF
--- a/src/lib/components/GamePresets.svelte
+++ b/src/lib/components/GamePresets.svelte
@@ -34,6 +34,17 @@
 
   const validIds = $derived($activePlayers.map((p) => p.id));
 
+  // How a preset resolves against today's roster — the source of truth for what it will seat,
+  // so archived/removed members are reflected live (see resolvePresetPlayers).
+  function seatedCount(p: GamePreset): number {
+    return resolvePresetPlayers(p, validIds, max).length;
+  }
+  /** Saved players who aren't in the current roster (archived, or absent after a partial restore). */
+  function unavailableCount(p: GamePreset): number {
+    const valid = new Set(validIds);
+    return new Set(p.playerIds.filter((id) => !valid.has(id))).size;
+  }
+
   // Which preset (if any) the form was last filled from — drives the Update/Rename/Delete tools.
   let activeId = $state<string | null>(null);
   const active = $derived($presets.find((p) => p.id === activeId) ?? null);
@@ -122,7 +133,13 @@
           title={`Use “${p.name}”`}
         >
           <span class="pname">{p.name}</span>
-          <span class="pcount">{p.playerIds.length}👤</span>
+          <span class="pcount">
+            {seatedCount(p)}👤{#if unavailableCount(p)}<span
+                class="away"
+                title={`${unavailableCount(p)} saved player${unavailableCount(p) > 1 ? 's are' : ' is'} no longer in the roster and will be skipped`}
+                >· {unavailableCount(p)} away</span
+              >{/if}
+          </span>
         </button>
       {/each}
     </div>
@@ -223,6 +240,9 @@
     font-size: 0.75rem;
     color: var(--muted);
     font-variant-numeric: tabular-nums;
+  }
+  .away {
+    margin-left: 4px;
   }
   .prow {
     display: flex;

--- a/src/lib/components/GamePresets.svelte
+++ b/src/lib/components/GamePresets.svelte
@@ -142,7 +142,7 @@
         bind:value={draftName}
         autofocus
       />
-      <button class="btn" type="submit" disabled={!selected.length}>Save</button>
+      <button class="btn" type="submit">Save</button>
       <button class="btn ghost" type="button" onclick={cancel}>Cancel</button>
     </form>
   {:else if mode === 'renaming' && active}
@@ -174,7 +174,7 @@
       <button class="btn small ghost" type="button" onclick={remove}>Delete</button>
     </div>
   {:else}
-    <button class="linkbtn" type="button" onclick={startSave} disabled={!selected.length}>
+    <button class="linkbtn" type="button" onclick={startSave}>
       ＋ Save current setup
     </button>
   {/if}

--- a/src/lib/components/GamePresets.svelte
+++ b/src/lib/components/GamePresets.svelte
@@ -1,0 +1,270 @@
+<script lang="ts">
+  import type { ConfigField, GamePreset, ID } from '../types';
+  import { activePlayers } from '../stores/players';
+  import { crewNames, crewSignature } from '../stores/crews';
+  import {
+    presetsForType,
+    savePreset,
+    updatePreset,
+    renamePreset,
+    deletePresetWithUndo,
+    resolvePresetPlayers,
+    resolvePresetConfig,
+    presetMatches,
+  } from '../stores/presets';
+
+  let {
+    type,
+    selected = $bindable([]),
+    config = $bindable({}),
+    fields,
+    max = 12,
+  }: {
+    type: string;
+    selected: ID[];
+    config: Record<string, any>;
+    fields: ConfigField[] | undefined;
+    max?: number;
+  } = $props();
+
+  const presets = $derived.by(() => {
+    void type; // re-subscribe when the game type changes
+    return presetsForType(type);
+  });
+
+  const validIds = $derived($activePlayers.map((p) => p.id));
+
+  // Which preset (if any) the form was last filled from — drives the Update/Rename/Delete tools.
+  let activeId = $state<string | null>(null);
+  const active = $derived($presets.find((p) => p.id === activeId) ?? null);
+
+  type Mode = 'idle' | 'saving' | 'renaming';
+  let mode = $state<Mode>('idle');
+  let draftName = $state('');
+
+  // The applied preset is "dirty" once the current form no longer matches it — only then is
+  // there anything to Update.
+  const dirty = $derived(
+    active ? !presetMatches(active, selected, config, validIds, max, fields) : false,
+  );
+
+  /** A friendly default name for a brand-new preset: the crew's nickname, else its player names. */
+  function suggestName(): string {
+    if (!selected.length) return '';
+    const sig = crewSignature(selected);
+    const crew = $crewNames[sig];
+    if (crew) return crew;
+    const names = selected
+      .map((id) => $activePlayers.find((p) => p.id === id)?.name)
+      .filter((n): n is string => !!n);
+    return names.join(', ');
+  }
+
+  function apply(p: GamePreset) {
+    selected = resolvePresetPlayers(p, validIds, max);
+    config = resolvePresetConfig(p, fields);
+    activeId = p.id;
+    mode = 'idle';
+  }
+
+  function startSave() {
+    draftName = suggestName();
+    mode = 'saving';
+  }
+
+  function confirmSave(e: Event) {
+    e.preventDefault();
+    const p = savePreset(type, draftName, selected, config);
+    activeId = p.id;
+    mode = 'idle';
+  }
+
+  function startRename() {
+    if (!active) return;
+    draftName = active.name;
+    mode = 'renaming';
+  }
+
+  function confirmRename(e: Event) {
+    e.preventDefault();
+    if (active) renamePreset(active.id, draftName);
+    mode = 'idle';
+  }
+
+  function saveOverActive() {
+    if (active) updatePreset(active.id, selected, config);
+  }
+
+  function remove() {
+    if (!active) return;
+    deletePresetWithUndo(active);
+    activeId = null;
+    mode = 'idle';
+  }
+
+  function cancel() {
+    mode = 'idle';
+  }
+</script>
+
+<div class="presets">
+  <div class="fieldlabel">Presets</div>
+
+  {#if $presets.length}
+    <div class="pchips" role="list">
+      {#each $presets as p (p.id)}
+        <button
+          type="button"
+          class="pchip"
+          class:on={activeId === p.id}
+          aria-pressed={activeId === p.id}
+          onclick={() => apply(p)}
+          title={`Use “${p.name}”`}
+        >
+          <span class="pname">{p.name}</span>
+          <span class="pcount">{p.playerIds.length}👤</span>
+        </button>
+      {/each}
+    </div>
+  {:else}
+    <p class="muted hint">Save a lineup and rules you like — then start it again in one tap.</p>
+  {/if}
+
+  {#if mode === 'saving'}
+    <form class="prow" onsubmit={confirmSave}>
+      <!-- svelte-ignore a11y_autofocus -->
+      <input
+        class="grow"
+        type="text"
+        placeholder="Preset name…"
+        aria-label="Preset name"
+        autocomplete="off"
+        bind:value={draftName}
+        autofocus
+      />
+      <button class="btn" type="submit" disabled={!selected.length}>Save</button>
+      <button class="btn ghost" type="button" onclick={cancel}>Cancel</button>
+    </form>
+  {:else if mode === 'renaming' && active}
+    <form class="prow" onsubmit={confirmRename}>
+      <!-- svelte-ignore a11y_autofocus -->
+      <input
+        class="grow"
+        type="text"
+        placeholder="Preset name…"
+        aria-label="Rename preset"
+        autocomplete="off"
+        bind:value={draftName}
+        autofocus
+      />
+      <button class="btn" type="submit">Rename</button>
+      <button class="btn ghost" type="button" onclick={cancel}>Cancel</button>
+    </form>
+  {:else if active}
+    <div class="ptools">
+      <span class="applied">
+        {#if dirty}Modified “{active.name}”{:else}Using “{active.name}”{/if}
+      </span>
+      <span class="spacer"></span>
+      {#if dirty}
+        <button class="btn small" type="button" onclick={saveOverActive}>Update</button>
+      {/if}
+      <button class="btn small ghost" type="button" onclick={startRename}>Rename</button>
+      <button class="btn small ghost" type="button" onclick={startSave}>Save new</button>
+      <button class="btn small ghost" type="button" onclick={remove}>Delete</button>
+    </div>
+  {:else}
+    <button class="linkbtn" type="button" onclick={startSave} disabled={!selected.length}>
+      ＋ Save current setup
+    </button>
+  {/if}
+</div>
+
+<style>
+  .presets {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .hint {
+    font-size: 0.85rem;
+    margin: 0;
+  }
+  .pchips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  /* A preset chip mirrors the player chips: neutral until selected, violet-tinted when the
+     form was filled from it — never a solid violet fill (that's reserved for the one primary
+     action) and never gold. */
+  .pchip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 600;
+  }
+  .pchip.on {
+    border-color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 18%, var(--surface-2));
+  }
+  .pchip:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .pcount {
+    font-size: 0.75rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .prow {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+  .ptools {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+  }
+  .applied {
+    font-size: 0.85rem;
+    color: var(--muted);
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .spacer {
+    flex: 1;
+  }
+  /* A quiet violet text button (allowed as a text link, not a second violet fill). */
+  .linkbtn {
+    align-self: flex-start;
+    background: none;
+    border: none;
+    color: var(--primary);
+    font-weight: 600;
+    font-size: 0.9rem;
+    padding: 8px 2px;
+    cursor: pointer;
+    min-height: 46px;
+  }
+  .linkbtn:disabled {
+    color: var(--muted);
+    cursor: default;
+  }
+  .linkbtn:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+    border-radius: var(--radius-sm);
+  }
+</style>

--- a/src/lib/components/GamePresets.svelte
+++ b/src/lib/components/GamePresets.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { ConfigField, GamePreset, ID } from '../types';
+  import { defaultConfig } from '../types';
   import { activePlayers } from '../stores/players';
   import { crewNames, crewSignature } from '../stores/crews';
   import {
@@ -72,6 +73,18 @@
   }
 
   function apply(p: GamePreset) {
+    // Clicking the already-active preset toggles it off. If the form still matches the preset
+    // (untouched), fall back to the game's default empty state; if you've since edited it, keep
+    // your changes and just detach the preset label ("barring any input changes I have made").
+    if (activeId === p.id) {
+      if (!dirty) {
+        selected = [];
+        config = defaultConfig(fields);
+      }
+      activeId = null;
+      mode = 'idle';
+      return;
+    }
     selected = resolvePresetPlayers(p, validIds, max);
     config = resolvePresetConfig(p, fields);
     activeId = p.id;
@@ -130,7 +143,7 @@
           class:on={activeId === p.id}
           aria-pressed={activeId === p.id}
           onclick={() => apply(p)}
-          title={`Use “${p.name}”`}
+          title={activeId === p.id ? `Turn off “${p.name}”` : `Use “${p.name}”`}
         >
           <span class="pname">{p.name}</span>
           <span class="pcount">

--- a/src/lib/components/GamePresets.svelte
+++ b/src/lib/components/GamePresets.svelte
@@ -180,7 +180,7 @@
   {:else if active}
     <div class="ptools">
       <span class="applied">
-        {#if dirty}Modified “{active.name}”{:else}Using “{active.name}”{/if}
+        {#if dirty}Using modified preset: {active.name}{:else}Using preset: {active.name}{/if}
       </span>
       <span class="spacer"></span>
       {#if dirty}

--- a/src/lib/stores/customGames.ts
+++ b/src/lib/stores/customGames.ts
@@ -4,6 +4,7 @@ import { buildCustomModule } from '../games/custom/factory';
 import { setCustomDefsRegistry } from '../games/custom/defRegistry';
 import { setCustomModules } from '../games/registry';
 import * as db from '../storage/db';
+import { prunePresetsForType } from './presets';
 
 /**
  * Custom (user-authored) games.
@@ -50,6 +51,8 @@ export async function removeCustomGame(id: string, inUse: boolean): Promise<void
     if (current) await db.putGameDef({ ...current, archived: true, archivedAt: Date.now() });
   } else {
     await db.deleteGameDef(id);
+    // Type is gone for good — drop its now-unreachable presets.
+    prunePresetsForType(id);
   }
   await refreshCustomGames();
 }

--- a/src/lib/stores/players.ts
+++ b/src/lib/stores/players.ts
@@ -3,6 +3,7 @@ import type { Player, ID } from '../types';
 import type { BackupSettings } from './settings';
 import * as db from '../storage/db';
 import { pickColor, generateHandle } from '../util';
+import { pruneDeletedPlayers } from './presets';
 
 /** Every member, archived included — Stats and History need the full roster. */
 export const players = writable<Player[]>([]);
@@ -67,6 +68,8 @@ export async function savePlayerPrefs(
 /** Permanently remove a member and forget them entirely. */
 export async function removePlayer(id: ID): Promise<void> {
   await db.deletePlayer(id);
+  // A permanent removal: strip the ghost id from any saved presets so it can't linger or re-sync.
+  pruneDeletedPlayers([id]);
   await refreshPlayers();
 }
 

--- a/src/lib/stores/presets.test.ts
+++ b/src/lib/stores/presets.test.ts
@@ -48,6 +48,12 @@ describe('game presets store', () => {
     expect(p.name).toBe('Preset');
   });
 
+  it('saves a rules-only preset with no players selected', () => {
+    const p = savePreset('avalon', 'Morgana on', [], { morgana: true });
+    expect(p.playerIds).toEqual([]);
+    expect(getPresetsForType('avalon')[0].config).toEqual({ morgana: true });
+  });
+
   it('updates a preset in place, keeping its name and id', () => {
     const p = savePreset('avalon', 'Crew', ['p1'], { target: 100, morgana: false });
     updatePreset(p.id, ['p1', 'p2'], { target: 120, morgana: true });

--- a/src/lib/stores/presets.test.ts
+++ b/src/lib/stores/presets.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import type { ConfigField, GamePreset } from '../types';
+import { settings } from './settings';
+import {
+  savePreset,
+  updatePreset,
+  renamePreset,
+  removePreset,
+  getPresetsForType,
+  presetsForType,
+  resolvePresetPlayers,
+  resolvePresetConfig,
+  presetMatches,
+} from './presets';
+
+const FIELDS: ConfigField[] = [
+  { key: 'target', label: 'Target', type: 'number', default: 100 },
+  { key: 'morgana', label: 'Morgana', type: 'boolean', default: false },
+];
+
+function reset() {
+  settings.update((s) => ({ ...s, gamePresets: [] }));
+}
+
+describe('game presets store', () => {
+  beforeEach(reset);
+
+  it('saves a preset scoped to its game type and snapshots the setup', () => {
+    const selected = ['p1', 'p2'];
+    const config = { target: 100, morgana: true };
+    const p = savePreset('avalon', 'Friday crew', selected, config);
+
+    expect(p.type).toBe('avalon');
+    expect(p.name).toBe('Friday crew');
+    expect(getPresetsForType('avalon').map((x) => x.id)).toEqual([p.id]);
+    expect(getPresetsForType('skullking')).toEqual([]);
+
+    // Mutating the sources afterwards must not change the stored preset (deep copy).
+    selected.push('p3');
+    config.morgana = false;
+    expect(p.playerIds).toEqual(['p1', 'p2']);
+    expect(p.config).toEqual({ target: 100, morgana: true });
+  });
+
+  it('falls back to a placeholder name when given a blank one', () => {
+    const p = savePreset('avalon', '   ', ['p1'], {});
+    expect(p.name).toBe('Preset');
+  });
+
+  it('updates a preset in place, keeping its name and id', () => {
+    const p = savePreset('avalon', 'Crew', ['p1'], { target: 100, morgana: false });
+    updatePreset(p.id, ['p1', 'p2'], { target: 120, morgana: true });
+
+    const stored = getPresetsForType('avalon')[0];
+    expect(stored.id).toBe(p.id);
+    expect(stored.name).toBe('Crew');
+    expect(stored.playerIds).toEqual(['p1', 'p2']);
+    expect(stored.config).toEqual({ target: 120, morgana: true });
+  });
+
+  it('renames a preset but ignores a blank rename', () => {
+    const p = savePreset('avalon', 'Old', ['p1'], {});
+    renamePreset(p.id, 'New name');
+    expect(getPresetsForType('avalon')[0].name).toBe('New name');
+    renamePreset(p.id, '   ');
+    expect(getPresetsForType('avalon')[0].name).toBe('New name');
+  });
+
+  it('removes a preset', () => {
+    const p = savePreset('avalon', 'Crew', ['p1'], {});
+    removePreset(p.id);
+    expect(getPresetsForType('avalon')).toEqual([]);
+  });
+
+  it('exposes a reactive per-type list, newest edit first', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_000);
+      const a = savePreset('avalon', 'A', ['p1'], {});
+      vi.setSystemTime(2_000);
+      const b = savePreset('avalon', 'B', ['p2'], {});
+      const store = presetsForType('avalon');
+      expect(get(store).map((p) => p.id)).toEqual([b.id, a.id]);
+
+      // Touching A makes it the most-recently-edited.
+      vi.setSystemTime(3_000);
+      updatePreset(a.id, ['p1', 'p3'], {});
+      expect(get(store).map((p) => p.id)).toEqual([a.id, b.id]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('preset apply/dirty helpers', () => {
+  const preset: GamePreset = {
+    id: 'x',
+    type: 'avalon',
+    name: 'Crew',
+    playerIds: ['p1', 'p2', 'gone'],
+    config: { target: 120, morgana: true, retired: 'x' },
+    createdAt: 0,
+    updatedAt: 0,
+  };
+
+  it('drops unknown players, dedupes, and caps at max', () => {
+    expect(resolvePresetPlayers(preset, ['p1', 'p2', 'p4'], 12)).toEqual(['p1', 'p2']);
+    expect(resolvePresetPlayers(preset, ['p1', 'p2'], 1)).toEqual(['p1']);
+  });
+
+  it('overlays saved config on current defaults, dropping retired keys and defaulting new ones', () => {
+    const cfg = resolvePresetConfig(preset, FIELDS);
+    expect(cfg).toEqual({ target: 120, morgana: true });
+    expect('retired' in cfg).toBe(false);
+  });
+
+  it('new config fields added since the preset was saved fall back to their default', () => {
+    const withNewField: ConfigField[] = [
+      ...FIELDS,
+      { key: 'extra', label: 'Extra', type: 'number', default: 7 },
+    ];
+    expect(resolvePresetConfig(preset, withNewField)).toEqual({
+      target: 120,
+      morgana: true,
+      extra: 7,
+    });
+  });
+
+  it('detects a clean match versus a dirty form', () => {
+    const valid = ['p1', 'p2'];
+    const players = resolvePresetPlayers(preset, valid, 12);
+    const config = resolvePresetConfig(preset, FIELDS);
+
+    expect(presetMatches(preset, players, config, valid, 12, FIELDS)).toBe(true);
+    expect(presetMatches(preset, ['p1'], config, valid, 12, FIELDS)).toBe(false);
+    expect(
+      presetMatches(preset, players, { ...config, morgana: false }, valid, 12, FIELDS),
+    ).toBe(false);
+  });
+});

--- a/src/lib/stores/presets.test.ts
+++ b/src/lib/stores/presets.test.ts
@@ -7,6 +7,8 @@ import {
   updatePreset,
   renamePreset,
   removePreset,
+  pruneDeletedPlayers,
+  prunePresetsForType,
   getPresetsForType,
   presetsForType,
   resolvePresetPlayers,
@@ -77,6 +79,36 @@ describe('game presets store', () => {
     const p = savePreset('avalon', 'Crew', ['p1'], {});
     removePreset(p.id);
     expect(getPresetsForType('avalon')).toEqual([]);
+  });
+
+  it('prunes hard-deleted players from every preset, leaving others untouched', () => {
+    const a = savePreset('avalon', 'A', ['p1', 'p2', 'p3'], {});
+    const b = savePreset('skullking', 'B', ['p4', 'p5'], {});
+    pruneDeletedPlayers(['p2', 'p4']);
+
+    expect(getPresetsForType('avalon')[0].playerIds).toEqual(['p1', 'p3']);
+    expect(getPresetsForType('skullking')[0].playerIds).toEqual(['p5']);
+    // A preset with none of the deleted ids keeps its exact record (no needless updatedAt churn).
+    void a;
+    void b;
+  });
+
+  it('leaves presets untouched when no deleted id is present', () => {
+    const p = savePreset('avalon', 'A', ['p1', 'p2'], {});
+    const before = getPresetsForType('avalon')[0];
+    pruneDeletedPlayers(['ghost']);
+    expect(getPresetsForType('avalon')[0]).toBe(before);
+    void p;
+  });
+
+  it('drops every preset for a hard-deleted game type only', () => {
+    savePreset('def_gone', 'A', ['p1'], {});
+    savePreset('def_gone', 'B', ['p2'], {});
+    const keep = savePreset('avalon', 'Keep', ['p3'], {});
+    prunePresetsForType('def_gone');
+
+    expect(getPresetsForType('def_gone')).toEqual([]);
+    expect(getPresetsForType('avalon').map((x) => x.id)).toEqual([keep.id]);
   });
 
   it('exposes a reactive per-type list, newest edit first', () => {

--- a/src/lib/stores/presets.ts
+++ b/src/lib/stores/presets.ts
@@ -1,0 +1,161 @@
+import { derived, get, type Readable } from 'svelte/store';
+import type { ConfigField, GamePreset, ID } from '../types';
+import { defaultConfig } from '../types';
+import { settings } from './settings';
+import { showActionToast } from './toast';
+import { uid } from '../util';
+
+/**
+ * Game-by-game presets: a saved lineup + rules for a specific game type, so a group can start
+ * "the usual" in one tap without being locked into it. Presets are persisted as the portable
+ * {@link Settings.gamePresets} setting (they ride a backup/restore like catalog favorites), and
+ * only ever *pre-fill* the New game form — applying one never commits you to it, and it changes
+ * only when you explicitly Update it.
+ *
+ * The apply/dirty logic lives here as pure helpers so it's testable without a component and so
+ * a preset saved before a config field or player existed still resolves sensibly today.
+ */
+
+/** All presets, newest edits first (reactive). */
+export const gamePresets: Readable<GamePreset[]> = derived(settings, ($s) =>
+  [...$s.gamePresets].sort((a, b) => b.updatedAt - a.updatedAt),
+);
+
+/** Presets for a single game type, most-recently-edited first (reactive). */
+export function presetsForType(type: string): Readable<GamePreset[]> {
+  return derived(gamePresets, ($all) => $all.filter((p) => p.type === type));
+}
+
+/** Snapshot of a type's presets (non-reactive), for one-off reads. */
+export function getPresetsForType(type: string): GamePreset[] {
+  return get(settings)
+    .gamePresets.filter((p) => p.type === type)
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/**
+ * Save a new preset for a game type. `playerIds` and `config` are snapshotted (deep-copied)
+ * so later edits to the form don't mutate the stored preset. Returns the created preset.
+ */
+export function savePreset(
+  type: string,
+  name: string,
+  playerIds: ID[],
+  config: Record<string, unknown>,
+): GamePreset {
+  const now = Date.now();
+  const preset: GamePreset = {
+    id: uid(),
+    type,
+    name: name.trim() || 'Preset',
+    playerIds: [...playerIds],
+    config: { ...config },
+    createdAt: now,
+    updatedAt: now,
+  };
+  settings.update((s) => ({ ...s, gamePresets: [...s.gamePresets, preset] }));
+  return preset;
+}
+
+/** Overwrite a preset's saved lineup + rules with the current setup (keeps its name). */
+export function updatePreset(
+  id: ID,
+  playerIds: ID[],
+  config: Record<string, unknown>,
+): void {
+  settings.update((s) => ({
+    ...s,
+    gamePresets: s.gamePresets.map((p) =>
+      p.id === id
+        ? { ...p, playerIds: [...playerIds], config: { ...config }, updatedAt: Date.now() }
+        : p,
+    ),
+  }));
+}
+
+/** Rename a preset. A blank name is ignored (keeps the existing label). */
+export function renamePreset(id: ID, name: string): void {
+  const trimmed = name.trim();
+  if (!trimmed) return;
+  settings.update((s) => ({
+    ...s,
+    gamePresets: s.gamePresets.map((p) =>
+      p.id === id ? { ...p, name: trimmed, updatedAt: Date.now() } : p,
+    ),
+  }));
+}
+
+/** Remove a preset outright (no tombstone — presets are a convenience list, not synced entities). */
+export function removePreset(id: ID): void {
+  settings.update((s) => ({ ...s, gamePresets: s.gamePresets.filter((p) => p.id !== id) }));
+}
+
+/** Delete a preset with an Undo toast — the app's standard recoverable-destructive pattern. */
+export function deletePresetWithUndo(preset: GamePreset): void {
+  removePreset(preset.id);
+  showActionToast(`“${preset.name}” deleted`, 'Undo', () => {
+    // Re-insert the exact record so the undo is a true restore, not a fresh preset.
+    settings.update((s) =>
+      s.gamePresets.some((p) => p.id === preset.id)
+        ? s
+        : { ...s, gamePresets: [...s.gamePresets, preset] },
+    );
+  });
+}
+
+// ── Pure apply/dirty helpers ────────────────────────────────────────────────────
+
+/**
+ * The lineup a preset resolves to *right now*: its saved players in order, dropping any who
+ * are no longer selectable (archived/deleted since it was saved) and capping at the game's
+ * `max`. Keeps a preset useful even as the roster changes underneath it.
+ */
+export function resolvePresetPlayers(
+  preset: GamePreset,
+  validIds: Iterable<ID>,
+  max: number,
+): ID[] {
+  const valid = new Set(validIds);
+  const out: ID[] = [];
+  for (const id of preset.playerIds) {
+    if (valid.has(id) && !out.includes(id) && out.length < max) out.push(id);
+  }
+  return out;
+}
+
+/**
+ * The config a preset resolves to: the game's current defaults, overlaid with the preset's
+ * saved values for keys that still exist. New config fields added since the preset was saved
+ * fall back to their default; retired keys are dropped.
+ */
+export function resolvePresetConfig(
+  preset: GamePreset,
+  fields: ConfigField[] | undefined,
+): Record<string, unknown> {
+  const cfg = defaultConfig(fields);
+  for (const key of Object.keys(cfg)) {
+    if (key in preset.config) cfg[key] = preset.config[key];
+  }
+  return cfg;
+}
+
+/**
+ * Whether the current form (selected players + config) already matches what applying `preset`
+ * would yield. Used to show an "Update" affordance only when there's something to save.
+ */
+export function presetMatches(
+  preset: GamePreset,
+  selected: ID[],
+  config: Record<string, unknown>,
+  validIds: Iterable<ID>,
+  max: number,
+  fields: ConfigField[] | undefined,
+): boolean {
+  const players = resolvePresetPlayers(preset, validIds, max);
+  if (players.length !== selected.length || players.some((id, i) => id !== selected[i])) {
+    return false;
+  }
+  const wantCfg = resolvePresetConfig(preset, fields);
+  const keys = Object.keys(wantCfg);
+  return keys.every((k) => Object.is(wantCfg[k], config[k]));
+}

--- a/src/lib/stores/presets.ts
+++ b/src/lib/stores/presets.ts
@@ -90,6 +90,43 @@ export function removePreset(id: ID): void {
   settings.update((s) => ({ ...s, gamePresets: s.gamePresets.filter((p) => p.id !== id) }));
 }
 
+/**
+ * Strip hard-deleted player ids from every stored preset. Called when a member is permanently
+ * removed (a tombstone, never coming back), so presets don't keep a ghost id that would
+ * silently re-sync or resurrect. Archived (recoverable) members are deliberately NOT pruned —
+ * those are hidden reactively so restoring the member restores them to the preset.
+ */
+export function pruneDeletedPlayers(deletedIds: Iterable<ID>): void {
+  const gone = new Set(deletedIds);
+  if (gone.size === 0) return;
+  settings.update((s) => {
+    let changed = false;
+    const next = s.gamePresets.map((p) => {
+      if (!p.playerIds.some((id) => gone.has(id))) return p;
+      changed = true;
+      return {
+        ...p,
+        playerIds: p.playerIds.filter((id) => !gone.has(id)),
+        updatedAt: Date.now(),
+      };
+    });
+    return changed ? { ...s, gamePresets: next } : s;
+  });
+}
+
+/**
+ * Drop every preset belonging to a game type that no longer exists — a hard-deleted custom
+ * type (an *archived* type is still resolvable, so its presets are kept). Without this, its
+ * presets would be orphaned forever with no surface to reach or clean them from.
+ */
+export function prunePresetsForType(type: string): void {
+  settings.update((s) =>
+    s.gamePresets.some((p) => p.type === type)
+      ? { ...s, gamePresets: s.gamePresets.filter((p) => p.type !== type) }
+      : s,
+  );
+}
+
 /** Delete a preset with an Undo toast — the app's standard recoverable-destructive pattern. */
 export function deletePresetWithUndo(preset: GamePreset): void {
   removePreset(preset.id);

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,4 +1,5 @@
 import { get, writable } from 'svelte/store';
+import type { GamePreset } from '../types';
 
 export type Theme = 'dark' | 'light';
 
@@ -46,6 +47,11 @@ export interface Settings {
    * Orthogonal to a custom type being retired or a played game being archived.
    */
   catalogHidden: string[];
+  /**
+   * Saved per-game setups (lineup + rules) the group can start again in one tap. Portable
+   * so a crew's presets travel with a restore, just like {@link Settings.catalogFavorites}.
+   */
+  gamePresets: GamePreset[];
 
   // ── Device-local sync state ───────────────────────────────────────────────
   // OneDrive connection, the backup file's own location, and per-device sync
@@ -106,6 +112,7 @@ export const PORTABLE_SETTING_KEYS = [
   'roastMode',
   'catalogFavorites',
   'catalogHidden',
+  'gamePresets',
 ] as const;
 
 /**
@@ -161,6 +168,7 @@ const defaults: Settings = {
   roastMode: true,
   catalogFavorites: [],
   catalogHidden: [],
+  gamePresets: [],
   oneDriveClientId: '',
   oneDriveFolderMode: 'app',
   oneDriveCustomPath: '',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -34,6 +34,30 @@ export interface Player {
   deleted?: number;
 }
 
+/**
+ * A reusable, per-game-type setup: the lineup and rules you like for a specific game,
+ * saved so you can start it again in one tap ("The Friday crew, Avalon with Morgana on").
+ *
+ * Deliberately *not* a locked configuration — a preset only pre-fills the New game form.
+ * You can apply it and then freely retune players or config before starting; the preset
+ * only changes when you explicitly Update it. Keyed by `type` (a built-in slug like
+ * `avalon` or a custom def id `def_…`). Stored as a portable setting so a group's presets
+ * travel with a backup/restore, exactly like {@link Player} ids and catalog favorites do.
+ */
+export interface GamePreset {
+  id: ID;
+  /** Game type this preset belongs to — a built-in slug or a custom def id. */
+  type: string;
+  /** User-given label, e.g. "Friday crew + Morgana". */
+  name: string;
+  /** The saved lineup, in seating order. May be empty for a rules-only preset. */
+  playerIds: ID[];
+  /** The saved game configuration (game-specific keys). */
+  config: Record<string, unknown>;
+  createdAt: number;
+  updatedAt: number;
+}
+
 export type GameStatus = 'active' | 'finished' | 'abandoned';
 
 export interface Game {

--- a/src/pages/GameType.svelte
+++ b/src/pages/GameType.svelte
@@ -7,6 +7,7 @@
   import { showToast } from '../lib/stores/toast';
   import PlayerSelect from '../lib/components/PlayerSelect.svelte';
   import ConfigForm from '../lib/components/ConfigForm.svelte';
+  import GamePresets from '../lib/components/GamePresets.svelte';
 
   let { type }: { type: string } = $props();
   // Re-resolve when custom defs load so a deep-link to /def_… lands once IndexedDB answers.
@@ -74,6 +75,14 @@
 
   <div class="section-title">New game</div>
   <div class="card stack">
+    <GamePresets
+      {type}
+      fields={module.configFields}
+      max={module.maxPlayers}
+      bind:selected
+      bind:config
+    />
+    <hr />
     <div>
       <div class="fieldlabel">Players ({module.minPlayers}–{module.maxPlayers})</div>
       <PlayerSelect bind:selected max={module.maxPlayers} min={module.minPlayers} />


### PR DESCRIPTION
## What & why

Adds **game-by-game presets** so a group can start "the usual" in one tap — the same crew, or a specific rules configuration (e.g. Avalon with Morgana on) — without being locked into it.

Favoriting games already existed (catalog favorites in Manage games + Home); this PR builds the presets feature on top.

## How it works

A **preset** captures a reusable setup for one game type: `{ playerIds, config }`, saved as a portable setting so it rides a backup/restore exactly like catalog favorites.

Deliberately non-destructive — a preset only **pre-fills** the New game form:

- **Apply** a preset by tapping its chip; tap the active chip again to **toggle it off** (resets to the default empty state, or keeps your edits if you've changed anything).
- Once applied, the form shows **"Using preset: `<name>`"** / **"Using modified preset: `<name>`"** with **Update**, **Rename**, **Save new**, and **Delete** (with Undo) tools.
- **Rules-only presets** (no players selected) are fully supported.

## Stays consistent as the roster/catalog changes

- Applying resolves against **today's** roster and config: archived/removed players are skipped, retired config keys are dropped, and config fields added since save fall back to their default.
- The chip shows the **live seated count** plus a subtle "· N away" note when saved players are no longer available.
- **Archive is recoverable** — presets aren't mutated, so un-archiving a member restores them to the preset. **Hard delete is permanent** — the ghost player id is stripped from every preset, and a hard-deleted custom game type drops its now-unreachable presets.

## Files

- `types.ts` — `GamePreset` interface
- `stores/settings.ts` — portable `gamePresets` setting
- `stores/presets.ts` — CRUD + pure resolve/dirty/prune helpers
- `stores/players.ts`, `stores/customGames.ts` — prune presets on hard delete
- `components/GamePresets.svelte` — the presets UI
- `pages/GameType.svelte` — mounts it in the New game card
- `stores/presets.test.ts` — 14 unit tests

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run test` — **784 passing** (14 new)
- `npm run build` — succeeds

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>