### PR TITLE
Custom Game creator: guardrails, guidance & Edit/Duplicate/Delete

### DIFF
--- a/src/lib/games/custom/scoring.test.ts
+++ b/src/lib/games/custom/scoring.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+import type { ID, Player, Round } from '../../types';
+import {
+  scoreCustomRow,
+  scoreCustomRound,
+  customMaxRounds,
+  customIsFinished,
+  describeCustomRound,
+} from './scoring';
+import {
+  blankDef,
+  duplicateDef,
+  validateDef,
+  defWarnings,
+  firstEmoji,
+  newColumn,
+  effectiveColumns,
+  COUNTER_COLUMN_KEY,
+  MAX_NAME_LEN,
+  MAX_COLUMN_LABEL_LEN,
+  type CustomGameDef,
+} from './types';
+
+function player(id: ID, name: string): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+
+/** A counter-shaped def (single implicit column). */
+function counterDef(over: Partial<CustomGameDef> = {}): CustomGameDef {
+  return { ...blankDef(), name: 'Counter', inputShape: 'counter', ...over };
+}
+
+/** A columns-shaped def with a scoring + a penalty column. */
+function columnsDef(over: Partial<CustomGameDef> = {}): CustomGameDef {
+  const gain = { ...newColumn('Gain'), key: 'g' };
+  const pen = { ...newColumn('Penalty'), key: 'p', negative: true };
+  return {
+    ...blankDef(),
+    name: 'Columns',
+    inputShape: 'columns',
+    columns: [gain, pen],
+    ...over,
+  };
+}
+
+describe('scoreCustomRow', () => {
+  it('sums positive columns and subtracts penalty columns', () => {
+    const def = columnsDef();
+    expect(scoreCustomRow({ g: 10, p: 3 }, def)).toBe(7);
+    expect(scoreCustomRow({ g: 0, p: 5 }, def)).toBe(-5);
+  });
+
+  it('treats a missing/blank row as zero', () => {
+    const def = columnsDef();
+    expect(scoreCustomRow(undefined, def)).toBe(0);
+    expect(scoreCustomRow({}, def)).toBe(0);
+  });
+
+  it('coerces non-numeric cell values to zero', () => {
+    const def = columnsDef();
+    expect(scoreCustomRow({ g: NaN as unknown as number, p: 2 }, def)).toBe(-2);
+  });
+
+  it('uses the single implicit column for a counter def', () => {
+    const def = counterDef();
+    expect(effectiveColumns(def)).toHaveLength(1);
+    expect(scoreCustomRow({ [COUNTER_COLUMN_KEY]: 4 }, def)).toBe(4);
+    expect(scoreCustomRow({ [COUNTER_COLUMN_KEY]: -6 }, def)).toBe(-6);
+  });
+});
+
+describe('scoreCustomRound', () => {
+  it('scores every player in order', () => {
+    const def = columnsDef();
+    const players = [player('a', 'Ann'), player('b', 'Bo')];
+    const input = { values: { a: { g: 8, p: 1 }, b: { g: 2, p: 0 } } };
+    expect(scoreCustomRound(input, players, def)).toEqual({ a: 7, b: 2 });
+  });
+
+  it('defaults a player with no row to zero', () => {
+    const def = counterDef();
+    const players = [player('a', 'Ann'), player('b', 'Bo')];
+    const input = { values: { a: { [COUNTER_COLUMN_KEY]: 5 } } };
+    expect(scoreCustomRound(input, players, def)).toEqual({ a: 5, b: 0 });
+  });
+});
+
+describe('customMaxRounds', () => {
+  it('returns the round limit when positive, else null', () => {
+    expect(customMaxRounds(counterDef({ roundLimit: 5 }))).toBe(5);
+    expect(customMaxRounds(counterDef({ roundLimit: 0 }))).toBeNull();
+  });
+});
+
+describe('customIsFinished', () => {
+  it('never finishes without a target', () => {
+    expect(customIsFinished({ a: 999 }, counterDef({ target: 0 }))).toBe(false);
+  });
+
+  it('finishes when any total reaches the target (high wins: first to X)', () => {
+    const def = counterDef({ target: 100, lowerIsBetter: false });
+    expect(customIsFinished({ a: 90, b: 80 }, def)).toBe(false);
+    expect(customIsFinished({ a: 100, b: 80 }, def)).toBe(true);
+  });
+
+  it('finishes on the target as a bust ceiling (low wins ends like Hearts to 100)', () => {
+    const def = counterDef({ target: 100, lowerIsBetter: true });
+    expect(customIsFinished({ a: 40, b: 101 }, def)).toBe(true);
+  });
+});
+
+describe('describeCustomRound', () => {
+  const round = (input: unknown): Round => ({
+    id: 'r', gameId: 'g', index: 0, input, deltas: {}, createdAt: 0,
+  });
+
+  it('summarises a counter round with signed values, skipping zeros', () => {
+    const def = counterDef();
+    const players = [player('a', 'Ann'), player('b', 'Bo')];
+    const r = round({ values: { a: { [COUNTER_COLUMN_KEY]: 5 }, b: { [COUNTER_COLUMN_KEY]: 0 } } });
+    expect(describeCustomRound(def, r, players)).toBe('Ann +5');
+  });
+
+  it('summarises a columns round as slash-joined values', () => {
+    const def = columnsDef();
+    const players = [player('a', 'Ann')];
+    const r = round({ values: { a: { g: 8, p: 1 } } });
+    expect(describeCustomRound(def, r, players)).toBe('Ann 8/1');
+  });
+
+  it('returns "no change" when nothing was entered', () => {
+    const def = counterDef();
+    const players = [player('a', 'Ann')];
+    expect(describeCustomRound(def, round({ values: { a: {} } }), players)).toBe('no change');
+  });
+});
+
+describe('validateDef', () => {
+  it('accepts a well-formed def', () => {
+    expect(validateDef(counterDef({ name: 'Rummy' }))).toBeNull();
+    expect(validateDef(columnsDef({ name: 'Whist' }))).toBeNull();
+  });
+
+  it('requires a name', () => {
+    expect(validateDef(counterDef({ name: '   ' }))).toMatch(/name/i);
+  });
+
+  it('caps the name length', () => {
+    expect(validateDef(counterDef({ name: 'x'.repeat(MAX_NAME_LEN + 1) }))).toMatch(/under/i);
+  });
+
+  it('rejects min < 1 and max < min', () => {
+    expect(validateDef(counterDef({ minPlayers: 0 }))).toMatch(/Minimum/i);
+    expect(validateDef(counterDef({ minPlayers: 4, maxPlayers: 2 }))).toMatch(/Max players/i);
+  });
+
+  it('requires every column to have a label', () => {
+    const def = columnsDef();
+    def.columns[1].label = '  ';
+    expect(validateDef(def)).toMatch(/label/i);
+  });
+
+  it('rejects duplicate column names (case-insensitive)', () => {
+    const def = columnsDef();
+    def.columns[0].label = 'Bid';
+    def.columns[1].label = 'bid';
+    expect(validateDef(def)).toMatch(/different name/i);
+  });
+
+  it('caps column label length', () => {
+    const def = columnsDef();
+    def.columns[0].label = 'y'.repeat(MAX_COLUMN_LABEL_LEN + 1);
+    expect(validateDef(def)).toMatch(/column names under/i);
+  });
+
+  it('rejects an all-subtracting column set (unwinnable)', () => {
+    const def = columnsDef();
+    def.columns.forEach((c) => (c.negative = true));
+    expect(validateDef(def)).toMatch(/add to the score/i);
+  });
+});
+
+describe('defWarnings', () => {
+  it('warns when both a target and a round limit are set', () => {
+    expect(defWarnings(counterDef({ target: 100, roundLimit: 10 }))).toContain(
+      'Whichever comes first ends the game: the target or the round limit.',
+    );
+  });
+
+  it('is silent for a clean single-target def', () => {
+    expect(defWarnings(counterDef({ target: 100, roundLimit: 0 }))).toHaveLength(0);
+  });
+});
+
+describe('firstEmoji', () => {
+  it('keeps a single emoji', () => {
+    expect(firstEmoji('🎯')).toBe('🎯');
+  });
+
+  it('collapses a ZWJ sequence to one glyph', () => {
+    expect(firstEmoji('🏴‍☠️')).toBe('🏴‍☠️');
+  });
+
+  it('drops trailing text after the first glyph', () => {
+    expect(firstEmoji('🎲 dice')).toBe('🎲');
+  });
+
+  it('returns empty for blank input', () => {
+    expect(firstEmoji('   ')).toBe('');
+    expect(firstEmoji(undefined)).toBe('');
+  });
+});
+
+describe('duplicateDef', () => {
+  it('clones into a fresh unsaved def with a new id and copy name', () => {
+    const src = columnsDef({ name: 'Skat', archived: true, archivedAt: 1, deleted: 2 });
+    const dup = duplicateDef(src);
+    expect(dup.id).not.toBe(src.id);
+    expect(dup.id.startsWith('def_')).toBe(true);
+    expect(dup.name).toBe('Skat copy');
+    expect(dup.archived).toBe(false);
+    expect(dup.archivedAt).toBeUndefined();
+    expect(dup.deleted).toBeUndefined();
+    // Columns are deep-copied, not shared.
+    expect(dup.columns).not.toBe(src.columns);
+    dup.columns[0].label = 'Changed';
+    expect(src.columns[0].label).toBe('Gain');
+  });
+});

--- a/src/lib/games/custom/types.ts
+++ b/src/lib/games/custom/types.ts
@@ -22,6 +22,40 @@ export const DEFAULT_EMOJI = '🎲';
 /** The single implicit column used by a `counter`-shaped game. */
 export const COUNTER_COLUMN_KEY = 'v';
 
+/**
+ * Field length caps. Kept small so a game name/tagline never overflows a catalog tile or the
+ * live preview, and a column label stays readable on the round-entry stepper. Enforced both by
+ * the inputs' `maxlength` (soft, in the builder) and by {@link validateDef} (hard, on save).
+ */
+export const MAX_NAME_LEN = 24;
+export const MAX_TAGLINE_LEN = 48;
+export const MAX_COLUMN_LABEL_LEN = 16;
+
+/** A curated palette of game-night emojis offered as one-tap picks in the builder. */
+export const EMOJI_CHOICES = [
+  '🎲', '🃏', '👑', '🏆', '🎯', '🀄', '♠️', '♥️', '♦️', '♣️',
+  '🎰', '🎳', '🏀', '⚽', '🏈', '🥏', '🏓', '🎱', '🧩', '🕹️',
+  '🍻', '🎉', '🔥', '⭐', '💎', '🚀', '🐉', '🦄', '🐔', '🎩',
+];
+
+/**
+ * The first *grapheme* of an emoji field — collapses a whole ZWJ sequence (e.g. 🏴‍☠️) to one
+ * visible glyph and drops trailing text, so the catalog tile always shows a single clean emoji
+ * instead of whatever a user pasted or typed. Returns '' when the input has no usable glyph.
+ */
+export function firstEmoji(input: string | undefined): string {
+  const trimmed = (input ?? '').trim();
+  if (!trimmed) return '';
+  // Prefer grapheme segmentation where available (keeps ZWJ/flag/keycap sequences intact).
+  const Seg = (Intl as unknown as { Segmenter?: typeof Intl.Segmenter }).Segmenter;
+  if (Seg) {
+    const seg = new Seg(undefined, { granularity: 'grapheme' });
+    for (const s of seg.segment(trimmed)) return s.segment;
+    return '';
+  }
+  return Array.from(trimmed)[0] ?? '';
+}
+
 export type CustomInputShape = 'counter' | 'columns';
 
 export interface CustomColumn {
@@ -129,12 +163,44 @@ export function duplicateDef(src: CustomGameDef): CustomGameDef {
 
 /** Validate a def for saving. Returns a human-readable error, or null when valid. */
 export function validateDef(def: CustomGameDef): string | null {
-  if (!def.name.trim()) return 'Give your game a name.';
+  const name = def.name.trim();
+  if (!name) return 'Give your game a name.';
+  if (name.length > MAX_NAME_LEN) return `Keep the name under ${MAX_NAME_LEN} characters.`;
+  if (def.tagline.trim().length > MAX_TAGLINE_LEN) {
+    return `Keep the tagline under ${MAX_TAGLINE_LEN} characters.`;
+  }
   if (!Number.isFinite(def.minPlayers) || def.minPlayers < 1) return 'Minimum players must be at least 1.';
   if (def.maxPlayers < def.minPlayers) return "Max players can't be less than min players.";
   if (def.inputShape === 'columns') {
     if (def.columns.length < 1) return 'Add at least one scoring column.';
     if (def.columns.some((c) => !c.label.trim())) return 'Every column needs a label.';
+    if (def.columns.some((c) => c.label.trim().length > MAX_COLUMN_LABEL_LEN)) {
+      return `Keep column names under ${MAX_COLUMN_LABEL_LEN} characters.`;
+    }
+    const seen = new Set<string>();
+    for (const c of def.columns) {
+      const key = c.label.trim().toLowerCase();
+      if (seen.has(key)) return 'Give each column a different name.';
+      seen.add(key);
+    }
+    if (def.columns.every((c) => c.negative)) {
+      return 'At least one column must add to the score, or no one can win.';
+    }
   }
   return null;
+}
+
+/**
+ * Non-blocking guidance shown live in the builder — things that are *valid* but probably not what
+ * the author intended, surfaced as gentle nudges rather than hard errors. Pure and testable.
+ */
+export function defWarnings(def: CustomGameDef): string[] {
+  const out: string[] = [];
+  if (def.target && def.target > 0 && def.roundLimit && def.roundLimit > 0) {
+    out.push('Whichever comes first ends the game: the target or the round limit.');
+  }
+  if (def.inputShape === 'columns' && def.columns.length === 1) {
+    out.push('One column works, but “One number” is simpler for a single value.');
+  }
+  return out;
 }

--- a/src/pages/CustomGameEdit.svelte
+++ b/src/pages/CustomGameEdit.svelte
@@ -7,7 +7,13 @@
     blankDef,
     newColumn,
     validateDef,
+    defWarnings,
+    firstEmoji,
+    EMOJI_CHOICES,
     DEFAULT_EMOJI,
+    MAX_NAME_LEN,
+    MAX_TAGLINE_LEN,
+    MAX_COLUMN_LABEL_LEN,
     type CustomGameDef,
   } from '../lib/games/custom/types';
   import { customGameDefs, customGamesLoaded, saveCustomGame } from '../lib/stores/customGames';
@@ -22,6 +28,15 @@
   let dir = $state<'high' | 'low'>('high');
   let shape = $state<'counter' | 'columns'>('counter');
   let loadedKey = $state<string | null>(null);
+  // Snapshot of the def as loaded, so Cancel can warn before discarding real edits.
+  let snapshot = $state<string>('');
+
+  function serialize(d: CustomGameDef): string {
+    // Everything the author can change; volatile timestamps are excluded so an untouched
+    // form never reads as "dirty".
+    const { createdAt: _c, updatedAt: _u, ...rest } = d;
+    return JSON.stringify(rest);
+  }
 
   // Load the def to edit (or a blank one) once it's resolvable. Depends on the store so a
   // cold deep-link to /create/<id> fills in as soon as IndexedDB answers.
@@ -33,6 +48,7 @@
         dir = 'high';
         shape = 'counter';
         loadedKey = '__new__';
+        snapshot = serialize(def);
       }
       return;
     }
@@ -42,6 +58,7 @@
       dir = def.lowerIsBetter ? 'low' : 'high';
       shape = def.inputShape;
       loadedKey = id;
+      snapshot = serialize(def);
     }
   });
 
@@ -54,6 +71,8 @@
     if (shape === 'columns' && def.columns.length === 0) def.columns = [newColumn('')];
   });
 
+  const dirty = $derived(serialize(def) !== snapshot);
+
   const notFound = $derived(!!id && $customGamesLoaded && !$customGameDefs.some((d) => d.id === id));
 
   // A plain-language recap of what the author has built — reinforces meaning without color.
@@ -63,7 +82,7 @@
       const n = def.columns.length;
       parts.push(`${n} column${n === 1 ? '' : 's'}`);
     }
-    if (def.target && def.target > 0) parts.push(`first to ${def.target}`);
+    if (def.target && def.target > 0) parts.push(`${targetPhrase} ${def.target}`);
     if (def.roundLimit && def.roundLimit > 0) {
       parts.push(`${def.roundLimit} round${def.roundLimit === 1 ? '' : 's'}`);
     }
@@ -79,18 +98,18 @@
     { value: 'columns', label: 'Columns' },
   ];
 
-  function addColumn() {
-    def.columns = [...def.columns, newColumn('')];
-  }
-  function removeColumn(i: number) {
-    def.columns = def.columns.filter((_, j) => j !== i);
-  }
+  // For a "lowest wins" game a target isn't "first to N" — it's a bust ceiling that *ends*
+  // the game (like Hearts to 100), so the label/summary copy flips with the win direction.
+  const targetLabel = $derived(dir === 'low' ? 'End the game at' : 'Target score');
+  const targetPhrase = $derived(dir === 'low' ? 'ends at' : 'first to');
 
-  async function save() {
-    const clean: CustomGameDef = {
+  // Normalize the working def exactly as it will be saved — shared by the live validation
+  // preview and save() so the two never disagree.
+  function buildClean(): CustomGameDef {
+    return {
       ...def,
       name: def.name.trim(),
-      emoji: (def.emoji || '').trim() || DEFAULT_EMOJI,
+      emoji: firstEmoji(def.emoji) || DEFAULT_EMOJI,
       tagline: def.tagline.trim(),
       help: (def.help ?? '').trim(),
       minPlayers: Math.max(1, Math.round(def.minPlayers) || 1),
@@ -104,18 +123,52 @@
           : def.columns,
       updatedAt: Date.now(),
     };
+  }
+
+  // Live guidance: the blocking error (if any) and any soft, non-blocking nudges. Surfaced
+  // in-place so the author is guided *before* tapping the button — not only via a save toast.
+  const error = $derived(validateDef(buildClean()));
+  const warnings = $derived.by(() => {
+    const list = defWarnings(buildClean());
+    const name = def.name.trim().toLowerCase();
+    if (name) {
+      const clash = $customGameDefs.some(
+        (d) => d.id !== def.id && !d.archived && !d.deleted && d.name.trim().toLowerCase() === name,
+      );
+      if (clash) list.push(`You already have a game called “${def.name.trim()}”.`);
+    }
+    return list;
+  });
+
+  function addColumn() {
+    def.columns = [...def.columns, newColumn('')];
+  }
+  function removeColumn(i: number) {
+    def.columns = def.columns.filter((_, j) => j !== i);
+  }
+
+  async function save() {
+    const clean = buildClean();
     const err = validateDef(clean);
     if (err) {
       showToast(err);
       return;
     }
+    // Snapshot the saved state so the follow-up navigation isn't treated as discarding edits.
+    snapshot = serialize(clean);
     await saveCustomGame(clean);
     showToast(editing ? 'Game updated.' : 'Game created.');
     navigate(`/${clean.id}`);
   }
 
   function cancel() {
+    if (dirty && !confirm('Discard your changes?')) return;
     navigate(editing ? `/${def.id}` : '/');
+  }
+
+  /** One-tap emoji from the curated palette. */
+  function pickEmoji(e: string) {
+    def.emoji = e;
   }
 </script>
 
@@ -135,8 +188,8 @@
   </div>
 
   <div class="section-title">Preview</div>
-  <div class="preview gametile" aria-hidden="true">
-    <span class="emoji">{def.emoji || DEFAULT_EMOJI}</span>
+  <div class="preview gametile" aria-label={`Preview: ${def.name.trim() || 'Untitled game'}. ${def.tagline.trim() || summary}`}>
+    <span class="emoji" aria-hidden="true">{firstEmoji(def.emoji) || DEFAULT_EMOJI}</span>
     <span class="name">{def.name.trim() || 'Untitled game'}</span>
     <span class="tag">{def.tagline.trim() || summary}</span>
   </div>
@@ -160,16 +213,32 @@
         <input
           type="text"
           bind:value={def.name}
+          maxlength={MAX_NAME_LEN}
           placeholder="Rummy to 500"
           aria-label="Game name"
         />
       </div>
+    </div>
+    <div class="emoji-pick" role="group" aria-label="Suggested emojis">
+      {#each EMOJI_CHOICES as e (e)}
+        <button
+          type="button"
+          class="emoji-opt"
+          class:on={firstEmoji(def.emoji) === e}
+          aria-pressed={firstEmoji(def.emoji) === e}
+          aria-label={`Use ${e}`}
+          onclick={() => pickEmoji(e)}
+        >
+          {e}
+        </button>
+      {/each}
     </div>
     <div>
       <div class="fieldlabel">Tagline <span class="muted">(optional)</span></div>
       <input
         type="text"
         bind:value={def.tagline}
+        maxlength={MAX_TAGLINE_LEN}
         placeholder="Low score takes it"
         aria-label="Tagline"
       />
@@ -204,6 +273,7 @@
                 class="collabel"
                 type="text"
                 bind:value={col.label}
+                maxlength={MAX_COLUMN_LABEL_LEN}
                 placeholder={`Column ${i + 1}`}
                 aria-label={`Column ${i + 1} name`}
               />
@@ -232,7 +302,7 @@
   <div class="card stack">
     <div class="row spread optrow">
       <div>
-        <div class="fieldlabel">Target score</div>
+        <div class="fieldlabel">{targetLabel}</div>
         <div class="muted sm">0 = no target</div>
       </div>
       <Stepper bind:value={def.target} min={0} step={def.step && def.step > 1 ? def.step : 10} />
@@ -274,7 +344,17 @@
   </div>
 
   <div class="actions stack">
-    <button class="btn primary block" onclick={save} disabled={!def.name.trim()}>
+    {#if warnings.length}
+      <div class="notes" role="note">
+        {#each warnings as w (w)}
+          <div class="note muted sm">💡 {w}</div>
+        {/each}
+      </div>
+    {/if}
+    {#if error && def.name.trim()}
+      <div class="formerror sm" role="alert">⚠ {error}</div>
+    {/if}
+    <button class="btn primary block" onclick={save} disabled={!!error}>
       {editing ? 'Save changes' : 'Create game'}
     </button>
     <button class="btn ghost block" onclick={cancel}>Cancel</button>
@@ -304,6 +384,51 @@
     width: 64px;
     text-align: center;
     font-size: 1.4rem;
+  }
+  /* One-tap suggested emojis — a wrapping grid of neutral chips (no gold, no second violet). */
+  .emoji-pick {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .emoji-opt {
+    width: 46px;
+    height: 46px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.35rem;
+    line-height: 1;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    cursor: pointer;
+    transition: transform 0.05s ease, background 0.15s ease, border-color 0.15s ease;
+  }
+  .emoji-opt:hover {
+    background: var(--surface-3);
+  }
+  .emoji-opt:active {
+    transform: translateY(1px);
+  }
+  .emoji-opt.on {
+    border-color: var(--primary);
+    background: var(--surface-3);
+  }
+  .emoji-opt:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .notes {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 4px;
+  }
+  /* Errors carry a ⚠ glyph + words so meaning never rides on color alone. */
+  .formerror {
+    color: var(--bad);
+    margin-bottom: 4px;
   }
   /* Column rows are a form group on the next surface step up — not nested cards (no shadow). */
   .colrow {

--- a/src/pages/GameType.svelte
+++ b/src/pages/GameType.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
   import { getModule } from '../lib/games/registry';
   import { defaultConfig } from '../lib/types';
-  import { activeGames, createGame } from '../lib/stores/games';
-  import { customGameDefs } from '../lib/stores/customGames';
+  import { activeGames, createGame, games } from '../lib/stores/games';
+  import {
+    customGameDefs,
+    removeCustomGame,
+    restoreCustomGame,
+    saveCustomGame,
+  } from '../lib/stores/customGames';
+  import { isCustomType, duplicateDef } from '../lib/games/custom/types';
+  import { editCustomHref } from '../lib/stores/catalog';
   import { navigate, link } from '../lib/router';
-  import { showToast } from '../lib/stores/toast';
+  import { showToast, showActionToast } from '../lib/stores/toast';
   import PlayerSelect from '../lib/components/PlayerSelect.svelte';
   import ConfigForm from '../lib/components/ConfigForm.svelte';
   import BackLink from '../lib/components/BackLink.svelte';
@@ -16,6 +23,12 @@
     void $customGameDefs;
     return getModule(type);
   });
+
+  // The editable definition behind a custom type (undefined for built-ins), plus whether any
+  // game of this type was ever played — which turns Delete into an archive (retain history).
+  const def = $derived($customGameDefs.find((d) => d.id === type));
+  const isCustom = $derived(isCustomType(type));
+  const playedCount = $derived($games.filter((g) => g.type === type).length);
 
   let selected = $state<string[]>([]);
   let config = $state<Record<string, any>>({});
@@ -45,6 +58,30 @@
     const g = await createGame(type, [...selected], { ...config });
     navigate(`/play/${g.id}`);
   }
+
+  // Clone-and-tweak: save a fresh copy, then open it in the builder to adjust.
+  async function duplicate() {
+    if (!def) return;
+    const copy = duplicateDef(def);
+    await saveCustomGame(copy);
+    showToast('Duplicated — tweak your copy.');
+    navigate(editCustomHref(copy.id));
+  }
+
+  // Delete a custom type. Played types archive (history/stats keep the right scoring); unplayed
+  // ones hard-delete. Either way it's undoable from the toast — the app's standard pattern.
+  async function del() {
+    if (!def) return;
+    const inUse = playedCount > 0;
+    const snapshot = { ...def, columns: def.columns.map((c) => ({ ...c })) };
+    await removeCustomGame(def.id, inUse);
+    const label = inUse ? `${def.name} archived` : `${def.name} deleted`;
+    showActionToast(label, 'Undo', () => {
+      if (inUse) void restoreCustomGame(snapshot.id);
+      else void saveCustomGame(snapshot);
+    });
+    navigate('/');
+  }
 </script>
 
 {#if !module}
@@ -62,6 +99,14 @@
       <div class="muted">{module.tagline}</div>
     </div>
   </div>
+
+  {#if isCustom && def}
+    <div class="authoring" aria-label="Custom game actions">
+      <a class="btn small" href={editCustomHref(type)} use:link>Edit</a>
+      <button class="btn small ghost" type="button" onclick={duplicate}>Duplicate</button>
+      <button class="btn small danger" type="button" onclick={del}>Delete</button>
+    </div>
+  {/if}
 
   {#if activeOfType.length}
     <div class="section-title">In progress</div>
@@ -100,6 +145,15 @@
 {/if}
 
 <style>
+  .authoring {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin: 6px 4px 2px;
+  }
+  .authoring .btn {
+    text-decoration: none;
+  }
   .resume {
     text-decoration: none;
     color: inherit;


### PR DESCRIPTION
## Custom Game creator: guardrails, guidance & the Edit/Duplicate/Delete lifecycle

Focus area: the no-code **Custom Game creator** (`/create`, `src/lib/games/custom`, `src/pages/CustomGameEdit.svelte`, `src/pages/GameType.svelte`). Goal: better validation, guidance, and error prevention while keeping it delightful and no-code — plus wiring up the author lifecycle the README already promises.

### Critique (12 items)

| # | Item | Type | Status |
|---|------|------|--------|
| 1 | **Duplicate & Delete missing from a custom game's page.** README promises Edit/Duplicate/Delete; the store exposed `removeCustomGame`/`restoreCustomGame` and `duplicateDef` but no UI ever called them (dead code, broken promise). Only *Edit* existed, in Manage games. | Bug/feature gap | ✅ Implemented |
| 2 | **No duplicate column-label validation.** Two columns named "Bid" make round entry ambiguous. | Bug/error-prevention | ✅ Implemented |
| 3 | **Emoji field accepts arbitrary text** (`maxlength=8` free text) — you could set "abc" as the tile emoji; no picker. | Error-prevention/UX | ✅ Implemented (grapheme sanitize + one-tap palette) |
| 4 | **Target copy wrong for "lowest wins."** Summary always said *"first to X"*, but for a low-wins game the target is a bust ceiling that *ends* the game (Hearts-to-100), so the label misleads. | Correctness/UX | ✅ Implemented (direction-aware copy) |
| 5 | **No inline validation.** Errors surfaced only as a save-time toast; the disabled button gave no reason. | UX | ✅ Implemented (live error + soft warnings) |
| 6 | **No length caps** on name/tagline/column labels → overflowing catalog tiles/preview. | Design/error-prevention | ✅ Implemented (`maxlength` + validation) |
| 7 | **All-subtracting columns** produce an unwinnable game with no warning. | Guidance | ✅ Implemented (blocking validation) |
| 8 | **No unit tests for the custom engine.** Every built-in game has a `*.test.ts`; the declarative→deterministic core had none. | Quality gap | ✅ Implemented (`scoring.test.ts`, 28 cases) |
| 9 | **Duplicate game names allowed silently** — confusing catalog. | UX | ✅ Implemented (non-blocking warning) |
| 10 | **Cancel/back silently discards unsaved edits.** | Error-prevention | ✅ Implemented (dirty-confirm) |
| 11 | **Preview tile is entirely `aria-hidden`** → screen-reader users get nothing from the live preview. | A11y | ✅ Implemented (accessible label) |
| 12 | **Redundant `newColumn` uid / target-step coupling nuances** noted while reviewing. | Minor | ➖ Left as-is (no user-facing issue) |

### Implemented (11 of 12)

**Validation & pure logic — `src/lib/games/custom/types.ts`**
- Duplicate-label + all-subtract rejection; name/tagline/column length caps.
- `firstEmoji()` collapses the emoji field to one grapheme (keeps ZWJ sequences like 🏴‍☠️ intact).
- `defWarnings()` for non-blocking nudges; `EMOJI_CHOICES` palette.

**Builder UX — `src/pages/CustomGameEdit.svelte`**
- One-tap suggested-emoji palette; live inline error + soft warnings; direction-aware target label/summary; duplicate-name warning; discard-changes confirm; `maxlength`s; accessible preview.

**Author lifecycle — `src/pages/GameType.svelte`**
- Edit / Duplicate / Delete on a custom game's page. Delete **archives** a played type (history/stats keep the right name/emoji/scoring) and **hard-deletes** an unplayed one — both undoable from the toast. Duplicate clones-and-opens for tweaking. Design-system compliant (secondary/danger buttons; the single violet primary stays "Start game").

**Tests — `src/lib/games/custom/scoring.test.ts` (new, 28 cases)**
- Penalty columns, counter vs columns, target as first-to-X *and* as a low-wins bust ceiling, `maxRounds`, `describeRound`, `validateDef`, `defWarnings`, `firstEmoji`, `duplicateDef`.

### Verification
- `npm run check` → 0 errors, 0 warnings
- `npm run build` → success
- `npx vitest run` → **809 passed (31 files)**, including the 28 new custom-engine tests

Design non-negotiables respected: one violet primary per screen, Crown Gold untouched, ≥46px targets, tabular-nums preserved, state never by color alone (⚠/💡 glyphs + text), identical chrome.
