### PR TITLE
a11y: focus rings, modal focus trap, table semantics & form labels (WCAG 2.2 AA)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -186,7 +186,7 @@
 </div>
 
 {#if $toast}
-  <div class="toast" role="status" aria-live="polite">
+  <div class="toast" role="status" aria-live="polite" aria-atomic="true">
     <span>{$toast.message}</span>
     {#if $toast.action}
       <button class="toast-action" onclick={$toast.action.run}>{$toast.action.label}</button>

--- a/src/app.css
+++ b/src/app.css
@@ -75,6 +75,31 @@ html[data-contrast] .btn:focus-visible {
   outline-offset: 2px;
 }
 
+/* Honor the OS "increase contrast" preference the same way the manual toggle
+   does, so users who set it system-wide get stronger borders, muted text and
+   focus rings without hunting for the in-app switch. */
+@media (prefers-contrast: more) {
+  html[data-theme="dark"] {
+    --text: #ffffff;
+    --muted: #c8cbef;
+    --border: #5a5d8a;
+  }
+  html[data-theme="light"] {
+    --text: #000000;
+    --muted: #3a3c54;
+    --border: #9a9ab0;
+  }
+  input:focus,
+  select:focus,
+  .btn:focus-visible,
+  a:focus-visible,
+  .iconbtn:focus-visible,
+  .gametile:focus-visible,
+  .tabbar a:focus-visible {
+    outline-width: 3px;
+  }
+}
+
 * { box-sizing: border-box; }
 
 html, body { margin: 0; padding: 0; }
@@ -139,6 +164,17 @@ input[type="search"]::-webkit-search-cancel-button {
 input:focus, select:focus, .btn:focus-visible {
   outline: 2px solid var(--primary);
   outline-offset: 1px;
+}
+/* One focus vocabulary everywhere: links, icon buttons, game tiles and the
+   bottom tab bar share the same Royal Violet ring so every interactive element
+   is visibly focusable for keyboard and switch users (WCAG 2.4.7). */
+a:focus-visible,
+.iconbtn:focus-visible,
+.gametile:focus-visible,
+.tabbar a:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
 }
 label,
 .fieldlabel { display: block; font-size: 0.9rem; color: var(--muted); margin-bottom: 6px; }

--- a/src/lib/a11y/focusTrap.test.ts
+++ b/src/lib/a11y/focusTrap.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { nextTrapTarget } from './focusTrap';
+
+// Lightweight stand-ins — nextTrapTarget only uses reference identity and order.
+function els(n: number): HTMLElement[] {
+  return Array.from({ length: n }, () => ({ focus() {} }) as unknown as HTMLElement);
+}
+
+describe('nextTrapTarget', () => {
+  it('returns null when there is nothing focusable', () => {
+    expect(nextTrapTarget([], null, false)).toBeNull();
+  });
+
+  it('wraps from the last element back to the first on Tab', () => {
+    const f = els(3);
+    expect(nextTrapTarget(f, f[2], false)).toBe(f[0]);
+  });
+
+  it('wraps from the first element to the last on Shift+Tab', () => {
+    const f = els(3);
+    expect(nextTrapTarget(f, f[0], true)).toBe(f[2]);
+  });
+
+  it('lets the browser handle a normal move in the middle', () => {
+    const f = els(3);
+    expect(nextTrapTarget(f, f[1], false)).toBeNull();
+    expect(nextTrapTarget(f, f[1], true)).toBeNull();
+  });
+
+  it('pulls focus back inside when it has escaped the trap', () => {
+    const f = els(3);
+    const stray = { focus() {} } as unknown as HTMLElement;
+    expect(nextTrapTarget(f, stray, false)).toBe(f[0]);
+    expect(nextTrapTarget(f, stray, true)).toBe(f[2]);
+    expect(nextTrapTarget(f, null, false)).toBe(f[0]);
+  });
+
+  it('cycles a single focusable back onto itself', () => {
+    const f = els(1);
+    expect(nextTrapTarget(f, f[0], false)).toBe(f[0]);
+    expect(nextTrapTarget(f, f[0], true)).toBe(f[0]);
+  });
+});

--- a/src/lib/a11y/focusTrap.ts
+++ b/src/lib/a11y/focusTrap.ts
@@ -1,0 +1,79 @@
+/**
+ * A focus trap for modal dialogs (`role="dialog" aria-modal="true"`). Keyboard
+ * and screen-reader users must not be able to Tab out of an open modal into the
+ * page behind it (WCAG 2.4.3 Focus Order / 2.1.2 No Keyboard Trap — the escape
+ * here is the Escape key, wired up by the dialog itself). The action keeps Tab /
+ * Shift+Tab cycling inside the node and restores focus to whatever opened the
+ * dialog when it closes.
+ */
+
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+/** Visible, tabbable descendants of `container`, in DOM order. */
+export function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+    (el) => !el.hasAttribute('inert') && (el.offsetParent !== null || el === document.activeElement),
+  );
+}
+
+/**
+ * Given the tabbable elements, the currently focused element, and whether Shift
+ * is held, return the element that should receive focus when a Tab press would
+ * otherwise leave the trap — or `null` to let the browser handle a normal move.
+ * Pure (no DOM), so the wrap-around logic is unit-testable in isolation.
+ */
+export function nextTrapTarget(
+  focusables: HTMLElement[],
+  active: HTMLElement | null,
+  shift: boolean,
+): HTMLElement | null {
+  if (focusables.length === 0) return null;
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  const idx = active ? focusables.indexOf(active) : -1;
+  // Focus somewhere outside the trap (e.g. the dialog container itself): pull it
+  // back to the near edge in the direction of travel.
+  if (idx === -1) return shift ? last : first;
+  if (shift && active === first) return last;
+  if (!shift && active === last) return first;
+  return null;
+}
+
+/** Svelte action: trap Tab focus within `node` and restore focus on teardown. */
+export function focusTrap(node: HTMLElement) {
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Tab') return;
+    const focusables = getFocusable(node);
+    const target = nextTrapTarget(
+      focusables,
+      document.activeElement as HTMLElement | null,
+      e.shiftKey,
+    );
+    if (target) {
+      e.preventDefault();
+      target.focus();
+    }
+  }
+
+  node.addEventListener('keydown', onKeydown);
+
+  return {
+    destroy() {
+      node.removeEventListener('keydown', onKeydown);
+      // Return focus to whatever opened the dialog so keyboard users aren't
+      // dumped at the top of the document.
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus();
+      }
+    },
+  };
+}

--- a/src/lib/components/Avatar.svelte
+++ b/src/lib/components/Avatar.svelte
@@ -5,7 +5,8 @@
     name,
     color,
     size = 28,
-  }: { name: string; color: string; size?: number } = $props();
+    decorative = false,
+  }: { name: string; color: string; size?: number; decorative?: boolean } = $props();
 
   const resolved = $derived(resolvePlayerColor(color, $settings.colorBlind));
   const ink = $derived(textOn(resolved));
@@ -14,7 +15,8 @@
 <span
   class="avatar"
   style="--c:{resolved}; --ink:{ink}; width:{size}px; height:{size}px; font-size:{Math.round(size * 0.38)}px"
-  title={name}
+  title={decorative ? undefined : name}
+  aria-hidden={decorative ? 'true' : undefined}
 >
   {initials(name)}
 </span>

--- a/src/lib/components/PlaySheet.svelte
+++ b/src/lib/components/PlaySheet.svelte
@@ -12,6 +12,7 @@
   import Avatar from './Avatar.svelte';
   import SignalShare from './SignalShare.svelte';
   import QrScanner from './QrScanner.svelte';
+  import { focusTrap } from '../a11y/focusTrap';
 
   let {
     mode,
@@ -151,7 +152,7 @@
   onkeydown={(e) => e.key === 'Enter' && onclose()}
 ></div>
 
-<div class="sheet" role="dialog" aria-modal="true" aria-label="Play together" tabindex="-1" bind:this={sheet}>
+<div class="sheet" role="dialog" aria-modal="true" aria-label="Play together" tabindex="-1" bind:this={sheet} use:focusTrap>
   <div class="grabber" aria-hidden="true"></div>
 
   <div class="row spread">

--- a/src/lib/components/PlayerSelect.svelte
+++ b/src/lib/components/PlayerSelect.svelte
@@ -37,11 +37,12 @@
         type="button"
         class="chip"
         class:on={selected.includes(p.id)}
+        aria-pressed={selected.includes(p.id)}
         onclick={() => toggle(p.id)}
       >
-        <Avatar name={p.name} color={p.color} size={22} />
+        <Avatar name={p.name} color={p.color} size={22} decorative />
         {p.name}
-        {#if selected.includes(p.id)}<span class="ord">{selected.indexOf(p.id) + 1}</span>{/if}
+        {#if selected.includes(p.id)}<span class="ord" aria-hidden="true">{selected.indexOf(p.id) + 1}</span>{/if}
       </button>
     {/each}
     {#if $roster.length === 0}
@@ -50,7 +51,7 @@
   </div>
 
   <form class="row" onsubmit={(e) => { e.preventDefault(); add(); }}>
-    <input class="grow" type="text" placeholder="Add a player…" bind:value={newName} />
+    <input class="grow" type="text" placeholder="Add a player…" aria-label="Add a player by name" bind:value={newName} />
     <button class="btn" type="button" onclick={addRandom} aria-label="Add a random player" title="Surprise me">🎲</button>
     <button class="btn" type="submit">Add</button>
   </form>

--- a/src/lib/components/Scoreboard.svelte
+++ b/src/lib/components/Scoreboard.svelte
@@ -26,8 +26,13 @@
 </script>
 
 <table>
+  <caption class="sr-only">Standings by rank</caption>
   <thead>
-    <tr><th>#</th><th>Player</th><th>Score</th></tr>
+    <tr>
+      <th scope="col"><span class="sr-only">Rank</span><span aria-hidden="true">#</span></th>
+      <th scope="col">Player</th>
+      <th scope="col">Score</th>
+    </tr>
   </thead>
   <tbody>
     {#each ranked as s (s.playerId)}
@@ -36,7 +41,7 @@
         <td>{s.rank}</td>
         <td>
           <span class="row" style="gap: 8px">
-            {#if p}<Avatar name={p.name} color={p.color} size={24} />{p.name}{/if}
+            {#if p}<Avatar name={p.name} color={p.color} size={24} decorative />{p.name}{/if}
             {#if youId && s.playerId === youId}<span class="you">You</span>{/if}
             {#if winners.includes(s.playerId)}
               <span aria-hidden="true" title="Winner">🏆</span><span class="sr-only">Winner</span>

--- a/src/lib/components/ShareResultsSheet.svelte
+++ b/src/lib/components/ShareResultsSheet.svelte
@@ -17,6 +17,7 @@
     type RecapView,
   } from '../share/recap';
   import Scoreboard from './Scoreboard.svelte';
+  import { focusTrap } from '../a11y/focusTrap';
 
   let { payload, onclose }: { payload: RecapPayload; onclose: () => void } = $props();
 
@@ -155,7 +156,7 @@
   onkeydown={(e) => e.key === 'Enter' && onclose()}
 ></div>
 
-<div class="sheet" role="dialog" aria-modal="true" aria-label="Share results" tabindex="-1" bind:this={sheet}>
+<div class="sheet" role="dialog" aria-modal="true" aria-label="Share results" tabindex="-1" bind:this={sheet} use:focusTrap>
   <div class="grabber" aria-hidden="true"></div>
 
   <div class="row spread">

--- a/src/lib/components/Stepper.svelte
+++ b/src/lib/components/Stepper.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { clamp } from '../util';
+
   let {
     value = $bindable(0),
     min = -Infinity,
@@ -15,10 +17,16 @@
   const incLabel = $derived(label ? `Increase ${label}` : 'Increase');
 
   function dec() {
-    value = Math.max(min, (Number(value) || 0) - step);
+    value = clamp((Number(value) || 0) - step, min, max);
   }
   function inc() {
-    value = Math.min(max, (Number(value) || 0) + step);
+    value = clamp((Number(value) || 0) + step, min, max);
+  }
+  // Keyboard users can type straight into the field; clamp on change so a typed
+  // value can't slip past the bounds the − / + buttons enforce.
+  function clampTyped() {
+    if (value == null || Number.isNaN(Number(value))) return;
+    value = clamp(Number(value), min, max);
   }
 </script>
 
@@ -26,7 +34,16 @@
   <button type="button" class="iconbtn" onclick={dec} disabled={value <= min} aria-label={decLabel}>
     −
   </button>
-  <input type="number" bind:value {min} {max} {step} inputmode="numeric" aria-label={fieldLabel} />
+  <input
+    type="number"
+    bind:value
+    {min}
+    {max}
+    {step}
+    inputmode="numeric"
+    aria-label={fieldLabel}
+    onchange={clampTyped}
+  />
   <button type="button" class="iconbtn" onclick={inc} disabled={value >= max} aria-label={incLabel}>
     +
   </button>

--- a/src/lib/stores/toast.ts
+++ b/src/lib/stores/toast.ts
@@ -20,12 +20,14 @@ export function showToast(message: string, ms = 2200): void {
   timer = setTimeout(() => toast.set(null), ms);
 }
 
-/** A toast with a single action (e.g. Undo). Stays longer so it's tappable. */
+/** A toast with a single action (e.g. Undo). Stays longer so keyboard and
+ * screen-reader users have time to Tab to and trigger the action before it
+ * auto-dismisses. */
 export function showActionToast(
   message: string,
   label: string,
   run: () => void,
-  ms = 6000,
+  ms = 9000,
 ): void {
   toast.set({
     message,

--- a/src/lib/util.test.ts
+++ b/src/lib/util.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { clamp } from './util';
+
+// The Stepper's − / + buttons and its typed-value guard both route through
+// `clamp`, so a keyboard user can never push a score past its bounds.
+describe('clamp', () => {
+  it('returns the value unchanged when within range', () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+  });
+
+  it('pins to the minimum when below range', () => {
+    expect(clamp(-3, 0, 10)).toBe(0);
+  });
+
+  it('pins to the maximum when above range', () => {
+    expect(clamp(42, 0, 10)).toBe(10);
+  });
+
+  it('honors the exact bounds', () => {
+    expect(clamp(0, 0, 10)).toBe(0);
+    expect(clamp(10, 0, 10)).toBe(10);
+  });
+
+  it('supports negative ranges', () => {
+    expect(clamp(-50, -13, 13)).toBe(-13);
+    expect(clamp(50, -13, 13)).toBe(13);
+  });
+});

--- a/src/pages/Players.svelte
+++ b/src/pages/Players.svelte
@@ -55,7 +55,7 @@
 <h1>Players</h1>
 
 <form class="row" onsubmit={(e) => { e.preventDefault(); add(); }} style="margin-bottom: 14px">
-  <input class="grow" type="text" placeholder="New player name…" bind:value={newName} />
+  <input class="grow" type="text" placeholder="New player name…" aria-label="New player name" bind:value={newName} />
   <button class="iconbtn" type="button" onclick={generatePlayer} aria-label="Generate a player" title="Surprise me with a name">🎲</button>
   <button class="btn primary" type="submit">Add</button>
 </form>


### PR DESCRIPTION
## Accessibility (WCAG 2.2 AA) pass

Score King is already strongly accessibility-aware (announcer live region, skip link, route focus management, reduced-motion engine, colour-blind palette, contrast/OLED toggles, `role="switch"`, `radiogroup` segmented control). This PR closes the remaining concrete gaps found while auditing the scoreboard, steppers, dialogs, toasts and forms.

### Critique items identified
1. **Icon buttons have no visible focus ring** — settings button, stepper − / +, Players lead/edit buttons rely on the UA default. *(2.4.7)*
2. **Bottom tab bar links have no focus ring** — the desktop sidebar had one, the mobile tab bar didn't. *(2.4.7)*
3. **Game tiles (the primary Home action) have no focus ring.** *(2.4.7)*
4. **Text links use only the UA focus outline** — inconsistent with the "one focus vocabulary" rule.
5. **Scoreboard table lacks semantics** — no caption, no `th scope`, and a bare "#" header a screen reader can't interpret. *(1.3.1)*
6. **Player-select toggle chips have no `aria-pressed`** — selected state was conveyed to AT by colour/badge only. *(4.1.2)*
7. **"Add player" inputs use a placeholder as their only label.** *(3.3.2 / 4.1.2)*
8. **Avatar initials double-announce** next to a visible player name ("A D Ada Lovelace").
9. **Modal sheets don't trap focus** — Tab could leave "Play together" / "Share results" into the page behind them, and focus wasn't restored on close. *(2.4.3)*
10. **OS `prefers-contrast: more` is ignored** — only the manual toggle strengthened contrast.
11. **Toast Undo is easy to miss** — live region wasn't atomic and the action window was short for keyboard/AT users.
12. **Stepper doesn't clamp typed values** — the − / + buttons clamp to min/max but direct keyboard entry didn't.

### Implemented (all 12)
- **Focus rings (1–4):** one Royal Violet `:focus-visible` ring for `.iconbtn`, `.gametile`, `.tabbar a` and text links.
- **OS contrast (10):** `@media (prefers-contrast: more)` mirrors the manual High-contrast toggle (text, borders, 3px focus rings).
- **Focus trap (9):** reusable `focusTrap` action wired into both modal sheets; Tab/Shift+Tab cycle inside and focus returns to the opener on close. Pure `nextTrapTarget` helper is unit-tested.
- **Scoreboard semantics (5):** screen-reader `<caption>`, `th scope="col"`, and a real "Rank" label.
- **Toggle state (6, 8):** `aria-pressed` on player chips; paired avatars marked decorative (`aria-hidden`) so state isn't colour-only and initials aren't read twice.
- **Form labels (7):** accessible names on the placeholder-only "add player" inputs (PlayerSelect + Players).
- **Stepper clamp (12):** typed values clamp to `min`/`max` on change, via the shared `clamp` helper.
- **Toast (11):** `aria-atomic="true"` live region; Undo action toast window lengthened.

### Tests
- New `src/lib/a11y/focusTrap.test.ts` (wrap-around focus logic) and `src/lib/util.test.ts` (clamp).
- `npm run check` → 0 errors / 0 warnings.
- `npm test` → **840 passed** (+11 new).
- `npm run build` → success.

Respects the DESIGN.md non-negotiables: no new violet fills, no Crown Gold on controls, ≥46px targets untouched, reduced-motion behaviour preserved, chrome identical per game.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>