### PR TITLE
Onboarding & first-run: welcome hero, PWA install, empty-state guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#7c5cff" />
     <meta name="description" content="Score King - keep score for cards and party games. Hearts, Spades, Cribbage, Skull King and more." />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Score King" />
+    <link rel="apple-touch-icon" href="%BASE_URL%favicon.svg" />
     <title>Score King</title>
   </head>
   <body>

--- a/src/lib/components/InstallPrompt.svelte
+++ b/src/lib/components/InstallPrompt.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { installAvailable, promptInstall, isIOS, isStandalone } from '../stores/install';
+
+  // Decide the affordance once: a real install button where the browser supports it, a manual
+  // "Add to Home Screen" hint on iOS, and nothing at all when already installed.
+  const standalone = isStandalone();
+  const ios = isIOS();
+
+  let busy = $state(false);
+  async function install() {
+    busy = true;
+    try {
+      await promptInstall();
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+{#if !standalone}
+  {#if $installAvailable}
+    <button class="btn primary block" onclick={install} disabled={busy}>
+      <span aria-hidden="true">⬇️</span> Install Score King
+    </button>
+  {:else if ios}
+    <p class="ioshint muted sm">
+      <span aria-hidden="true">📲</span>
+      Install it: tap <strong>Share</strong> then <strong>Add to Home Screen</strong>.
+    </p>
+  {/if}
+{/if}
+
+<style>
+  .ioshint {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    justify-content: center;
+    margin: 0;
+    text-align: center;
+  }
+  .sm {
+    font-size: 0.85rem;
+  }
+</style>

--- a/src/lib/components/PlayerSelect.svelte
+++ b/src/lib/components/PlayerSelect.svelte
@@ -5,6 +5,7 @@
 
   let {
     selected = $bindable([]),
+    min = 0,
     max = 12,
   }: { selected: ID[]; min?: number; max?: number } = $props();
 
@@ -44,7 +45,7 @@
       </button>
     {/each}
     {#if $roster.length === 0}
-      <span class="muted">No players yet — add some below.</span>
+      <span class="muted">{min > 1 ? `No players yet — add at least ${min} below.` : 'No players yet — add some below.'}</span>
     {/if}
   </div>
 

--- a/src/lib/components/WelcomeHero.svelte
+++ b/src/lib/components/WelcomeHero.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import { dismissWelcome } from '../stores/onboarding';
+  import InstallPrompt from './InstallPrompt.svelte';
+</script>
+
+<section class="card hero" aria-labelledby="welcome-heading">
+  <button class="dismiss iconbtn" onclick={dismissWelcome} aria-label="Dismiss welcome" title="Dismiss">✕</button>
+
+  <div class="crown" aria-hidden="true">👑</div>
+  <h1 id="welcome-heading" class="hero-title">Welcome to Score King</h1>
+  <p class="lede">
+    Keep score for cards &amp; party games — pick a game below, add your players, and start
+    tapping in rounds.
+  </p>
+
+  <ul class="assurances" aria-label="What to expect">
+    <li><span aria-hidden="true">🔒</span> Saved on this device</li>
+    <li><span aria-hidden="true">📴</span> Works fully offline</li>
+    <li><span aria-hidden="true">🙌</span> No account needed</li>
+  </ul>
+
+  <div class="hero-actions">
+    <InstallPrompt />
+  </div>
+</section>
+
+<style>
+  .hero {
+    position: relative;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    padding: 24px 18px 20px;
+    margin-top: 4px;
+  }
+  .dismiss {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+  }
+  .crown {
+    font-size: 2.6rem;
+    line-height: 1;
+  }
+  .hero-title {
+    margin: 0;
+  }
+  .lede {
+    margin: 0;
+    color: var(--muted);
+    max-width: 42ch;
+  }
+  .assurances {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+    margin: 6px 0 2px;
+    padding: 0;
+  }
+  .assurances li {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 999px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 0.82rem;
+    font-weight: 600;
+  }
+  .hero-actions {
+    width: 100%;
+    max-width: 320px;
+    margin-top: 6px;
+  }
+</style>

--- a/src/lib/stores/install.ts
+++ b/src/lib/stores/install.ts
@@ -1,0 +1,70 @@
+import { writable } from 'svelte/store';
+
+/**
+ * PWA install: capture the browser's deferred `beforeinstallprompt` so the app can offer
+ * "Install" on its own terms (in the first-run welcome), and detect iOS/standalone so we can
+ * fall back to an "Add to Home Screen" hint where Chrome's prompt doesn't exist.
+ *
+ * Installing is core to the product promise — a local-first PWA that lives on the home screen
+ * and works offline — yet the browser only surfaces it in a menu most people never open. This
+ * keeps a single captured event at module scope so the affordance survives navigation and the
+ * event that fired before any component mounted.
+ */
+
+type InstallOutcome = 'accepted' | 'dismissed' | 'unavailable';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+let deferred: BeforeInstallPromptEvent | null = null;
+
+/** True once the browser has offered a native install prompt we can replay on demand. */
+export const installAvailable = writable(false);
+/** True once the app has been installed this session (hides the affordance). */
+export const installed = writable(false);
+
+/** Attach the global listeners. Called once from boot so no early event is missed. */
+export function initInstallPrompt(): void {
+  if (typeof window === 'undefined') return;
+  window.addEventListener('beforeinstallprompt', (e) => {
+    // Stop Chrome's mini-infobar; we surface install ourselves in the welcome hero.
+    e.preventDefault();
+    deferred = e as BeforeInstallPromptEvent;
+    installAvailable.set(true);
+  });
+  window.addEventListener('appinstalled', () => {
+    deferred = null;
+    installAvailable.set(false);
+    installed.set(true);
+  });
+}
+
+/** Replay the captured install prompt. Returns the user's choice, or 'unavailable'. */
+export async function promptInstall(): Promise<InstallOutcome> {
+  if (!deferred) return 'unavailable';
+  await deferred.prompt();
+  const { outcome } = await deferred.userChoice;
+  deferred = null;
+  installAvailable.set(false);
+  return outcome;
+}
+
+/** iOS Safari never fires `beforeinstallprompt`; detect it so we can show a manual hint. */
+export function isIOS(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || '';
+  const iOSDevice = /iPad|iPhone|iPod/.test(ua);
+  // iPadOS 13+ reports as desktop Safari but exposes touch on a Mac-like UA.
+  const iPadOS = navigator.platform === 'MacIntel' && (navigator.maxTouchPoints ?? 0) > 1;
+  return iOSDevice || iPadOS;
+}
+
+/** True when already running as an installed PWA (so no install affordance is needed). */
+export function isStandalone(): boolean {
+  if (typeof window === 'undefined') return false;
+  const displayMode = window.matchMedia?.('(display-mode: standalone)').matches ?? false;
+  const iosStandalone = (navigator as unknown as { standalone?: boolean }).standalone === true;
+  return displayMode || iosStandalone;
+}

--- a/src/lib/stores/onboarding.test.ts
+++ b/src/lib/stores/onboarding.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+describe('onboarding welcome dismissal', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Re-import fresh each test so the store re-reads localStorage on module load.
+    vi.resetModules();
+  });
+
+  it('defaults to not-dismissed on a clean device', async () => {
+    const { welcomeDismissed } = await import('./onboarding');
+    expect(get(welcomeDismissed)).toBe(false);
+  });
+
+  it('persists dismissal to localStorage and the store', async () => {
+    const { welcomeDismissed, dismissWelcome } = await import('./onboarding');
+    dismissWelcome();
+    expect(get(welcomeDismissed)).toBe(true);
+    expect(localStorage.getItem('sk_welcome_dismissed')).toBe('1');
+  });
+
+  it('reads a previously-dismissed flag on load', async () => {
+    localStorage.setItem('sk_welcome_dismissed', '1');
+    vi.resetModules();
+    const { welcomeDismissed } = await import('./onboarding');
+    expect(get(welcomeDismissed)).toBe(true);
+  });
+});

--- a/src/lib/stores/onboarding.ts
+++ b/src/lib/stores/onboarding.ts
@@ -1,0 +1,30 @@
+import { writable } from 'svelte/store';
+
+/**
+ * First-run welcome: a one-time, device-local flag remembering that the player has seen (and
+ * dismissed) the welcome hero on Home. Device-local by design — it's about *this* browser's
+ * first impression, not a portable preference — so it lives in localStorage rather than the
+ * backed-up settings.
+ */
+
+const KEY = 'sk_welcome_dismissed';
+
+function load(): boolean {
+  try {
+    return localStorage.getItem(KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export const welcomeDismissed = writable<boolean>(load());
+
+/** Permanently dismiss the first-run welcome hero. */
+export function dismissWelcome(): void {
+  welcomeDismissed.set(true);
+  try {
+    localStorage.setItem(KEY, '1');
+  } catch {
+    // Private-mode / storage-blocked: dismissal simply won't persist, which is harmless.
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import App from './App.svelte'
 import { applySettings } from './lib/stores/settings'
 import { initIdentity } from './lib/stores/identity'
 import { startAutoSync } from './lib/storage/autosync'
+import { initInstallPrompt } from './lib/stores/install'
 
 // A Microsoft sign-in uses a full-page redirect. When the browser returns from Microsoft the
 // URL carries the auth response (in the hash or query). Detect that, let MSAL consume it, then
@@ -26,6 +27,7 @@ async function boot() {
     }
   }
   applySettings()
+  initInstallPrompt()
   registerSW({ immediate: true })
   mount(App, { target: document.getElementById('app')! })
   // Apply the lead member's saved look to this device, then keep them in sync.

--- a/src/pages/GameType.svelte
+++ b/src/pages/GameType.svelte
@@ -2,6 +2,7 @@
   import { getModule } from '../lib/games/registry';
   import { defaultConfig } from '../lib/types';
   import { activeGames, createGame, games } from '../lib/stores/games';
+  import { activePlayers } from '../lib/stores/players';
   import {
     customGameDefs,
     removeCustomGame,
@@ -141,6 +142,15 @@
     <button class="btn primary block" onclick={start} disabled={selected.length < module.minPlayers}>
       Start game
     </button>
+    {#if selected.length < module.minPlayers}
+      <p class="startneed muted sm" role="status">
+        {#if $activePlayers.length === 0}
+          Add {module.minPlayers} player{module.minPlayers === 1 ? '' : 's'} above to start your first game.
+        {:else}
+          Pick {module.minPlayers - selected.length} more player{module.minPlayers - selected.length === 1 ? '' : 's'} to start.
+        {/if}
+      </p>
+    {/if}
   </div>
 {/if}
 
@@ -163,5 +173,12 @@
     border-top: 1px solid var(--border);
     width: 100%;
     margin: 4px 0;
+  }
+  .startneed {
+    margin: 0;
+    text-align: center;
+  }
+  .sm {
+    font-size: 0.85rem;
   }
 </style>

--- a/src/pages/History.svelte
+++ b/src/pages/History.svelte
@@ -242,7 +242,12 @@
 <h1>History</h1>
 
 {#if $activeGames.length === 0 && archivedGames.length === 0}
-  <div class="empty">No games yet. Start one from the Games tab.</div>
+  <div class="empty firstrun">
+    <div class="firstrun-emoji" aria-hidden="true">📜</div>
+    <p><strong>No games yet.</strong></p>
+    <p class="muted">Finished and in-progress games land here, grouped by date, crew, and game.</p>
+    <a class="btn primary" href="/" use:link>Start a game</a>
+  </div>
 {:else}
   {#if showControls}
     <div class="controls">
@@ -394,6 +399,25 @@
 {/if}
 
 <style>
+  .firstrun {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+  }
+  .firstrun p {
+    margin: 0;
+    max-width: 46ch;
+  }
+  .firstrun-emoji {
+    font-size: 2.2rem;
+    line-height: 1;
+    margin-bottom: 4px;
+  }
+  .firstrun .btn {
+    margin-top: 10px;
+    text-decoration: none;
+  }
   .controls {
     display: flex;
     flex-direction: column;

--- a/src/pages/Home.svelte
+++ b/src/pages/Home.svelte
@@ -6,6 +6,8 @@
   import { link, navigate } from '../lib/router';
   import { relativeTime, normalizeJoinCode } from '../lib/util';
   import { isLiveSupported, isNearbySupported } from '../lib/live/session';
+  import { welcomeDismissed } from '../lib/stores/onboarding';
+  import WelcomeHero from '../lib/components/WelcomeHero.svelte';
   import {
     startableTypes,
     sectionize,
@@ -29,6 +31,10 @@
   const recent = $derived(
     $games.filter((g) => g.status === 'finished' && !g.archived).slice(0, 4),
   );
+
+  // First-run welcome: shown only until the very first game exists (or it's dismissed), so
+  // returning players never see it. A brand-new device has no games at all.
+  const showWelcome = $derived($games.length === 0 && !$welcomeDismissed);
 
   // ── Catalog: search + mutually-exclusive sections over the startable game types ──
   let search = $state('');
@@ -63,6 +69,10 @@
     return (ids ?? []).map((id) => $players.find((p) => p.id === id)?.name ?? '?').join(' & ');
   }
 </script>
+
+{#if showWelcome}
+  <WelcomeHero />
+{/if}
 
 {#if active.length}
   <div class="section-title">Continue</div>

--- a/src/pages/Players.svelte
+++ b/src/pages/Players.svelte
@@ -61,7 +61,12 @@
 </form>
 
 {#if $activePlayers.length === 0 && archived.length === 0}
-  <div class="empty">No players yet — add your regulars above.</div>
+  <div class="empty firstrun">
+    <div class="firstrun-emoji" aria-hidden="true">👥</div>
+    <p><strong>Add your regulars once.</strong></p>
+    <p class="muted">Players are shared across every game and leaderboard — add them here and
+    they'll be ready to pick whenever you start a game. Tap 🎲 for a surprise name.</p>
+  </div>
 {:else if $activePlayers.length > 0}
   <div class="player-grid">
     {#each $activePlayers as p (p.id)}
@@ -250,5 +255,20 @@
   }
   .card.arch {
     opacity: 0.82;
+  }
+  .firstrun {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+  }
+  .firstrun p {
+    margin: 0;
+    max-width: 46ch;
+  }
+  .firstrun-emoji {
+    font-size: 2.2rem;
+    line-height: 1;
+    margin-bottom: 4px;
   }
 </style>


### PR DESCRIPTION
﻿## Focus: Onboarding & first-run experience

An audit of what a brand-new user sees the first time they open Score King, and improvements to make that first 30 seconds obvious, reassuring, and installable — while respecting every DESIGN.md non-negotiable.

### Critique items identified (12)
1. **No first-run welcome / orientation on Home** — a new user gets a bare game grid with no framing. ✅ implemented
2. **No in-app PWA install affordance** — `beforeinstallprompt` was never captured; iOS got no hint. ✅ implemented
3. **`index.html` missing iOS PWA meta tags** (`apple-mobile-web-app-*`, `apple-touch-icon`) — degraded "Add to Home Screen". ✅ implemented
4. **First game blocked with weak signposting** — the disabled "Start game" button never said *why*. ✅ implemented
5. **Players first-run empty state was bare** — didn't explain the shared cross-game roster. ✅ implemented
6. **History empty state was text-only** — no path back to starting a game. ✅ implemented
7. **Local-first trust message absent on first run** (offline / on-device / no account). ✅ implemented (in the hero)
8. **`PlayerSelect` `min` prop declared but unused** — dead code and lost guidance. ✅ implemented
9. **No "pick a game to begin" microcopy** on the empty catalog. ✅ implemented (in the hero)
10. Stats first-run states are already good — noted, no change.
11. Join/Nearby discoverability is acceptable — noted, no change.
12. **Welcome must never nag** — dismissal has to persist. ✅ implemented (device-local flag + tests)

### What I implemented
- **`WelcomeHero`** on Home, shown only until the first game exists (or it is dismissed): crown motif, one-line orientation, and three reassurance chips (on device / offline / no account). Co-signals with icon + text, never colour alone.
- **PWA install** — a global `install` store captures `beforeinstallprompt`, offers a single **Install Score King** primary action, and falls back to an **iOS Add-to-Home-Screen** hint. Added iOS meta tags + `apple-touch-icon`.
- **Needs-more-players hint** under the game-type "Start game" button, so the first game is never a silent dead end.
- **Richer empty states** for Players (shared-roster copy) and History (a **Start a game** CTA).
- **Wired `PlayerSelect.min`** into its empty hint.
- **Unit tests** for the onboarding dismissal store.

### Design compliance
- Exactly one Royal Violet primary per screen; Crown Gold untouched (leader/winner only).
- Depth via the surface ramp + pill chips; no new shadows; glass only where it already was.
- >=46px touch targets; state co-signalled by icon + text; honors reduced motion (no new animations).
- Chrome unchanged game-to-game.

### Verification
- `npm run check` -> **0 errors, 0 warnings**
- `npm test` -> **829 passing** (826 + 3 new)
- `npm run build` -> **success** (PWA service worker generated; only pre-existing chunk-size/dynamic-import warnings)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
