### PR TITLE
Accessibility & inclusion pass: SR announcements, route titles/focus, skip link, labelled steppers, switch semantics, privacy hardening

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { pathStore, parseRoute, link } from './lib/router';
+  import { onMount, tick } from 'svelte';
+  import { pathStore, parseRoute, link, titleForRoute } from './lib/router';
   import { toast } from './lib/stores/toast';
   import { settings } from './lib/stores/settings';
+  import { announce } from './lib/stores/announcer';
   import Home from './pages/Home.svelte';
   import Players from './pages/Players.svelte';
   import History from './pages/History.svelte';
@@ -22,10 +23,33 @@
   import Recap from './pages/Recap.svelte';
   import NotFound from './pages/NotFound.svelte';
   import SyncBubble from './lib/components/SyncBubble.svelte';
+  import Announcer from './lib/components/Announcer.svelte';
 
   let current = $state(window.location.pathname || '/');
   onMount(() => pathStore.subscribe((v) => (current = v)));
   const route = $derived(parseRoute(current));
+
+  let mainEl: HTMLElement | undefined = $state();
+  // Skip the very first render: the initial page load already places focus and
+  // sets the title, so only *navigations* move focus and re-announce.
+  let mounted = false;
+
+  // Keep the document title, focus, and a polite announcement in lockstep with
+  // the route so screen-reader and keyboard users perceive each navigation the
+  // way a sighted user does at a glance.
+  $effect(() => {
+    const title = titleForRoute(route);
+    document.title = title;
+    if (!mounted) {
+      mounted = true;
+      return;
+    }
+    announce(title.split(' · ')[0]);
+    void (async () => {
+      await tick();
+      mainEl?.focus();
+    })();
+  });
 
   // Which primary nav item is active — shared by the mobile tab bar and the
   // desktop sidebar rail so both stay in lockstep.
@@ -51,9 +75,22 @@
     return () => document.removeEventListener('visibilitychange', onVis);
   });
 
+  // A manual "hide now" is offered on the play screen whenever the guard is on,
+  // so a player can veil the board on purpose before handing the phone over —
+  // not only when the tab is backgrounded.
+  const canHideNow = $derived($settings.privacyGuard && route.name === 'play' && !veiled);
+  function hideNow() {
+    veiled = true;
+  }
+
   function reveal() {
     veiled = false;
   }
+
+  let veilBtn: HTMLButtonElement | undefined = $state();
+  $effect(() => {
+    if (veiled) veilBtn?.focus();
+  });
 </script>
 
 {#snippet navLinks()}
@@ -63,7 +100,9 @@
   <a href="/stats" use:link class:active={navActive.stats}><span class="ico" aria-hidden="true">📊</span><span class="lbl">Stats</span></a>
 {/snippet}
 
-<div class="shell">
+<a href="#main-content" class="skip-link">Skip to content</a>
+
+<div class="shell" inert={veiled}>
   <aside class="sidebar">
     <a class="brand sidebar-brand" href="/" use:link>
       <img src="/favicon.svg" alt="" />
@@ -90,7 +129,7 @@
       </div>
     </header>
 
-<main class="app">
+<main class="app" id="main-content" tabindex="-1" bind:this={mainEl}>
   {#if route.name === 'home'}
     <Home />
   {:else if route.name === 'players'}
@@ -155,8 +194,21 @@
   </div>
 {/if}
 
+<Announcer />
+
+{#if canHideNow}
+  <button class="hide-now" onclick={hideNow} title="Hide scores from view">
+    <span aria-hidden="true">🙈</span> Hide scores
+  </button>
+{/if}
+
 {#if veiled}
-  <button class="veil" onclick={reveal} aria-label="Reveal scores">
+  <button
+    class="veil"
+    onclick={reveal}
+    aria-label="Scores hidden. Reveal scores."
+    bind:this={veilBtn}
+  >
     <span class="veil-card">
       <span class="veil-emoji" aria-hidden="true">🙈</span>
       <strong>Scores hidden</strong>
@@ -166,6 +218,63 @@
 {/if}
 
 <style>
+  /* Skip link: off-screen until focused, then anchored top-center over the app
+     bar so keyboard users can jump past the persistent nav (WCAG 2.4.1). */
+  .skip-link {
+    position: fixed;
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, -120%);
+    z-index: 100;
+    padding: 10px 18px;
+    min-height: 46px;
+    display: inline-flex;
+    align-items: center;
+    background: var(--primary);
+    color: #fff;
+    font-weight: 700;
+    border-radius: 0 0 var(--radius-sm) var(--radius-sm);
+    box-shadow: var(--shadow);
+    transition: transform 0.15s ease;
+  }
+  .skip-link:focus-visible {
+    transform: translate(-50%, 0);
+    outline: 2px solid #fff;
+    outline-offset: -4px;
+    text-decoration: none;
+  }
+
+  /* Manual privacy hide: a thumb-zone pill above the bottom bar so a player can
+     veil the board on purpose before setting the phone down. */
+  .hide-now {
+    position: fixed;
+    left: 50%;
+    bottom: calc(86px + env(safe-area-inset-bottom));
+    transform: translateX(-50%);
+    z-index: 60;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 40px;
+    padding: 0 16px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: color-mix(in srgb, var(--surface-3) 92%, transparent);
+    backdrop-filter: blur(8px);
+    color: var(--text);
+    font-weight: 700;
+    font-size: 0.85rem;
+    cursor: pointer;
+    box-shadow: var(--shadow);
+  }
+  .hide-now:hover {
+    background: var(--surface-3);
+  }
+  .hide-now:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+
   .veil {
     position: fixed;
     inset: 0;

--- a/src/lib/a11y.test.ts
+++ b/src/lib/a11y.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { parseRoute, titleForRoute } from './router';
+import { announce, announcement } from './stores/announcer';
+
+describe('titleForRoute', () => {
+  it('uses the bare app name on Home', () => {
+    expect(titleForRoute(parseRoute('/'))).toBe('Score King');
+  });
+
+  it('prefixes the page label for interior routes', () => {
+    expect(titleForRoute(parseRoute('/players'))).toBe('Players · Score King');
+    expect(titleForRoute(parseRoute('/accessibility'))).toBe('Accessibility & display · Score King');
+  });
+
+  it('labels dynamic game and play routes generically', () => {
+    expect(titleForRoute(parseRoute('/skullking'))).toBe('Start a game · Score King');
+    expect(titleForRoute(parseRoute('/play/abc'))).toBe('Now playing · Score King');
+  });
+
+  it('labels the not-found route', () => {
+    expect(titleForRoute(parseRoute('/foo/bar'))).toBe('Not found · Score King');
+  });
+});
+
+describe('announce', () => {
+  it('publishes a trimmed message and bumps the sequence', () => {
+    const before = get(announcement).seq;
+    announce('  Round 1 saved.  ');
+    const after = get(announcement);
+    expect(after.message).toBe('Round 1 saved.');
+    expect(after.seq).toBe(before + 1);
+  });
+
+  it('re-announces identical text with a fresh sequence', () => {
+    announce('Ada leads with 42.');
+    const first = get(announcement);
+    announce('Ada leads with 42.');
+    const second = get(announcement);
+    expect(second.message).toBe(first.message);
+    expect(second.seq).toBe(first.seq + 1);
+  });
+
+  it('ignores empty or whitespace-only messages', () => {
+    const before = get(announcement).seq;
+    announce('   ');
+    announce('');
+    expect(get(announcement).seq).toBe(before);
+  });
+});

--- a/src/lib/components/Announcer.svelte
+++ b/src/lib/components/Announcer.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { announcement } from '../stores/announcer';
+
+  // A visually hidden, polite live region mounted once at the app root. Keyed by
+  // `seq` so identical consecutive messages still re-announce; `role="status"`
+  // plus aria-live="polite" waits for a pause instead of interrupting.
+  let text = $state('');
+  let seen = -1;
+
+  $effect(() => {
+    const a = $announcement;
+    if (a.seq !== seen) {
+      seen = a.seq;
+      // Clear first so screen readers reliably re-read a repeated message.
+      text = '';
+      queueMicrotask(() => (text = a.message));
+    }
+  });
+</script>
+
+<div class="sr-only" role="status" aria-live="polite" aria-atomic="true">{text}</div>

--- a/src/lib/components/Scoreboard.svelte
+++ b/src/lib/components/Scoreboard.svelte
@@ -19,6 +19,10 @@
 
   const byId = $derived(new Map(players.map((p) => [p.id, p])));
   const ranked = $derived(standings(totals, lowerIsBetter));
+  // A leader only exists once scores diverge — at 0-0 nobody is "leading yet",
+  // so the crown stays hidden until someone pulls ahead (mirrors the gold `.lead`
+  // number meaning without shouting a crown over every tied-at-zero player).
+  const hasLeader = $derived(ranked.length > 1 && ranked.some((r) => r.total !== ranked[0].total));
 </script>
 
 <table>
@@ -34,7 +38,11 @@
           <span class="row" style="gap: 8px">
             {#if p}<Avatar name={p.name} color={p.color} size={24} />{p.name}{/if}
             {#if youId && s.playerId === youId}<span class="you">You</span>{/if}
-            {#if winners.includes(s.playerId)}<span title="Winner">🏆</span>{/if}
+            {#if winners.includes(s.playerId)}
+              <span aria-hidden="true" title="Winner">🏆</span><span class="sr-only">Winner</span>
+            {:else if s.rank === 1 && hasLeader}
+              <span aria-hidden="true" title="Leading">👑</span><span class="sr-only">Leading</span>
+            {/if}
           </span>
         </td>
         <td class="num" class:lead={s.rank === 1}>{s.total}</td>

--- a/src/lib/components/Stepper.svelte
+++ b/src/lib/components/Stepper.svelte
@@ -4,7 +4,15 @@
     min = -Infinity,
     max = Infinity,
     step = 1,
-  }: { value: number; min?: number; max?: number; step?: number } = $props();
+    label = '',
+  }: { value: number; min?: number; max?: number; step?: number; label?: string } = $props();
+
+  // A meaningful accessible name for the number field and its buttons. Callers
+  // pass the thing being counted (usually a player's name) so a screen reader
+  // announces "Decrease Ada" rather than a bare "decrease" with no context.
+  const fieldLabel = $derived(label || 'Value');
+  const decLabel = $derived(label ? `Decrease ${label}` : 'Decrease');
+  const incLabel = $derived(label ? `Increase ${label}` : 'Increase');
 
   function dec() {
     value = Math.max(min, (Number(value) || 0) - step);
@@ -15,11 +23,11 @@
 </script>
 
 <div class="stepper">
-  <button type="button" class="iconbtn" onclick={dec} disabled={value <= min} aria-label="decrease">
+  <button type="button" class="iconbtn" onclick={dec} disabled={value <= min} aria-label={decLabel}>
     −
   </button>
-  <input type="number" bind:value {min} {max} {step} inputmode="numeric" />
-  <button type="button" class="iconbtn" onclick={inc} disabled={value >= max} aria-label="increase">
+  <input type="number" bind:value {min} {max} {step} inputmode="numeric" aria-label={fieldLabel} />
+  <button type="button" class="iconbtn" onclick={inc} disabled={value >= max} aria-label={incLabel}>
     +
   </button>
 </div>

--- a/src/lib/components/Switch.svelte
+++ b/src/lib/components/Switch.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  // A themed on/off switch. It renders a native checkbox with role="switch" so
+  // assistive tech announces "on/off" instead of "checked/unchecked"; the
+  // accessible name comes from the surrounding <label> row (or the `label` prop
+  // when used without one). Controlled: the parent owns the value via `checked`
+  // and reacts to `onchange`.
+  let {
+    checked = false,
+    disabled = false,
+    label = '',
+    onchange,
+  }: {
+    checked?: boolean;
+    disabled?: boolean;
+    label?: string;
+    onchange?: (value: boolean) => void;
+  } = $props();
+</script>
+
+<span class="switch">
+  <input
+    type="checkbox"
+    role="switch"
+    {checked}
+    {disabled}
+    aria-label={label || undefined}
+    onchange={(e) => onchange?.(e.currentTarget.checked)}
+  />
+  <span class="track"><span class="thumb"></span></span>
+</span>
+
+<style>
+  .switch {
+    position: relative;
+    display: inline-flex;
+    flex: none;
+  }
+  .switch input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    opacity: 0;
+    cursor: pointer;
+  }
+  .switch input:disabled {
+    cursor: not-allowed;
+  }
+  .track {
+    width: 46px;
+    height: 26px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    display: inline-flex;
+    align-items: center;
+    padding: 2px;
+    transition: background 0.15s ease;
+  }
+  .thumb {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #fff;
+    transition: transform 0.15s ease;
+  }
+  .switch input:checked + .track {
+    background: var(--primary);
+    border-color: var(--primary);
+  }
+  .switch input:checked + .track .thumb {
+    transform: translateX(20px);
+  }
+  .switch input:focus-visible + .track {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+</style>

--- a/src/lib/games/custom/CustomRoundEditor.svelte
+++ b/src/lib/games/custom/CustomRoundEditor.svelte
@@ -47,7 +47,7 @@
                 {c.label}{#if c.negative}<span class="neg" aria-label="subtracts"> −</span>{/if}
               </span>
               {#if input.values?.[p.id]}
-                <Stepper bind:value={input.values[p.id][c.key]} {step} />
+                <Stepper bind:value={input.values[p.id][c.key]} {step} label={`${p.name} ${c.label}`} />
               {/if}
             </div>
           {/each}
@@ -60,7 +60,7 @@
           <strong>{p.name}</strong>
         </span>
         {#if input.values?.[p.id]}
-          <Stepper bind:value={input.values[p.id][COUNTER_COLUMN_KEY]} {step} />
+          <Stepper bind:value={input.values[p.id][COUNTER_COLUMN_KEY]} {step} label={p.name} />
         {/if}
       </div>
     {/if}

--- a/src/lib/games/golf/GolfEditor.svelte
+++ b/src/lib/games/golf/GolfEditor.svelte
@@ -39,7 +39,7 @@
           <Avatar name={p.name} color={p.color} />
           <strong>{p.name}</strong>
         </span>
-        <Stepper bind:value={input.scores[p.id]} min={floor} max={ceil} />
+        <Stepper bind:value={input.scores[p.id]} min={floor} max={ceil} label={p.name} />
       </div>
       <div class="row spread foot">
         <span class="tag" class:under={tag === 'under'}>

--- a/src/lib/games/hearts/HeartsEditor.svelte
+++ b/src/lib/games/hearts/HeartsEditor.svelte
@@ -32,7 +32,7 @@
           <Avatar name={p.name} color={p.color} />
           <strong>{p.name}</strong>
         </span>
-        <Stepper bind:value={input.hearts[p.id]} min={0} max={13} />
+        <Stepper bind:value={input.hearts[p.id]} min={0} max={13} label={`${p.name} hearts`} />
       </div>
       <div class="row" style="gap: 8px">
         <button type="button" class="toggle" class:on={input.queen === p.id} onclick={() => setQueen(p.id)}>

--- a/src/lib/games/skullking/SkullKingEditor.svelte
+++ b/src/lib/games/skullking/SkullKingEditor.svelte
@@ -50,8 +50,8 @@
         </span>
       </div>
       <div class="fields">
-        <label class="f">Bid<Stepper bind:value={row.bid} min={0} max={n} /></label>
-        <label class="f">Won<Stepper bind:value={row.actual} min={0} max={n} /></label>
+        <label class="f">Bid<Stepper bind:value={row.bid} min={0} max={n} label={`${p.name} bid`} /></label>
+        <label class="f">Won<Stepper bind:value={row.actual} min={0} max={n} label={`${p.name} won`} /></label>
         <label class="f">Bonus<input type="number" step="10" bind:value={row.bonus} /></label>
       </div>
     </div>

--- a/src/lib/games/tally/TallyEditor.svelte
+++ b/src/lib/games/tally/TallyEditor.svelte
@@ -14,7 +14,7 @@
         <Avatar name={p.name} color={p.color} />
         <strong>{p.name}</strong>
       </span>
-      <Stepper bind:value={input.deltas[p.id]} step={1} />
+      <Stepper bind:value={input.deltas[p.id]} step={1} label={p.name} />
     </div>
   {/each}
 </div>

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -113,6 +113,42 @@ const RESERVED: Record<string, RouteName> = {
   create: 'customedit',
 };
 
+/**
+ * Human-readable page title per route, used to keep `document.title` in sync as
+ * the SPA navigates (WCAG 2.4.2 Page Titled) and to announce the new page to
+ * assistive tech. Game-specific routes fall back to a sensible generic label;
+ * pages that know their own subject (a game, a custom def) can refine it later.
+ */
+const ROUTE_TITLES: Record<RouteName, string> = {
+  home: 'Games',
+  players: 'Players',
+  history: 'History',
+  stats: 'Stats',
+  court: 'The Court',
+  wrapped: 'Wrapped',
+  tonight: "Tonight's Recap",
+  settings: 'Settings',
+  accessibility: 'Accessibility & display',
+  managegames: 'Manage games',
+  browse: 'Browse games',
+  gameplay: 'Gameplay',
+  play: 'Now playing',
+  join: 'Join live game',
+  nearby: 'Play nearby',
+  recap: 'Recap',
+  gametype: 'Start a game',
+  customedit: 'Create a game',
+  notfound: 'Not found',
+};
+
+const APP_NAME = 'Score King';
+
+/** The `document.title` string for a route (e.g. "Players · Score King"). */
+export function titleForRoute(route: Route): string {
+  const label = ROUTE_TITLES[route.name];
+  return route.name === 'home' || !label ? APP_NAME : `${label} · ${APP_NAME}`;
+}
+
 export function parseRoute(path: string): Route {
   const clean = path.replace(/^\/+|\/+$/g, '');
   const segs = clean === '' ? [''] : clean.split('/');

--- a/src/lib/stores/announcer.ts
+++ b/src/lib/stores/announcer.ts
@@ -1,0 +1,26 @@
+import { writable } from 'svelte/store';
+
+/**
+ * A single app-wide polite live region. Components call {@link announce} to have
+ * a short message read by screen readers without stealing focus or showing any
+ * visible UI — used for score changes, saved rounds, and route changes that a
+ * sighted player perceives at a glance but an assistive-tech user otherwise
+ * wouldn't. The value carries a monotonic `seq` so re-announcing the *same*
+ * text (e.g. two identical saves) still updates the DOM and re-triggers the SR.
+ */
+export interface Announcement {
+  message: string;
+  seq: number;
+}
+
+export const announcement = writable<Announcement>({ message: '', seq: 0 });
+
+let seq = 0;
+
+/** Queue a message for the shared polite live region. Empty strings are ignored. */
+export function announce(message: string): void {
+  const trimmed = message.trim();
+  if (!trimmed) return;
+  seq += 1;
+  announcement.set({ message: trimmed, seq });
+}

--- a/src/pages/Accessibility.svelte
+++ b/src/pages/Accessibility.svelte
@@ -2,6 +2,7 @@
   import { settings } from '../lib/stores/settings';
   import { PALETTE } from '../lib/util';
   import Segmented from '../lib/components/Segmented.svelte';
+  import Switch from '../lib/components/Switch.svelte';
   import Avatar from '../lib/components/Avatar.svelte';
   import BackLink from '../lib/components/BackLink.svelte';
 
@@ -101,14 +102,7 @@
     <span class="name">High contrast</span>
     <span class="muted sm">Bolder text, stronger borders, chunkier focus rings.</span>
   </span>
-  <span class="switch">
-    <input
-      type="checkbox"
-      checked={$settings.highContrast}
-      onchange={(e) => setBool('highContrast', e.currentTarget.checked)}
-    />
-    <span class="track"><span class="thumb"></span></span>
-  </span>
+  <Switch checked={$settings.highContrast} onchange={(v) => setBool('highContrast', v)} />
 </label>
 
 <label class="card sw-row row spread" class:dim={oledDisabled}>
@@ -118,15 +112,7 @@
       {oledDisabled ? 'Switch to the dark theme to use true black.' : 'Pure-black surfaces save power and deepen contrast.'}
     </span>
   </span>
-  <span class="switch">
-    <input
-      type="checkbox"
-      checked={$settings.oled}
-      disabled={oledDisabled}
-      onchange={(e) => setBool('oled', e.currentTarget.checked)}
-    />
-    <span class="track"><span class="thumb"></span></span>
-  </span>
+  <Switch checked={$settings.oled} disabled={oledDisabled} onchange={(v) => setBool('oled', v)} />
 </label>
 
 <div class="section-title">Motion &amp; colour</div>
@@ -144,14 +130,7 @@
     <span class="name">Colour-blind palette</span>
     <span class="muted sm">Swaps player colours for a set that stays distinct across colour vision types.</span>
   </span>
-  <span class="switch">
-    <input
-      type="checkbox"
-      checked={$settings.colorBlind}
-      onchange={(e) => setBool('colorBlind', e.currentTarget.checked)}
-    />
-    <span class="track"><span class="thumb"></span></span>
-  </span>
+  <Switch checked={$settings.colorBlind} onchange={(v) => setBool('colorBlind', v)} />
 </label>
 
 <style>
@@ -224,52 +203,5 @@
   }
   .sw-row.dim {
     opacity: 0.55;
-  }
-
-  .switch {
-    position: relative;
-    display: inline-flex;
-    flex: none;
-  }
-  .switch input {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    opacity: 0;
-    cursor: pointer;
-  }
-  .switch input:disabled {
-    cursor: not-allowed;
-  }
-  .track {
-    width: 46px;
-    height: 26px;
-    border-radius: 999px;
-    background: var(--surface-3);
-    border: 1px solid var(--border);
-    display: inline-flex;
-    align-items: center;
-    padding: 2px;
-    transition: background 0.15s ease;
-  }
-  .thumb {
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    background: #fff;
-    transition: transform 0.15s ease;
-  }
-  .switch input:checked + .track {
-    background: var(--primary);
-    border-color: var(--primary);
-  }
-  .switch input:checked + .track .thumb {
-    transform: translateX(20px);
-  }
-  .switch input:focus-visible + .track {
-    outline: 2px solid var(--primary);
-    outline-offset: 2px;
   }
 </style>

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -21,6 +21,7 @@
   import { computeTotals } from '../lib/scoring';
   import { navigate, link, absoluteUrl } from '../lib/router';
   import { showToast, showActionToast } from '../lib/stores/toast';
+  import { announce } from '../lib/stores/announcer';
   import { relativeTime, generateJoinCode } from '../lib/util';
   import { settings } from '../lib/stores/settings';
   import { leadMember } from '../lib/stores/identity';
@@ -148,6 +149,19 @@
     return () => disableWakeLock();
   });
 
+  // A short, glanceable standing for screen readers — who's on top and by what
+  // number — so an assistive-tech user learns what a sighted player sees the
+  // moment a round lands, without having to re-read the whole board.
+  function leaderSummary(): string {
+    const leaders = orderedPlayers.filter((p) => leaderIds.has(p.id));
+    if (leaders.length === 0) return '';
+    const best = totals[leaders[0].id] ?? 0;
+    const names = leaders.map((p) => p.name).join(' and ');
+    return leaders.length === 1
+      ? `${names} leads with ${best}.`
+      : `${names} tie for the lead with ${best}.`;
+  }
+
   async function saveRound() {
     if (!game || !module || !draft) return;
     const snap = $state.snapshot(draft);
@@ -167,7 +181,10 @@
     });
     if (!saved) return;
     const newest = rounds[rounds.length - 1];
-    if (newest) pulseRow(newest.id);
+    if (newest) {
+      pulseRow(newest.id);
+      announce(`Round ${newest.index + 1} saved. ${leaderSummary()}`);
+    }
   }
 
   // Briefly pulse a scorecard row green to confirm it just landed. The host's own saves and
@@ -204,6 +221,7 @@
       await load();
       publish();
     });
+    announce(`Round ${ed.index + 1} updated. ${leaderSummary()}`);
   }
 
   async function del(r: Round) {
@@ -232,6 +250,12 @@
       game = await finishGame(game);
       publish();
     });
+    const names = (game?.winnerIds ?? [])
+      .map((wid) => plist.find((p) => p.id === wid)?.name ?? '?')
+      .join(' and ');
+    if (names) {
+      announce(`Game finished. ${names} ${(game?.winnerIds?.length ?? 0) > 1 ? 'tie for the win' : 'wins'}.`);
+    }
   }
   async function doReopen() {
     if (!game) return;

--- a/src/pages/GameplaySettings.svelte
+++ b/src/pages/GameplaySettings.svelte
@@ -2,6 +2,7 @@
   import { settings } from '../lib/stores/settings';
   import { isWakeLockSupported } from '../lib/wakelock';
   import BackLink from '../lib/components/BackLink.svelte';
+  import Switch from '../lib/components/Switch.svelte';
 
   const wakeSupported = isWakeLockSupported();
 
@@ -26,15 +27,11 @@
         : 'Your browser doesn’t support screen wake lock.'}
     </span>
   </span>
-  <span class="switch">
-    <input
-      type="checkbox"
-      checked={$settings.keepAwake}
-      disabled={!wakeSupported}
-      onchange={(e) => setBool('keepAwake', e.currentTarget.checked)}
-    />
-    <span class="track"><span class="thumb"></span></span>
-  </span>
+  <Switch
+    checked={$settings.keepAwake}
+    disabled={!wakeSupported}
+    onchange={(v) => setBool('keepAwake', v)}
+  />
 </label>
 
 <label class="card sw-row row spread">
@@ -42,14 +39,7 @@
     <span class="name">Privacy peek-guard</span>
     <span class="muted sm">Blurs the board when you set the phone down, so a passer-by can’t read the scores. Tap to reveal.</span>
   </span>
-  <span class="switch">
-    <input
-      type="checkbox"
-      checked={$settings.privacyGuard}
-      onchange={(e) => setBool('privacyGuard', e.currentTarget.checked)}
-    />
-    <span class="track"><span class="thumb"></span></span>
-  </span>
+  <Switch checked={$settings.privacyGuard} onchange={(v) => setBool('privacyGuard', v)} />
 </label>
 
 <style>
@@ -70,52 +60,5 @@
   .sw-row {
     cursor: pointer;
     gap: 14px;
-  }
-
-  .switch {
-    position: relative;
-    display: inline-flex;
-    flex: none;
-  }
-  .switch input {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    opacity: 0;
-    cursor: pointer;
-  }
-  .switch input:disabled {
-    cursor: not-allowed;
-  }
-  .track {
-    width: 46px;
-    height: 26px;
-    border-radius: 999px;
-    background: var(--surface-3);
-    border: 1px solid var(--border);
-    display: inline-flex;
-    align-items: center;
-    padding: 2px;
-    transition: background 0.15s ease;
-  }
-  .thumb {
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    background: #fff;
-    transition: transform 0.15s ease;
-  }
-  .switch input:checked + .track {
-    background: var(--primary);
-    border-color: var(--primary);
-  }
-  .switch input:checked + .track .thumb {
-    transform: translateX(20px);
-  }
-  .switch input:focus-visible + .track {
-    outline: 2px solid var(--primary);
-    outline-offset: 2px;
   }
 </style>


### PR DESCRIPTION
﻿## Accessibility & inclusion pass

Focus area: **Accessibility & inclusion**. Audited against WCAG 2.2 AA and the PRODUCT.md accessibility brief. Full critique (10+ items); the implemented subset is marked with a check.

### Critique

1. [x] **Score changes were not announced to screen readers.** Saving a round only produced a visual green pulse. *Change:* shared polite live region (`Announcer`) + `announce()` store; GamePlay announces "Round N saved. Ada leads with 42." on save/edit and the winner on finish. Files: `src/lib/stores/announcer.ts`, `src/lib/components/Announcer.svelte`, `src/App.svelte`, `src/pages/GamePlay.svelte`.
2. [x] **SPA page title never changed** (always "Score King") — no context on nav (WCAG 2.4.2). *Change:* `titleForRoute()` + reactive `document.title`. Files: `src/lib/router.ts`, `src/App.svelte`.
3. [x] **No focus management on route change** (WCAG 2.4.3). *Change:* move focus to `<main tabindex="-1">` and announce the new page per navigation. Files: `src/App.svelte`.
4. [x] **No skip-to-content link** (WCAG 2.4.1). *Change:* focus-revealed skip link to `#main-content`. Files: `src/App.svelte`.
5. [x] **Stepper field had no accessible name; +/- buttons were generic** (WCAG 4.1.2 / 1.3.1). *Change:* `label` prop -> input `aria-label` + "Decrease {name}"/"Increase {name}"; wired names through Tally, Hearts, Skull King, Golf, and the custom-game editor. Files: `src/lib/components/Stepper.svelte` + editors.
6. [x] **Privacy peek-guard was passive and leaky** (tab-hide only; scores stayed in the a11y tree / keyboard-reachable while veiled). *Change:* manual **Hide scores** button, `inert` on the shell while veiled, focus moved to the reveal button. Files: `src/App.svelte`.
7. [x] **Toggle switches announced as plain checkboxes**, CSS duplicated across two pages. *Change:* shared `Switch` with `role="switch"`; Accessibility + Gameplay settings reuse it. Files: `src/lib/components/Switch.svelte`, `src/pages/Accessibility.svelte`, `src/pages/GameplaySettings.svelte`.
8. [x] **Scoreboard leaned on gold color for the leader; winner emoji used `title` only.** *Change (Color-Is-Never-Alone):* crown + SR-only "Leading" once scores diverge, SR-only "Winner" beside the trophy. Files: `src/lib/components/Scoreboard.svelte`.
9. [ ] **Accessibility accommodations split across two hubs** — keep-awake/privacy live under "Gameplay" though the brief frames them as a11y. Proposed: cross-link into the Accessibility hub. (organizational)
10. [ ] **Muted-text contrast borderline in default themes** for 0.8rem metadata; high-contrast mode masks it. Proposed: contrast sweep of `--muted`. (needs full palette check)
11. [ ] **Table mode / large table-wide standings** from the brief doesn't exist yet. Proposed: per-game opt-in big board. (larger feature)
12. [ ] **Reduced-motion audit for JS-driven animation** to match the solid CSS kill-switch. (follow-up)

### Implemented
Items **1-8**.

### Verify
- `npm run check` -> 0 errors, 0 warnings
- `npm run build` -> succeeds
- `npx vitest run` -> all suites pass; added `src/lib/a11y.test.ts` (titleForRoute + announce)

No new settings, so the PORTABLE/LOCAL settings guard is untouched.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
