### PR TITLE
Sync & backup UX: safer titles, honest status, a11y co-signals, on-demand pull

### DIFF
--- a/src/lib/components/SyncBubble.svelte
+++ b/src/lib/components/SyncBubble.svelte
@@ -30,7 +30,7 @@
       : status === 'synced'
         ? 'Synced!'
         : status === 'conflict'
-          ? 'Conflict'
+          ? 'Needs merge'
           : status === 'pending'
             ? 'Pending'
             : status === 'offline'
@@ -47,7 +47,7 @@
     status === 'syncing'
       ? 'Backing up to OneDrive…'
       : status === 'conflict'
-        ? 'Backup changed on another device — tap to resolve'
+        ? 'Also edited on another device — tap to merge; nothing is lost'
         : status === 'pending'
           ? 'Sync pending — reconnect to OneDrive'
           : status === 'offline'
@@ -58,6 +58,11 @@
                 ? 'Backed up · ' + relativeTime($settings.lastSync)
                 : 'Not backed up yet',
   );
+
+  // A shape/glyph co-signal so the two collapsed resting states (backed up vs not) never read
+  // by color alone — honoring the Color-Is-Never-Alone rule for color-blind players. The
+  // expanded states already carry a text label, so they need no extra glyph.
+  const glyph = $derived(tone === 'ok' ? '✓' : tone === 'idle' ? '↑' : '');
 
   // --- progress fill (slow >1s syncs only); never carries into the synced state ---
   let showFill = $state(false);
@@ -166,7 +171,11 @@
       <span class="sb-fill" style="width: {Math.round(progress * 100)}%" aria-hidden="true"></span>
     {/if}
     <span class="sb-dot" class:spin={status === 'syncing'} bind:this={dotEl}></span>
-    {#if expanded}<span class="sb-text">{label}</span>{/if}
+    {#if expanded}
+      <span class="sb-text">{label}</span>
+    {:else if glyph}
+      <span class="sb-glyph" aria-hidden="true">{glyph}</span>
+    {/if}
   </a>
 {/if}
 
@@ -251,6 +260,23 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  /* Compact shape co-signal for the collapsed resting states (backed up ✓ vs not ↑),
+     so status never reads by color alone. */
+  .sb-glyph {
+    position: relative;
+    z-index: 1;
+    margin-left: -2px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--tone);
+  }
+  /* Not-backed-up: a hollow ring reinforces "nothing stored yet" beyond the muted hue. */
+  .syncbubble.idle .sb-dot {
+    background: none;
+    border: 2px solid var(--tone);
   }
 
   .syncbubble.celebrate {

--- a/src/lib/storage/onedrive.ts
+++ b/src/lib/storage/onedrive.ts
@@ -331,7 +331,9 @@ export const oneDrive: SyncProvider = {
     return { snapshot, etag: item.eTag ?? null };
   },
   async peekEtag(opts?: PushOptions): Promise<string | null> {
-    const accessToken = await token(opts?.interactive ?? true);
+    // Default to a silent (non-interactive) token: peekEtag exists only for the background
+    // poll, which must never yank the user to a Microsoft redirect just to check a version.
+    const accessToken = await token(opts?.interactive ?? false);
     // Metadata-only read, narrowed to just the eTag: the cheapest way to tell whether the remote
     // moved. No download URL, no file body. cache:'no-store' so a poll always sees the latest.
     const meta = await graph(

--- a/src/lib/storage/sync.test.ts
+++ b/src/lib/storage/sync.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import {
+  sanitizeBackupTitle,
+  isValidBackupTitle,
+  fileNameForTitle,
+  titleFromFileName,
+  sameBackupFile,
+  isBackupFile,
+  serializeSnapshot,
+  deserializeSnapshot,
+  mergeSnapshots,
+  DEFAULT_BACKUP_FILE,
+  type Snapshot,
+} from './sync';
+
+// A backup's title IS its OneDrive file name, so the title↔file mapping has to be
+// forgiving of what users type without producing surprising or unsafe file names.
+describe('sanitizeBackupTitle', () => {
+  it('trims and collapses whitespace', () => {
+    expect(sanitizeBackupTitle('  Friday   Crew  ')).toBe('Friday Crew');
+  });
+
+  it('replaces characters OneDrive forbids in a file name', () => {
+    expect(sanitizeBackupTitle('a/b:c*?"<>|d')).toBe('a b c d');
+  });
+
+  it('drops a trailing .json the user typed (no double extension)', () => {
+    expect(sanitizeBackupTitle('Backup.json')).toBe('Backup');
+    expect(fileNameForTitle('Backup.json')).toBe('Backup.json');
+  });
+
+  it('caps the length at 60 characters', () => {
+    expect(sanitizeBackupTitle('x'.repeat(200))).toHaveLength(60);
+  });
+});
+
+describe('isValidBackupTitle', () => {
+  it('accepts a title with letters or numbers', () => {
+    expect(isValidBackupTitle('Crew 2')).toBe(true);
+  });
+
+  it('rejects an empty or illegal-only title (would silently hijack Main)', () => {
+    expect(isValidBackupTitle('   ')).toBe(false);
+    expect(isValidBackupTitle('***')).toBe(false);
+    expect(isValidBackupTitle('/\\:*?"<>|')).toBe(false);
+  });
+});
+
+describe('fileNameForTitle / titleFromFileName', () => {
+  it('round-trips a normal title', () => {
+    const file = fileNameForTitle('Friday Crew');
+    expect(file).toBe('Friday Crew.json');
+    expect(titleFromFileName(file)).toBe('Friday Crew');
+  });
+
+  it('falls back to the Default file for an unusable title', () => {
+    expect(fileNameForTitle('***')).toBe(DEFAULT_BACKUP_FILE);
+  });
+});
+
+describe('sameBackupFile', () => {
+  it('treats file names case-insensitively (OneDrive is case-insensitive)', () => {
+    expect(sameBackupFile('Crew.json', 'crew.json')).toBe(true);
+    expect(sameBackupFile('Crew.json', 'Krew.json')).toBe(false);
+  });
+});
+
+describe('isBackupFile', () => {
+  it('accepts .json files and skips hidden/temp files', () => {
+    expect(isBackupFile('Main.json')).toBe(true);
+    expect(isBackupFile('notes.txt')).toBe(false);
+    expect(isBackupFile('.~lock.json')).toBe(false);
+    expect(isBackupFile('~$Main.json')).toBe(false);
+  });
+});
+
+describe('serialize/deserialize snapshot', () => {
+  const snap: Snapshot = {
+    players: [{ id: 'p1' }] as unknown as Snapshot['players'],
+    games: [{ id: 'g1' }] as unknown as Snapshot['games'],
+    rounds: [{ id: 'r1' }] as unknown as Snapshot['rounds'],
+    gameDefs: [],
+    settings: { theme: 'light' },
+    exportedAt: 123,
+  };
+
+  it('round-trips through the JSON envelope', () => {
+    const back = deserializeSnapshot(serializeSnapshot(snap));
+    expect(back).not.toBeNull();
+    expect(back!.players).toEqual(snap.players);
+    expect(back!.exportedAt).toBe(123);
+    expect(back!.settings).toEqual({ theme: 'light' });
+  });
+
+  it('rejects a foreign JSON file so a restore cannot wipe local data', () => {
+    expect(deserializeSnapshot('{"hello":"world"}')).toBeNull();
+    expect(deserializeSnapshot('not json at all')).toBeNull();
+  });
+
+  it('accepts a legacy bare-snapshot export (no envelope)', () => {
+    const legacy = JSON.stringify({ players: [], games: [], rounds: [] });
+    const back = deserializeSnapshot(legacy);
+    expect(back).not.toBeNull();
+    expect(back!.gameDefs).toEqual([]);
+    expect(back!.settings).toEqual({});
+  });
+});
+
+describe('mergeSnapshots', () => {
+  const mk = (arr: Array<{ id: string; updatedAt?: number }>) =>
+    arr as unknown as Snapshot['players'] & Snapshot['games'] & Snapshot['rounds'];
+
+  it('unions records by id, newest write winning', () => {
+    const local: Snapshot = {
+      players: mk([
+        { id: 'a', updatedAt: 10 },
+        { id: 'b', updatedAt: 5 },
+      ]),
+      games: mk([]),
+      rounds: mk([]),
+      gameDefs: [],
+      settings: { theme: 'dark' },
+      exportedAt: 1,
+    };
+    const remote: Snapshot = {
+      players: mk([
+        { id: 'b', updatedAt: 20 }, // newer than local b
+        { id: 'c', updatedAt: 1 }, // only on remote
+      ]),
+      games: mk([]),
+      rounds: mk([]),
+      gameDefs: [],
+      settings: { theme: 'light' },
+      exportedAt: 2,
+    };
+    const merged = mergeSnapshots(local, remote);
+    const byId = Object.fromEntries(
+      (merged.players as unknown as Array<{ id: string; updatedAt: number }>).map((p) => [
+        p.id,
+        p.updatedAt,
+      ]),
+    );
+    expect(byId).toEqual({ a: 10, b: 20, c: 1 });
+    // Device-local prefs are taken from `local` — a merge must never restyle this device.
+    expect(merged.settings).toEqual({ theme: 'dark' });
+  });
+});

--- a/src/lib/storage/sync.ts
+++ b/src/lib/storage/sync.ts
@@ -65,10 +65,22 @@ const ILLEGAL_NAME_CHARS = /[\\/:*?"<>|]/g;
 /** Clean a user title into something safe to use as a file name. */
 export function sanitizeBackupTitle(title: string): string {
   return title
+    // Drop a trailing ".json" the user typed themselves, so "Backup.json" doesn't
+    // become the file "Backup.json.json" (and round-trip to the wrong display title).
+    .replace(/\.json$/i, '')
     .replace(ILLEGAL_NAME_CHARS, ' ')
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, 60);
+}
+
+/**
+ * Whether a user-typed title yields a usable, non-empty file name. A title made only of
+ * illegal characters (e.g. "***") sanitizes to empty and would otherwise silently fall back
+ * to the Default "Main" backup — so callers should reject it with a clear message instead.
+ */
+export function isValidBackupTitle(title: string): boolean {
+  return sanitizeBackupTitle(title).length > 0;
 }
 
 /** Build the file name for a user title (the title is the file name). */
@@ -81,6 +93,16 @@ export function fileNameForTitle(title: string): string {
 /** Derive a display title from a backup file name. */
 export function titleFromFileName(file: string): string {
   return file.replace(/\.json$/i, '').trim();
+}
+
+/**
+ * Whether two backup file names address the same OneDrive file. OneDrive/SharePoint file
+ * names are case-insensitive, so "Crew.json" and "crew.json" are the same file — comparing
+ * case-sensitively would let a "duplicate" slip past the add/rename guards and then fail
+ * with a confusing server error.
+ */
+export function sameBackupFile(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
 }
 
 /** Whether a folder child looks like one of our backup files. */

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -9,9 +9,12 @@
     deserializeSnapshot,
     getOneDrive,
     reconcile,
+    pullMerge,
     DEFAULT_BACKUP_FILE,
     fileNameForTitle,
     titleFromFileName,
+    isValidBackupTitle,
+    sameBackupFile,
     ConflictError,
   } from '../lib/storage/sync';
   import type { BackupInfo } from '../lib/storage/sync';
@@ -20,7 +23,7 @@
   import { refreshGames } from '../lib/stores/games';
   import { refreshPlayers } from '../lib/stores/players';
   import { showToast } from '../lib/stores/toast';
-  import { relativeTime, relativeTimeSec } from '../lib/util';
+  import { relativeTime, relativeTimeSec, formatDate } from '../lib/util';
   import JsonIcon from '../lib/components/JsonIcon.svelte';
 
   let override = $state($settings.oneDriveClientId);
@@ -39,6 +42,15 @@
 
   const activeFileName = $derived($settings.oneDriveBackupFile || DEFAULT_BACKUP_FILE);
 
+  // The active backup's own last-modified time on OneDrive (from the loaded list). Lets the
+  // status reflect an existing cloud backup even before THIS device has synced this session —
+  // otherwise a freshly connected device wrongly reads "Not backed up yet".
+  const activeBackupModified = $derived(
+    backups.find((b) => sameBackupFile(b.file, activeFileName))?.modifiedAt ?? null,
+  );
+  // Prefer this device's own last-sync stamp; fall back to the file's remote modified time.
+  const lastBackedUp = $derived($settings.lastSync ?? activeBackupModified);
+
   const configured = $derived(!!(override.trim() || ONEDRIVE_CLIENT_ID));
 
   const dotClass = $derived(
@@ -50,7 +62,7 @@
         ? 'warn'
         : $autoSyncStatus === 'offline'
           ? 'off'
-          : $settings.lastSync
+          : lastBackedUp
             ? 'ok'
             : '',
   );
@@ -59,15 +71,15 @@
     $autoSyncStatus === 'syncing'
       ? 'Syncing…'
       : $autoSyncStatus === 'conflict'
-        ? 'Backup changed on another device — tap Merge'
+        ? 'Backup also changed on another device — tap Merge (nothing is lost)'
         : $autoSyncStatus === 'pending'
           ? 'Sync pending — reconnect to OneDrive'
           : $autoSyncStatus === 'offline'
             ? 'Offline — changes will back up when you reconnect'
             : $autoSyncStatus === 'error'
               ? 'Sync failed — will retry shortly'
-              : $settings.lastSync
-                ? 'Synced · Backed up ' + relativeTime($settings.lastSync)
+              : lastBackedUp
+                ? 'Synced · Backed up ' + relativeTime(lastBackedUp)
                 : 'Not backed up yet',
   );
 
@@ -186,8 +198,12 @@
   async function addBackup() {
     const title = newTitle.trim();
     if (!title || backupBusy) return;
+    if (!isValidBackupTitle(title)) {
+      showToast('Give the backup a name with letters or numbers');
+      return;
+    }
     const file = fileNameForTitle(title);
-    if (displayBackups.some((b) => b.file === file)) {
+    if (displayBackups.some((b) => sameBackupFile(b.file, file))) {
       showToast('A backup with that name already exists');
       return;
     }
@@ -260,12 +276,16 @@
   async function commitRename(b: BackupInfo) {
     const title = renameTitle.trim();
     if (!title || backupBusy) return;
+    if (!isValidBackupTitle(title)) {
+      showToast('Give the backup a name with letters or numbers');
+      return;
+    }
     const newFile = fileNameForTitle(title);
     if (newFile === b.file) {
       cancelRename();
       return;
     }
-    if (displayBackups.some((x) => x.file === newFile)) {
+    if (displayBackups.some((x) => !sameBackupFile(x.file, b.file) && sameBackupFile(x.file, newFile))) {
       showToast('A backup with that name already exists');
       return;
     }
@@ -375,6 +395,43 @@
   }
 
   /**
+   * Pull the active backup and merge in anything newer from other devices, WITHOUT requiring a
+   * local edit first. Useful when auto-sync is off, or to reassure the user that this device is
+   * caught up. Never destructive — union by id, newest-per-record wins, tombstones preserved.
+   */
+  async function checkForUpdates() {
+    busy = true;
+    try {
+      const od = await getOneDrive();
+      const res = await pullMerge(od, { interactive: true });
+      signedIn = od.isSignedIn();
+      if (!res) {
+        showToast('Nothing backed up yet');
+      } else {
+        setActiveBackupEtag(res.etag);
+        markSynced(Date.now());
+        if (res.changedLocal) {
+          await refreshPlayers();
+          await refreshGames();
+          showToast('Pulled in the latest changes');
+        } else {
+          showToast('Already up to date');
+        }
+        markSyncSettled();
+      }
+      void loadBackups(false);
+    } catch (e) {
+      if (e instanceof ConflictError) {
+        await resolveConflict();
+      } else {
+        showToast(errMsg(e));
+      }
+    } finally {
+      busy = false;
+    }
+  }
+
+  /**
    * The active backup changed on another device since our last sync. Merge the two
    * copies per entity (union by id, newest write wins) and write the result to both
    * sides — so edits from this device and the other one both survive. Only a same-record
@@ -456,19 +513,25 @@
   }
 
   async function exportJson() {
-    const blob = new Blob([serializeSnapshot(await buildSnapshot())], {
+    const snap = await buildSnapshot();
+    const blob = new Blob([serializeSnapshot(snap)], {
       type: 'application/json',
     });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'score-king-backup.json';
+    // Date the file so repeated exports sit side by side instead of colliding/auto-numbering.
+    const d = new Date();
+    const stamp = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    a.download = `score-king-backup-${stamp}.json`;
     a.click();
     URL.revokeObjectURL(url);
+    showToast('Saved ' + a.download);
   }
 
   async function importJson(e: Event) {
-    const file = (e.target as HTMLInputElement).files?.[0];
+    const input = e.target as HTMLInputElement;
+    const file = input.files?.[0];
     if (!file) return;
     try {
       const snap = deserializeSnapshot(await file.text());
@@ -476,13 +539,23 @@
         showToast('Invalid backup file');
         return;
       }
-      if (!confirm('Replace local data with this file?')) return;
+      const summary = `${snap.players.length} players, ${snap.games.length} games, ${snap.rounds.length} rounds`;
+      const when = snap.exportedAt ? ` (saved ${formatDate(snap.exportedAt)})` : '';
+      if (
+        !confirm(
+          `Replace this device's data with this file${when}?\n\nIt contains ${summary}. Anything on this device that isn't in the file is discarded.`,
+        )
+      )
+        return;
       await restoreSnapshot(snap);
       await refreshPlayers();
       await refreshGames();
-      showToast('Imported backup');
+      showToast('Imported ' + summary);
     } catch {
       showToast('Invalid backup file');
+    } finally {
+      // Clear the picker so re-importing the same file fires onchange again.
+      input.value = '';
     }
   }
 </script>
@@ -588,6 +661,13 @@
       {#if $settings.autoSync && checkedText}
         <span class="muted" style="font-size: 0.72rem; margin-top: -4px">{checkedText}</span>
       {/if}
+
+      <div class="syncrow row spread">
+        <span class="sm muted" style="min-width: 0">Pull in changes from your other devices</span>
+        <button class="btn small ghost" onclick={checkForUpdates} disabled={busy}>
+          Check for updates
+        </button>
+      </div>
 
       <div class="syncrow stack" style="gap: 6px">
         <div class="row spread">
@@ -1076,8 +1156,8 @@
     flex: none;
   }
   .bkicon {
-    width: 38px;
-    height: 38px;
+    width: 46px;
+    height: 46px;
     font-size: 1rem;
   }
   .bkicon:disabled {


### PR DESCRIPTION
## Critique 8 — OneDrive sync & backup

Audit of the optional cloud backup (connect/disconnect, header sync bubble, Sync now / Restore, multiple titled backups, auto-backup, merge/conflict messaging, and local JSON export/import) through the lens of **clarity, trust, and error/edge states**. Explored `src/lib/storage/{sync,onedrive,autosync}.ts`, `stores/settings.ts`, `pages/Settings.svelte`, and `components/SyncBubble.svelte`.

### Critique items (12) — implemented unless noted

1. **[Bug] Double `.json` extension** — a title ending in `.json` ("Backup.json") produced the file `Backup.json.json`. `sanitizeBackupTitle` now strips a trailing `.json`.
2. **[Bug] Illegal-only titles silently hijack the Default "Main" backup** — `fileNameForTitle("***")` returned `Main.json`. Added `isValidBackupTitle`; add/rename now reject with a clear message.
3. **[Bug] Case-sensitive duplicate detection** — OneDrive file names are case-insensitive, so "Crew.json" vs "crew.json" slipped past the dedupe guard and later failed with a confusing server error. Added `sameBackupFile` and used it in add/rename checks.
4. **[A11y] SyncBubble signalled resting state by colour alone** — collapsed pill was just a green vs grey dot. Added a shape/glyph co-signal (backed-up check, not-yet arrow) and a hollow ring for not-backed-up, honouring the Colour-Is-Never-Alone rule.
5. **[A11y] Backup rename/delete icon buttons were 38px** — below the >=46px touch-target non-negotiable. Bumped to 46px.
6. **[Trust] Status read "Not backed up yet" even when a cloud backup existed** — it relied on device-local `lastSync`. Now falls back to the active backup's remote `modifiedAt`.
7. **[Copy] "Conflict" alarmed users about a non-destructive merge** — softened to "Needs merge" and clarified nothing is lost (bubble + Settings).
8. **[Feature] Local export was a fixed filename with no feedback** — now dates the file (`score-king-backup-YYYY-MM-DD.json`) and shows a toast.
9. **[Feature] No on-demand pull/merge** — added a **Check for updates** button running `pullMerge` (valuable when auto-sync is off); non-destructive.
10. **[Feedback] Import replaced data silently** — the confirm now summarises record counts and save date; result toast reports what was imported; picker resets so re-importing the same file works.
11. **[Robustness] `peekEtag` defaulted to `interactive: true`** — a footgun for its background-only use. Defaults to non-interactive to match its docs.
12. **[Design, deferred] Destructive backup actions use native `confirm()`** — DESIGN.md prefers themed in-app confirmation, but the whole app uses native `confirm()`; changing only backup would break cross-screen consistency. Recommend an app-wide follow-up.

### Design non-negotiables
Respected: one Royal Violet primary per screen ("Sync now"/"Merge" primary; "Check for updates" is a ghost action), >=46px touch targets, never colour-alone state, tabular chrome untouched, identical shell. No Crown Gold introduced.

### Tests
- Added `src/lib/storage/sync.test.ts` (title/file mapping, `.json` stripping, validity, case-insensitive dedupe, envelope round-trip incl. legacy + foreign-file rejection, per-entity merge newest-wins + device-pref preservation).
- `npm run check` — 0 errors / 0 warnings
- `npm test` — 909 passed (42 files)
- `npm run build` — succeeds (pre-existing chunk-size / dynamic-import warnings only)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>