### PR TITLE
Custom game creator: restore stranded archives, safe duplicate, reorder columns, a11y fixes

### DIFF
--- a/src/lib/games/custom/scoring.test.ts
+++ b/src/lib/games/custom/scoring.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   blankDef,
   duplicateDef,
+  moveColumn,
   validateDef,
   defWarnings,
   firstEmoji,
@@ -18,6 +19,7 @@ import {
   COUNTER_COLUMN_KEY,
   MAX_NAME_LEN,
   MAX_COLUMN_LABEL_LEN,
+  MAX_HELP_LEN,
   type CustomGameDef,
 } from './types';
 
@@ -149,6 +151,13 @@ describe('validateDef', () => {
     expect(validateDef(counterDef({ name: 'x'.repeat(MAX_NAME_LEN + 1) }))).toMatch(/under/i);
   });
 
+  it('caps the how-to-play length', () => {
+    expect(validateDef(counterDef({ name: 'Rummy', help: 'y'.repeat(MAX_HELP_LEN + 1) }))).toMatch(
+      /how-to-play under/i,
+    );
+    expect(validateDef(counterDef({ name: 'Rummy', help: 'y'.repeat(MAX_HELP_LEN) }))).toBeNull();
+  });
+
   it('rejects min < 1 and max < min', () => {
     expect(validateDef(counterDef({ minPlayers: 0 }))).toMatch(/Minimum/i);
     expect(validateDef(counterDef({ minPlayers: 4, maxPlayers: 2 }))).toMatch(/Max players/i);
@@ -225,5 +234,36 @@ describe('duplicateDef', () => {
     expect(dup.columns).not.toBe(src.columns);
     dup.columns[0].label = 'Changed';
     expect(src.columns[0].label).toBe('Gain');
+  });
+
+  it('truncates the copy name so a duplicate of a max-length name stays savable', () => {
+    const src = counterDef({ name: 'x'.repeat(MAX_NAME_LEN) });
+    const dup = duplicateDef(src);
+    expect(dup.name.length).toBeLessThanOrEqual(MAX_NAME_LEN);
+    // A truncated-but-valid name must not itself trip the length validation.
+    expect(validateDef(dup)).toBeNull();
+  });
+});
+
+describe('moveColumn', () => {
+  const cols = () => [
+    { ...newColumn('A'), key: 'a' },
+    { ...newColumn('B'), key: 'b' },
+    { ...newColumn('C'), key: 'c' },
+  ];
+
+  it('moves a column up and down, returning a new array', () => {
+    const src = cols();
+    const up = moveColumn(src, 2, -1);
+    expect(up.map((c) => c.key)).toEqual(['a', 'c', 'b']);
+    expect(up).not.toBe(src);
+    expect(moveColumn(src, 0, 1).map((c) => c.key)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('is a no-op at the bounds or for out-of-range indices', () => {
+    const src = cols();
+    expect(moveColumn(src, 0, -1)).toBe(src);
+    expect(moveColumn(src, 2, 1)).toBe(src);
+    expect(moveColumn(src, 5, -1)).toBe(src);
   });
 });

--- a/src/lib/games/custom/types.ts
+++ b/src/lib/games/custom/types.ts
@@ -30,6 +30,8 @@ export const COUNTER_COLUMN_KEY = 'v';
 export const MAX_NAME_LEN = 24;
 export const MAX_TAGLINE_LEN = 48;
 export const MAX_COLUMN_LABEL_LEN = 16;
+/** How-to-play rules text cap — keeps the in-game help popover glanceable, not a wall of text. */
+export const MAX_HELP_LEN = 500;
 
 /** A curated palette of game-night emojis offered as one-tap picks in the builder. */
 export const EMOJI_CHOICES = [
@@ -123,6 +125,21 @@ export function newColumn(label = ''): CustomColumn {
   return { key: 'c' + uid().replace(/-/g, '').slice(0, 8), label, negative: false };
 }
 
+/**
+ * Move the column at `from` by `delta` (−1 up, +1 down), returning a new array. Out-of-range
+ * moves are no-ops so callers can wire up/down buttons without bounds-checking themselves.
+ * Column *order* is author-facing (it's the left-to-right order of the round-entry steppers),
+ * so reordering is a real edit — pure and testable here.
+ */
+export function moveColumn(columns: CustomColumn[], from: number, delta: number): CustomColumn[] {
+  const to = from + delta;
+  if (from < 0 || from >= columns.length || to < 0 || to >= columns.length) return columns;
+  const next = columns.slice();
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+}
+
 /** A blank definition ready for the builder. */
 export function blankDef(): CustomGameDef {
   const now = Date.now();
@@ -148,10 +165,14 @@ export function blankDef(): CustomGameDef {
 /** A deep copy of `src` as a brand-new (unsaved) definition, e.g. for "Duplicate". */
 export function duplicateDef(src: CustomGameDef): CustomGameDef {
   const now = Date.now();
+  // The " copy" suffix can push a max-length name over MAX_NAME_LEN, which would make the
+  // clone fail validation the moment it's opened in the builder. Truncate so a duplicate is
+  // always immediately re-savable.
+  const copyName = `${src.name} copy`.trim().slice(0, MAX_NAME_LEN).trim();
   return {
     ...src,
     id: CUSTOM_ID_PREFIX + uid(),
-    name: `${src.name} copy`.trim(),
+    name: copyName,
     columns: src.columns.map((c) => ({ ...c })),
     createdAt: now,
     updatedAt: now,
@@ -168,6 +189,9 @@ export function validateDef(def: CustomGameDef): string | null {
   if (name.length > MAX_NAME_LEN) return `Keep the name under ${MAX_NAME_LEN} characters.`;
   if (def.tagline.trim().length > MAX_TAGLINE_LEN) {
     return `Keep the tagline under ${MAX_TAGLINE_LEN} characters.`;
+  }
+  if ((def.help ?? '').trim().length > MAX_HELP_LEN) {
+    return `Keep the how-to-play under ${MAX_HELP_LEN} characters.`;
   }
   if (!Number.isFinite(def.minPlayers) || def.minPlayers < 1) return 'Minimum players must be at least 1.';
   if (def.maxPlayers < def.minPlayers) return "Max players can't be less than min players.";

--- a/src/lib/stores/customGames.ts
+++ b/src/lib/stores/customGames.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { writable, derived, type Readable } from 'svelte/store';
 import type { CustomGameDef } from '../games/custom/types';
 import { buildCustomModule } from '../games/custom/factory';
 import { setCustomDefsRegistry } from '../games/custom/defRegistry';
@@ -19,6 +19,18 @@ export const customGameDefs = writable<CustomGameDef[]>([]);
 
 /** Flips to true after the first load from IndexedDB, so UI can tell "loading" from "empty". */
 export const customGamesLoaded = writable<boolean>(false);
+
+/**
+ * Retired (archived, not tombstoned) custom games. Kept out of the catalog but resolvable so
+ * their history/stats stay correct — this is the reactive source the Manage-games "Retired
+ * games" section reads so an archived type can always be found and restored (not just from the
+ * transient undo toast). Newest-retired first.
+ */
+export const archivedCustomGames: Readable<CustomGameDef[]> = derived(customGameDefs, ($defs) =>
+  $defs
+    .filter((d) => d.archived && !d.deleted)
+    .sort((a, b) => (b.archivedAt ?? 0) - (a.archivedAt ?? 0)),
+);
 
 /** Rebuild the synchronous registries (def lookup + compiled module map) from a def list. */
 function syncRegistries(defs: CustomGameDef[]): void {

--- a/src/pages/CustomGameEdit.svelte
+++ b/src/pages/CustomGameEdit.svelte
@@ -6,6 +6,7 @@
   import {
     blankDef,
     newColumn,
+    moveColumn,
     validateDef,
     defWarnings,
     firstEmoji,
@@ -14,6 +15,7 @@
     MAX_NAME_LEN,
     MAX_TAGLINE_LEN,
     MAX_COLUMN_LABEL_LEN,
+    MAX_HELP_LEN,
     type CustomGameDef,
   } from '../lib/games/custom/types';
   import { customGameDefs, customGamesLoaded, saveCustomGame } from '../lib/stores/customGames';
@@ -146,6 +148,13 @@
   function removeColumn(i: number) {
     def.columns = def.columns.filter((_, j) => j !== i);
   }
+  function moveCol(i: number, delta: number) {
+    def.columns = moveColumn(def.columns, i, delta);
+  }
+
+  // Target is a coarse goal (e.g. "first to 100"), so it steps in larger jumps than a single
+  // round entry — never the 1-or-2-per-tap of `points per tap`, which would make 100 a slog.
+  const targetStep = $derived(Math.max(10, Math.round(def.step) || 1));
 
   async function save() {
     const clean = buildClean();
@@ -281,15 +290,35 @@
                 <input type="checkbox" bind:checked={col.negative} />
                 Subtracts
               </label>
-              <button
-                type="button"
-                class="btn ghost remove"
-                onclick={() => removeColumn(i)}
-                disabled={def.columns.length <= 1}
-                aria-label={`Remove column ${i + 1}`}
-              >
-                ✕
-              </button>
+              <div class="colbtns">
+                <button
+                  type="button"
+                  class="btn ghost move"
+                  onclick={() => moveCol(i, -1)}
+                  disabled={i === 0}
+                  aria-label={`Move column ${i + 1} up`}
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  class="btn ghost move"
+                  onclick={() => moveCol(i, 1)}
+                  disabled={i === def.columns.length - 1}
+                  aria-label={`Move column ${i + 1} down`}
+                >
+                  ↓
+                </button>
+                <button
+                  type="button"
+                  class="btn ghost move"
+                  onclick={() => removeColumn(i)}
+                  disabled={def.columns.length <= 1}
+                  aria-label={`Remove column ${i + 1}`}
+                >
+                  ✕
+                </button>
+              </div>
             </div>
           {/each}
         </div>
@@ -305,7 +334,7 @@
         <div class="fieldlabel">{targetLabel}</div>
         <div class="muted sm">0 = no target</div>
       </div>
-      <Stepper bind:value={def.target} min={0} step={def.step && def.step > 1 ? def.step : 10} />
+      <Stepper bind:value={def.target} min={0} step={targetStep} />
     </div>
     <div class="row spread optrow">
       <div>
@@ -338,6 +367,7 @@
       class="help-area"
       rows="3"
       bind:value={def.help}
+      maxlength={MAX_HELP_LEN}
       placeholder="A sentence or two of rules, shown in the in-game help."
       aria-label="How to play"
     ></textarea>
@@ -351,8 +381,12 @@
         {/each}
       </div>
     {/if}
-    {#if error && def.name.trim()}
-      <div class="formerror sm" role="alert">⚠ {error}</div>
+    {#if error}
+      {#if def.name.trim()}
+        <div class="formerror sm" role="alert">⚠ {error}</div>
+      {:else}
+        <div class="formhint sm" role="status">💡 {error}</div>
+      {/if}
     {/if}
     <button class="btn primary block" onclick={save} disabled={!!error}>
       {editing ? 'Save changes' : 'Create game'}
@@ -430,10 +464,17 @@
     color: var(--bad);
     margin-bottom: 4px;
   }
+  /* The pre-first-edit nudge (e.g. "name your game") is guidance, not a mistake — muted with a
+     💡, so a disabled Create button always says *why*, without shouting error-coral at a blank form. */
+  .formhint {
+    color: var(--muted);
+    margin-bottom: 4px;
+  }
   /* Column rows are a form group on the next surface step up — not nested cards (no shadow). */
   .colrow {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 10px;
     padding: 8px;
     background: var(--surface-2);
@@ -441,27 +482,38 @@
     border-radius: var(--radius-sm);
   }
   .collabel {
-    flex: 1;
+    flex: 1 1 150px;
     min-width: 0;
   }
   .neg {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
+    gap: 8px;
     margin: 0;
+    /* ≥46px tap target: the whole label (checkbox + word) is one comfortable one-handed hit. */
+    min-height: 46px;
+    padding: 0 4px;
     color: var(--text);
     font-size: 0.9rem;
     white-space: nowrap;
     cursor: pointer;
   }
   .neg input {
-    width: 20px;
-    height: 20px;
+    width: 22px;
+    height: 22px;
   }
-  .remove {
+  /* Reorder + remove cluster: keeps the row controls together and pushes them to the trailing
+     edge so labels line up as the group wraps below the field on a narrow phone. */
+  .colbtns {
+    display: flex;
+    gap: 6px;
+    margin-left: auto;
+  }
+  .move {
     flex: none;
     width: 46px;
     padding: 0;
+    font-size: 1.05rem;
   }
   .addcol {
     margin-top: 4px;

--- a/src/pages/ManageGames.svelte
+++ b/src/pages/ManageGames.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { settings } from '../lib/stores/settings';
-  import { link } from '../lib/router';
+  import { link, navigate } from '../lib/router';
+  import { showToast } from '../lib/stores/toast';
   import BackLink from '../lib/components/BackLink.svelte';
   import {
     startableTypes,
@@ -13,12 +14,23 @@
     CREATE_ROUTE,
     CUSTOM_GAMES_ENABLED,
   } from '../lib/stores/catalog';
+  import {
+    customGameDefs,
+    archivedCustomGames,
+    restoreCustomGame,
+    saveCustomGame,
+  } from '../lib/stores/customGames';
+  import { duplicateDef } from '../lib/games/custom/types';
 
   let query = $state('');
 
   const mods = $derived($startableTypes);
   const favs = $derived($settings.catalogFavorites);
   const hidden = $derived($settings.catalogHidden);
+
+  // Retired (archived) custom games — resolvable but out of the catalog. Surfaced here so a
+  // deleted-but-still-referenced custom type can always be restored, not only from the toast.
+  const retired = $derived($archivedCustomGames.filter((d) => matchModule(d, query)));
 
   // Stable registry order here (favoriting reorders the *catalog*, not this list) so rows
   // don't jump under your thumb while you curate.
@@ -30,7 +42,24 @@
   );
 
   const searching = $derived(query.trim().length > 0);
-  const nothing = $derived(visible.length === 0 && hiddenModules.length === 0);
+  const nothing = $derived(
+    visible.length === 0 && hiddenModules.length === 0 && retired.length === 0,
+  );
+
+  // Clone-and-tweak from the manage list: save a fresh copy, then open it in the builder.
+  async function duplicate(id: string) {
+    const def = $customGameDefs.find((d) => d.id === id);
+    if (!def) return;
+    const copy = duplicateDef(def);
+    await saveCustomGame(copy);
+    showToast('Duplicated — tweak your copy.');
+    navigate(editCustomHref(copy.id));
+  }
+
+  async function restore(id: string, name: string) {
+    await restoreCustomGame(id);
+    showToast(`${name} restored to your games.`);
+  }
 </script>
 
 <BackLink href="/" label="Games" />
@@ -73,6 +102,9 @@
           <span class="actions">
             {#if CUSTOM_GAMES_ENABLED && isCustomType(m.id)}
               <a class="btn small ghost" href={editCustomHref(m.id)} use:link>Edit</a>
+              <button class="btn small ghost" type="button" onclick={() => duplicate(m.id)}>
+                Duplicate
+              </button>
             {/if}
             <button
               class="starbtn"
@@ -110,6 +142,32 @@
           <span class="actions">
             <button class="btn small" type="button" onclick={() => setHidden(m.id, false)}>
               Show
+            </button>
+          </span>
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  {#if retired.length}
+    <div class="section-title">Retired games</div>
+    <p class="lede muted">
+      Deleted custom games you’ve played are kept here so their history and stats stay correct.
+      Restore one to bring it back to the catalog.
+    </p>
+    <div class="card list">
+      {#each retired as d (d.id)}
+        <div class="mrow">
+          <span class="info dim">
+            <span class="emoji" aria-hidden="true">{d.emoji}</span>
+            <span class="meta">
+              <span class="name">{d.name}</span>
+              <span class="muted sm">{d.tagline || 'Retired'}</span>
+            </span>
+          </span>
+          <span class="actions">
+            <button class="btn small" type="button" onclick={() => restore(d.id, d.name)}>
+              Restore
             </button>
           </span>
         </div>


### PR DESCRIPTION
## Custom game creator — audit & improvements

Audited the no-code **custom game creator** (`src/lib/games/custom/`, `CustomGameEdit.svelte`,
plus the Edit/Duplicate/Delete/archive surfaces) against `DESIGN.md` and the
`copilot-instructions.md` non-negotiables. Below is the full critique; **8 of 12** items are
implemented in this PR.

### Critique

| # | Item | Why it matters | Status |
|---|------|----------------|--------|
| 1 | **Archived custom games are stranded** | Deleting a *played* custom game archives it, but the catalog hides archived defs and the only Restore path was the transient undo toast. Once dismissed, the game was unreachable and unmanageable. | ✅ Fixed |
| 2 | **Duplicate can persist an unsavable name** | `duplicateDef` appends `" copy"`, pushing a 24-char name to 29 (> `MAX_NAME_LEN`). GameType saved it *without* validating, so the editor then blocked re-saving. | ✅ Fixed |
| 3 | **Disabled "Create game" gives no reason** | The primary action is `disabled` while invalid, but the error was hidden when the name was empty — a first-time author faced a dead button with zero guidance. | ✅ Fixed |
| 4 | **"Subtracts" penalty checkbox is a 20px tap target** | Violates the ≥46px one-handed rule. | ✅ Fixed |
| 5 | **Target stepper increments awkwardly** | It reused `points per tap`, so a step of 2 made the target crawl by 2s — reaching 100 took 50 taps. | ✅ Fixed |
| 6 | **Columns can't be reordered** | Bid/Tricks entry order matters, but columns could only be added/removed. | ✅ Fixed |
| 7 | **Manage games lacked Duplicate** | Edit/Duplicate/Delete lived only on the game-type page; Manage games exposed only Edit. | ✅ Fixed |
| 8 | **How-to-play text is uncapped** | No length cap could overflow the in-game help popover. | ✅ Fixed |
| 9 | Cancel uses a native `confirm()` | DESIGN prefers themed in-app confirms; guarding truly-unrecoverable discard with a native dialog is a defensible exception. | 📝 Noted |
| 10 | Emoji field accepts arbitrary text | Free-text is only collapsed by `firstEmoji` on preview/save — already handled everywhere shown. | 📝 Noted |
| 11 | No in-builder scoring simulation | Preview shows the tile only, not a sample round. Larger effort. | 📝 Noted |
| 12 | Counter defs keep stray unused columns | Toggling columns→counter leaves old columns on the saved def; harmless, round-trips if toggled back. | 📝 Noted |

### What changed

- **Retired games section** in Manage games — lists archived custom defs with **Restore**
  (new `archivedCustomGames` derived store); also adds **Duplicate** for parity.
- **`duplicateDef`** truncates the copy name to `MAX_NAME_LEN` so a duplicate is always
  immediately re-savable.
- **Column reordering** (move up / down) in the builder via a new pure `moveColumn` helper.
- **Penalty toggle** is now a ≥46px tappable label.
- **Disabled Create button** always explains why — a muted 💡 hint before the first edit,
  a coral ⚠ alert once a name is present (state co-signalled by icon + text, never colour alone).
- **Target stepper** uses a coarse `max(10, step)` increment.
- **How-to-play** capped at `MAX_HELP_LEN` (validated + `maxlength`).

All changes respect the design non-negotiables: no new Royal Violet fills, no Crown Gold on
controls, surface-ramp depth, `tabular-nums` untouched, ≥46px targets, state never colour-alone,
and motion still covered by the global `prefers-reduced-motion` rule.

### Testing

- `npm run check` → 0 errors, 0 warnings
- `npm test` → **868 passing** (+4 new: help cap, truncated-duplicate, `moveColumn` up/down + bounds)
- `npm run build` → succeeds (only the pre-existing chunk-size / dynamic-import notices)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
