### PR TITLE
In-round gameplay & scoreboard UX: Crown Gold scarcity, live validation, running totals, gap-to-leader

### DIFF
--- a/src/lib/components/Scoreboard.svelte
+++ b/src/lib/components/Scoreboard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { ID, Player } from '../types';
-  import { standings } from '../scoring';
+  import { standings, leaders } from '../scoring';
   import Avatar from './Avatar.svelte';
 
   let {
@@ -19,10 +19,23 @@
 
   const byId = $derived(new Map(players.map((p) => [p.id, p])));
   const ranked = $derived(standings(totals, lowerIsBetter));
-  // A leader only exists once scores diverge — at 0-0 nobody is "leading yet",
-  // so the crown stays hidden until someone pulls ahead (mirrors the gold `.lead`
-  // number meaning without shouting a crown over every tied-at-zero player).
-  const hasLeader = $derived(ranked.length > 1 && ranked.some((r) => r.total !== ranked[0].total));
+  // A leader only exists once scores diverge — at an all-tie (including 0-0)
+  // nobody is "leading yet", so the crown and the gold `.lead` number stay
+  // hidden. `leaders()` is the shared source of truth for that scarcity.
+  const leaderSet = $derived(leaders(totals, players.map((p) => p.id), lowerIsBetter));
+  const winnerSet = $derived(new Set(winners));
+  // Gold (`.lead`) marks the reigning leader now, or the winner once the game is
+  // over — never a row that's merely tied-at-zero with everyone else.
+  const isGold = (id: ID) => leaderSet.has(id) || winnerSet.has(id);
+  // How far a trailing player sits behind the best score, as a positive number,
+  // so "5 back" reads the same whether high or low totals win.
+  const best = $derived(
+    ranked.length ? ranked[0].total : 0,
+  );
+  const singleLeader = $derived(leaderSet.size === 1);
+  function gap(total: number): number {
+    return Math.abs(total - best);
+  }
 </script>
 
 <table>
@@ -37,20 +50,28 @@
   <tbody>
     {#each ranked as s (s.playerId)}
       {@const p = byId.get(s.playerId)}
-      <tr class:winner={winners.includes(s.playerId)}>
+      {@const behind = gap(s.total)}
+      <tr class:winner={winnerSet.has(s.playerId)}>
         <td>{s.rank}</td>
         <td>
           <span class="row" style="gap: 8px">
             {#if p}<Avatar name={p.name} color={p.color} size={24} decorative />{p.name}{/if}
             {#if youId && s.playerId === youId}<span class="you">You</span>{/if}
-            {#if winners.includes(s.playerId)}
+            {#if winnerSet.has(s.playerId)}
               <span aria-hidden="true" title="Winner">🏆</span><span class="sr-only">Winner</span>
-            {:else if s.rank === 1 && hasLeader}
+            {:else if leaderSet.has(s.playerId)}
               <span aria-hidden="true" title="Leading">👑</span><span class="sr-only">Leading</span>
             {/if}
           </span>
         </td>
-        <td class="num" class:lead={s.rank === 1}>{s.total}</td>
+        <td class="num" class:lead={isGold(s.playerId)}>
+          <span class="total">{s.total}</span>
+          {#if leaderSet.size && !leaderSet.has(s.playerId) && !winnerSet.has(s.playerId)}
+            <span class="gap">{behind} back</span>
+          {:else if singleLeader && leaderSet.has(s.playerId) && winnerSet.size === 0 && ranked.length > 1}
+            <span class="gap">leads by {gap(ranked[1].total)}</span>
+          {/if}
+        </td>
       </tr>
     {/each}
   </tbody>
@@ -60,6 +81,22 @@
   .num {
     font-variant-numeric: tabular-nums;
     font-weight: 700;
+    text-align: right;
+    white-space: nowrap;
+  }
+  .num .total {
+    display: block;
+  }
+  /* The distance to the leader, co-signalled by the word "back"/"leads" so it
+     never depends on position or colour alone. Quiet by default — the score is
+     the headline; the gap is the footnote. */
+  .gap {
+    display: block;
+    font-size: 0.72rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--muted);
+    margin-top: 1px;
   }
   .you {
     flex: none;

--- a/src/lib/games/hearts/HeartsEditor.svelte
+++ b/src/lib/games/hearts/HeartsEditor.svelte
@@ -77,12 +77,4 @@
   .toggle.on .sub {
     color: rgba(255, 255, 255, 0.8);
   }
-  .toggle.jack.on {
-    background: var(--accent);
-    border-color: #b88600;
-    color: #1c1d2e;
-  }
-  .toggle.jack.on .sub {
-    color: rgba(0, 0, 0, 0.6);
-  }
 </style>

--- a/src/lib/scoring.test.ts
+++ b/src/lib/scoring.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { computeTotals, standings, leaders } from './scoring';
+import type { Round } from './types';
+
+const round = (index: number, deltas: Record<string, number>): Round =>
+  ({ id: `r${index}`, gameId: 'g', index, input: {}, deltas }) as unknown as Round;
+
+describe('computeTotals', () => {
+  it('sums deltas per player and defaults absent players to 0', () => {
+    const rounds = [round(0, { a: 3, b: 1 }), round(1, { a: 2, b: 4 })];
+    expect(computeTotals(rounds, ['a', 'b', 'c'])).toEqual({ a: 5, b: 5, c: 0 });
+  });
+});
+
+describe('standings', () => {
+  it('ranks higher-is-better and shares a rank on ties', () => {
+    const s = standings({ a: 5, b: 5, c: 2 });
+    expect(s.map((x) => [x.playerId, x.rank])).toEqual([
+      ['a', 1],
+      ['b', 1],
+      ['c', 3],
+    ]);
+  });
+});
+
+describe('leaders', () => {
+  it('is empty at the opening all-tie (0-0)', () => {
+    expect(leaders({ a: 0, b: 0 }, ['a', 'b']).size).toBe(0);
+  });
+
+  it('is empty on any mid-game all-tie', () => {
+    expect(leaders({ a: 7, b: 7, c: 7 }, ['a', 'b', 'c']).size).toBe(0);
+  });
+
+  it('is empty for a solo game (no rival to lead)', () => {
+    expect(leaders({ a: 9 }, ['a']).size).toBe(0);
+  });
+
+  it('marks the single highest scorer when higher is better', () => {
+    expect([...leaders({ a: 5, b: 3 }, ['a', 'b'])]).toEqual(['a']);
+  });
+
+  it('marks the single lowest scorer when lower is better', () => {
+    expect([...leaders({ a: 5, b: 3 }, ['a', 'b'], true)]).toEqual(['b']);
+  });
+
+  it('marks every player tied for the top (but not everyone)', () => {
+    const l = leaders({ a: 5, b: 5, c: 2 }, ['a', 'b', 'c']);
+    expect(l.has('a')).toBe(true);
+    expect(l.has('b')).toBe(true);
+    expect(l.has('c')).toBe(false);
+  });
+
+  it('treats missing totals as 0', () => {
+    expect([...leaders({ a: 4 }, ['a', 'b'])]).toEqual(['a']);
+  });
+});

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -17,6 +17,30 @@ export interface Standing {
   rank: number;
 }
 
+/**
+ * The player ID(s) strictly ahead of everyone else — the current leader(s).
+ *
+ * Returns an empty set until scores actually diverge: while every player shares
+ * the same total (including the opening 0-0, or any mid-game all-tie) there is
+ * no leader yet, so the 👑 and the gold `.lead` number stay hidden. A solo game
+ * has no rival to lead, so it also returns empty. This is the single source of
+ * truth for "who gets Crown Gold right now" so the scarcity rule can't drift
+ * between the scoreboard and the scorecard footer.
+ */
+export function leaders(
+  totals: Record<ID, number>,
+  playerIds: ID[],
+  lowerIsBetter = false,
+): Set<ID> {
+  const ids = new Set<ID>();
+  if (playerIds.length < 2) return ids;
+  const vals = playerIds.map((id) => totals[id] ?? 0);
+  const best = lowerIsBetter ? Math.min(...vals) : Math.max(...vals);
+  if (vals.every((v) => v === best)) return ids; // nobody has pulled ahead
+  for (const id of playerIds) if ((totals[id] ?? 0) === best) ids.add(id);
+  return ids;
+}
+
 export function standings(
   totals: Record<ID, number>,
   lowerIsBetter = false,

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -18,7 +18,7 @@
   } from '../lib/stores/games';
   import { getModule } from '../lib/games/registry';
   import { customGameDefs } from '../lib/stores/customGames';
-  import { computeTotals } from '../lib/scoring';
+  import { computeTotals, leaders } from '../lib/scoring';
   import { navigate, link, absoluteUrl } from '../lib/router';
   import { showToast, showActionToast } from '../lib/stores/toast';
   import { announce } from '../lib/stores/announcer';
@@ -62,6 +62,9 @@
   let editing = $state<Round | null>(null);
   let editDraft = $state<any>(null);
   let justSavedId = $state<string | null>(null);
+  // Scorecard cells can show each round's delta (default) or the running total
+  // through that round, so you can see how the lead was built and when it changed.
+  let showRunning = $state(false);
 
   const module = $derived.by(() => {
     void $customGameDefs;
@@ -76,18 +79,47 @@
   );
   const totals = $derived(game ? computeTotals(rounds, game.playerIds) : {});
   const lower = $derived(game && module ? resolveLower(module, game.config) : false);
-  const leaderIds = $derived.by(() => {
-    const ids = new Set<string>();
-    if (!game || rounds.length === 0 || orderedPlayers.length === 0) return ids;
-    const vals = orderedPlayers.map((p) => totals[p.id] ?? 0);
-    const best = lower ? Math.min(...vals) : Math.max(...vals);
-    for (const p of orderedPlayers) if ((totals[p.id] ?? 0) === best) ids.add(p.id);
-    return ids;
-  });
+  // Shared "who's actually ahead" rule: empty until scores diverge, so the gold
+  // footer total and the leader announcement never crown a tied-at-zero table.
+  const leaderIds = $derived(game ? leaders(totals, game.playerIds, lower) : new Set<string>());
   const maxR = $derived(
     game && module && module.maxRounds ? module.maxRounds(game.config, game.playerIds.length) : null,
   );
   const canAddRound = $derived(maxR == null || rounds.length < maxR);
+  // Validate the in-progress entry live so an invalid round is caught inline —
+  // Save is disabled with the reason shown — instead of only surfacing as a
+  // transient toast after a tap that's easy to miss one-handed in dim light.
+  const draftError = $derived.by(() => {
+    if (!game || !module || !draft) return null;
+    try {
+      return module.validateRound($state.snapshot(draft), buildCtx(rounds.length, totals));
+    } catch {
+      return null;
+    }
+  });
+  const editError = $derived.by(() => {
+    if (!game || !module || !editing || editDraft == null) return null;
+    try {
+      return module.validateRound(
+        $state.snapshot(editDraft),
+        buildCtx(editing.index, totalsBefore(editing.index)),
+      );
+    } catch {
+      return null;
+    }
+  });
+  // Cumulative total for each player through each round, keyed by round id, for
+  // the "Running totals" scorecard view.
+  const runningTotals = $derived.by(() => {
+    const acc: Record<string, number> = {};
+    for (const pid of game?.playerIds ?? []) acc[pid] = 0;
+    const map: Record<string, Record<string, number>> = {};
+    for (const r of rounds) {
+      for (const [pid, d] of Object.entries(r.deltas)) acc[pid] = (acc[pid] ?? 0) + d;
+      map[r.id] = { ...acc };
+    }
+    return map;
+  });
   const finishedReady = $derived.by(() => {
     if (!game || !module) return false;
     if (maxR != null && rounds.length >= maxR) return true;
@@ -513,9 +545,12 @@
     <div class="card stack" style="margin-top: 12px">
       <strong>Editing round {editing.index + 1}</strong>
       <EditorC bind:input={editDraft} ctx={ectx} />
+      {#if editError}
+        <p class="entry-error" role="alert">⚠️ {editError}</p>
+      {/if}
       <div class="row" style="gap: 10px">
         <button class="btn grow" onclick={cancelEdit}>Cancel</button>
-        <button class="btn primary grow" onclick={saveEdit}>Save changes</button>
+        <button class="btn primary grow" onclick={saveEdit} disabled={!!editError}>Save changes</button>
       </div>
       <button class="btn danger block" onclick={() => editing && del(editing)}>
         Delete round {editing.index + 1}
@@ -530,7 +565,10 @@
         {#if draft}
           <AddEditor bind:input={draft} ctx={actx} />
         {/if}
-        <button class="btn primary block" onclick={saveRound}>Save round</button>
+        {#if draftError}
+          <p class="entry-error" role="alert">⚠️ {draftError}</p>
+        {/if}
+        <button class="btn primary block" onclick={saveRound} disabled={!!draftError}>Save round</button>
       </div>
     {:else}
       <div class="card center" style="margin-top: 12px">All {maxR} rounds played.</div>
@@ -542,7 +580,9 @@
         <button class="btn {canAddRound ? '' : 'primary'}" onclick={doFinish}>Finish &amp; record winner</button>
       </div>
     {:else}
-      <button class="btn ghost block" style="margin-top: 12px" onclick={doFinish}>Finish game now</button>
+      {#if rounds.length}
+        <button class="btn ghost block" style="margin-top: 12px" onclick={doFinish}>Finish game now</button>
+      {/if}
     {/if}
     <button
       class="btn ghost block"
@@ -553,7 +593,16 @@
   {/if}
 
   {#if rounds.length}
-    <div class="section-title">Scorecard</div>
+    <div class="row spread scorecard-head">
+      <div class="section-title" style="margin: 0">Scorecard</div>
+      <button
+        type="button"
+        class="btn small ghost"
+        onclick={() => (showRunning = !showRunning)}
+        aria-pressed={showRunning}
+        title="Toggle between each round's points and the running total"
+      >{showRunning ? '∑ Running totals' : '± Per round'}</button>
+    </div>
     <div class="scroll">
       <table class="matrix">
         <thead>
@@ -570,7 +619,7 @@
             <tr class:flash={r.id === justSavedId}>
               <td>{r.index + 1}</td>
               {#each orderedPlayers as p (p.id)}
-                <td class="num">{fmt(r.deltas[p.id])}</td>
+                <td class="num">{showRunning ? (runningTotals[r.id]?.[p.id] ?? 0) : fmt(r.deltas[p.id])}</td>
               {/each}
               <td class="acts">
                 {#if game.status === 'active'}
@@ -589,7 +638,7 @@
           <tr>
             <th scope="row">Total</th>
             {#each orderedPlayers as p (p.id)}
-              <td class="num" class:lead={leaderIds.has(p.id)}>{totals[p.id] ?? 0}</td>
+              <td class="num" class:lead={leaderIds.has(p.id) || (game.winnerIds ?? []).includes(p.id)}>{totals[p.id] ?? 0}</td>
             {/each}
             <td></td>
           </tr>
@@ -661,6 +710,24 @@
     .livedot.reconnecting {
       animation-duration: 3s;
     }
+  }
+  .scorecard-head {
+    align-items: center;
+    margin-top: 18px;
+    margin-bottom: 8px;
+  }
+  /* Inline round-entry error: an assertive alert co-signalled with ⚠️ and words
+     (never colour alone) so an invalid round is clear before Save is even tapped.
+     Save is disabled while this shows, so the reason is always on screen. */
+  .entry-error {
+    margin: 0;
+    padding: 9px 12px;
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--bad) 12%, var(--surface-2));
+    border: 1px solid color-mix(in srgb, var(--bad) 45%, var(--border));
+    color: var(--text);
+    font-size: 0.9rem;
+    font-weight: 600;
   }
   .banner {
     margin-top: 12px;


### PR DESCRIPTION
## Focus: in-round gameplay & scoreboard UX

Audited the active-game loop (`GamePlay.svelte`, `Scoreboard.svelte`, `Stepper.svelte`, and the per-game round editors). Below are 12 concrete critique items; the first 6 are **implemented** in this PR, the rest are documented for follow-up.

### Implemented

1. **Crown Gold shown when nobody is leading (0-0 / any all-tie).** *Why:* DESIGN reserves Crown Gold for a real leader/winner — its whole power is scarcity. The scoreboard applied `.lead` gold to rank-1 whenever `rank === 1` (so every player at 0-0 got a gold score), and the scorecard footer's `leaderIds` included *everyone* on an all-tie, so at kickoff the whole table glowed gold with no crown. The leader announcement also read "X and Y tie for the lead with 0" at 0-0. *Fix:* new shared `leaders()` helper in `scoring.ts` (empty until scores diverge, empty for a solo game) is now the single source of truth for the scoreboard crown + gold number, the scorecard footer total, and the SR leader summary. Unit-tested (`scoring.test.ts`).
2. **Crown Gold used as a decorative button fill.** *Why:* the Hearts diamond-Jack toggle filled with `var(--accent)` (Crown Gold) when selected — a direct violation of "gold is never a button/decoration." *Fix:* removed the gold override; the toggle uses the standard selected state, and its meaning is still carried by its `(-10)` label.
3. **Scorecard only shows per-round deltas — no running totals.** *Why:* you can't see *how* the lead was built or *when* it changed; you only see each round's points. *Fix:* added a low-emphasis **Per round / Running totals** toggle (`aria-pressed`, not a violet fill so the single primary stays "Save round") that switches the matrix cells to cumulative totals.
4. **Invalid rounds only surface as a transient toast after tapping Save.** *Why:* a 2.2s toast is easy to miss one-handed in a dim room, and the button gives no hint it won't work. *Fix:* the entry is validated live; **Save is disabled with the reason shown inline** as an assertive `role="alert"` (warning icon + text, never colour-alone), for both the add-round and edit-round cards.
5. **Scoreboard gives no sense of the gap.** *Why:* "who's winning" is visible but "by how much / how far behind am I" isn't — a core in-game question. *Fix:* added a quiet **"N back"** on trailing rows and **"leads by N"** on a sole leader, co-signalled with words (colour-blind safe) and rendered `tabular-nums`.
6. **"Finish game now" is offered for a game with zero rounds.** *Why:* finishing an unplayed game records a meaningless all-zero result. *Fix:* the mid-game "Finish game now" action is hidden until at least one round exists (Abandon still available).

### Documented (not in this PR)

7. **Deleting a round requires entering edit mode first** (tap edit -> scroll -> "Delete round"). A direct, reachable delete affordance on the row (with the existing Undo toast) would be faster.
8. **No Enter-to-save from the stepper.** Wrapping the entry card in a `<form>` with a submit button would let keyboard/one-handed users save without reaching for a separate button — but needs an audit of every editor's buttons for missing `type="button"` first, so deferred.
9. **Validation toast is `aria-live="polite"`.** For a *blocking* error, assertive is more appropriate. (Item 4 mitigates this with an inline `role="alert"`, but the toast path remains for host/guest live saves.)
10. **Scorecard column headers are avatar-only.** The score matrix uses `<th>` with just an `<Avatar>` and no visible/associated player name text, which is thin for a data table read by assistive tech.
11. **`Finish` vs `Abandon` are two stacked full-width ghost buttons** with similar weight; grouping/relabelling would reduce the "which one ends without a winner?" ambiguity.
12. **Scoreboard doesn't show per-round movement.** After a round lands, a brief "+5 / -2" delta beside each player (paired with the existing green row pulse) would make momentum glanceable, not just the new standing.

### DESIGN compliance
- Crown Gold now strictly leader/winner only (items 1-2); one Royal Violet primary per screen preserved (the running-totals toggle and inline error are neutral/semantic, not violet).
- New numbers render `tabular-nums`; touch targets >=46px; state co-signalled with icon/word/number, never colour alone; no new motion (respects existing `prefers-reduced-motion`).

### Tests
- `npm run check` -> 0 errors / 0 warnings
- `npm test` -> **864 passed** (9 new in `scoring.test.ts`)
- `npm run build` -> success (pre-existing chunk-size note only)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
