### PR TITLE
Home catalog: quick-favorite tiles, finished-order fix, category search & a11y

### DIFF
--- a/src/lib/components/CreateTile.svelte
+++ b/src/lib/components/CreateTile.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { link } from '../router';
+  import { CREATE_ROUTE } from '../stores/catalog';
+
+  /**
+   * The single "＋ Create a game" catalog affordance — a dashed tile with a violet ＋ (never a
+   * solid fill, so it stays the one quiet add-accent, not a second primary action). Shared by
+   * Home and Browse so the entry point reads identically everywhere.
+   */
+</script>
+
+<a class="gametile createtile" href={CREATE_ROUTE} use:link>
+  <span class="emoji" aria-hidden="true">＋</span>
+  <span class="name">Create a game</span>
+  <span class="tag">Build your own scorer</span>
+</a>
+
+<style>
+  .createtile {
+    border-style: dashed;
+  }
+  .createtile .emoji {
+    color: var(--primary);
+    font-weight: 700;
+  }
+</style>

--- a/src/lib/components/GameTile.svelte
+++ b/src/lib/components/GameTile.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { link } from '../router';
+  import { toggleFavorite, type CatalogType } from '../stores/catalog';
+
+  /**
+   * The single game-catalog tile shared by every catalog surface (Home + Browse), so a tile
+   * reads identically everywhere (DESIGN.md: "consistency is the feature"). It optionally shows
+   * a quiet quick-favorite star, so a group can pin the games they actually play without
+   * detouring to Manage games.
+   *
+   * The star is a *sibling* of the link (never a `<button>` nested inside an `<a>`, which is
+   * invalid) and sits above it, so tapping it pins/unpins without navigating. State is carried
+   * by ★/☆ + `aria-pressed` + a visually-hidden label — never colour alone — and the star is
+   * never Crown Gold (reserved for the leader/winner) nor a second Royal Violet fill.
+   */
+  let {
+    type,
+    favorite = false,
+    showFavorite = true,
+  }: {
+    type: CatalogType;
+    favorite?: boolean;
+    showFavorite?: boolean;
+  } = $props();
+</script>
+
+<div class="tile-wrap">
+  <a class="gametile" class:with-star={showFavorite} href={`/${type.id}`} use:link>
+    <span class="emoji">{type.emoji}</span>
+    <span class="name">{type.name}</span>
+    <span class="tag">{type.tagline}</span>
+  </a>
+  {#if showFavorite}
+    <button
+      class="tile-star"
+      class:on={favorite}
+      type="button"
+      aria-pressed={favorite}
+      title={favorite ? `Unfavorite ${type.name}` : `Favorite ${type.name}`}
+      onclick={() => toggleFavorite(type.id)}
+    >
+      <span aria-hidden="true">{favorite ? '★' : '☆'}</span>
+      <span class="sr-only">{favorite ? `Unfavorite ${type.name}` : `Favorite ${type.name}`}</span>
+    </button>
+  {/if}
+</div>
+
+<style>
+  .tile-wrap {
+    position: relative;
+    display: flex;
+  }
+  /* Fill the grid cell so tiles in a wrapped row keep equal height. */
+  .gametile {
+    flex: 1 1 auto;
+  }
+  /* Keep the name/tagline clear of the corner star. */
+  .gametile.with-star {
+    padding-right: 46px;
+  }
+  /* A neutral star: outline ☆ vs filled ★ + aria-pressed carry the state — never gold
+     (reserved for the leader/winner) and never a second violet fill. Idle stays quiet so a
+     grid of tiles doesn't turn noisy; it lifts to full strength on hover/focus/favorite. */
+  .tile-star {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 46px;
+    height: 46px;
+    border: none;
+    background: transparent;
+    color: var(--muted);
+    font-size: 1.25rem;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0.45;
+    border-radius: var(--radius-sm);
+    transition:
+      opacity 0.15s ease,
+      color 0.15s ease,
+      background 0.15s ease;
+  }
+  .tile-star:hover {
+    opacity: 1;
+    background: var(--surface-2);
+    color: var(--text);
+  }
+  .tile-star.on {
+    opacity: 1;
+    color: var(--text);
+  }
+  .tile-star:focus-visible {
+    opacity: 1;
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .tile-star {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/stores/catalog.test.ts
+++ b/src/lib/stores/catalog.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import type { Game } from '../types';
+import { settings } from './settings';
+import {
+  foldSearch,
+  matchModule,
+  recentlyFinished,
+  sectionize,
+  recentTypeIds,
+  toggleFavorite,
+  setHidden,
+  isFavorite,
+  isHidden,
+  type CatalogType,
+} from './catalog';
+
+/** Minimal Game factory — only the fields the catalog helpers read. */
+function game(partial: Partial<Game> & Pick<Game, 'id' | 'type'>): Game {
+  return {
+    config: {},
+    playerIds: [],
+    status: 'finished',
+    createdAt: 0,
+    roundCount: 0,
+    ...partial,
+  } as Game;
+}
+
+const HEARTS: CatalogType = { id: 'hearts', name: 'Hearts', emoji: '♥️', tagline: 'Avoid the points' };
+const SKULL: CatalogType = { id: 'skullking', name: 'Skull King', emoji: '🏴‍☠️', tagline: 'Bid your tricks' };
+const CODENAMES: CatalogType = { id: 'codenames', name: 'Codenames', emoji: '🕵️', tagline: 'Word clues' };
+
+describe('foldSearch', () => {
+  it('lower-cases and strips diacritics', () => {
+    expect(foldSearch('  ÚNO ')).toBe('uno');
+    expect(foldSearch('Crème')).toBe('creme');
+  });
+});
+
+describe('matchModule', () => {
+  it('matches name, tagline, and keyword aliases case-insensitively', () => {
+    expect(matchModule(HEARTS, 'heart')).toBe(true);
+    expect(matchModule(HEARTS, 'AVOID')).toBe(true);
+    expect(matchModule({ ...HEARTS, keywords: ['black lady'] }, 'lady')).toBe(true);
+    expect(matchModule(HEARTS, 'poker')).toBe(false);
+  });
+
+  it('matches by category label so searching a kind surfaces the whole family', () => {
+    // hearts + skullking are "Card Games"; codenames is "Party & Social".
+    expect(matchModule(HEARTS, 'card')).toBe(true);
+    expect(matchModule(SKULL, 'cards')).toBe(true);
+    expect(matchModule(CODENAMES, 'party')).toBe(true);
+    expect(matchModule(CODENAMES, 'card')).toBe(false);
+  });
+
+  it('is diacritic-insensitive both ways', () => {
+    expect(matchModule({ ...HEARTS, name: 'Piñata' }, 'pinata')).toBe(true);
+  });
+
+  it('empty query matches everything', () => {
+    expect(matchModule(HEARTS, '   ')).toBe(true);
+  });
+});
+
+describe('recentlyFinished', () => {
+  it('orders by finishedAt (newest first), not store order', () => {
+    const games = [
+      game({ id: 'a', type: 'hearts', createdAt: 100, finishedAt: 200 }),
+      game({ id: 'b', type: 'skullking', createdAt: 10, finishedAt: 900 }),
+      game({ id: 'c', type: 'codenames', createdAt: 50, finishedAt: 500 }),
+    ];
+    expect(recentlyFinished(games).map((g) => g.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('excludes unfinished and archived games', () => {
+    const games = [
+      game({ id: 'a', type: 'hearts', status: 'active', finishedAt: undefined }),
+      game({ id: 'b', type: 'hearts', status: 'abandoned', finishedAt: 800 }),
+      game({ id: 'c', type: 'hearts', finishedAt: 700, archived: true }),
+      game({ id: 'd', type: 'hearts', finishedAt: 600 }),
+    ];
+    expect(recentlyFinished(games).map((g) => g.id)).toEqual(['d']);
+  });
+
+  it('honours the limit', () => {
+    const games = Array.from({ length: 6 }, (_, i) =>
+      game({ id: `g${i}`, type: 'hearts', finishedAt: i }),
+    );
+    expect(recentlyFinished(games, 2)).toHaveLength(2);
+  });
+
+  it('falls back to createdAt when finishedAt is missing', () => {
+    const games = [
+      game({ id: 'a', type: 'hearts', createdAt: 300, finishedAt: undefined }),
+      game({ id: 'b', type: 'hearts', createdAt: 100, finishedAt: 200 }),
+    ];
+    // 'a' has no finishedAt → uses createdAt 300, which beats b's 200.
+    expect(recentlyFinished(games).map((g) => g.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('recentTypeIds', () => {
+  it('lists distinct types most-recently-played first', () => {
+    const games = [
+      game({ id: 'a', type: 'hearts', finishedAt: 100 }),
+      game({ id: 'b', type: 'skullking', finishedAt: 300 }),
+      game({ id: 'c', type: 'hearts', finishedAt: 500 }),
+    ];
+    expect(recentTypeIds(games)).toEqual(['hearts', 'skullking']);
+  });
+});
+
+describe('sectionize', () => {
+  const types = [HEARTS, SKULL, CODENAMES];
+
+  it('splits favorites / recent / remainder with no repeats', () => {
+    const games = [game({ id: 'a', type: 'codenames', finishedAt: 100 })];
+    const s = sectionize(types, games, ['skullking'], []);
+    expect(s.favorites.map((t) => t.id)).toEqual(['skullking']);
+    expect(s.recent.map((t) => t.id)).toEqual(['codenames']);
+    expect(s.remainder.map((t) => t.id)).toEqual(['hearts']);
+  });
+
+  it('excludes hidden types from every section', () => {
+    const s = sectionize(types, [], [], ['codenames']);
+    const all = [...s.favorites, ...s.recent, ...s.remainder].map((t) => t.id);
+    expect(all).not.toContain('codenames');
+  });
+
+  it('a favorited + recently-played type stays only in favorites', () => {
+    const games = [game({ id: 'a', type: 'hearts', finishedAt: 100 })];
+    const s = sectionize(types, games, ['hearts'], []);
+    expect(s.favorites.map((t) => t.id)).toEqual(['hearts']);
+    expect(s.recent.map((t) => t.id)).not.toContain('hearts');
+  });
+});
+
+describe('favorite + hidden metadata', () => {
+  beforeEach(() => {
+    settings.update((s) => ({ ...s, catalogFavorites: [], catalogHidden: [] }));
+  });
+
+  it('toggleFavorite pins then unpins', () => {
+    toggleFavorite('hearts');
+    expect(isFavorite('hearts')).toBe(true);
+    expect(get(settings).catalogFavorites).toEqual(['hearts']);
+    toggleFavorite('hearts');
+    expect(isFavorite('hearts')).toBe(false);
+  });
+
+  it('setHidden hides then shows', () => {
+    setHidden('hearts', true);
+    expect(isHidden('hearts')).toBe(true);
+    setHidden('hearts', false);
+    expect(isHidden('hearts')).toBe(false);
+  });
+});

--- a/src/lib/stores/catalog.ts
+++ b/src/lib/stores/catalog.ts
@@ -189,12 +189,45 @@ export function sectionize(
   return { favorites, recent, remainder };
 }
 
-/** Case-insensitive match over name + tagline + optional keyword aliases. */
+/**
+ * Fold a string for searching: lower-cased and diacritic-stripped (NFD → drop combining
+ * marks), so a plain typing of "Uno" still matches an accented "Úno" tagline and vice-versa.
+ */
+export function foldSearch(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim();
+}
+
+/**
+ * Case- and diacritic-insensitive match over name + tagline + optional keyword aliases, plus
+ * the type's category label so a group can search by *kind* ("cards", "party", "sports") and
+ * surface every game in that family — not just ones whose name happens to contain the word.
+ */
 export function matchModule(t: CatalogType, query: string): boolean {
-  const q = query.trim().toLowerCase();
+  const q = foldSearch(query);
   if (!q) return true;
-  const hay = [t.name, t.tagline, ...(t.keywords ?? [])].join(' ').toLowerCase();
+  const cat = categoryOf(t.id);
+  const catLabel = CATEGORY_ORDER.find((c) => c.id === cat)?.label ?? '';
+  // Both the category id ("cards") and its label ("Card Games") go in the haystack so either
+  // the short kind word or the display name surfaces the whole family.
+  const hay = foldSearch([t.name, t.tagline, cat, catLabel, ...(t.keywords ?? [])].join(' '));
   return hay.includes(q);
+}
+
+/**
+ * The most-recently-*finished* games, newest first — the source for Home's "Recent results".
+ * Ordered by `finishedAt` (falling back to `createdAt`) rather than the store's create order,
+ * so a long-running game that only wrapped up today ranks above a quicker one that was started
+ * later but is still open. Archived games are excluded.
+ */
+export function recentlyFinished(games: Game[], limit = RECENT_LIMIT): Game[] {
+  return games
+    .filter((g) => g.status === 'finished' && !g.archived)
+    .sort((a, b) => (b.finishedAt ?? b.createdAt) - (a.finishedAt ?? a.createdAt))
+    .slice(0, limit);
 }
 
 // ── Categories: group the catalog by game "type" for the browse page ──────────────

--- a/src/lib/stores/customGames.ts
+++ b/src/lib/stores/customGames.ts
@@ -67,5 +67,7 @@ export async function restoreCustomGame(id: string): Promise<void> {
 }
 
 // Populate on startup so getModule resolves custom types for deep links (e.g. /def_… or
-// /play/<id> of a custom game) as soon as IndexedDB answers.
-void refreshCustomGames();
+// /play/<id> of a custom game) as soon as IndexedDB answers. Best-effort: if storage is
+// unavailable (private-mode quirks, SSR, or a test environment without IndexedDB), the app
+// still boots with just the built-in games rather than crashing on an unhandled rejection.
+void refreshCustomGames().catch(() => {});

--- a/src/pages/Browse.svelte
+++ b/src/pages/Browse.svelte
@@ -2,13 +2,13 @@
   import { settings } from '../lib/stores/settings';
   import { link } from '../lib/router';
   import BackLink from '../lib/components/BackLink.svelte';
+  import GameTile from '../lib/components/GameTile.svelte';
+  import CreateTile from '../lib/components/CreateTile.svelte';
   import {
     startableTypes,
     groupByCategory,
     matchModule,
     CUSTOM_GAMES_ENABLED,
-    CREATE_ROUTE,
-    type CatalogType,
     type GameCategory,
   } from '../lib/stores/catalog';
 
@@ -17,6 +17,7 @@
   let activeCats = $state<GameCategory[]>([]);
 
   const mods = $derived($startableTypes);
+  const favs = $derived($settings.catalogFavorites);
   const searching = $derived(search.trim().length > 0);
 
   // Ordered, non-empty category sections over the visible (non-hidden) catalog.
@@ -45,28 +46,19 @@
       : [...activeCats, id];
   }
 
+  function isFav(id: string): boolean {
+    return favs.includes(id);
+  }
+  function clearSearch(e: KeyboardEvent) {
+    if (e.key === 'Escape') search = '';
+  }
+
   // Drop any selected category that no longer exists (e.g. every game in it got hidden).
   $effect(() => {
     const valid = new Set(groups.map((g) => g.meta.id));
     if (activeCats.some((c) => !valid.has(c))) activeCats = activeCats.filter((c) => valid.has(c));
   });
 </script>
-
-{#snippet tile(m: CatalogType)}
-  <a class="gametile" href={`/${m.id}`} use:link>
-    <span class="emoji">{m.emoji}</span>
-    <span class="name">{m.name}</span>
-    <span class="tag">{m.tagline}</span>
-  </a>
-{/snippet}
-
-{#snippet createTile()}
-  <a class="gametile createtile" href={CREATE_ROUTE} use:link>
-    <span class="emoji" aria-hidden="true">＋</span>
-    <span class="name">Create a game</span>
-    <span class="tag">Build your own scorer</span>
-  </a>
-{/snippet}
 
 <BackLink href="/" label="Games" />
 
@@ -85,7 +77,13 @@
     autocorrect="off"
     spellcheck="false"
     bind:value={search}
+    onkeydown={clearSearch}
   />
+</div>
+
+<div class="sr-only" aria-live="polite" role="status">
+  {#if searching}{searchResults.length}
+    {searchResults.length === 1 ? 'game' : 'games'} match “{search.trim()}”{/if}
 </div>
 
 {#if !searching}
@@ -117,8 +115,12 @@
 
 {#if searching}
   {#if searchResults.length}
+    <p class="result-count muted">
+      {searchResults.length}
+      {searchResults.length === 1 ? 'game' : 'games'} match “{search.trim()}”
+    </p>
     <div class="grid">
-      {#each searchResults as m (m.id)}{@render tile(m)}{/each}
+      {#each searchResults as m (m.id)}<GameTile type={m} favorite={isFav(m.id)} />{/each}
     </div>
   {:else}
     <div class="empty">No games match “{search.trim()}”.</div>
@@ -130,12 +132,12 @@
       <span class="cat-count">{g.types.length}</span>
     </div>
     <div class="grid">
-      {#each g.types as m (m.id)}{@render tile(m)}{/each}
+      {#each g.types as m (m.id)}<GameTile type={m} favorite={isFav(m.id)} />{/each}
     </div>
   {/each}
   {#if showCreate}
     <div class="create-wrap">
-      <div class="grid">{@render createTile()}</div>
+      <div class="grid"><CreateTile /></div>
     </div>
   {/if}
 {/if}
@@ -230,13 +232,10 @@
   .create-wrap {
     margin-top: 18px;
   }
-  /* The single "add" accent: a dashed tile with a violet ＋ — never a solid fill. */
-  .createtile {
-    border-style: dashed;
-  }
-  .createtile .emoji {
-    color: var(--primary);
-    font-weight: 700;
+  .result-count {
+    margin: 2px 4px 12px;
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
   }
   @media (prefers-reduced-motion: reduce) {
     .chip {

--- a/src/pages/Home.svelte
+++ b/src/pages/Home.svelte
@@ -8,14 +8,15 @@
   import { isLiveSupported, isNearbySupported } from '../lib/live/session';
   import { welcomeDismissed } from '../lib/stores/onboarding';
   import WelcomeHero from '../lib/components/WelcomeHero.svelte';
+  import GameTile from '../lib/components/GameTile.svelte';
+  import CreateTile from '../lib/components/CreateTile.svelte';
   import {
     startableTypes,
     sectionize,
     matchModule,
+    recentlyFinished,
     SEARCH_THRESHOLD,
     CUSTOM_GAMES_ENABLED,
-    CREATE_ROUTE,
-    type CatalogType,
   } from '../lib/stores/catalog';
 
   const liveSupported = isLiveSupported();
@@ -28,9 +29,9 @@
   }
 
   const active = $derived($games.filter((g) => g.status === 'active' && !g.archived));
-  const recent = $derived(
-    $games.filter((g) => g.status === 'finished' && !g.archived).slice(0, 4),
-  );
+  // Ordered by when each game actually finished (not the store's create order), so the four
+  // shown are truly the most-recently-wrapped-up games.
+  const recent = $derived(recentlyFinished($games));
 
   // First-run welcome: shown only until the very first game exists (or it's dismissed), so
   // returning players never see it. A brand-new device has no games at all.
@@ -39,6 +40,7 @@
   // ── Catalog: search + mutually-exclusive sections over the startable game types ──
   let search = $state('');
   const mods = $derived($startableTypes);
+  const favs = $derived($settings.catalogFavorites);
   const showSearch = $derived(mods.length >= SEARCH_THRESHOLD);
   const searching = $derived(search.trim().length > 0);
   const sections = $derived(
@@ -62,6 +64,13 @@
   const remainderPreview = $derived(sections.remainder.slice(0, REMAINDER_PREVIEW));
   const moreCount = $derived(sections.remainder.length - remainderPreview.length);
 
+  function isFav(id: string): boolean {
+    return favs.includes(id);
+  }
+  function clearSearch(e: KeyboardEvent) {
+    if (e.key === 'Escape') search = '';
+  }
+
   function names(ids: string[]): string {
     return ids.map((id) => $players.find((p) => p.id === id)?.name ?? '?').join(', ');
   }
@@ -80,11 +89,11 @@
     {#each active as g (g.id)}
       {@const m = getModule(g.type)}
       <a class="card row spread tile" href={`/play/${g.id}`} use:link>
-        <span class="row" style="gap: 12px">
+        <span class="row who" style="gap: 12px">
           <span class="big-emoji">{m?.emoji ?? '🎲'}</span>
-          <span>
+          <span class="who-col">
             <div><strong>{m?.name ?? g.type}</strong></div>
-            <div class="muted sm">{names(g.playerIds)}</div>
+            <div class="muted sm players">{names(g.playerIds)}</div>
           </span>
         </span>
         <span class="pill">Round {g.roundCount + 1}</span>
@@ -92,14 +101,6 @@
     {/each}
   </div>
 {/if}
-
-{#snippet tile(m: CatalogType)}
-  <a class="gametile" href={`/${m.id}`} use:link>
-    <span class="emoji">{m.emoji}</span>
-    <span class="name">{m.name}</span>
-    <span class="tag">{m.tagline}</span>
-  </a>
-{/snippet}
 
 {#snippet head(label: string, withManage: boolean)}
   <div class="section-title cathead">
@@ -112,24 +113,33 @@
 
 {#if showSearch}
   <div class="catalog-bar">
-    <input
-      class="catalog-search"
-      type="text"
-      placeholder="Search games…"
-      aria-label="Search games"
-      autocapitalize="off"
-      autocorrect="off"
-      spellcheck="false"
-      bind:value={search}
-    />
+    <span class="catalog-search-wrap">
+      <span class="search-ico" aria-hidden="true">🔍</span>
+      <input
+        class="catalog-search"
+        type="search"
+        placeholder="Search games…"
+        aria-label="Search games"
+        autocapitalize="off"
+        autocorrect="off"
+        spellcheck="false"
+        bind:value={search}
+        onkeydown={clearSearch}
+      />
+    </span>
     <a class="manage-link inbar" href="/manage-games" use:link>Manage</a>
   </div>
 {/if}
 
+<div class="sr-only" aria-live="polite" role="status">
+  {#if searching}{searchResults.length}
+    {searchResults.length === 1 ? 'game' : 'games'} match “{search.trim()}”{/if}
+</div>
+
 {#if searching}
   {#if searchResults.length}
     <div class="grid">
-      {#each searchResults as m (m.id)}{@render tile(m)}{/each}
+      {#each searchResults as m (m.id)}<GameTile type={m} favorite={isFav(m.id)} />{/each}
     </div>
   {:else}
     <div class="empty">No games match “{search.trim()}”.</div>
@@ -138,32 +148,28 @@
   {#if sections.favorites.length}
     {@render head('Favorites', !showSearch && firstSection === 'fav')}
     <div class="grid">
-      {#each sections.favorites as m (m.id)}{@render tile(m)}{/each}
+      {#each sections.favorites as m (m.id)}<GameTile type={m} favorite={true} />{/each}
     </div>
   {/if}
   {#if sections.recent.length}
     {@render head('Recently played', !showSearch && firstSection === 'recent')}
     <div class="grid">
-      {#each sections.recent as m (m.id)}{@render tile(m)}{/each}
+      {#each sections.recent as m (m.id)}<GameTile type={m} favorite={isFav(m.id)} />{/each}
     </div>
   {/if}
   {#if showRemainder}
     <div class="section-title cathead">
       <span>{remainderTitle}</span>
       {#if moreCount > 0}
-        <a class="manage-link" href="/browse" use:link>See all →</a>
+        <a class="manage-link" href="/browse" use:link>See all {sections.remainder.length} →</a>
       {:else if !showSearch && firstSection === 'rem'}
         <a class="manage-link" href="/manage-games" use:link>Manage</a>
       {/if}
     </div>
     <div class="grid">
-      {#each remainderPreview as m (m.id)}{@render tile(m)}{/each}
+      {#each remainderPreview as m (m.id)}<GameTile type={m} favorite={isFav(m.id)} />{/each}
       {#if CUSTOM_GAMES_ENABLED}
-        <a class="gametile createtile" href={CREATE_ROUTE} use:link>
-          <span class="emoji" aria-hidden="true">＋</span>
-          <span class="name">Create a game</span>
-          <span class="tag">Build your own scorer</span>
-        </a>
+        <CreateTile />
       {/if}
     </div>
   {/if}
@@ -235,8 +241,23 @@
     gap: 10px;
     margin: 18px 4px 4px;
   }
+  .catalog-search-wrap {
+    position: relative;
+    flex: 1;
+    display: flex;
+  }
+  .catalog-search-wrap .search-ico {
+    position: absolute;
+    left: 13px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    opacity: 0.7;
+    font-size: 0.95rem;
+  }
   .catalog-search {
     flex: 1;
+    padding-left: 40px;
   }
   .cathead {
     display: flex;
@@ -257,13 +278,15 @@
   .manage-link.inbar {
     padding: 8px;
   }
-  /* The single "add" accent on Home: a dashed tile with a violet ＋ — never a solid fill. */
-  .createtile {
-    border-style: dashed;
+  /* Keep a long player roster from shoving the "Round N" pill off the Continue card. */
+  .who,
+  .who-col {
+    min-width: 0;
   }
-  .createtile .emoji {
-    color: var(--primary);
-    font-weight: 700;
+  .players {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .sm {
     font-size: 0.85rem;

--- a/src/pages/ManageGames.svelte
+++ b/src/pages/ManageGames.svelte
@@ -6,6 +6,7 @@
     startableTypes,
     toggleFavorite,
     setHidden,
+    hideWithUndo,
     matchModule,
     isCustomType,
     editCustomHref,
@@ -83,7 +84,7 @@
               <span aria-hidden="true">{fav ? '★' : '☆'}</span>
               <span class="sr-only">{fav ? `Unfavorite ${m.name}` : `Favorite ${m.name}`}</span>
             </button>
-            <button class="btn small ghost" type="button" onclick={() => setHidden(m.id, true)}>
+            <button class="btn small ghost" type="button" onclick={() => hideWithUndo(m.id, m.name)}>
               Hide
             </button>
           </span>


### PR DESCRIPTION
## Critique 3 — Home catalog & game discovery

An audit of the Home page catalog and game discovery, plus a cohesive implementation
pass. All changes respect the DESIGN.md non-negotiables (one Royal Violet action per
screen, Crown Gold reserved for leader/winner, surface ramp for depth, tabular-nums,
≥46px targets, never color-alone, `prefers-reduced-motion`, identical chrome per game).

### Critique items (11)

| # | Item | Why it matters | Fix | Shipped |
|---|------|----------------|-----|:---:|
| 1 | **Recent results ordered by creation, not finish time** (BUG) | Home read finished games in the store's create-desc order, so a game created long ago but finished today could be missing or misordered. | New `recentlyFinished()` helper sorts by `finishedAt` (falls back to `createdAt`). | ✅ |
| 2 | **No quick-favorite on catalog tiles** (FEATURE) | Pinning a game required a detour to Manage games. | Inline neutral star on every tile (Home + Browse) — one tap to pin/unpin. | ✅ |
| 3 | **Favorited games showed no indicator in the catalog** (UX) | You couldn't tell which tiles were pinned. | Star renders filled ★ (+ `aria-pressed`) when favorited. | ✅ |
| 4 | **Tile markup duplicated across Home & Browse** (MAINTAINABILITY) | Two copies of the tile drift apart; quick-favorite would need adding twice. | Extracted shared `GameTile` + `CreateTile` components. | ✅ |
| 5 | **Search couldn't match categories** (FEATURE) | Typing "cards"/"party" found nothing. | `matchModule` folds the category id + label into the haystack; also diacritic-insensitive (`foldSearch`). | ✅ |
| 6 | **Search result count not announced** (A11y) | Result grid updated silently for screen-reader users. | `aria-live="polite"` status with the match count on Home and Browse. | ✅ |
| 7 | **No clear-search affordance** (UX) | Home search was `type=text` (no native clear) with no Escape-to-clear, and lacked Browse's search icon. | `type=search` + Escape-to-clear + a search icon on Home. | ✅ |
| 8 | **Hide had no Undo; `hideWithUndo` defined but unused** (INCONSISTENCY) | Breaks the app's standard recoverable-destructive (Undo toast) pattern. | Wired Manage games' Hide button to `hideWithUndo`. | ✅ |
| 9 | **"All games" preview hid the remainder count** (UX) | "See all →" gave no sense of how many more games exist. | Now "See all N →". | ✅ |
| 10 | **Continue-card roster could overflow** (BUG) | A long player list shoved the "Round N" pill off the card. | `min-width:0` + ellipsis truncation on the roster. | ✅ |
| 11 | **Browse search had no result count** (UX) | A filtered result set had no context. | Adds a tabular-nums result-count line above Browse results. | ✅ |

Plus a robustness fix surfaced while testing: the custom-games **startup refresh is now
best-effort** (`.catch`) so the app boots with built-ins instead of throwing an unhandled
rejection when IndexedDB is unavailable (private-mode quirks / SSR / test env).

### Additional notes (outside this theme, not changed)
- The main bundle is a single >500 KB chunk (build warns). Code-splitting per game module
  would help first-load on the catalog; left as a follow-up to keep this PR cohesive.

### Design compliance
- Quick-favorite star is **neutral** (muted → text), never Crown Gold and never a second
  Royal Violet fill; state co-signalled by ★/☆ + `aria-pressed` + a visually-hidden label.
- Category chips keep the standard active-pill (surface-2 + ink) treatment.
- All new interactive targets are ≥46px; the star transition honours `prefers-reduced-motion`.

### Tests
- `npm run check` → 0 errors, 0 warnings
- `npm test` → **855 passed** (37 files; +15 new `catalog.test.ts` cases)
- `npm run build` → succeeds

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
