### PR TITLE
Live & nearby multiplayer: honest disconnects, in-app confirms, manual retry

### DIFF
--- a/src/lib/components/PlaySheet.svelte
+++ b/src/lib/components/PlaySheet.svelte
@@ -132,6 +132,24 @@
     phase = 'idle';
   }
 
+  // Switching transports disconnects anyone already joined, so guard it with the same inline
+  // themed confirm the app uses for destructive actions — never a native window.confirm (a
+  // DESIGN non-negotiable). Only when someone besides the host is present.
+  let confirmSwitch = $state<null | 'online' | 'nearby'>(null);
+  function requestSwitch(to: 'online' | 'nearby') {
+    if (roster.length > 1) confirmSwitch = to;
+    else onswitch(to);
+  }
+
+  // Ending closes the game for every guest at once, so guard it with an inline confirm when
+  // there's more than just the host present — mirroring the app's confirm/undo pattern for
+  // destructive actions rather than ending on a single stray tap.
+  let confirmEnd = $state(false);
+  function requestEnd() {
+    if (roster.length > 1) confirmEnd = true;
+    else onend();
+  }
+
   function onKeydown(e: KeyboardEvent) {
     if (e.key === 'Escape') onclose();
   }
@@ -237,13 +255,44 @@
     {/if}
   {/if}
 
-  {#if mode === 'online' && canGoNearby}
-    <button class="switch" onclick={() => onswitch('nearby')}>📡 No internet? Switch to nearby</button>
+  {#if confirmSwitch}
+    <div class="endconfirm">
+      <p class="note">
+        Switching to {confirmSwitch === 'nearby' ? 'nearby' : 'online'} disconnects the
+        {roster.length - 1}
+        {roster.length - 1 === 1 ? 'player' : 'players'} who already joined — they’ll need a fresh invite. Continue?
+      </p>
+      <div class="row" style="gap: 10px">
+        <button class="btn grow" onclick={() => (confirmSwitch = null)}>Keep this game</button>
+        <button
+          class="btn grow"
+          onclick={() => {
+            const to = confirmSwitch;
+            confirmSwitch = null;
+            if (to) onswitch(to);
+          }}
+        >
+          Switch anyway
+        </button>
+      </div>
+    </div>
+  {:else if mode === 'online' && canGoNearby}
+    <button class="switch" onclick={() => requestSwitch('nearby')}>📡 No internet? Switch to nearby</button>
   {:else if mode === 'nearby' && canGoOnline}
-    <button class="switch" onclick={() => onswitch('online')}>🌐 Switch to online — share a link</button>
+    <button class="switch" onclick={() => requestSwitch('online')}>🌐 Switch to online — share a link</button>
   {/if}
 
-  <button class="btn danger block" onclick={onend}>End live game</button>
+  {#if confirmEnd}
+    <div class="endconfirm">
+      <p class="note">End the game for everyone? Guests drop out — your scoreboard stays safe on this device.</p>
+      <div class="row" style="gap: 10px">
+        <button class="btn grow" onclick={() => (confirmEnd = false)}>Keep playing</button>
+        <button class="btn danger grow" onclick={onend}>End for everyone</button>
+      </div>
+    </div>
+  {:else}
+    <button class="btn danger block" onclick={requestEnd}>End live game</button>
+  {/if}
 </div>
 
 <style>
@@ -431,6 +480,11 @@
   .switch:hover {
     border-color: var(--primary);
     color: var(--text);
+  }
+  .endconfirm {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
   }
   @keyframes rise {
     from {

--- a/src/lib/components/ReplicaBoard.svelte
+++ b/src/lib/components/ReplicaBoard.svelte
@@ -17,6 +17,9 @@
     liveParticipants,
     claimSeat,
     liveConnection,
+    liveReconnectable,
+    connectionNote,
+    retryReconnectNow,
     liveIntentRejected,
   } from '../live/session';
   import Scoreboard from './Scoreboard.svelte';
@@ -64,6 +67,7 @@
 
   const me = $derived($liveSelf);
   const conn = $derived($liveConnection);
+  const connNote = $derived(connectionNote(conn, $liveReconnectable));
   // Seats already claimed by *other* devices — disabled in the picker so two phones can't
   // both be Alice. My own claim is excluded, so re-opening the picker keeps my seat pickable.
   const takenByOthers = $derived(
@@ -178,10 +182,13 @@
 </script>
 
 {#if replica && gmodule}
-  {#if conn !== 'online'}
-    <div class="connbar" class:off={conn === 'offline'} role="status">
+  {#if connNote}
+    <div class="connbar" class:off={conn === 'offline'} role="status" aria-live="polite">
       <span class="cdot" aria-hidden="true"></span>
-      <span>{conn === 'reconnecting' ? 'Reconnecting…' : 'Offline — trying to reconnect. The host still has the game.'}</span>
+      <span class="cnote">{connNote}</span>
+      {#if conn === 'offline' && $liveReconnectable}
+        <button class="trynow" onclick={retryReconnectNow}>Try now</button>
+      {/if}
     </div>
   {/if}
   {#if choosing}
@@ -298,6 +305,30 @@
     border: 1px solid color-mix(in srgb, var(--warn) 45%, var(--border));
     font-size: 0.85rem;
     line-height: 1.35;
+  }
+  .cnote {
+    flex: 1;
+  }
+  /* Low-emphasis retry — never a second Royal-Violet primary; the board's one primary stays
+     "Add round". Kept ≥44px wide with a legible tap area for one-handed use. */
+  .trynow {
+    flex: none;
+    min-height: 34px;
+    padding: 6px 12px;
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-size: 0.82rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .trynow:hover {
+    border-color: var(--primary);
+  }
+  .trynow:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
   }
   .connbar.off {
     background: var(--surface-2);

--- a/src/lib/live/connection.ts
+++ b/src/lib/live/connection.ts
@@ -1,0 +1,44 @@
+/**
+ * Live-connection health vocabulary, kept dependency-free so the copy that reassures guests
+ * can be unit-tested without booting the whole session engine (which imports the durable
+ * stores). {@link ../live/session} re-exports these; UI can import from either.
+ */
+
+/**
+ * Health of the live connection, kept *separate* from the game lifecycle. A dropped socket
+ * never ends the game — the host stays authoritative and local-first — it just flips this to
+ * 'reconnecting' (auto-healing) or 'offline' (still retrying, or, for nearby, dropped for good).
+ */
+export type LiveConnection = 'online' | 'reconnecting' | 'offline';
+
+/**
+ * The banner copy for a non-online connection, or null when online. Pure so it can be unit
+ * tested and shared verbatim by the guest board. A reconnectable transport (the relay)
+ * promises an auto-heal; a non-reconnectable one (nearby WebRTC, whose handshake is
+ * hand-carried and can't be re-signaled) tells the guest how to get back in by hand — never
+ * that we're "trying to reconnect", which we can't. Either way the reassurance is the same:
+ * the scores so far are safe on the host.
+ */
+export function connectionNote(conn: LiveConnection, reconnectable: boolean): string | null {
+  if (conn === 'online') return null;
+  if (conn === 'reconnecting') return 'Reconnecting…';
+  return reconnectable
+    ? 'Offline — trying to reconnect. The host still has the game.'
+    : 'Disconnected — ask the host for a fresh invite to rejoin. Your scores so far are safe.';
+}
+
+/**
+ * How a guest's session ended, split into an honest heading and body. 'lost' means the link
+ * simply dropped (a nearby WebRTC channel can't be re-signalled), so we never claim the host
+ * "closed" it — and the body points the guest at a fresh invite. 'ended' (or null) is the
+ * deliberate host-end. Pure so both exit screens share verbatim, tested copy.
+ */
+export function endedTitle(reason: 'ended' | 'lost' | null): string {
+  return reason === 'lost' ? 'Lost the connection' : 'The game ended';
+}
+
+export function endedBody(reason: 'ended' | 'lost' | null): string {
+  return reason === 'lost'
+    ? 'The nearby link dropped. Scan a fresh invite from the host to rejoin — your scores so far are safe.'
+    : 'The host closed the session.';
+}

--- a/src/lib/live/protocol.ts
+++ b/src/lib/live/protocol.ts
@@ -66,5 +66,7 @@ export type LiveMessage =
   | { t: 'reject'; reason: string }
   // anyone → all: leaving cleanly
   | { t: 'bye' }
-  // leader → all: the session is ending
-  | { t: 'closed' };
+  // leader → all: the session is ending. `reason` separates a deliberate host-end ('ended',
+  // the default when omitted) from a transport synthesising a close because the link dropped
+  // ('lost') — so a guest can be told the honest truth instead of always "the host closed it".
+  | { t: 'closed'; reason?: 'ended' | 'lost' };

--- a/src/lib/live/session.test.ts
+++ b/src/lib/live/session.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { connectionNote, endedTitle, endedBody } from './connection';
+
+describe('connectionNote', () => {
+  it('is silent while online, regardless of transport', () => {
+    expect(connectionNote('online', true)).toBeNull();
+    expect(connectionNote('online', false)).toBeNull();
+  });
+
+  it('shows the same reconnecting copy for either transport', () => {
+    expect(connectionNote('reconnecting', true)).toBe('Reconnecting…');
+    expect(connectionNote('reconnecting', false)).toBe('Reconnecting…');
+  });
+
+  it('promises an auto-heal only when the transport can reconnect (relay)', () => {
+    const note = connectionNote('offline', true);
+    expect(note).toMatch(/reconnect/i);
+    expect(note).toMatch(/host still has the game/i);
+  });
+
+  it('never claims to reconnect a nearby session it cannot re-signal', () => {
+    const note = connectionNote('offline', false);
+    // The core bug this guards: a nearby (WebRTC) guest must not be told we're reconnecting.
+    expect(note).not.toMatch(/trying to reconnect/i);
+    expect(note).toMatch(/fresh invite/i);
+  });
+
+  it('always reassures the guest their scores are safe when offline', () => {
+    expect(connectionNote('offline', true)).toMatch(/game|safe/i);
+    expect(connectionNote('offline', false)).toMatch(/safe/i);
+  });
+});
+
+describe('session end copy', () => {
+  it('names a deliberate host-end honestly', () => {
+    expect(endedTitle('ended')).toBe('The game ended');
+    expect(endedBody('ended')).toMatch(/host closed/i);
+  });
+
+  it('treats a missing reason as a deliberate host-end (back-compat with old peers)', () => {
+    expect(endedTitle(null)).toBe('The game ended');
+    expect(endedBody(null)).toMatch(/host closed/i);
+  });
+
+  it('never claims the host "closed" a session the link merely dropped', () => {
+    expect(endedTitle('lost')).toBe('Lost the connection');
+    const body = endedBody('lost');
+    expect(body).not.toMatch(/host closed/i);
+    // Points the guest at how to get back in, and reassures them nothing was lost.
+    expect(body).toMatch(/fresh invite/i);
+    expect(body).toMatch(/safe/i);
+  });
+});

--- a/src/lib/live/session.ts
+++ b/src/lib/live/session.ts
@@ -29,6 +29,7 @@ import { settings } from '../stores/settings';
 import { players } from '../stores/players';
 import { showToast } from '../stores/toast';
 import { uid, generateHandle, PALETTE } from '../util';
+import type { LiveConnection } from './connection';
 
 export type LiveStatus = 'off' | 'connecting' | 'hosting' | 'guest' | 'error';
 
@@ -52,10 +53,28 @@ export const liveIntentRejected = writable<number>(0);
 /**
  * Health of the live connection, kept *separate* from {@link liveStatus} (the game lifecycle).
  * A dropped socket never ends the game — the host stays authoritative and local-first — it just
- * flips this to 'reconnecting' (auto-healing) or 'offline' (still retrying, game safe).
+ * flips this to 'reconnecting' (auto-healing) or 'offline' (still retrying, game safe). The copy
+ * helper lives in {@link ./connection} so it can be unit-tested without booting the engine.
  */
-export type LiveConnection = 'online' | 'reconnecting' | 'offline';
+export { connectionNote, endedTitle, endedBody } from './connection';
+export type { LiveConnection } from './connection';
 export const liveConnection = writable<LiveConnection>('online');
+
+/**
+ * Why a live session ended, for the guest's exit screen: 'ended' = the host deliberately closed
+ * it; 'lost' = the transport synthesised a close because the link dropped (nearby WebRTC can't
+ * re-signal). Null when no session has ended. Lets a nearby guest be told the honest truth — and
+ * offered a rejoin — instead of always reading "the host closed the session".
+ */
+export const liveEndReason = writable<'ended' | 'lost' | null>(null);
+
+/**
+ * Whether the active transport can silently heal a dropped connection (the relay) or not
+ * (nearby WebRTC, whose handshake is hand-carried and can't be re-signaled, and same-browser
+ * BroadcastChannel). Drives honest connection copy: a nearby guest must be told to ask for a
+ * fresh invite, never that we're "trying to reconnect" — which we can't.
+ */
+export const liveReconnectable = writable<boolean>(false);
 
 /** Convenience: a session is live when hosting or joined as a guest. */
 export const liveActive = derived(liveStatus, ($s) => $s === 'hosting' || $s === 'guest');
@@ -99,6 +118,10 @@ let joinTimer: ReturnType<typeof setTimeout> | undefined;
 // automatically, so it reflects health but does not auto-reconnect.
 let unsubStatus: (() => void) | null = null;
 let reconnectable = false;
+function setReconnectable(v: boolean): void {
+  reconnectable = v;
+  liveReconnectable.set(v);
+}
 let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
 let reconnectAttempts = 0;
 let reconnecting = false;
@@ -160,11 +183,11 @@ function makeTransport(code: string): SessionTransport {
   // browser profile). The engine above this line is identical either way.
   if (isRelayConfigured()) {
     liveRemote.set(true);
-    reconnectable = true;
+    setReconnectable(true);
     return new RelayTransport(effectiveRelayUrl(), code);
   }
   liveRemote.set(false);
-  reconnectable = false;
+  setReconnectable(false);
   return new BroadcastChannelTransport(code);
 }
 
@@ -221,6 +244,7 @@ export async function joinSession(code: string, self: Participant): Promise<void
   liveCode.set(code);
   liveReplica.set(null);
   liveError.set(null);
+  liveEndReason.set(null);
   liveStatus.set('connecting');
 
   transport = makeTransport(code);
@@ -312,7 +336,7 @@ export async function startHostingNearby(
   const rtc = new WebRtcTransport(code, 'leader');
   transport = rtc;
   liveRemote.set(true);
-  reconnectable = false;
+  setReconnectable(false);
   unsubMessage = transport.onMessage(onLeaderMessage);
   unsubStatus = transport.onStatus(onTransportStatus);
   try {
@@ -345,12 +369,13 @@ export async function joinSessionNearby(self: Participant): Promise<NearbyGuestC
   liveCode.set(null);
   liveReplica.set(null);
   liveError.set(null);
+  liveEndReason.set(null);
   liveStatus.set('connecting');
 
   const rtc = new WebRtcTransport('', 'guest');
   transport = rtc;
   liveRemote.set(true);
-  reconnectable = false;
+  setReconnectable(false);
   unsubMessage = transport.onMessage(onGuestMessage);
   unsubStatus = transport.onStatus(onTransportStatus);
 
@@ -426,8 +451,11 @@ function onLeaderMessage(env: TransportEnvelope): void {
     upsertPeer({ ...m.participant, role: 'guest' });
     send({ t: 'peers', peers });
   } else if (m.t === 'bye') {
+    // Name who left so the host isn't left guessing why the roster count dropped.
+    const gone = peers.find((p) => p.id === env.from);
     setPeers(peers.filter((p) => p.id !== env.from));
     send({ t: 'peers', peers });
+    if (gone) showToast(`${gone.name} left the game.`);
   }
 }
 
@@ -449,9 +477,23 @@ function onGuestMessage(env: TransportEnvelope): void {
   } else if (m.t === 'peers') {
     setPeers(m.peers);
   } else if (m.t === 'reject') {
-    showToast(m.reason);
+    // A reject during the initial handshake (still 'connecting') means we never actually got in —
+    // e.g. a protocol-version mismatch. Surface it as the join error right away instead of a toast
+    // the user might miss followed by a misleading "no game found" once the join timer elapses.
+    if (get(liveStatus) === 'connecting') {
+      clearJoinTimer();
+      liveError.set(m.reason);
+      liveStatus.set('error');
+      void teardown();
+    } else {
+      showToast(m.reason);
+    }
   } else if (m.t === 'closed') {
-    showToast('The host ended the live game.');
+    // 'lost' = the link dropped (nearby can't re-signal); 'ended' (default) = a deliberate
+    // host-end. The guest exit screen reads this to tell the honest truth + offer a rejoin.
+    const reason = m.reason ?? 'ended';
+    liveEndReason.set(reason);
+    if (reason === 'ended') showToast('The host ended the live game.');
     void teardown();
     liveStatus.set('off');
     liveCode.set(null);
@@ -559,6 +601,21 @@ function stopReconnect(): void {
   reconnecting = false;
 }
 
+/**
+ * Guest/host control: force a reconnect attempt right now instead of waiting out the backoff.
+ * Only meaningful for a reconnectable (relay) session that has gone offline; a no-op otherwise,
+ * so the UI can wire it up unconditionally. Resets the backoff so the retry fires immediately.
+ */
+export function retryReconnectNow(): void {
+  if (tearing || !reconnectable || !isEstablished()) return;
+  reconnectAttempts = 0;
+  if (reconnectTimer !== undefined) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = undefined;
+  }
+  beginReconnect();
+}
+
 let netAttached = false;
 function onNetOnline(): void {
   // Connectivity is back — reset backoff and retry now instead of waiting out the timer.
@@ -607,7 +664,7 @@ async function teardown(): Promise<void> {
   seq = 0;
   opChain = Promise.resolve();
   liveRemote.set(false);
-  reconnectable = false;
+  setReconnectable(false);
   liveConnection.set('online');
   tearing = false;
 }

--- a/src/lib/live/signal.test.ts
+++ b/src/lib/live/signal.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { encodeSignal, decodeSignal, SIGNAL_VERSION } from './signal';
+
+const sampleSdp =
+  'v=0\r\no=- 46117 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=group:BUNDLE 0\r\n' +
+  'm=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\na=mid:0\r\na=sctp-port:5000\r\n';
+
+describe('signal codec', () => {
+  it('round-trips an offer through the compact wire form', async () => {
+    const wire = await encodeSignal({ k: 'offer', c: 'ABCDE', i: 'inv123', s: sampleSdp });
+    expect(wire.startsWith(`sk${SIGNAL_VERSION}.`)).toBe(true);
+    const sig = await decodeSignal(wire);
+    expect(sig).toEqual({ v: SIGNAL_VERSION, k: 'offer', c: 'ABCDE', i: 'inv123', s: sampleSdp });
+  });
+
+  it('round-trips an answer and preserves the invite id that pairs it to an offer', async () => {
+    const wire = await encodeSignal({ k: 'answer', c: 'ABCDE', i: 'inv123', s: sampleSdp });
+    const sig = await decodeSignal(wire);
+    expect(sig.k).toBe('answer');
+    expect(sig.i).toBe('inv123');
+    expect(sig.c).toBe('ABCDE');
+  });
+
+  it('tolerates surrounding whitespace from a sloppy copy-paste', async () => {
+    const wire = await encodeSignal({ k: 'offer', c: 'ABCDE', i: 'x', s: sampleSdp });
+    const sig = await decodeSignal(`  \n${wire}\n `);
+    expect(sig.s).toBe(sampleSdp);
+  });
+
+  it('rejects a string that is not a nearby-play code with friendly copy', async () => {
+    await expect(decodeSignal('https://example.com/join/ABCDE')).rejects.toThrow(
+      /doesn’t look like a nearby-play code/i,
+    );
+  });
+
+  it('rejects a corrupted payload rather than throwing a raw decode error', async () => {
+    const wire = await encodeSignal({ k: 'offer', c: 'ABCDE', i: 'x', s: sampleSdp });
+    // Corrupt the base64url body while keeping the header framing intact.
+    const parts = wire.split('.');
+    const corrupted = `${parts[0]}.${parts[1]}.${parts[2].slice(0, -4)}$$$$`;
+    await expect(decodeSignal(corrupted)).rejects.toThrow(/corrupted|different app version/i);
+  });
+});

--- a/src/lib/live/webrtc.ts
+++ b/src/lib/live/webrtc.ts
@@ -273,8 +273,9 @@ export class WebRtcTransport implements SessionTransport {
       // Tell the engine this guest left, so it drops them and re-broadcasts the roster.
       if (conn.peerId) this.deliver({ from: conn.peerId, seq: -1, msg: { t: 'bye' } });
     } else {
-      // The host is gone — the engine tears the guest session down on `closed`.
-      this.deliver({ from: conn.peerId ?? '', seq: -1, msg: { t: 'closed' } });
+      // The host is gone — the engine tears the guest session down on `closed`. Flag it 'lost'
+      // (a dropped link, not a deliberate host-end) so the guest reads honest copy + a rejoin.
+      this.deliver({ from: conn.peerId ?? '', seq: -1, msg: { t: 'closed', reason: 'lost' } });
     }
   }
 

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -363,15 +363,10 @@
     }
   }
 
-  /** Swap transports from inside the sheet without ending the session (host's explicit choice). */
+  /** Swap transports from inside the sheet without ending the session (host's explicit choice).
+   * PlaySheet owns the "this disconnects joined players" confirm (an in-app themed dialog), so by
+   * the time this runs the host has already agreed. */
   async function switchMode(to: 'online' | 'nearby') {
-    if (
-      $liveParticipants.length > 1 &&
-      typeof window !== 'undefined' &&
-      !window.confirm('Switching will disconnect the players who already joined. Continue?')
-    ) {
-      return;
-    }
     if (to === 'nearby') await startNearby();
     else await startLive();
   }

--- a/src/pages/LiveJoin.svelte
+++ b/src/pages/LiveJoin.svelte
@@ -12,6 +12,9 @@
     liveReplica,
     liveParticipants,
     liveError,
+    liveEndReason,
+    endedTitle,
+    endedBody,
   } from '../lib/live/session';
   import ReplicaBoard from '../lib/components/ReplicaBoard.svelte';
 
@@ -57,33 +60,42 @@
         <div class="muted" style="font-size: 0.8rem">Live game · code {joinCode}</div>
       </span>
     </span>
-    <span class="live"><span class="dot" aria-hidden="true"></span>{$liveParticipants.length}</span>
+    <span class="live" aria-label={`${$liveParticipants.length} connected`}>
+      <span class="dot" aria-hidden="true"></span>{$liveParticipants.length}
+    </span>
   </div>
 
   <ReplicaBoard />
 
   <button class="btn ghost block" style="margin-top: 14px" onclick={leave}>Leave game</button>
 {:else if $liveStatus === 'error'}
-  <div class="empty">
+  <div class="empty" role="alert">
     <h2>Couldn’t join</h2>
     <p class="muted">{$liveError ?? 'That live game isn’t reachable.'}</p>
     <a class="btn primary" href="/" use:link>Back to games</a>
+    <p class="muted reassure">No worries — you can still keep score on your own device.</p>
   </div>
 {:else if everConnected}
-  <div class="empty">
-    <h2>The live game ended</h2>
-    <p class="muted">The host closed the session.</p>
+  <div class="empty" role="status">
+    <h2>{endedTitle($liveEndReason)}</h2>
+    <p class="muted">{endedBody($liveEndReason)}</p>
     <a class="btn primary" href="/" use:link>Back to games</a>
   </div>
 {:else}
-  <div class="empty">
+  <div class="empty" role="status" aria-live="polite">
     <div class="spinner" aria-hidden="true"></div>
     <h2>Joining game {joinCode}…</h2>
     <p class="muted">Connecting you to the host.</p>
+    <button class="btn ghost" onclick={leave}>Cancel</button>
+    <p class="muted reassure">Live play is optional — every game still works fully offline.</p>
   </div>
 {/if}
 
 <style>
+  .reassure {
+    margin-top: 4px;
+    font-size: 0.82rem;
+  }
   .live {
     display: inline-flex;
     align-items: center;

--- a/src/pages/NearbyJoin.svelte
+++ b/src/pages/NearbyJoin.svelte
@@ -17,6 +17,9 @@
     liveReplica,
     liveParticipants,
     liveError,
+    liveEndReason,
+    endedTitle,
+    endedBody,
     type NearbyGuestControls,
   } from '../lib/live/session';
   import ReplicaBoard from '../lib/components/ReplicaBoard.svelte';
@@ -110,24 +113,32 @@
         <div class="muted" style="font-size: 0.8rem">Nearby game</div>
       </span>
     </span>
-    <span class="live"><span class="dot" aria-hidden="true"></span>{$liveParticipants.length}</span>
+    <span class="live" aria-label={`${$liveParticipants.length} connected`}>
+      <span class="dot" aria-hidden="true"></span>{$liveParticipants.length}
+    </span>
   </div>
 
   <ReplicaBoard />
 
   <button class="btn ghost block" style="margin-top: 14px" onclick={leave}>Leave game</button>
 {:else if $liveStatus === 'error'}
-  <div class="empty">
+  <div class="empty" role="alert">
     <h2>Couldn’t connect</h2>
     <p class="muted">{$liveError ?? 'The nearby game isn’t reachable.'}</p>
     <button class="btn primary" onclick={restart}>Try again</button>
     <a class="btn ghost" href="/" use:link style="margin-top: 8px">Back to games</a>
+    <p class="muted reassure">Nearby play is optional — every game still works on its own.</p>
   </div>
 {:else if everConnected}
-  <div class="empty">
-    <h2>The game ended</h2>
-    <p class="muted">The host closed the session.</p>
-    <a class="btn primary" href="/" use:link>Back to games</a>
+  <div class="empty" role="status">
+    <h2>{endedTitle($liveEndReason)}</h2>
+    <p class="muted">{endedBody($liveEndReason)}</p>
+    {#if $liveEndReason === 'lost'}
+      <button class="btn primary" onclick={restart}>Scan a new invite</button>
+      <a class="btn ghost" href="/" use:link style="margin-top: 8px">Back to games</a>
+    {:else}
+      <a class="btn primary" href="/" use:link>Back to games</a>
+    {/if}
   </div>
 {:else}
   <div class="join">
@@ -151,7 +162,7 @@
         <span>Show this reply to the host:</span>
       </div>
       <SignalShare text={answer} caption="The host scans or pastes this to connect you" />
-      <div class="waiting">
+      <div class="waiting" role="status" aria-live="polite">
         <div class="spinner" aria-hidden="true"></div>
         <span class="muted">Waiting for the host to connect you…</span>
       </div>
@@ -205,6 +216,11 @@
     align-items: center;
     justify-content: center;
     gap: 10px;
+  }
+  .reassure {
+    margin-top: 4px;
+    font-size: 0.82rem;
+    text-align: center;
   }
   .spinner {
     width: 22px;


### PR DESCRIPTION
## Critique 7 — Live & nearby multiplayer UX

An audit of the co-play experience (hosting live, joining by code/link/QR over the relay or device-to-device over WebRTC, the handshake, connection status, the shared follower board, and host-authority) plus fixes. All changes sit **above** the host-authoritative `SessionTransport` seam — the engine is untouched — and respect the DESIGN.md non-negotiables.

### Critique items

**Implemented in this PR**

1. **Dishonest disconnect copy (bug).** A dropped nearby WebRTC link synthesised the *same* `closed` message as a deliberate host-end, so a guest whose connection merely dropped was told "The host closed the session." — misleading, since nearby can't be re-signalled. → Carry a `reason` (`'ended' | 'lost'`) on `closed`; the guest exit screen now reads the truth (**"Lost the connection"**) and offers a **"Scan a new invite"** rejoin, while still reassuring that scores are safe.
2. **Native `window.confirm` on transport-switch (design non-negotiable).** Switching online↔nearby popped a browser dialog — DESIGN.md mandates in-app themed confirms, not native dialogs. → Replaced with an inline themed confirm in `PlaySheet` (mirrors the existing End-game confirm), kept neutral so it never adds a second Royal-Violet primary.
3. **No manual retry for a stalled relay reconnect (UX).** Once a relay guest went "offline" (backoff exhausted), waiting was the only option. → Added a low-emphasis **"Try now"** button on the offline connbar (reconnectable sessions only) that resets backoff and retries immediately.
4. **Host has no awareness when a guest drops/leaves (UX).** The roster count just silently fell. → The leader now gets a toast naming who left.
5. **Bare-number connection counts unlabeled (a11y).** The live-count pills on the join screens were just a coloured dot + number to a screen reader. → Added descriptive `aria-label`s ("N connected").
6. **Test coverage gap.** Only `connectionNote` was covered. → Extracted the connection + end-of-session copy into a pure, dependency-free helper (`connection.ts`) and added **signal-codec round-trip/rejection tests** and **end-copy tests** (+8 tests, 786 → 794).

**Also folded in from in-progress work on this theme** (kept and built upon): the honesty-aware `connectionNote` (never tells a nearby guest we're "reconnecting" when we can't), the inline End-game confirm, surfacing a handshake-time `reject` as the join error instead of a missable toast, and reassurance copy + `aria-live` on the connecting/error states.

**Noted, deferred (out of scope / larger)**

7. **Leadership transfer** ("elect a new leader") is described in ARCHITECTURE.md but unimplemented — a substantial protocol addition; deferred.
8. The join spinner can wait up to ~12s (relay 8s open + 4s welcome) showing only a spinner — mitigated by the existing Cancel button; a staged "still connecting…" hint could go further.
9. Validated (no change needed): reduced-motion fallbacks and never-color-alone hold across the live surfaces; the same-browser sheet correctly hides the QR (a scanning phone can't join a same-origin session); one Royal-Violet primary per live screen holds after these changes.

### Verification
- `npm run check` → 0 errors, 0 warnings
- `npm test` → **794 passed** (32 files; +8 new)
- `npm run build` → success (only pre-existing chunk-size / dynamic-import warnings)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
