### PR TITLE
Redesign volleyball: open team-based play with drag-and-drop rosters

### DIFF
--- a/src/lib/games/volleyball/VolleyballEditor.svelte
+++ b/src/lib/games/volleyball/VolleyballEditor.svelte
@@ -1,161 +1,457 @@
 <script lang="ts">
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
-  import type { VolleyballInput } from './index';
-  import { isDecidingSet, readConfig, setWinner, targetForSet, type Side } from './logic';
+  import { PALETTE } from '../../util';
+  import type { VolleyballInput } from './logic';
+  import {
+    cloneTeams,
+    foldStandings,
+    makeTeam,
+    readConfig,
+    setWinner,
+    type Team,
+    unassigned,
+  } from './logic';
+  import { rosterDnd } from './drag';
 
   let { input = $bindable(), ctx }: { input: VolleyballInput; ctx: RoundContext } = $props();
 
   const cfg = $derived(readConfig(ctx.config));
-  const pa = $derived(ctx.players[0]);
-  const pb = $derived(ctx.players[1]);
+  const pool = $derived(ctx.players);
+  const playerById = $derived(new Map(pool.map((p) => [p.id, p])));
 
-  // Sets won so far (the running match score) come from the totals-before-this-round.
-  const setsA = $derived(Number(ctx.totals[pa?.id]) || 0);
-  const setsB = $derived(Number(ctx.totals[pb?.id]) || 0);
-  const setNumber = $derived(setsA + setsB + 1);
-  const deciding = $derived(isDecidingSet(setsA, setsB, cfg.setsToWin));
-  const target = $derived(targetForSet(cfg, setsA, setsB));
+  // Recorded sets so far (this round is not among them) → live team standings.
+  const priorSets = $derived(
+    [...ctx.rounds]
+      .sort((a, b) => a.index - b.index)
+      .map((r) => r.input as VolleyballInput)
+      .filter((i) => i && Array.isArray(i.teams)),
+  );
+  const standings = $derived(foldStandings(input.teams ?? [], priorSets, cfg));
+  const leaderId = $derived(standings[0]?.setsWon > 0 ? standings[0].team.id : null);
+  const setNumber = $derived(ctx.roundIndex + 1);
 
-  const ptsA = $derived(Number(input.points[pa?.id]) || 0);
-  const ptsB = $derived(Number(input.points[pb?.id]) || 0);
-  const result = $derived(setWinner(ptsA, ptsB, target, cfg.winBy2, cfg.hardCap));
+  const home = $derived(input.teams?.find((t) => t.id === input.home));
+  const away = $derived(input.teams?.find((t) => t.id === input.away));
+  const ptsHome = $derived(Number(input.points?.home) || 0);
+  const ptsAway = $derived(Number(input.points?.away) || 0);
+  const target = $derived(cfg.pointsPerSet);
+  const result = $derived(setWinner(ptsHome, ptsAway, target, cfg.winBy2, cfg.hardCap));
 
-  function bump(id: string, delta: number) {
-    input.points[id] = Math.max(0, (Number(input.points[id]) || 0) + delta);
+  const benchIds = $derived(unassigned(input.teams ?? [], pool.map((p) => p.id)));
+
+  // ── Score entry ──────────────────────────────────────────────────────────
+  function bump(slot: 'home' | 'away', delta: number) {
+    const next = Math.max(0, (Number(input.points?.[slot]) || 0) + delta);
+    input.points = { ...input.points, [slot]: next };
   }
-  function onType(id: string, value: string) {
+  function onType(slot: 'home' | 'away', value: string) {
     const n = Math.floor(Number(value));
-    input.points[id] = Number.isFinite(n) && n > 0 ? n : 0;
+    input.points = { ...input.points, [slot]: Number.isFinite(n) && n > 0 ? n : 0 };
+  }
+  function swapSides() {
+    const h = input.home;
+    input.home = input.away;
+    input.away = h;
+    input.points = { home: ptsAway, away: ptsHome };
   }
 
-  /** Would one more point here win the set — and would that win the match? */
-  function pointKind(side: Side): 'match' | 'set' | null {
-    if (result) return null;
-    const na = side === 'a' ? ptsA + 1 : ptsA;
-    const nb = side === 'b' ? ptsB + 1 : ptsB;
-    if (setWinner(na, nb, target, cfg.winBy2, cfg.hardCap) !== side) return null;
-    const setsAfter = (side === 'a' ? setsA : setsB) + 1;
-    return setsAfter >= cfg.setsToWin ? 'match' : 'set';
+  /** Would one more point here win the set? */
+  function isSetPoint(slot: 'home' | 'away'): boolean {
+    if (result) return false;
+    const na = slot === 'home' ? ptsHome + 1 : ptsHome;
+    const nb = slot === 'away' ? ptsAway + 1 : ptsAway;
+    const side = slot === 'home' ? 'a' : 'b';
+    return setWinner(na, nb, target, cfg.winBy2, cfg.hardCap) === side;
   }
-
-  const kindA = $derived(pointKind('a'));
-  const kindB = $derived(pointKind('b'));
-  const deuce = $derived(!result && cfg.winBy2 && ptsA >= target - 1 && ptsB >= target - 1);
-
-  const sideList = $derived([
-    { side: 'a' as Side, player: pa, sets: setsA, points: ptsA, won: result === 'a', kind: kindA },
-    { side: 'b' as Side, player: pb, sets: setsB, points: ptsB, won: result === 'b', kind: kindB },
-  ]);
+  const spHome = $derived(isSetPoint('home'));
+  const spAway = $derived(isSetPoint('away'));
+  const deuce = $derived(!result && cfg.winBy2 && ptsHome >= target - 1 && ptsAway >= target - 1);
 
   const status = $derived.by(() => {
     if (result) {
-      const w = result === 'a' ? pa : pb;
-      const hi = Math.max(ptsA, ptsB);
-      const lo = Math.min(ptsA, ptsB);
-      return { emoji: '✅', text: `${w?.name ?? 'Winner'} takes the set ${hi}–${lo}`, tone: 'good' };
+      const w = result === 'a' ? home : away;
+      const hi = Math.max(ptsHome, ptsAway);
+      const lo = Math.min(ptsHome, ptsAway);
+      return { emoji: '✅', text: `${w?.name ?? 'Winner'} take the set ${hi}–${lo}`, tone: 'good' };
     }
-    if (kindA || kindB) {
-      const side = kindA ? pa : pb;
-      const kind = kindA ?? kindB;
-      return {
-        emoji: kind === 'match' ? '🏆' : '🎯',
-        text: `${kind === 'match' ? 'Match point' : 'Set point'} — ${side?.name ?? ''}`,
-        tone: 'warn',
-      };
+    if (spHome || spAway) {
+      const t = spHome ? home : away;
+      return { emoji: '🎯', text: `Set point — ${t?.name ?? ''}`, tone: 'warn' };
     }
     if (deuce) return { emoji: '🔁', text: 'Deuce — must win by two', tone: 'muted' };
-    return {
-      emoji: '🏐',
-      text: `Rally to ${target}${cfg.winBy2 ? ', win by two' : ''}`,
-      tone: 'muted',
-    };
+    return { emoji: '🏐', text: `Rally to ${target}${cfg.winBy2 ? ', win by two' : ''}`, tone: 'muted' };
   });
+
+  // ── Team management ──────────────────────────────────────────────────────
+  let managing = $state(false);
+  let picking = $state<'home' | 'away' | null>(null);
+  let selectedMember = $state<string | null>(null);
+
+  const EMOJIS = ['🦈', '🦅', '🐉', '🐺', '🦁', '🐯', '🦂', '🐍', '🔥', '⚡', '🌊', '🏐', '🚀', '👑', '💥', '🌟'];
+
+  function commit(teams: Team[]) {
+    input.teams = teams;
+  }
+  function updateTeam(id: string, patch: Partial<Team>) {
+    commit((input.teams ?? []).map((t) => (t.id === id ? { ...t, ...patch, memberIds: patch.memberIds ?? t.memberIds } : t)));
+  }
+  function cycleEmoji(t: Team) {
+    const i = EMOJIS.indexOf(t.emoji);
+    updateTeam(t.id, { emoji: EMOJIS[(i + 1) % EMOJIS.length] });
+  }
+  function addTeam() {
+    const teams = cloneTeams(input.teams ?? []);
+    teams.push(makeTeam(teams.length));
+    commit(teams);
+  }
+  function removeTeam(id: string) {
+    if ((input.teams?.length ?? 0) <= 2) return;
+    commit((input.teams ?? []).filter((t) => t.id !== id));
+    if (input.home === id) input.home = (input.teams?.find((t) => t.id !== id && t.id !== input.away)?.id) ?? '';
+    if (input.away === id) input.away = (input.teams?.find((t) => t.id !== id && t.id !== input.home)?.id) ?? '';
+  }
+  /** Move a member to a team, or to the bench (toTeamId = null). Clears the selection. */
+  function moveMember(memberId: string | null, toTeamId: string | null) {
+    if (!memberId) return;
+    const teams = (input.teams ?? []).map((t) => ({
+      ...t,
+      memberIds: t.memberIds.filter((m) => m !== memberId),
+    }));
+    if (toTeamId) {
+      const t = teams.find((x) => x.id === toTeamId);
+      if (t) t.memberIds = [...t.memberIds, memberId];
+    }
+    commit(teams);
+    selectedMember = null;
+  }
+  function toggleSelect(memberId: string) {
+    selectedMember = selectedMember === memberId ? null : memberId;
+  }
+
+  /** Drop-zone target -> moveMember. The bench zone reports the string "bench". */
+  function onDrop(playerId: string, target: string) {
+    moveMember(playerId, target === 'bench' ? null : target);
+  }
+
+  function overCap(t: Team): boolean {
+    return cfg.teamSize > 0 && t.memberIds.length > cfg.teamSize;
+  }
+
+  const selectedName = $derived(selectedMember ? playerById.get(selectedMember)?.name ?? '' : '');
 </script>
 
-<div class="stack">
-  <div class="row spread meta">
-    <span class="pill">🏐 Set {setNumber} · to {target}</span>
-    {#if deciding}
-      <span class="pill decider">⭐ Deciding set</span>
-    {:else}
-      <span class="pill">Best of {cfg.setsToWin * 2 - 1}</span>
-    {/if}
+<div class="stack" use:rosterDnd={{ onMove: onDrop }}>
+  <!-- ── Standings board ── -->
+  <div class="board" role="table" aria-label="Team standings">
+    {#each standings as s (s.team.id)}
+      {@const lead = s.team.id === leaderId}
+      <div class="trow" class:lead role="row">
+        <span class="tident">
+          <span class="temoji" style={`--tc:${s.team.color}`}>{s.team.emoji}</span>
+          <span class="tmeta">
+            <span class="tname">{s.team.name}</span>
+            <span class="troster">
+              {#each s.team.memberIds.slice(0, 6) as m (m)}
+                {@const p = playerById.get(m)}
+                {#if p}<Avatar name={p.name} color={p.color} size={16} />{/if}
+              {/each}
+              {#if s.team.memberIds.length === 0}<span class="muted xs">no players yet</span>{/if}
+            </span>
+          </span>
+        </span>
+        <span class="tsets">
+          {#if lead}<span class="crown" aria-hidden="true">👑</span>{/if}
+          <span class="setn tnum" class:goldnum={lead}>{s.setsWon}</span>
+          <span class="setl">{s.setsWon === 1 ? 'set' : 'sets'}</span>
+        </span>
+      </div>
+    {/each}
   </div>
 
-  <p
-    class="status"
-    class:good={status.tone === 'good'}
-    class:warn={status.tone === 'warn'}
-    aria-live="polite"
-  >
+  <!-- ── This set ── -->
+  <div class="row spread meta">
+    <span class="pill">🏐 Set {setNumber} · to {target}</span>
+    <button type="button" class="linklike" onclick={() => (managing = !managing)} aria-expanded={managing}>
+      {managing ? '✕ Done editing' : '⚙ Manage teams'}
+    </button>
+  </div>
+
+  <p class="status" class:good={status.tone === 'good'} class:warn={status.tone === 'warn'} aria-live="polite">
     <span aria-hidden="true">{status.emoji}</span>
     <span>{status.text}</span>
   </p>
 
-  <div class="sides">
-    {#each sideList as s (s.player?.id)}
-      <div class="side" class:won={s.won}>
-        <div class="shead">
-          <span class="who">
-            <Avatar name={s.player?.name ?? '?'} color={s.player?.color ?? '#7c5cff'} />
-            <strong class="nm">{s.player?.name ?? '—'}</strong>
-          </span>
-          <span class="pips" role="img" aria-label={`${s.sets} of ${cfg.setsToWin} sets won`}>
-            {#each Array(cfg.setsToWin) as _, i (i)}
-              <span class="pip" class:on={i < s.sets}></span>
+  <div class="match">
+    {#each [{ slot: 'home' as const, team: home, pts: ptsHome, sp: spHome }, { slot: 'away' as const, team: away, pts: ptsAway, sp: spAway }] as s (s.slot)}
+      <div class="side" class:won={(s.slot === 'home' ? result === 'a' : result === 'b')} data-drop={s.team?.id ?? undefined} style={`--tc:${s.team?.color ?? 'var(--primary)'}`}>
+        <button
+          type="button"
+          class="sidehead"
+          onclick={() => (picking = picking === s.slot ? null : s.slot)}
+          aria-label={`Choose the ${s.slot} team (currently ${s.team?.name ?? 'none'})`}
+        >
+          <span class="temoji sm" style={`--tc:${s.team?.color ?? '#7c5cff'}`}>{s.team?.emoji ?? '🏐'}</span>
+          <span class="pickname">{s.team?.name ?? 'Pick team'}</span>
+          {#if (input.teams?.length ?? 0) > 2}<span class="caret" aria-hidden="true">▾</span>{/if}
+        </button>
+
+        {#if picking === s.slot && (input.teams?.length ?? 0) > 2}
+          <div class="picklist" role="listbox">
+            {#each input.teams as t (t.id)}
+              {@const taken = t.id === (s.slot === 'home' ? input.away : input.home)}
+              <button
+                type="button"
+                class="pickopt"
+                class:on={t.id === s.team?.id}
+                disabled={taken}
+                onclick={() => {
+                  if (s.slot === 'home') input.home = t.id; else input.away = t.id;
+                  picking = null;
+                }}
+              >
+                <span class="temoji xs" style={`--tc:${t.color}`}>{t.emoji}</span>
+                <span>{t.name}</span>
+                {#if taken}<span class="muted xs">playing</span>{/if}
+              </button>
             {/each}
-          </span>
-        </div>
+          </div>
+        {/if}
 
         <label class="scorewrap">
-          <span class="sr-only">{s.player?.name} points this set</span>
+          <span class="sr-only">{s.team?.name} points this set</span>
           <input
             class="score"
-            class:score-good={s.won}
+            class:score-good={s.slot === 'home' ? result === 'a' : result === 'b'}
             type="number"
             inputmode="numeric"
             min="0"
-            value={s.points}
-            oninput={(e) => onType(s.player?.id, e.currentTarget.value)}
+            value={s.pts}
+            oninput={(e) => onType(s.slot, e.currentTarget.value)}
           />
         </label>
 
         <div class="ctrls">
-          <button
-            type="button"
-            class="minus"
-            onclick={() => bump(s.player?.id, -1)}
-            disabled={s.points <= 0}
-            aria-label={`Take a point back from ${s.player?.name}`}
-          >
-            −1
-          </button>
-          <button
-            type="button"
-            class="plus"
-            class:pt={!!s.kind}
-            onclick={() => bump(s.player?.id, 1)}
-            aria-label={`Add a point for ${s.player?.name}`}
-          >
+          <button type="button" class="minus" onclick={() => bump(s.slot, -1)} disabled={s.pts <= 0} aria-label={`Take a point back from ${s.team?.name}`}>−1</button>
+          <button type="button" class="plus" class:pt={s.sp} onclick={() => bump(s.slot, 1)} aria-label={`Add a point for ${s.team?.name}`}>
             <span class="big">+1</span>
-            {#if s.kind}<span class="ptlabel">{s.kind === 'match' ? 'match pt' : 'set pt'}</span>{/if}
+            {#if s.sp}<span class="ptlabel">set pt</span>{/if}
           </button>
         </div>
       </div>
     {/each}
   </div>
+
+  <button type="button" class="swap" onclick={swapSides} aria-label="Swap which side is home and away">⇄ Swap sides</button>
+
+  <!-- ── Manage teams ── -->
+  {#if managing}
+    <div class="manage stack">
+      {#if selectedMember}
+        <div class="movebar" aria-live="polite">
+          <span class="mvlabel">Move <strong>{selectedName}</strong> to</span>
+          <div class="mvtargets">
+            {#each input.teams as t (t.id)}
+              <button type="button" class="mvbtn" onclick={() => moveMember(selectedMember, t.id)}>
+                <span aria-hidden="true">{t.emoji}</span> {t.name}
+              </button>
+            {/each}
+            <button type="button" class="mvbtn bench" onclick={() => moveMember(selectedMember, null)}>🪑 Bench</button>
+            <button type="button" class="mvbtn ghost" onclick={() => (selectedMember = null)}>Cancel</button>
+          </div>
+        </div>
+      {:else}
+        <p class="draghint"><span aria-hidden="true">✋</span> Drag players between teams and the bench — or tap one to pick a spot.</p>
+      {/if}
+
+      {#each input.teams as t (t.id)}
+        <div class="tcard" data-drop={t.id} style={`--tc:${t.color}`}>
+          <div class="tcard-head">
+            <button type="button" class="temoji btn-emoji" style={`--tc:${t.color}`} onclick={() => cycleEmoji(t)} aria-label="Change team emoji" title="Tap to change emoji">{t.emoji}</button>
+            <input class="tnameinput" value={t.name} oninput={(e) => updateTeam(t.id, { name: e.currentTarget.value })} aria-label="Team name" />
+            <span class="tcount" class:over={overCap(t)}>
+              {t.memberIds.length}{cfg.teamSize > 0 ? `/${cfg.teamSize}` : ''}
+            </span>
+            {#if (input.teams?.length ?? 0) > 2}
+              <button type="button" class="iconx" onclick={() => removeTeam(t.id)} aria-label={`Remove ${t.name}`}>🗑</button>
+            {/if}
+          </div>
+
+          <div class="palette" role="group" aria-label="Team colour">
+            {#each PALETTE as c (c)}
+              <button type="button" class="dot" class:sel={t.color === c} style={`background:${c}`} onclick={() => updateTeam(t.id, { color: c })} aria-label="Set team colour"></button>
+            {/each}
+          </div>
+
+          <div class="chips dropzone">
+            {#each t.memberIds as m (m)}
+              {@const p = playerById.get(m)}
+              {#if p}
+                <button
+                  type="button"
+                  class="chip draggable"
+                  class:sel={selectedMember === m}
+                  data-player-id={m}
+                  data-player-name={p.name}
+                  data-player-color={p.color}
+                  onclick={() => toggleSelect(m)}
+                >
+                  <span class="grip" aria-hidden="true">⠿</span>
+                  <Avatar name={p.name} color={p.color} size={20} />
+                  <span>{p.name}</span>
+                </button>
+              {/if}
+            {/each}
+            {#if t.memberIds.length === 0}
+              <span class="muted xs emptyhint">Drop players here</span>
+            {/if}
+          </div>
+        </div>
+      {/each}
+
+      <button type="button" class="addteam" onclick={addTeam} disabled={(input.teams?.length ?? 0) >= 8}>＋ Add team</button>
+
+      <div class="bench-area" data-drop="bench">
+        <div class="section-lbl">🪑 Bench</div>
+        <div class="chips dropzone">
+          {#each benchIds as m (m)}
+            {@const p = playerById.get(m)}
+            {#if p}
+              <button
+                type="button"
+                class="chip draggable"
+                class:sel={selectedMember === m}
+                data-player-id={m}
+                data-player-name={p.name}
+                data-player-color={p.color}
+                onclick={() => toggleSelect(m)}
+              >
+                <span class="grip" aria-hidden="true">⠿</span>
+                <Avatar name={p.name} color={p.color} size={20} />
+                <span>{p.name}</span>
+              </button>
+            {/if}
+          {/each}
+          {#if benchIds.length === 0}<span class="muted xs emptyhint">Everyone's on a team</span>{/if}
+        </div>
+      </div>
+    </div>
+  {/if}
 </div>
 
 <style>
   .meta {
     align-items: center;
   }
-  .pill.decider {
+  .linklike {
+    background: none;
+    border: none;
+    color: var(--muted);
+    font: inherit;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    padding: 6px 2px;
+    min-height: 40px;
+  }
+  .linklike:hover {
     color: var(--text);
-    border-color: color-mix(in srgb, var(--text) 22%, var(--border));
   }
 
+  /* ── Standings board ── */
+  .board {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .trow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 8px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .trow.lead {
+    border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+    background: color-mix(in srgb, var(--accent) 8%, var(--surface-2));
+  }
+  .tident {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+  .temoji {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    flex: none;
+    font-size: 1.1rem;
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--tc, var(--primary)) 20%, var(--surface-3));
+    border: 1px solid color-mix(in srgb, var(--tc, var(--primary)) 45%, var(--border));
+  }
+  .temoji.sm {
+    width: 28px;
+    height: 28px;
+    font-size: 1rem;
+  }
+  .temoji.xs {
+    width: 22px;
+    height: 22px;
+    font-size: 0.85rem;
+    border-radius: var(--radius-sm);
+  }
+  .tmeta {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .tname {
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .troster {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+  }
+  .tsets {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 5px;
+    flex: none;
+  }
+  .crown {
+    font-size: 0.9rem;
+    align-self: center;
+  }
+  .setn {
+    font-size: 1.5rem;
+    font-weight: 800;
+  }
+  .goldnum {
+    color: var(--accent-ink);
+  }
+  .setl {
+    font-size: 0.7rem;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .tnum {
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* ── Status ── */
   .status {
     display: flex;
     align-items: center;
@@ -181,12 +477,12 @@
     background: color-mix(in srgb, var(--warn) 12%, var(--surface-2));
   }
 
-  .sides {
+  /* ── Match (two contesting sides) ── */
+  .match {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 10px;
   }
-
   .side {
     display: flex;
     flex-direction: column;
@@ -195,45 +491,78 @@
     background: var(--surface-2);
     border: 1px solid var(--border);
     border-radius: var(--radius);
+    position: relative;
   }
   .side.won {
     border-color: color-mix(in srgb, var(--good) 55%, var(--border));
   }
-
-  .shead {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    min-height: 30px;
-  }
-  .who {
+  .sidehead {
     display: flex;
     align-items: center;
     gap: 8px;
-    min-width: 0;
+    min-height: 40px;
+    padding: 4px 6px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
   }
-  .nm {
+  .sidehead:hover {
+    border-color: var(--primary);
+  }
+  .pickname {
+    font-weight: 700;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    flex: 1;
+    min-width: 0;
   }
-
-  .pips {
-    display: inline-flex;
-    gap: 4px;
+  .caret {
+    color: var(--muted);
     flex: none;
   }
-  .pip {
-    width: 9px;
-    height: 9px;
-    border-radius: 50%;
-    border: 1.5px solid var(--muted);
-    box-sizing: border-box;
+  .picklist {
+    position: absolute;
+    z-index: 5;
+    top: 54px;
+    left: 6px;
+    right: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 6px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow);
   }
-  .pip.on {
-    background: var(--text);
-    border-color: var(--text);
+  .pickopt {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px;
+    min-height: 40px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text);
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+  }
+  .pickopt:hover {
+    background: var(--surface-2);
+  }
+  .pickopt.on {
+    background: color-mix(in srgb, var(--primary) 20%, var(--surface-2));
+  }
+  .pickopt:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
   .scorewrap {
@@ -294,9 +623,6 @@
     opacity: 0.4;
     cursor: not-allowed;
   }
-
-  /* The +1 is the courtside hero: large, thumb-friendly. It stays a neutral
-     raised control so the screen keeps a single Royal Violet primary (Save). */
   .plus {
     flex: 1;
     min-height: 56px;
@@ -327,9 +653,315 @@
     color: var(--warn);
   }
 
+  .swap {
+    align-self: center;
+    background: none;
+    border: none;
+    color: var(--muted);
+    font: inherit;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    padding: 8px 12px;
+    min-height: 40px;
+  }
+  .swap:hover {
+    color: var(--text);
+  }
+
+  /* ── Manage teams ── */
+  .manage {
+    padding: 12px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    gap: 12px;
+  }
+  .movebar {
+    position: sticky;
+    top: 6px;
+    z-index: 4;
+    padding: 10px;
+    background: var(--surface-3);
+    border: 1px solid color-mix(in srgb, var(--primary) 40%, var(--border));
+    border-radius: var(--radius-sm);
+  }
+  .mvlabel {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 0.9rem;
+  }
+  .mvtargets {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .mvbtn {
+    min-height: 40px;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+  .mvbtn:hover {
+    border-color: var(--primary);
+  }
+  .mvbtn.bench {
+    background: var(--surface-2);
+  }
+  .mvbtn.ghost {
+    color: var(--muted);
+    border-style: dashed;
+  }
+
+  .tcard {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
+  .tcard-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .btn-emoji {
+    cursor: pointer;
+  }
+  .tnameinput {
+    flex: 1;
+    min-width: 0;
+    height: 40px;
+    padding: 0 10px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font: inherit;
+    font-weight: 700;
+  }
+  .tcount {
+    flex: none;
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  .tcount.over {
+    color: var(--warn);
+  }
+  .iconx {
+    flex: none;
+    width: 40px;
+    height: 40px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    cursor: pointer;
+    font-size: 0.9rem;
+  }
+  .iconx:hover {
+    border-color: var(--bad);
+  }
+
+  .palette {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .dot {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    border: 2px solid transparent;
+    cursor: pointer;
+    padding: 0;
+  }
+  .dot.sel {
+    border-color: var(--text);
+  }
+
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 10px 5px 5px;
+    min-height: 40px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 600;
+    font-size: 0.85rem;
+  }
+  .chip.sel {
+    border-color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 18%, var(--surface));
+  }
+  .chip.draggable {
+    touch-action: none;
+    cursor: grab;
+    user-select: none;
+    -webkit-user-select: none;
+    transition:
+      transform 0.12s ease,
+      border-color 0.15s ease,
+      background 0.15s ease,
+      box-shadow 0.15s ease;
+  }
+  .chip.draggable:active {
+    cursor: grabbing;
+  }
+  .chip.draggable:hover {
+    border-color: color-mix(in srgb, var(--primary) 55%, var(--border));
+  }
+  .grip {
+    color: var(--muted);
+    font-size: 0.9rem;
+    line-height: 1;
+    letter-spacing: -0.15em;
+    padding-left: 2px;
+    opacity: 0.7;
+  }
+
+  .draghint {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--muted);
+  }
+
+  /* Drop zones: the chip trays inside team cards / bench, and live match sides. */
+  .dropzone {
+    min-height: 46px;
+    align-content: flex-start;
+    padding: 4px;
+    margin: -4px;
+    border-radius: var(--radius-sm);
+    transition: background 0.15s ease;
+  }
+  .emptyhint {
+    align-self: center;
+    padding: 6px 2px;
+  }
+  .tcard {
+    border-left: 3px solid color-mix(in srgb, var(--tc, var(--primary)) 70%, var(--border));
+    transition:
+      border-color 0.15s ease,
+      box-shadow 0.15s ease,
+      transform 0.12s ease;
+  }
+  /* A team card / bench / match side lit up as the active drop target. */
+  :global(.tcard.drop-hot),
+  :global(.bench-area.drop-hot),
+  :global(.side.drop-hot) {
+    border-color: color-mix(in srgb, var(--tc, var(--primary)) 70%, var(--border));
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--tc, var(--primary)) 55%, transparent);
+  }
+  :global(.tcard.drop-hot) .dropzone,
+  :global(.bench-area.drop-hot) .dropzone {
+    background: color-mix(in srgb, var(--tc, var(--primary)) 12%, transparent);
+  }
+
+  /* Floating drag ghost — appended to <body>, so styled globally. */
+  :global(.vb-drag-ghost) {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1000;
+    pointer-events: none;
+    padding: 8px 14px;
+    border-radius: 999px;
+    font-weight: 700;
+    font-size: 0.85rem;
+    color: #fff;
+    background: color-mix(in srgb, var(--ghost-color, #7c5cff) 92%, #000);
+    border: 1px solid color-mix(in srgb, #fff 30%, transparent);
+    box-shadow: 0 10px 24px -6px color-mix(in srgb, var(--ghost-color, #7c5cff) 60%, transparent);
+    transition: transform 0.04s linear;
+  }
+  :global(body.vb-dragging) {
+    cursor: grabbing;
+  }
+  :global(body.vb-dragging) * {
+    cursor: grabbing !important;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .chip.draggable,
+    .tcard,
+    .dropzone,
+    :global(.vb-drag-ghost) {
+      transition: none;
+    }
+  }
+
+  .addteam {
+    align-self: flex-start;
+    min-height: 40px;
+    padding: 8px 14px;
+    border: 1px dashed var(--border);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .addteam:hover:not(:disabled) {
+    border-color: var(--primary);
+  }
+  .addteam:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .bench-area {
+    padding-top: 10px;
+    border-top: 1px solid var(--border);
+  }
+  .section-lbl {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--muted);
+    margin-bottom: 8px;
+  }
+
+  .muted {
+    color: var(--muted);
+  }
+  .xs {
+    font-size: 0.75rem;
+  }
+
   .minus:focus-visible,
   .plus:focus-visible,
-  .score:focus-visible {
+  .score:focus-visible,
+  .sidehead:focus-visible,
+  .chip:focus-visible,
+  .mvbtn:focus-visible,
+  .dot:focus-visible,
+  .addteam:focus-visible,
+  .tnameinput:focus-visible {
     outline: 2px solid var(--primary);
     outline-offset: 1px;
   }

--- a/src/lib/games/volleyball/drag.ts
+++ b/src/lib/games/volleyball/drag.ts
@@ -1,0 +1,161 @@
+/**
+ * Pointer-based drag-and-drop for the volleyball roster — works with mouse *and*
+ * touch (native HTML5 DnD is unreliable on touch, so we drive it from pointer
+ * events). It stays deliberately gesture-friendly:
+ *
+ *  - A press that never moves past {@link THRESHOLD} is *not* a drag, so the chip's
+ *    native click still fires (that's the accessible tap-to-select path).
+ *  - A real drag moves a floating ghost, highlights the drop zone under the pointer,
+ *    and on release reports `(playerId, target)`. The click that the browser fires
+ *    after the pointer sequence is swallowed so a drop never also selects.
+ *
+ * Drop zones are any element carrying `data-drop="<teamId>"` (or `data-drop="bench"`).
+ * Draggable chips carry `data-player-id="<id>"`. The action is placed once on a
+ * container; zones are matched globally via `elementFromPoint`, so a chip can be
+ * dragged onto a team card, the bench, or a live match side anywhere on screen.
+ */
+
+export interface RosterDndParams {
+  /** Called on a successful drop. `target` is a team id or the string `"bench"`. */
+  onMove: (playerId: string, target: string) => void;
+}
+
+const THRESHOLD = 6; // px of travel before a press becomes a drag
+
+export function rosterDnd(node: HTMLElement, params: RosterDndParams) {
+  let current = params;
+
+  let pointerId: number | null = null;
+  let sourceId: string | null = null;
+  let startX = 0;
+  let startY = 0;
+  let dragging = false;
+  let ghost: HTMLDivElement | null = null;
+  let hotZone: Element | null = null;
+  let suppressClick = false;
+
+  const reduceMotion = () =>
+    typeof window !== 'undefined' &&
+    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
+  function onPointerDown(e: PointerEvent) {
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    const chip = (e.target as Element | null)?.closest('[data-player-id]') as HTMLElement | null;
+    if (!chip || !node.contains(chip)) return;
+    const id = chip.dataset.playerId;
+    if (!id) return;
+
+    sourceId = id;
+    pointerId = e.pointerId;
+    startX = e.clientX;
+    startY = e.clientY;
+    dragging = false;
+
+    window.addEventListener('pointermove', onPointerMove, { passive: false });
+    window.addEventListener('pointerup', onPointerUp);
+    window.addEventListener('pointercancel', onPointerUp);
+  }
+
+  function beginDrag(label: string, color: string) {
+    dragging = true;
+    ghost = document.createElement('div');
+    ghost.className = 'vb-drag-ghost';
+    ghost.textContent = label;
+    ghost.style.setProperty('--ghost-color', color || '#7c5cff');
+    if (reduceMotion()) ghost.style.transition = 'none';
+    document.body.appendChild(ghost);
+    document.body.classList.add('vb-dragging');
+  }
+
+  function moveGhost(x: number, y: number) {
+    if (ghost) ghost.style.transform = `translate(${x}px, ${y}px) translate(-50%, -150%)`;
+  }
+
+  function setHot(zone: Element | null) {
+    if (zone === hotZone) return;
+    hotZone?.classList.remove('drop-hot');
+    hotZone = zone;
+    hotZone?.classList.add('drop-hot');
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (e.pointerId !== pointerId || !sourceId) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+
+    if (!dragging) {
+      if (Math.hypot(dx, dy) < THRESHOLD) return;
+      const chip = node.querySelector<HTMLElement>(`[data-player-id="${cssEscape(sourceId)}"]`);
+      const label = chip?.dataset.playerName || chip?.textContent?.trim() || 'Player';
+      const color = chip?.dataset.playerColor || '';
+      beginDrag(label, color);
+    }
+
+    e.preventDefault(); // stop touch scroll once we're really dragging
+    moveGhost(e.clientX, e.clientY);
+    const under = document.elementFromPoint(e.clientX, e.clientY);
+    setHot(under?.closest('[data-drop]') ?? null);
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (e.pointerId !== pointerId) return;
+    window.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', onPointerUp);
+    window.removeEventListener('pointercancel', onPointerUp);
+
+    const wasDragging = dragging;
+    const src = sourceId;
+    const target = hotZone?.getAttribute('data-drop') ?? null;
+    cleanup();
+
+    if (wasDragging) {
+      // Whether or not it landed on a zone, this pointer sequence was a drag, so
+      // don't let the trailing click select the chip.
+      suppressClick = true;
+      requestAnimationFrame(() => (suppressClick = false));
+      if (src && target) current.onMove(src, target);
+    }
+  }
+
+  function cleanup() {
+    ghost?.remove();
+    ghost = null;
+    setHot(null);
+    document.body.classList.remove('vb-dragging');
+    dragging = false;
+    sourceId = null;
+    pointerId = null;
+  }
+
+  function onClickCapture(e: MouseEvent) {
+    if (suppressClick) {
+      e.stopPropagation();
+      e.preventDefault();
+      suppressClick = false;
+    }
+  }
+
+  node.addEventListener('pointerdown', onPointerDown);
+  node.addEventListener('click', onClickCapture, true);
+
+  return {
+    update(next: RosterDndParams) {
+      current = next;
+    },
+    destroy() {
+      node.removeEventListener('pointerdown', onPointerDown);
+      node.removeEventListener('click', onClickCapture, true);
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', onPointerUp);
+      window.removeEventListener('pointercancel', onPointerUp);
+      cleanup();
+    },
+  };
+}
+
+/** Minimal CSS.escape fallback for attribute selectors (ids are uuids, but be safe). */
+function cssEscape(value: string): string {
+  const g = globalThis as unknown as { CSS?: { escape?: (v: string) => string } };
+  if (g.CSS?.escape) return g.CSS.escape(value);
+  return value.replace(/["\\\]]/g, '\\$&');
+}

--- a/src/lib/games/volleyball/index.ts
+++ b/src/lib/games/volleyball/index.ts
@@ -2,58 +2,60 @@ import type { GameModule, ID, Round, RoundContext } from '../../types';
 import Editor from './VolleyballEditor.svelte';
 import { volleyballStats } from './stats';
 import {
-  maxSets,
+  cloneTeams,
+  defaultTeams,
   readConfig,
-  setWinner,
-  targetForSet,
+  type Team,
   validateSetScore,
+  type VolleyballInput,
+  winningTeamId,
 } from './logic';
 
-/**
- * One set's final points, keyed by side (player) id. A volleyball match is
- * modelled as a sequence of sets: each round is a set, and the module banks a
- * "set won" (+1) to whoever took it, so a side's running total is its sets won —
- * exactly the number the big scoreboard should show. The match ends the moment a
- * side reaches the sets it needs (best-of-5 → 3, best-of-3 → 2).
- */
-export interface VolleyballInput {
-  points: Record<ID, number>;
+export type { VolleyballInput } from './logic';
+
+/** Recorded sets from prior rounds, in play order. */
+function recordedSets(ctx: RoundContext): VolleyballInput[] {
+  return [...ctx.rounds]
+    .sort((a, b) => a.index - b.index)
+    .map((r) => r.input as VolleyballInput)
+    .filter((i): i is VolleyballInput => !!i && Array.isArray(i.teams));
 }
 
-/** The two sides, in board order. Volleyball is always exactly two. */
-function sides(ctx: RoundContext): [ID, ID] {
-  return [ctx.players[0]?.id, ctx.players[1]?.id];
+/** The team lineup for the next set: carry the last set's teams forward, else seed fresh. */
+function carryTeams(ctx: RoundContext): Team[] {
+  const sets = recordedSets(ctx);
+  const last = sets[sets.length - 1];
+  if (last?.teams?.length) return cloneTeams(last.teams);
+  return defaultTeams(readConfig(ctx.config), ctx.players.map((p) => p.id));
 }
 
 export const volleyball: GameModule = {
   id: 'volleyball',
   name: 'Volleyball',
-  tagline: 'Rally scoring, win by two, best of five',
+  tagline: 'Build teams, rally to the set, climb the standings',
   emoji: '🏐',
-  keywords: ['volleyball', 'sets', 'rally', 'net', 'sport', 'beach', 'indoor', 'spike', 'match'],
+  keywords: ['volleyball', 'sets', 'rally', 'net', 'sport', 'beach', 'indoor', 'spike', 'teams', 'match'],
+  // A shared pool of players you split into teams — from a 2s beach duel up to several
+  // indoor sixes rotating through the court.
   minPlayers: 2,
-  maxPlayers: 2,
+  maxPlayers: 24,
   teams: true,
   configFields: [
     {
       key: 'format',
-      label: 'Match length',
+      label: 'Style of play',
       type: 'select',
-      default: 'bo5',
+      default: 'indoor',
       options: [
-        { value: 'bo5', label: 'Best of 5 (first to 3 sets)' },
-        { value: 'bo3', label: 'Best of 3 (first to 2 sets)' },
+        { value: 'beach', label: 'Beach — 2s' },
+        { value: 'fours', label: 'Fours — 4s' },
+        { value: 'indoor', label: 'Indoor — 6s' },
+        { value: 'custom', label: 'Custom — any size' },
       ],
+      help: 'Sets the suggested roster size per team. You can still put anyone anywhere.',
     },
-    { key: 'pointsPerSet', label: 'Points to win a set', type: 'number', default: 25, min: 1 },
-    {
-      key: 'decidingSetPoints',
-      label: 'Points to win the deciding set',
-      type: 'number',
-      default: 15,
-      min: 1,
-      help: 'The final set (2–2 in a best-of-5, 1–1 in a best-of-3) is played to this shorter target.',
-    },
+    { key: 'numberOfTeams', label: 'Teams to start with', type: 'number', default: 2, min: 2, max: 8, help: 'Seed this many teams from your player pool. Add, remove or rebrand them any time during play.' },
+    { key: 'pointsPerSet', label: 'Points to win a set', type: 'number', default: 25, min: 1, help: 'Rally scoring. Beach is usually 21, indoor 25.' },
     { key: 'winBy2', label: 'Win a set by two', type: 'boolean', default: true },
     {
       key: 'hardCap',
@@ -65,24 +67,28 @@ export const volleyball: GameModule = {
     },
   ],
 
-  createRoundInput: (ctx: RoundContext): VolleyballInput => ({
-    points: Object.fromEntries(ctx.players.map((p) => [p.id, 0])),
-  }),
+  createRoundInput: (ctx: RoundContext): VolleyballInput => {
+    const teams = carryTeams(ctx);
+    const ids = teams.map((t) => t.id);
+    const sets = recordedSets(ctx);
+    const last = sets[sets.length - 1];
+    const home = last?.home && ids.includes(last.home) ? last.home : ids[0] ?? '';
+    const away =
+      last?.away && ids.includes(last.away) && last.away !== home
+        ? last.away
+        : ids.find((id) => id !== home) ?? '';
+    return { teams, home, away, points: { home: 0, away: 0 } };
+  },
 
   validateRound: (input: VolleyballInput, ctx: RoundContext): string | null => {
-    if (ctx.players.length !== 2) return 'Volleyball is played by exactly two sides.';
+    if (!input?.teams?.length) return 'Set up your teams first.';
+    if (!input.home || !input.away) return 'Pick the two teams playing this set.';
+    if (input.home === input.away) return 'A team can’t play itself — pick two different teams.';
     const cfg = readConfig(ctx.config);
-    const [a, b] = sides(ctx);
-    const setsA = Number(ctx.totals[a]) || 0;
-    const setsB = Number(ctx.totals[b]) || 0;
-    if (setsA >= cfg.setsToWin || setsB >= cfg.setsToWin) {
-      return 'The match is already won — no more sets to play.';
-    }
-    const target = targetForSet(cfg, setsA, setsB);
     return validateSetScore(
-      Number(input.points[a]) || 0,
-      Number(input.points[b]) || 0,
-      target,
+      Number(input.points?.home) || 0,
+      Number(input.points?.away) || 0,
+      cfg.pointsPerSet,
       cfg.winBy2,
       cfg.hardCap,
     );
@@ -90,53 +96,50 @@ export const volleyball: GameModule = {
 
   scoreRound: (input: VolleyballInput, ctx: RoundContext): Record<ID, number> => {
     const cfg = readConfig(ctx.config);
-    const [a, b] = sides(ctx);
-    const setsA = Number(ctx.totals[a]) || 0;
-    const setsB = Number(ctx.totals[b]) || 0;
-    const target = targetForSet(cfg, setsA, setsB);
-    const winner = setWinner(
-      Number(input.points[a]) || 0,
-      Number(input.points[b]) || 0,
-      target,
-      cfg.winBy2,
-      cfg.hardCap,
-    );
-    return { [a]: winner === 'a' ? 1 : 0, [b]: winner === 'b' ? 1 : 0 };
+    const deltas: Record<ID, number> = {};
+    for (const p of ctx.players) deltas[p.id] = 0;
+    const winId = winningTeamId(input, cfg);
+    if (!winId) return deltas;
+    const team = input.teams.find((t) => t.id === winId);
+    for (const m of team?.memberIds ?? []) {
+      if (m in deltas) deltas[m] += 1;
+    }
+    return deltas;
   },
 
-  // A match can't run longer than best-of allows (5 sets in a best-of-5).
-  maxRounds: (config) => maxSets(readConfig(config)),
+  // Open-ended: play as many sets as you like, finish when you're done.
+  isFinished: () => false,
 
-  // Finished the instant a side has banked the sets it needs.
-  isFinished: (totals, { config }) => {
-    const cfg = readConfig(config);
-    return Object.values(totals).some((t) => (Number(t) || 0) >= cfg.setsToWin);
-  },
-
-  describeRound: (round: Round, players): string => {
+  describeRound: (round: Round): string => {
     const input = round.input as VolleyballInput;
-    const [pa, pb] = players;
-    if (!pa || !pb) return '';
-    const a = Number(input.points[pa.id]) || 0;
-    const b = Number(input.points[pb.id]) || 0;
-    const winner = a > b ? pa : b > a ? pb : null;
-    return `${a}–${b}${winner ? ` · ${winner.name}` : ''}`;
+    if (!input?.teams) return '🏐 —';
+    const home = input.teams.find((t) => t.id === input.home);
+    const away = input.teams.find((t) => t.id === input.away);
+    const a = Number(input.points?.home) || 0;
+    const b = Number(input.points?.away) || 0;
+    const hn = home ? `${home.emoji} ${home.name}` : 'Home';
+    const an = away ? `${away.emoji} ${away.name}` : 'Away';
+    if (a === b) return `🏐 ${hn} ${a}–${b} ${an}`;
+    const win = a > b ? home : away;
+    const wn = win ? `${win.emoji} ${win.name}` : 'Winner';
+    return `🏐 ${wn} won ${Math.max(a, b)}–${Math.min(a, b)}`;
   },
 
   help: [
-    'Rally scoring: every serve wins a point for one side.',
-    'A set is played to 25 and must be won by two, so a tight set runs on',
-    '(25–23, 26–24, 30–28…) until a side leads by two.',
+    'Volleyball is an open, team-based session — no fixed match length.',
     '',
-    'The match is best of 5 — first side to win 3 sets takes it (or best of 3,',
-    'first to 2). If it reaches a deciding set (2–2, or 1–1), that set is played',
-    'to 15, still win by two.',
+    'Build any number of teams from your player pool, give each a name, emoji and',
+    'colour, and drop players onto whichever team you like. You can reshuffle',
+    'rosters or rebrand teams freely — set to set, or game to game.',
     '',
-    'Optional hard cap: set a ceiling (e.g. 27) where win-by-two stops and the',
-    'first side to the cap wins the set.',
+    'Each round is one set between the two teams you pick. Rally scoring: a point',
+    'on every serve, first to 25 (21 for beach), win by two — so a tight set runs',
+    'on (25–23, 26–24, 30–28…) until a side leads by two. Optional hard cap ends',
+    'the two-point chase at a ceiling you set (e.g. 27).',
     '',
-    'Enter each set’s final score as it ends; the board tracks sets won and calls',
-    'the match at set point.',
+    'A team’s standing is the sets it has won. Each player banks a set win when the',
+    'team they’re on takes a set, so the board tracks who’s racking up sets. Finish',
+    'the game whenever you’ve played enough.',
   ].join('\n'),
 
   stats: volleyballStats,

--- a/src/lib/games/volleyball/logic.ts
+++ b/src/lib/games/volleyball/logic.ts
@@ -1,38 +1,74 @@
 /**
- * Pure volleyball set/match logic — no Svelte, no app imports. Everything the
- * module needs to score a rally-scored match lives here so `*.test.ts` can
- * exercise the real rules (win-by-2, deuce, the deciding set, best-of formats,
- * an optional hard cap) without pulling in the editor.
+ * Pure volleyball logic — no Svelte. A volleyball game here is an *open, team-based
+ * session*: you build any number of branded teams from a shared pool of players,
+ * and each round is a single set between two chosen teams. Rosters and branding can
+ * be reshuffled freely, set to set. A team's standing is simply the sets it has won.
  *
- * A volleyball match is a race to win sets. Each set is rally-scored (a point on
- * every serve) to a target — 25 for a normal set, 15 for the deciding set — and
- * you must win by two, so a tight set climbs past the target (26–24, 30–28…)
- * until someone leads by two. The match is best-of-5 (first to 3 sets) or
- * best-of-3 (first to 2). We model each *set* as a round: the round records both
- * sides' final points, and the module banks one "set won" to the winner, so a
- * side's running total is simply the sets it has taken.
+ * Set scoring is classic rally scoring: a point on every serve, first to the target
+ * (25 by default, 21 for beach) and win by two — so a tight set climbs past the
+ * target (26–24, 30–28…) until a side leads by two, with an optional hard cap.
+ *
+ * Everything a set needs to be scored lives in the round `input` (the teams, which
+ * two contested the set, and the score), so `*.test.ts` can exercise the real rules
+ * without touching the editor, and the whole team model needs no app-level schema.
  */
 
+import { PALETTE, uid } from '../../util';
+
+/** The two contestants of a single set: `a` = home, `b` = away. */
 export type Side = 'a' | 'b';
 
+/** A branded team: an identity plus a roster of member (player) ids. */
+export interface Team {
+  id: string;
+  name: string;
+  emoji: string;
+  color: string;
+  memberIds: string[];
+}
+
+/** One recorded (or drafted) set. */
+export interface VolleyballInput {
+  /** Snapshot of the teams as they stood for this set (branding + rosters). */
+  teams: Team[];
+  /** Team id playing as home this set. */
+  home: string;
+  /** Team id playing as away this set. */
+  away: string;
+  /** Final points for the two contesting sides. */
+  points: { home: number; away: number };
+}
+
+export type Format = 'beach' | 'fours' | 'indoor' | 'custom';
+
+/** Per-format guidance: the roster size and the set target players expect. */
+export const FORMAT_PRESETS: Record<Format, { label: string; teamSize: number; pointsPerSet: number }> = {
+  beach: { label: 'Beach (2s)', teamSize: 2, pointsPerSet: 21 },
+  fours: { label: 'Fours (4s)', teamSize: 4, pointsPerSet: 25 },
+  indoor: { label: 'Indoor (6s)', teamSize: 6, pointsPerSet: 25 },
+  custom: { label: 'Custom', teamSize: 0, pointsPerSet: 25 },
+};
+
 export interface VolleyConfig {
-  /** Points to win a normal set (rally scoring). */
+  format: Format;
+  /** Players per team (0 = no limit, for Custom). Informs roster building + warnings. */
+  teamSize: number;
+  /** How many teams to seed a fresh session with. */
+  numberOfTeams: number;
+  /** Points to win a set (rally scoring). */
   pointsPerSet: number;
-  /** Points to win the deciding set (the tiebreak set is shorter). */
-  decidingSetPoints: number;
   /** Must a set be won by a two-point margin? */
   winBy2: boolean;
-  /** Sets needed to win the match — 3 = best of 5, 2 = best of 3. */
-  setsToWin: number;
   /** Score at which win-by-two stops (first to the cap takes the set). 0 = no cap. */
   hardCap: number;
 }
 
 export const DEFAULTS: VolleyConfig = {
+  format: 'indoor',
+  teamSize: 6,
+  numberOfTeams: 2,
   pointsPerSet: 25,
-  decidingSetPoints: 15,
   winBy2: true,
-  setsToWin: 3,
   hardCap: 0,
 };
 
@@ -44,41 +80,23 @@ export function readConfig(config: Record<string, unknown> | undefined): VolleyC
     return Number.isFinite(n) && n > 0 ? n : fallback;
   };
 
-  // `format` is the friendly control; `setsToWin` is honoured as a direct escape hatch.
-  let setsToWin: number;
-  if (cfg.format === 'bo3') setsToWin = 2;
-  else if (cfg.format === 'bo5') setsToWin = 3;
-  else setsToWin = posInt(cfg.setsToWin, DEFAULTS.setsToWin);
+  const format: Format = (['beach', 'fours', 'indoor', 'custom'] as const).includes(cfg.format as Format)
+    ? (cfg.format as Format)
+    : DEFAULTS.format;
+  const preset = FORMAT_PRESETS[format];
+  const teamSize = format === 'custom' ? Math.max(0, Math.floor(Number(cfg.teamSize)) || 0) : preset.teamSize;
 
   const capRaw = Math.floor(Number(cfg.hardCap));
   const hardCap = Number.isFinite(capRaw) && capRaw > 0 ? capRaw : 0;
 
   return {
-    pointsPerSet: posInt(cfg.pointsPerSet, DEFAULTS.pointsPerSet),
-    decidingSetPoints: posInt(cfg.decidingSetPoints, DEFAULTS.decidingSetPoints),
+    format,
+    teamSize,
+    numberOfTeams: Math.min(8, Math.max(2, posInt(cfg.numberOfTeams, DEFAULTS.numberOfTeams))),
+    pointsPerSet: posInt(cfg.pointsPerSet, preset.pointsPerSet),
     winBy2: cfg.winBy2 !== false,
-    setsToWin,
     hardCap,
   };
-}
-
-/** Total sets that can possibly be played in the match (e.g. best-of-5 → 5). */
-export function maxSets(cfg: VolleyConfig): number {
-  return cfg.setsToWin * 2 - 1;
-}
-
-/**
- * Is the upcoming set the deciding set? That's the moment the match is level with
- * each side one win short — 2–2 in a best-of-5, 1–1 in a best-of-3 — so the final
- * set is played to the (shorter) deciding target.
- */
-export function isDecidingSet(setsA: number, setsB: number, setsToWin: number): boolean {
-  return setsA === setsToWin - 1 && setsB === setsToWin - 1;
-}
-
-/** Target points for the set about to be played, given the sets won so far. */
-export function targetForSet(cfg: VolleyConfig, setsA: number, setsB: number): number {
-  return isDecidingSet(setsA, setsB, cfg.setsToWin) ? cfg.decidingSetPoints : cfg.pointsPerSet;
 }
 
 /** A cap only bites when it sits above the target; otherwise there's nothing to cap. */
@@ -91,13 +109,7 @@ function effectiveCap(target: number, hardCap: number): number {
  * a final score). Encodes rally scoring: reach the target and lead by two — unless
  * a hard cap is set, where the first side to the cap takes it by a single point.
  */
-export function setWinner(
-  a: number,
-  b: number,
-  target: number,
-  winBy2: boolean,
-  hardCap = 0,
-): Side | null {
+export function setWinner(a: number, b: number, target: number, winBy2: boolean, hardCap = 0): Side | null {
   if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
   if (a < 0 || b < 0) return null;
   if (a === b) return null; // level: nobody has won
@@ -120,13 +132,7 @@ export function setWinner(
  * is a legal end-of-set: someone has won, and the set stopped at the earliest
  * winning point (you can't overshoot, since a set ends the instant it's decided).
  */
-export function validateSetScore(
-  a: number,
-  b: number,
-  target: number,
-  winBy2: boolean,
-  hardCap = 0,
-): string | null {
+export function validateSetScore(a: number, b: number, target: number, winBy2: boolean, hardCap = 0): string | null {
   if (!Number.isInteger(a) || !Number.isInteger(b)) {
     return 'Enter whole point totals for each side.';
   }
@@ -147,47 +153,94 @@ export function validateSetScore(
   return null;
 }
 
-export interface SetScore {
-  a: number;
-  b: number;
+const TEAM_NAMES = ['Sharks', 'Eagles', 'Dragons', 'Wolves', 'Lions', 'Tigers', 'Scorpions', 'Vipers'];
+const TEAM_EMOJIS = ['🦈', '🦅', '🐉', '🐺', '🦁', '🐯', '🦂', '🐍'];
+
+/** Build a fresh team with whimsical default branding for slot `i`. */
+export function makeTeam(i: number, memberIds: string[] = []): Team {
+  return {
+    id: uid(),
+    name: TEAM_NAMES[i % TEAM_NAMES.length] ?? `Team ${i + 1}`,
+    emoji: TEAM_EMOJIS[i % TEAM_EMOJIS.length] ?? '🏐',
+    color: PALETTE[i % PALETTE.length],
+    memberIds: [...memberIds],
+  };
 }
 
-export interface MatchState {
-  /** Sets won by each side (only completed, legal sets are counted). */
-  setsA: number;
-  setsB: number;
-  /** Has a side reached `setsToWin`? */
-  decided: boolean;
-  /** Match winner once decided. */
-  winner: Side | null;
-  /** Target points for the *next* set to be played. */
-  nextTarget: number;
-  /** Is that next set the deciding set? */
-  nextDeciding: boolean;
+/** A deep-ish clone so a carried-forward roster edit never mutates a past set. */
+export function cloneTeams(teams: Team[]): Team[] {
+  return teams.map((t) => ({ ...t, memberIds: [...t.memberIds] }));
 }
 
 /**
- * Fold a sequence of set scores into the match standing. Sets are counted in
- * order (so the deciding-set target is applied at the right moment) and counting
- * stops once the match is won — trailing sets can't happen in a real match.
+ * Seed a session's teams: split the pool across `numberOfTeams`, round-robin, up to
+ * the format's roster size (Custom = no limit). Any overflow stays unassigned.
  */
-export function matchState(sets: SetScore[], cfg: VolleyConfig): MatchState {
-  let setsA = 0;
-  let setsB = 0;
-  for (const set of sets) {
-    if (setsA >= cfg.setsToWin || setsB >= cfg.setsToWin) break;
-    const target = targetForSet(cfg, setsA, setsB);
-    const winner = setWinner(set.a, set.b, target, cfg.winBy2, cfg.hardCap);
-    if (winner === 'a') setsA += 1;
-    else if (winner === 'b') setsB += 1;
+export function defaultTeams(cfg: VolleyConfig, pool: string[]): Team[] {
+  const n = Math.max(2, cfg.numberOfTeams);
+  const teams = Array.from({ length: n }, (_, i) => makeTeam(i));
+  const cap = cfg.teamSize > 0 ? cfg.teamSize : Infinity;
+  let start = 0;
+  for (const id of pool) {
+    let placed = false;
+    for (let k = 0; k < n; k++) {
+      const t = teams[(start + k) % n];
+      if (t.memberIds.length < cap) {
+        t.memberIds.push(id);
+        start = (start + k + 1) % n;
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) break; // every team full — the rest sit in the unassigned pool
   }
-  const decided = setsA >= cfg.setsToWin || setsB >= cfg.setsToWin;
-  return {
-    setsA,
-    setsB,
-    decided,
-    winner: decided ? (setsA > setsB ? 'a' : 'b') : null,
-    nextDeciding: isDecidingSet(setsA, setsB, cfg.setsToWin),
-    nextTarget: targetForSet(cfg, setsA, setsB),
-  };
+  return teams;
+}
+
+/** Pool member ids not currently on any team. */
+export function unassigned(teams: Team[], pool: string[]): string[] {
+  const taken = new Set(teams.flatMap((t) => t.memberIds));
+  return pool.filter((id) => !taken.has(id));
+}
+
+export interface TeamStanding {
+  team: Team;
+  setsWon: number;
+  setsPlayed: number;
+  pointsFor: number;
+}
+
+/**
+ * Fold recorded sets into per-team standings. Wins are aggregated by team *id* (so
+ * branding can be renamed mid-session without losing history), using the current
+ * `teams` list for identity/display. Sets whose team is no longer present are skipped.
+ */
+export function foldStandings(teams: Team[], sets: VolleyballInput[], cfg: VolleyConfig): TeamStanding[] {
+  const byId = new Map<string, TeamStanding>(
+    teams.map((t) => [t.id, { team: t, setsWon: 0, setsPlayed: 0, pointsFor: 0 }]),
+  );
+  for (const s of sets) {
+    const w = setWinner(s.points.home, s.points.away, cfg.pointsPerSet, cfg.winBy2, cfg.hardCap);
+    if (!w) continue;
+    const h = byId.get(s.home);
+    const a = byId.get(s.away);
+    if (h) {
+      h.setsPlayed += 1;
+      h.pointsFor += Number(s.points.home) || 0;
+      if (w === 'a') h.setsWon += 1;
+    }
+    if (a) {
+      a.setsPlayed += 1;
+      a.pointsFor += Number(s.points.away) || 0;
+      if (w === 'b') a.setsWon += 1;
+    }
+  }
+  return [...byId.values()].sort((x, y) => y.setsWon - x.setsWon || y.pointsFor - x.pointsFor);
+}
+
+/** The winning team's id for a set, or null while it's still live. */
+export function winningTeamId(input: VolleyballInput, cfg: VolleyConfig): string | null {
+  const w = setWinner(input.points.home, input.points.away, cfg.pointsPerSet, cfg.winBy2, cfg.hardCap);
+  if (!w) return null;
+  return w === 'a' ? input.home : input.away;
 }

--- a/src/lib/games/volleyball/stats.ts
+++ b/src/lib/games/volleyball/stats.ts
@@ -1,23 +1,21 @@
 import type { ID } from '../../types';
-import type { VolleyballInput } from './index';
+import type { VolleyballInput } from './logic';
 import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
 import { fmtInt } from '../../stats/format';
-import { matchState, readConfig, setWinner, targetForSet, type SetScore } from './logic';
+import { readConfig, setWinner } from './logic';
 
 interface SideAgg {
   setsWon: number;
   setsPlayed: number;
   pointsFor: number;
   deuceSets: number; // sets pushed past the target by the win-by-two rule
-  matchesWon: number;
-  sweeps: number; // matches won without dropping a set
 }
 
 /**
- * Volleyball stats, rebuilt from each game's recorded set scores. Pure and
- * config-aware: we replay every game's sets with its own rules (deciding-set
- * target, win-by-two, cap) so sets won, deuce battles and sweeps are exact —
- * mirroring how the module itself scores a set.
+ * Volleyball stats, rebuilt from each game's recorded sets. Pure and config-aware:
+ * every set is re-scored with its own game's rules, then credited to the players on
+ * the two contesting teams — so sets won, points and deuce battles land on the
+ * individuals who actually played them, regardless of how teams were shuffled.
  */
 export function volleyballStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
   const byGame = new Map<ID, typeof rounds>();
@@ -31,54 +29,49 @@ export function volleyballStats({ games, rounds, canonical }: GameStatsInput): G
   const get = (id: ID): SideAgg => {
     let a = per.get(id);
     if (!a) {
-      a = { setsWon: 0, setsPlayed: 0, pointsFor: 0, deuceSets: 0, matchesWon: 0, sweeps: 0 };
+      a = { setsWon: 0, setsPlayed: 0, pointsFor: 0, deuceSets: 0 };
       per.set(id, a);
     }
     return a;
   };
 
+  let totalSets = 0;
+  let totalDeuce = 0;
   let biggestSet: { hi: number; lo: number } | null = null;
 
   for (const game of games) {
-    const [rawA, rawB] = game.playerIds;
-    if (!rawA || !rawB) continue;
-    const idA = canonical(rawA);
-    const idB = canonical(rawB);
     const cfg = readConfig(game.config);
-
     const gameRounds = (byGame.get(game.id) ?? []).slice().sort((x, y) => x.index - y.index);
-    const setScores: SetScore[] = [];
 
-    let setsA = 0;
-    let setsB = 0;
     for (const r of gameRounds) {
       const input = r.input as VolleyballInput | undefined;
-      if (!input?.points) continue;
-      const a = Number(input.points[rawA]) || 0;
-      const b = Number(input.points[rawB]) || 0;
-      const target = targetForSet(cfg, setsA, setsB);
-      const winner = setWinner(a, b, target, cfg.winBy2, cfg.hardCap);
+      if (!input?.teams || !Array.isArray(input.teams)) continue;
+      const a = Number(input.points?.home) || 0;
+      const b = Number(input.points?.away) || 0;
+      const winner = setWinner(a, b, cfg.pointsPerSet, cfg.winBy2, cfg.hardCap);
       if (!winner) continue;
 
-      setScores.push({ a, b });
-      const aggA = get(idA);
-      const aggB = get(idB);
-      aggA.setsPlayed += 1;
-      aggB.setsPlayed += 1;
-      aggA.pointsFor += a;
-      aggB.pointsFor += b;
-      if (winner === 'a') {
-        aggA.setsWon += 1;
-        setsA += 1;
-      } else {
-        aggB.setsWon += 1;
-        setsB += 1;
-      }
+      const home = input.teams.find((t) => t.id === input.home);
+      const away = input.teams.find((t) => t.id === input.away);
+      const target = cfg.pointsPerSet;
+      const deuce = Math.max(a, b) > target;
 
-      // A "deuce" set is one dragged past its target by the win-by-two rule.
-      if (Math.max(a, b) > target) {
-        aggA.deuceSets += 1;
-        aggB.deuceSets += 1;
+      totalSets += 1;
+      if (deuce) totalDeuce += 1;
+
+      for (const m of home?.memberIds ?? []) {
+        const agg = get(canonical(m));
+        agg.setsPlayed += 1;
+        agg.pointsFor += a;
+        if (winner === 'a') agg.setsWon += 1;
+        if (deuce) agg.deuceSets += 1;
+      }
+      for (const m of away?.memberIds ?? []) {
+        const agg = get(canonical(m));
+        agg.setsPlayed += 1;
+        agg.pointsFor += b;
+        if (winner === 'b') agg.setsWon += 1;
+        if (deuce) agg.deuceSets += 1;
       }
 
       const hi = Math.max(a, b);
@@ -87,48 +80,22 @@ export function volleyballStats({ games, rounds, canonical }: GameStatsInput): G
         biggestSet = { hi, lo };
       }
     }
-
-    const state = matchState(setScores, cfg);
-    if (state.decided && state.winner) {
-      const winnerId = state.winner === 'a' ? idA : idB;
-      const loserSets = state.winner === 'a' ? state.setsB : state.setsA;
-      const agg = get(winnerId);
-      agg.matchesWon += 1;
-      if (loserSets === 0) agg.sweeps += 1;
-    }
   }
 
   const perPlayer: Record<ID, Metric[]> = {};
-  let totalSets = 0;
-  let totalDeuce = 0;
   for (const [id, a] of per) {
-    totalSets += a.setsWon;
-    totalDeuce += a.deuceSets;
     const metrics: Metric[] = [];
     if (a.setsWon) metrics.push({ key: 'v_sets', label: 'Sets won', value: `${a.setsWon}`, emoji: '🏐' });
-    if (a.pointsFor) {
-      metrics.push({ key: 'v_points', label: 'Points scored', value: fmtInt(a.pointsFor), emoji: '🔥' });
-    }
-    if (a.deuceSets) {
-      metrics.push({ key: 'v_deuce', label: 'Deuce sets', value: `${a.deuceSets}`, emoji: '😤' });
-    }
-    if (a.sweeps) metrics.push({ key: 'v_sweep', label: 'Sweeps', value: `${a.sweeps}`, emoji: '🧹' });
+    if (a.pointsFor) metrics.push({ key: 'v_points', label: 'Points scored', value: fmtInt(a.pointsFor), emoji: '🔥' });
+    if (a.deuceSets) metrics.push({ key: 'v_deuce', label: 'Deuce sets', value: `${a.deuceSets}`, emoji: '😤' });
     if (metrics.length) perPlayer[id] = metrics;
   }
 
   const global: Metric[] = [];
   if (totalSets) global.push({ key: 'v_sets_all', label: 'Sets played', value: `${totalSets}`, emoji: '🏐' });
-  if (totalDeuce) {
-    // Each deuce set is counted once per side above; halve for the true set count.
-    global.push({ key: 'v_deuce_all', label: 'Deuce sets', value: `${Math.round(totalDeuce / 2)}`, emoji: '😤' });
-  }
+  if (totalDeuce) global.push({ key: 'v_deuce_all', label: 'Deuce sets', value: `${totalDeuce}`, emoji: '😤' });
   if (biggestSet) {
-    global.push({
-      key: 'v_biggest',
-      label: 'Longest set',
-      value: `${biggestSet.hi}–${biggestSet.lo}`,
-      emoji: '⚔️',
-    });
+    global.push({ key: 'v_biggest', label: 'Longest set', value: `${biggestSet.hi}–${biggestSet.lo}`, emoji: '⚔️' });
   }
 
   return { perPlayer, global };

--- a/src/lib/games/volleyball/volleyball.test.ts
+++ b/src/lib/games/volleyball/volleyball.test.ts
@@ -1,19 +1,24 @@
 import { describe, expect, it } from 'vitest';
 import {
   DEFAULTS,
-  isDecidingSet,
-  matchState,
-  maxSets,
+  defaultTeams,
+  foldStandings,
+  makeTeam,
   readConfig,
   setWinner,
-  targetForSet,
+  type Team,
+  unassigned,
   validateSetScore,
-  type SetScore,
+  type VolleyballInput,
   type VolleyConfig,
+  winningTeamId,
 } from './logic';
 
-const bo5: VolleyConfig = { ...DEFAULTS };
-const bo3: VolleyConfig = { ...DEFAULTS, setsToWin: 2 };
+const cfg: VolleyConfig = { ...DEFAULTS };
+
+function set(home: string, away: string, h: number, a: number, teams: Team[]): VolleyballInput {
+  return { teams, home, away, points: { home: h, away: a } };
+}
 
 describe('setWinner — rally scoring & win by two', () => {
   it('awards a set at the target with a two-point lead', () => {
@@ -29,31 +34,18 @@ describe('setWinner — rally scoring & win by two', () => {
 
   it('keeps a deuce set going until someone leads by two', () => {
     expect(setWinner(26, 24, 25, true)).toBe('a');
-    expect(setWinner(24, 26, 25, true)).toBe('b');
     expect(setWinner(26, 25, 25, true)).toBeNull();
     expect(setWinner(30, 28, 25, true)).toBe('a');
   });
 
-  it('needs the target to be reached first', () => {
-    expect(setWinner(20, 15, 25, true)).toBeNull();
-    expect(setWinner(10, 2, 25, true)).toBeNull();
-  });
-
-  it('rejects a tie as a winner', () => {
-    expect(setWinner(25, 25, 25, true)).toBeNull();
-    expect(setWinner(0, 0, 25, true)).toBeNull();
-  });
-
   it('honours a one-point win when win-by-two is off', () => {
     expect(setWinner(25, 24, 25, false)).toBe('a');
-    expect(setWinner(25, 23, 25, false)).toBe('a');
     expect(setWinner(24, 23, 25, false)).toBeNull();
   });
 
-  it('scores the shorter deciding-set target', () => {
-    expect(setWinner(15, 13, 15, true)).toBe('a');
-    expect(setWinner(15, 14, 15, true)).toBeNull();
-    expect(setWinner(16, 14, 15, true)).toBe('a');
+  it('scores a beach target of 21', () => {
+    expect(setWinner(21, 19, 21, true)).toBe('a');
+    expect(setWinner(21, 20, 21, true)).toBeNull();
   });
 });
 
@@ -70,178 +62,136 @@ describe('setWinner — hard cap', () => {
 
   it('ignores a cap that is not above the target', () => {
     expect(setWinner(25, 24, 25, true, 25)).toBeNull();
-    expect(setWinner(25, 24, 25, true, 10)).toBeNull();
   });
 });
 
 describe('validateSetScore — only legal final scores pass', () => {
   it('accepts clean and deuce finals', () => {
     expect(validateSetScore(25, 23, 25, true)).toBeNull();
-    expect(validateSetScore(25, 0, 25, true)).toBeNull();
     expect(validateSetScore(26, 24, 25, true)).toBeNull();
-    expect(validateSetScore(27, 25, 25, true)).toBeNull();
     expect(validateSetScore(30, 28, 25, true)).toBeNull();
   });
 
   it('rejects a set that is not over yet', () => {
     expect(validateSetScore(25, 24, 25, true)).toMatch(/isn.t over/i);
-    expect(validateSetScore(20, 18, 25, true)).toMatch(/isn.t over/i);
     expect(validateSetScore(25, 25, 25, true)).toMatch(/isn.t over/i);
   });
 
   it('rejects an unreachable (overshot) score', () => {
-    // A set ends at 25–20; you can't play on to 26–20.
     expect(validateSetScore(26, 20, 25, true)).toMatch(/isn.t reachable/i);
-    expect(validateSetScore(28, 24, 25, true)).toMatch(/isn.t reachable/i);
   });
 
   it('rejects negative and non-integer scores', () => {
     expect(validateSetScore(-1, 25, 25, true)).toMatch(/negative/i);
     expect(validateSetScore(25.5, 20, 25, true)).toMatch(/whole/i);
   });
-
-  it('validates against the deciding-set target', () => {
-    expect(validateSetScore(15, 12, 15, true)).toBeNull();
-    expect(validateSetScore(15, 14, 15, true)).toMatch(/isn.t over/i);
-    expect(validateSetScore(17, 15, 15, true)).toBeNull();
-  });
-
-  it('respects the hard cap boundary', () => {
-    expect(validateSetScore(27, 26, 25, true, 27)).toBeNull();
-    expect(validateSetScore(28, 26, 25, true, 27)).toMatch(/isn.t reachable/i);
-  });
 });
 
-describe('deciding set & targets', () => {
-  it('detects the deciding set only when level one short', () => {
-    expect(isDecidingSet(2, 2, 3)).toBe(true);
-    expect(isDecidingSet(2, 1, 3)).toBe(false);
-    expect(isDecidingSet(1, 1, 2)).toBe(true);
-    expect(isDecidingSet(0, 0, 2)).toBe(false);
+describe('readConfig — formats, sizes & safe coercion', () => {
+  it('maps each style to a suggested roster size', () => {
+    expect(readConfig({ format: 'beach' }).teamSize).toBe(2);
+    expect(readConfig({ format: 'fours' }).teamSize).toBe(4);
+    expect(readConfig({ format: 'indoor' }).teamSize).toBe(6);
   });
 
-  it('uses the deciding target for the final set, the normal one otherwise', () => {
-    expect(targetForSet(bo5, 0, 0)).toBe(25);
-    expect(targetForSet(bo5, 2, 1)).toBe(25);
-    expect(targetForSet(bo5, 2, 2)).toBe(15);
-    expect(targetForSet(bo3, 1, 1)).toBe(15);
-  });
-
-  it('reports the maximum sets for a format', () => {
-    expect(maxSets(bo5)).toBe(5);
-    expect(maxSets(bo3)).toBe(3);
-  });
-});
-
-describe('matchState — folding sets into a result', () => {
-  it('calls a best-of-5 match at three sets', () => {
-    const sets: SetScore[] = [
-      { a: 25, b: 20 },
-      { a: 22, b: 25 },
-      { a: 25, b: 18 },
-      { a: 25, b: 22 },
-    ];
-    const s = matchState(sets, bo5);
-    expect(s.setsA).toBe(3);
-    expect(s.setsB).toBe(1);
-    expect(s.decided).toBe(true);
-    expect(s.winner).toBe('a');
-  });
-
-  it('plays a deciding fifth set to 15', () => {
-    const sets: SetScore[] = [
-      { a: 25, b: 20 },
-      { a: 20, b: 25 },
-      { a: 25, b: 23 },
-      { a: 23, b: 25 },
-      { a: 15, b: 12 }, // deciding set, shorter target
-    ];
-    const s = matchState(sets, bo5);
-    expect(s.setsA).toBe(3);
-    expect(s.setsB).toBe(2);
-    expect(s.winner).toBe('a');
-  });
-
-  it('a 15–12 fifth set would NOT count under normal-set rules (proves target switch)', () => {
-    // Same five sets but forced to a 25-point target everywhere: the fifth set
-    // (15–12) never reaches 25, so the match stays level and undecided.
-    const alwaysLong: VolleyConfig = { ...bo5, decidingSetPoints: 25 };
-    const sets: SetScore[] = [
-      { a: 25, b: 20 },
-      { a: 20, b: 25 },
-      { a: 25, b: 23 },
-      { a: 23, b: 25 },
-      { a: 15, b: 12 },
-    ];
-    const s = matchState(sets, alwaysLong);
-    expect(s.setsA).toBe(2);
-    expect(s.setsB).toBe(2);
-    expect(s.decided).toBe(false);
-  });
-
-  it('sweeps a best-of-3 at two sets', () => {
-    const s = matchState([{ a: 25, b: 20 }, { a: 25, b: 18 }], bo3);
-    expect(s.setsA).toBe(2);
-    expect(s.setsB).toBe(0);
-    expect(s.decided).toBe(true);
-    expect(s.winner).toBe('a');
-  });
-
-  it('stops counting once the match is already won', () => {
-    const sets: SetScore[] = [
-      { a: 25, b: 10 },
-      { a: 25, b: 10 },
-      { a: 25, b: 10 },
-      { a: 25, b: 10 }, // impossible trailing set — must be ignored
-    ];
-    const s = matchState(sets, bo5);
-    expect(s.setsA).toBe(3);
-    expect(s.setsB).toBe(0);
-  });
-
-  it('surfaces the next target/deciding flags mid-match', () => {
-    const s = matchState([{ a: 25, b: 20 }, { a: 20, b: 25 }, { a: 25, b: 23 }, { a: 22, b: 25 }], bo5);
-    expect(s.setsA).toBe(2);
-    expect(s.setsB).toBe(2);
-    expect(s.nextDeciding).toBe(true);
-    expect(s.nextTarget).toBe(15);
-  });
-
-  it('ignores incomplete sets when folding', () => {
-    const s = matchState([{ a: 25, b: 20 }, { a: 24, b: 24 }], bo5);
-    expect(s.setsA).toBe(1);
-    expect(s.setsB).toBe(0);
-    expect(s.decided).toBe(false);
-  });
-});
-
-describe('readConfig — safe coercion & formats', () => {
-  it('maps best-of formats to sets-to-win', () => {
-    expect(readConfig({ format: 'bo5' }).setsToWin).toBe(3);
-    expect(readConfig({ format: 'bo3' }).setsToWin).toBe(2);
+  it('lets Custom take a free-form team size', () => {
+    expect(readConfig({ format: 'custom', teamSize: 3 }).teamSize).toBe(3);
+    expect(readConfig({ format: 'custom' }).teamSize).toBe(0); // 0 = no limit
   });
 
   it('fills sensible defaults', () => {
-    const c = readConfig(undefined);
-    expect(c).toEqual(DEFAULTS);
+    expect(readConfig(undefined)).toEqual(DEFAULTS);
     expect(readConfig({}).pointsPerSet).toBe(25);
-    expect(readConfig({}).decidingSetPoints).toBe(15);
+    expect(readConfig({}).numberOfTeams).toBe(2);
+  });
+
+  it('clamps the team count to a sane range and floors the cap', () => {
+    expect(readConfig({ numberOfTeams: 1 }).numberOfTeams).toBe(2);
+    expect(readConfig({ numberOfTeams: 99 }).numberOfTeams).toBe(8);
+    expect(readConfig({ hardCap: 27.9 }).hardCap).toBe(27);
+    expect(readConfig({ hardCap: -3 }).hardCap).toBe(0);
   });
 
   it('respects win-by-two toggle and custom targets', () => {
     expect(readConfig({ winBy2: false }).winBy2).toBe(false);
-    expect(readConfig({ winBy2: true }).winBy2).toBe(true);
-    expect(readConfig({ pointsPerSet: 21, decidingSetPoints: 11 })).toMatchObject({
-      pointsPerSet: 21,
-      decidingSetPoints: 11,
-    });
+    expect(readConfig({ pointsPerSet: 15 }).pointsPerSet).toBe(15);
+    expect(readConfig({ pointsPerSet: -5 }).pointsPerSet).toBe(25);
+  });
+});
+
+describe('defaultTeams — seeding a pool', () => {
+  it('splits the pool round-robin across the requested number of teams', () => {
+    const teams = defaultTeams({ ...cfg, numberOfTeams: 2, teamSize: 6 }, ['p1', 'p2', 'p3', 'p4']);
+    expect(teams).toHaveLength(2);
+    expect(teams[0].memberIds).toEqual(['p1', 'p3']);
+    expect(teams[1].memberIds).toEqual(['p2', 'p4']);
   });
 
-  it('coerces junk to defaults and floors the cap', () => {
-    expect(readConfig({ pointsPerSet: -5 }).pointsPerSet).toBe(25);
-    expect(readConfig({ pointsPerSet: 'nonsense' }).pointsPerSet).toBe(25);
-    expect(readConfig({ hardCap: 0 }).hardCap).toBe(0);
-    expect(readConfig({ hardCap: 27.9 }).hardCap).toBe(27);
-    expect(readConfig({ hardCap: -3 }).hardCap).toBe(0);
+  it('honours the roster cap and leaves overflow unassigned', () => {
+    const teams = defaultTeams({ ...cfg, numberOfTeams: 2, teamSize: 1 }, ['p1', 'p2', 'p3', 'p4']);
+    expect(teams[0].memberIds).toEqual(['p1']);
+    expect(teams[1].memberIds).toEqual(['p2']);
+    expect(unassigned(teams, ['p1', 'p2', 'p3', 'p4'])).toEqual(['p3', 'p4']);
+  });
+
+  it('gives each team distinct branding', () => {
+    const teams = defaultTeams({ ...cfg, numberOfTeams: 3 }, []);
+    const ids = new Set(teams.map((t) => t.id));
+    expect(ids.size).toBe(3);
+    expect(teams[0].name).not.toBe(teams[1].name);
+    expect(teams[0].emoji).not.toBe(teams[1].emoji);
+  });
+});
+
+describe('winningTeamId — maps a set score to the winning team', () => {
+  const teams = [makeTeam(0, ['p1', 'p2']), makeTeam(1, ['p3', 'p4'])];
+  const [t0, t1] = teams;
+
+  it('returns the home team when home wins', () => {
+    expect(winningTeamId(set(t0.id, t1.id, 25, 20, teams), cfg)).toBe(t0.id);
+  });
+  it('returns the away team when away wins', () => {
+    expect(winningTeamId(set(t0.id, t1.id, 20, 25, teams), cfg)).toBe(t1.id);
+  });
+  it('returns null while the set is still live', () => {
+    expect(winningTeamId(set(t0.id, t1.id, 25, 24, teams), cfg)).toBeNull();
+  });
+});
+
+describe('foldStandings — sets won per team across a session', () => {
+  const teams = [makeTeam(0, ['p1']), makeTeam(1, ['p2']), makeTeam(2, ['p3'])];
+  const [t0, t1, t2] = teams;
+
+  it('counts sets won and sorts leaders first', () => {
+    const sets = [
+      set(t0.id, t1.id, 25, 20, teams),
+      set(t0.id, t2.id, 25, 22, teams),
+      set(t1.id, t2.id, 25, 18, teams),
+    ];
+    const table = foldStandings(teams, sets, cfg);
+    expect(table[0].team.id).toBe(t0.id);
+    expect(table[0].setsWon).toBe(2);
+    const t1row = table.find((r) => r.team.id === t1.id)!;
+    expect(t1row.setsWon).toBe(1);
+    expect(t1row.setsPlayed).toBe(2);
+  });
+
+  it('ignores unfinished sets', () => {
+    const table = foldStandings(teams, [set(t0.id, t1.id, 25, 24, teams)], cfg);
+    expect(table.every((r) => r.setsWon === 0)).toBe(true);
+  });
+
+  it('tracks points scored for each team', () => {
+    const table = foldStandings(teams, [set(t0.id, t1.id, 25, 20, teams)], cfg);
+    expect(table.find((r) => r.team.id === t0.id)!.pointsFor).toBe(25);
+    expect(table.find((r) => r.team.id === t1.id)!.pointsFor).toBe(20);
+  });
+
+  it('breaks a sets-won tie by points scored', () => {
+    const two = [makeTeam(0, ['p1']), makeTeam(1, ['p2'])];
+    const [a, b] = two;
+    // a wins 25-10; b wins 25-23 — both 1 set, but a scored more points overall.
+    const table = foldStandings(two, [set(a.id, b.id, 25, 10, two), set(a.id, b.id, 23, 25, two)], cfg);
+    expect(table[0].team.id).toBe(a.id);
   });
 });


### PR DESCRIPTION
## What & why

Reworks the **Volleyball** module from a fixed 2-player match into an **open, team-based session** — the way people actually play a pickup night: build teams from a shared player pool, pick who plays each set, and freely reshuffle rosters as the night goes on.

## Highlights

- **Team model** lives in the round `input` and carries forward set-to-set, so players can be reshuffled and teams rebranded (name / emoji / colour) at any point — no risky app-wide "team" primitive required.
- **Per-set matchup picker** chooses which two teams contest each set. Rally scoring, win-by-two, deuce and hard-cap logic are preserved as pure, well-tested functions.
- **Live standings board** (sets won), with the leader crowned in Crown Gold.
- **Coherent scoring**: a set win credits each winning member +1, so the app's per-player Scoreboard, Court and stats stay accurate.
- **Drag-and-drop roster management** (new): pointer-based, so it works on **mouse *and* touch**. Drag players between team cards, the bench, and the two live match sides, with a floating ghost and colour-coded drop-target highlighting. A short press still falls through to the accessible tap-to-select path.
- **Config**: style of play (beach 2s / fours / indoor 6s / custom), number of teams, points per set, win-by-two, hard cap.

## Design

Follows `DESIGN.md`: surface ramp for depth, exactly one primary action, Crown Gold reserved for the leader, `tabular-nums`, ≥46px touch targets, and `prefers-reduced-motion` honored on all drag animations.

## Testing

- `npm run check` — 0 errors / 0 warnings
- `npm test` — **767 passing** (27 volleyball-specific)
- `npm run build` — production build + PWA generation succeed
- Verified live: standings, matchup picker, scoring/steppers, set-point/deuce states, and drag-and-drop across teams, bench, and match sides

## Files

- `src/lib/games/volleyball/logic.ts` — team model + pure set logic
- `src/lib/games/volleyball/index.ts` — GameModule (team-based input, config, scoring)
- `src/lib/games/volleyball/VolleyballEditor.svelte` — standings, matchup, scoring, roster manager
- `src/lib/games/volleyball/drag.ts` — new reusable pointer drag-and-drop action
- `src/lib/games/volleyball/stats.ts` — team-aware per-player + global stats
- `src/lib/games/volleyball/volleyball.test.ts` — coverage for the new logic