### PR TITLE
History: glanceable winner score, round count, relative time + filter fix

### DIFF
--- a/src/lib/stores/games.ts
+++ b/src/lib/stores/games.ts
@@ -104,6 +104,7 @@ export async function finishGame(game: Game): Promise<Game> {
     status: 'finished',
     finishedAt: Date.now(),
     winnerIds: winners,
+    winnerScore: winners.length ? totals[winners[0]] : undefined,
     roundCount: rounds.length,
   };
   await db.putGame(updated);
@@ -112,7 +113,13 @@ export async function finishGame(game: Game): Promise<Game> {
 }
 
 export async function reopenGame(game: Game): Promise<Game> {
-  const updated: Game = { ...game, status: 'active', finishedAt: undefined, winnerIds: undefined };
+  const updated: Game = {
+    ...game,
+    status: 'active',
+    finishedAt: undefined,
+    winnerIds: undefined,
+    winnerScore: undefined,
+  };
   await db.putGame(updated);
   await refreshGames();
   return updated;
@@ -130,6 +137,7 @@ export async function abandonGame(game: Game): Promise<Game> {
     status: 'abandoned',
     finishedAt: Date.now(),
     winnerIds: undefined,
+    winnerScore: undefined,
     roundCount: rounds.length,
   };
   await db.putGame(updated);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,6 +70,13 @@ export interface Game {
   createdAt: number;
   finishedAt?: number;
   winnerIds?: ID[];
+  /**
+   * The winning total captured at finish time — a glanceable summary value for the
+   * History log (the leader's final score). Stored so History needn't re-read every
+   * game's rounds to show it. Cleared when a game is reopened or abandoned. Absent on
+   * games finished before this field existed (History degrades to no score for those).
+   */
+  winnerScore?: number;
   roundCount: number;
   /**
    * User archive: hidden from the History library's main list and from Home, kept

--- a/src/pages/History.svelte
+++ b/src/pages/History.svelte
@@ -11,7 +11,7 @@
   import { getModule } from '../lib/games/registry';
   import { getRounds } from '../lib/storage/db';
   import { link } from '../lib/router';
-  import { formatDateTime } from '../lib/util';
+  import { formatDateTime, relativeTime } from '../lib/util';
   import { showActionToast } from '../lib/stores/toast';
   import { crewSignature, crewNames, setCrewName } from '../lib/stores/crews';
   import Avatar from '../lib/components/Avatar.svelte';
@@ -19,6 +19,7 @@
   import type { Game, Player } from '../lib/types';
   import ShareResultsSheet from '../lib/components/ShareResultsSheet.svelte';
   import { buildRecapPayload, type RecapPayload } from '../lib/share/recap';
+  import { gameTime as ts, dateBucket, haystack, nameResolver } from './history';
 
   /** Below this many games, the list is glanceable on its own — no controls shown. */
   const CONTROLS_MIN = 6;
@@ -63,27 +64,24 @@
   const archivedGames = $derived($games.filter((g) => g.archived));
   const showControls = $derived($activeGames.length >= CONTROLS_MIN);
 
+  // When the controls are hidden (few active games) the search/status inputs are
+  // unmounted, so honoring a stale value here would silently hide games with no visible
+  // way to clear it. Gate the filters on the controls actually being shown.
+  const effSearch = $derived(showControls ? search : '');
+  const effStatus = $derived(showControls ? status : 'all');
+
   const viewSummary = $derived(
     [groupBy === 'date' ? null : GROUP_LABEL[groupBy], sort === 'oldest' ? 'Oldest' : null]
       .filter(Boolean)
       .join(' · '),
   );
 
-  function ts(g: Game): number {
-    return g.finishedAt ?? g.createdAt;
-  }
+  const nameOf = $derived(nameResolver(playerMap));
   function names(ids: string[]): string {
-    return ids.map((id) => playerMap.get(id)?.name ?? '?').join(', ');
+    return ids.map(nameOf).join(', ');
   }
   function winners(ids: string[] | undefined): string {
-    return (ids ?? []).map((id) => playerMap.get(id)?.name ?? '?').join(' & ');
-  }
-  function haystack(g: Game): string {
-    const m = getModule(g.type);
-    const parts = [m?.name ?? g.type, g.name ?? ''];
-    for (const id of g.playerIds) parts.push(playerMap.get(id)?.name ?? '');
-    for (const id of g.winnerIds ?? []) parts.push(playerMap.get(id)?.name ?? '');
-    return parts.join(' ').toLowerCase();
+    return (ids ?? []).map(nameOf).join(' & ');
   }
   function push<K, V>(m: Map<K, V[]>, k: K, v: V): void {
     const a = m.get(k);
@@ -93,9 +91,12 @@
 
   const filtered = $derived.by(() => {
     let list = $activeGames;
-    if (status !== 'all') list = list.filter((g) => g.status === status);
-    const q = search.trim().toLowerCase();
-    if (q) list = list.filter((g) => haystack(g).includes(q));
+    if (effStatus !== 'all') list = list.filter((g) => g.status === effStatus);
+    const q = effSearch.trim().toLowerCase();
+    if (q) {
+      const typeName = (type: string) => getModule(type)?.name ?? type;
+      list = list.filter((g) => haystack(g, typeName, nameOf).includes(q));
+    }
     return list;
   });
 
@@ -106,13 +107,8 @@
 
     if (groupBy === 'date') {
       const now = new Date();
-      const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-      const startOfWeek = startOfToday - ((now.getDay() + 6) % 7) * 86400000;
-      const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1).getTime();
-      const bucket = (t: number) =>
-        t >= startOfToday ? 'today' : t >= startOfWeek ? 'week' : t >= startOfMonth ? 'month' : 'earlier';
       const map = new Map<string, Game[]>();
-      for (const g of list) push(map, bucket(ts(g)), g);
+      for (const g of list) push(map, dateBucket(ts(g), now), g);
       const order = sort === 'oldest' ? [...DATE_BUCKETS].reverse() : DATE_BUCKETS;
       return order
         .filter((b) => map.has(b.key))
@@ -225,9 +221,10 @@
           {#if g.status === 'active'}<span class="pill">in progress</span>{:else if g.status === 'abandoned'}<span class="pill">🪦 abandoned</span>{/if}
         </span>
         <span class="muted sm oneline">{names(g.playerIds)}</span>
-        <span class="muted sm oneline">
-          {formatDateTime(ts(g))}
-          {#if g.status === 'finished'} · 🏆 {winners(g.winnerIds) || '—'}{/if}
+        <span class="muted sm oneline" title={formatDateTime(ts(g))}>
+          {relativeTime(ts(g))}
+          {#if g.roundCount} · {g.roundCount} {g.roundCount === 1 ? 'round' : 'rounds'}{/if}
+          {#if g.status === 'finished'} · 🏆 {winners(g.winnerIds) || '—'}{#if g.winnerScore != null} <strong class="lead score">{g.winnerScore}</strong>{/if}{/if}
           {#if g.status === 'abandoned'} · no winner{/if}
         </span>
       </span>
@@ -328,7 +325,10 @@
               placeholder="Crew name…"
               aria-label="Crew name"
               bind:value={crewDraft}
-              onkeydown={(e) => { if (e.key === 'Enter') saveCrewEdit(grp.signature!); }}
+              onkeydown={(e) => {
+                if (e.key === 'Enter') saveCrewEdit(grp.signature!);
+                else if (e.key === 'Escape') editingCrew = null;
+              }}
             />
             <button class="btn small primary" onclick={() => saveCrewEdit(grp.signature!)}>Save</button>
             <button class="btn small ghost" onclick={() => (editingCrew = null)}>Cancel</button>
@@ -371,6 +371,11 @@
               <span class="meta">
                 <span class="titleline"><strong>{m?.name ?? g.type}</strong></span>
                 <span class="muted sm oneline">{names(g.playerIds)}</span>
+                <span class="muted sm oneline" title={formatDateTime(ts(g))}>
+                  {relativeTime(ts(g))}
+                  {#if g.status === 'finished'} · 🏆 {winners(g.winnerIds) || '—'}{/if}
+                  {#if g.status === 'abandoned'} · no winner{/if}
+                </span>
               </span>
             </a>
             <span class="row actions">
@@ -563,6 +568,11 @@
   }
   .sm {
     font-size: 0.85rem;
+  }
+  /* Winner's final total in the summary — Crown Gold (.lead) + tabular so the
+     glanceable "who won and by how much" stays legible and non-jittering. */
+  .score {
+    font-variant-numeric: tabular-nums;
   }
   .arch {
     opacity: 0.82;

--- a/src/pages/history.test.ts
+++ b/src/pages/history.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, Player } from '../lib/types';
+import { gameTime, dateBucket, haystack, nameResolver } from './history';
+
+function game(partial: Partial<Game>): Game {
+  return {
+    id: 'g1',
+    type: 'hearts',
+    config: {},
+    playerIds: [],
+    status: 'finished',
+    createdAt: 0,
+    roundCount: 0,
+    ...partial,
+  };
+}
+
+function player(id: string, name: string): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+
+describe('gameTime', () => {
+  it('prefers finishedAt over createdAt', () => {
+    expect(gameTime(game({ createdAt: 100, finishedAt: 500 }))).toBe(500);
+  });
+  it('falls back to createdAt when unfinished', () => {
+    expect(gameTime(game({ createdAt: 100, finishedAt: undefined }))).toBe(100);
+  });
+});
+
+describe('dateBucket', () => {
+  // Anchor "now" to a fixed Wednesday 12:00 so buckets are deterministic.
+  const now = new Date(2024, 5, 12, 12, 0, 0); // Wed Jun 12 2024
+  const at = (y: number, m: number, d: number, h = 12) => new Date(y, m, d, h).getTime();
+
+  it('buckets a same-day timestamp as today', () => {
+    expect(dateBucket(at(2024, 5, 12, 1), now)).toBe('today');
+  });
+  it('buckets earlier this week (Monday) as week', () => {
+    expect(dateBucket(at(2024, 5, 10), now)).toBe('week'); // Monday
+  });
+  it('buckets last Sunday (previous week) as month', () => {
+    expect(dateBucket(at(2024, 5, 9), now)).toBe('month'); // Sunday before this week
+  });
+  it('buckets earlier this month as month', () => {
+    expect(dateBucket(at(2024, 5, 2), now)).toBe('month');
+  });
+  it('buckets a prior month as earlier', () => {
+    expect(dateBucket(at(2024, 4, 30), now)).toBe('earlier');
+  });
+});
+
+describe('haystack', () => {
+  const roster = new Map([
+    [player('p1', 'Ada').id, player('p1', 'Ada')],
+    [player('p2', 'Grace').id, player('p2', 'Grace')],
+  ]);
+  const nameFor = nameResolver(roster);
+  const typeName = (t: string) => (t === 'hearts' ? 'Hearts' : t);
+
+  it('includes game label, players and winners, lowercased', () => {
+    const g = game({ type: 'hearts', playerIds: ['p1', 'p2'], winnerIds: ['p2'] });
+    const h = haystack(g, typeName, nameFor);
+    expect(h).toContain('hearts');
+    expect(h).toContain('ada');
+    expect(h).toContain('grace');
+  });
+
+  it('includes an optional custom label', () => {
+    const g = game({ type: 'hearts', name: 'Rematch Night', playerIds: ['p1'] });
+    expect(haystack(g, typeName, nameFor)).toContain('rematch night');
+  });
+
+  it('resolves missing player ids to ? without throwing', () => {
+    const g = game({ type: 'tally', playerIds: ['ghost'] });
+    expect(haystack(g, (t) => t, nameFor)).toContain('?');
+  });
+});

--- a/src/pages/history.ts
+++ b/src/pages/history.ts
@@ -1,0 +1,44 @@
+import type { Game, Player } from '../lib/types';
+
+/** A game's timeline anchor: when it finished, else when it was created. */
+export function gameTime(g: Game): number {
+  return g.finishedAt ?? g.createdAt;
+}
+
+export type DateBucket = 'today' | 'week' | 'month' | 'earlier';
+
+/**
+ * Which date group a timestamp falls into, relative to `now`. Pure (takes `now`) so the
+ * bucketing is deterministic and unit-testable. "week" is the current calendar week
+ * starting Monday; "month" is the current calendar month.
+ */
+export function dateBucket(t: number, now: Date = new Date()): DateBucket {
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const startOfWeek = startOfToday - ((now.getDay() + 6) % 7) * 86400000;
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1).getTime();
+  if (t >= startOfToday) return 'today';
+  if (t >= startOfWeek) return 'week';
+  if (t >= startOfMonth) return 'month';
+  return 'earlier';
+}
+
+/**
+ * Lowercased searchable text for a game: game name, custom label, and every player's
+ * and winner's name. `nameFor` resolves a player id to a display name; `typeName`
+ * resolves the game's module label (falls back to the raw type slug).
+ */
+export function haystack(
+  g: Game,
+  typeName: (type: string) => string,
+  nameFor: (id: string) => string,
+): string {
+  const parts = [typeName(g.type), g.name ?? ''];
+  for (const id of g.playerIds) parts.push(nameFor(id));
+  for (const id of g.winnerIds ?? []) parts.push(nameFor(id));
+  return parts.join(' ').toLowerCase();
+}
+
+/** Player-name resolver from a roster map, with a `?` fallback for missing ids. */
+export function nameResolver(playerMap: Map<string, Player>): (id: string) => string {
+  return (id) => playerMap.get(id)?.name ?? '?';
+}


### PR DESCRIPTION
﻿## Focus area: the History page

The shared cross-game game log - resuming/viewing games, filtering, date grouping, deleting with undo, and **glanceable summaries (winner, date, score)**. Grounded in the real code plus PRODUCT.md/DESIGN.md.

### Critique (12 items)

1. **No score in the glanceable summary.** DESIGN calls for "winner, date, score" but the card showed only the winner name - the *score* was missing. -> **Implemented**
2. **Filter-stuck bug.** `filtered` applied `search`/`status` even when the controls are hidden (`activeGames < 6`), so a stale value could silently hide games with no visible way to clear it. -> **Implemented** (gated behind `showControls`).
3. **Round count never surfaced.** `Game.roundCount` was stored but unused in History; it is a cheap, glanceable "how long was this game." -> **Implemented**
4. **Absolute-only timestamp.** `formatDateTime` ("Jul 8, 6:47 PM") is less glanceable in a log than relative time; `relativeTime()` already existed but was unused here. -> **Implemented** (relative in the row, absolute in the `title` tooltip).
5. **No Crown Gold moment.** The winner had no gold in History even though the leader/winner is exactly where Crown Gold is sanctioned. -> **Implemented** (`.lead` gold + `tabular-nums`, co-signalled by trophy + name - never colour alone).
6. **Crew rename keyboard gap.** Enter saved but Escape did not cancel. -> **Implemented**
7. **Archived rows were bare** (name + players only) - hard to identify. -> **Implemented** (relative date + winner).
8. **Abandoned games only appear under "All"** and are easy to miss - noted for a future status affordance.
9. **Grouping/search logic was untested** and inline in the component. -> **Implemented** (extracted pure helpers + unit tests).
10. **`getModule` recomputed per keystroke** inside `haystack` - minor; the extract makes the type-name resolver injectable/cacheable.
11. **Search input niceties** (enterkeyhint / autocorrect) - noted, not changed.
12. **"Clear filters" leaves view options** (groupBy/sort) - intentional (view prefs != filters); documented here for reviewers.

### Implemented in this PR

- **Persist `winnerScore`** at finish time (`finishGame`); cleared on `reopenGame`/`abandonGame`. Games finished before this field degrade gracefully (no score shown). Rides sync as a plain `Game` field, no DB migration.
- **Richer card summary:** winner score in Crown Gold, round count, and relative time (absolute in tooltip).
- **Filter-stuck fix** via `effSearch`/`effStatus` gated on `showControls`.
- **Enriched archived rows** and **Escape-to-cancel** crew rename.
- **Extracted pure helpers** to `src/pages/history.ts` (`gameTime`, `dateBucket`, `haystack`, `nameResolver`) with **10 new unit tests** in `src/pages/history.test.ts`.

### Verification

- `npm run check` -> 0 errors / 0 warnings
- `npm run build` -> success (PWA generated)
- `npx vitest run src/pages/history.test.ts` -> 10/10 pass (full suite green; the shared CI box is heavily contended so local full runs are slow)

Design notes: one primary action per screen preserved (no new violet fill); Crown Gold stays scarce (winner only); numbers use `tabular-nums`; no new motion; chrome unchanged.
