### PR TITLE
Design system: retire token, color, shadow & glass drift

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -259,8 +259,7 @@
     padding: 0 16px;
     border-radius: 999px;
     border: 1px solid var(--border);
-    background: color-mix(in srgb, var(--surface-3) 92%, transparent);
-    backdrop-filter: blur(8px);
+    background: var(--surface-3);
     color: var(--text);
     font-weight: 700;
     font-size: 0.85rem;

--- a/src/app.css
+++ b/src/app.css
@@ -9,6 +9,7 @@
 
   --radius: 14px;
   --radius-sm: 9px;
+  --radius-chip: 10px;
   --gap: 14px;
   --card-gap: 6px;
   --maxw: 760px;
@@ -246,7 +247,7 @@ tbody tr:last-child td { border-bottom: none; }
 .tabbar a {
   display: flex; flex-direction: column; align-items: center; gap: 2px;
   font-size: 0.7rem; color: var(--muted); text-decoration: none;
-  padding: 4px 10px; border-radius: 10px; min-width: 56px;
+  padding: 4px 10px; border-radius: var(--radius-chip); min-width: 56px;
 }
 .tabbar a.active { color: var(--text); background: var(--surface-2); }
 .tabbar a .ico { font-size: 1.2rem; line-height: 1; }
@@ -378,7 +379,7 @@ tbody tr:last-child td { border-bottom: none; }
 
 .iconbtn {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 46px; height: 46px; border-radius: 10px;
+  width: 46px; height: 46px; border-radius: var(--radius-chip);
   border: 1px solid var(--border); background: var(--surface-2);
   color: var(--text); cursor: pointer; font-size: 1.1rem;
 }

--- a/src/lib/components/Segmented.svelte
+++ b/src/lib/components/Segmented.svelte
@@ -84,7 +84,7 @@
     font: inherit;
     font-weight: 700;
     cursor: pointer;
-    transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+    transition: background 0.15s ease, color 0.15s ease;
   }
   .seg:hover {
     color: var(--text);
@@ -92,7 +92,6 @@
   .seg.on {
     background: var(--primary);
     color: #fff;
-    box-shadow: 0 2px 12px color-mix(in srgb, var(--primary) 38%, transparent);
   }
   .seg:focus-visible {
     outline: 2px solid var(--primary);

--- a/src/lib/components/SyncBubble.svelte
+++ b/src/lib/components/SyncBubble.svelte
@@ -208,7 +208,7 @@
   }
 
   .syncbubble.busy {
-    --tone: #f7b955;
+    --tone: var(--warn);
   }
   .syncbubble.warn {
     --tone: var(--bad, #f87171);
@@ -217,7 +217,7 @@
     --tone: var(--muted);
   }
   .syncbubble.ok {
-    --tone: #29c785;
+    --tone: var(--good);
   }
   .syncbubble.idle {
     --tone: var(--muted);
@@ -231,7 +231,7 @@
     top: 0;
     bottom: 0;
     width: 0;
-    background: color-mix(in srgb, #f7b955 34%, transparent);
+    background: color-mix(in srgb, var(--warn) 34%, transparent);
     transition: width 0.2s ease;
     z-index: 0;
   }
@@ -280,7 +280,7 @@
   }
 
   .syncbubble.celebrate {
-    border-color: color-mix(in srgb, #29c785 55%, var(--border));
+    border-color: color-mix(in srgb, var(--good) 55%, var(--border));
   }
 
   @keyframes sb-spin {

--- a/src/lib/games/botc/BotcEditor.svelte
+++ b/src/lib/games/botc/BotcEditor.svelte
@@ -386,8 +386,8 @@
     gap: 8px;
   }
   .nom.executed {
-    border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
-    background: color-mix(in srgb, var(--accent) 8%, var(--surface-2));
+    border-color: var(--border);
+    background: var(--surface-3);
   }
   .nom-line {
     display: flex;
@@ -441,7 +441,7 @@
   .exec.on {
     background: var(--surface-3);
     color: var(--text);
-    border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+    border-color: var(--text);
   }
   .add {
     color: var(--muted);

--- a/src/lib/games/volleyball/VolleyballEditor.svelte
+++ b/src/lib/games/volleyball/VolleyballEditor.svelte
@@ -862,7 +862,7 @@
     padding: 6px 2px;
   }
   .tcard {
-    border-left: 3px solid color-mix(in srgb, var(--tc, var(--primary)) 70%, var(--border));
+    border-color: color-mix(in srgb, var(--tc, var(--primary)) 40%, var(--border));
     transition:
       border-color 0.15s ease,
       box-shadow 0.15s ease,
@@ -894,7 +894,7 @@
     color: #fff;
     background: color-mix(in srgb, var(--ghost-color, #7c5cff) 92%, #000);
     border: 1px solid color-mix(in srgb, #fff 30%, transparent);
-    box-shadow: 0 10px 24px -6px color-mix(in srgb, var(--ghost-color, #7c5cff) 60%, transparent);
+    box-shadow: var(--shadow);
     transition: transform 0.04s linear;
   }
   :global(body.vb-dragging) {

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -943,10 +943,10 @@
     background: var(--muted);
   }
   .dot.ok {
-    background: #29c785;
+    background: var(--good);
   }
   .dot.busy {
-    background: #f7b955;
+    background: var(--warn);
   }
   .dot.warn {
     background: var(--bad, #f87171);
@@ -974,7 +974,7 @@
     min-width: 0;
     padding: 7px 10px;
     border: 1px solid var(--border, rgba(127, 127, 127, 0.2));
-    border-radius: 8px;
+    border-radius: var(--radius-sm);
     background: var(--surface-2, rgba(127, 127, 127, 0.08));
   }
   .pathchip code {
@@ -1019,7 +1019,7 @@
     font-size: 0.64rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    background: #29c785;
+    background: var(--good);
     color: #04150d;
     padding: 1px 6px;
     border-radius: 999px;


### PR DESCRIPTION
## Critique 10 — Visual design system & theming polish

Audited `src/` styles against **DESIGN.md** / `.impeccable/design.json` / `.github/copilot-instructions.md`, hunting for token drift, hardcoded colors, stacked/decorative shadows, glass-rule bleed, Crown Gold misuse, and inconsistent radii.

### Critique items (13)

| # | Item | Why it matters | Status |
|---|------|----------------|--------|
| 1 | **Sync-status color drift** — `SyncBubble`/`Settings` hardcode `#29c785` (green) & `#f7b955` (amber) | A *second* green/amber alongside `--good`/`--warn` breaks the single palette and theme swapping (OLED/contrast). | ✅ Fixed → tokens |
| 2 | **Segmented control decorative violet glow** — `.seg.on { box-shadow: 0 2px 12px violet }` | Colored glow violates the Soft-Lift "one shadow" rule; depth should come from surface/fill. | ✅ Removed |
| 3 | **Volleyball drag-ghost colored glow shadow** — `0 10px 24px violet` | Second shadow vocabulary; should be the single Soft-Lift token. | ✅ Fixed → `var(--shadow)` |
| 4 | **BOTC Crown Gold misuse** — gold wash on `.nom.executed` + gold border on the `.exec.on` toggle | Gold on a button and on a non-winner state dilutes the Crown Gold Rule (leader/winner only). | ✅ Neutralized to surface ramp |
| 5 | **Colored `border-left` team stripe** on volleyball `.tcard` | DESIGN.md explicitly forbids colored side stripes — the classic "AI-generated UI" tell. | ✅ Replaced with subtle full tinted border |
| 6 | **Privacy pill uses glass** — `.hide-now` has `backdrop-filter: blur()` | Glass is reserved for the top app bar + bottom tab bar; a floating pill should be opaque like the toast. | ✅ Opaque `surface-3` |
| 7 | **Chip radius is a magic number** — `10px` literal in `.iconbtn`/`.tabbar`/editors | The `rounded.chip: 10px` token wasn't in CSS, so the value couldn't be governed centrally. | ✅ Added `--radius-chip`, applied in chrome |
| 8 | **Settings pathchip radius off-token** — `8px` vs the 9px control token | Small radius drift on a control-sized element. | ✅ → `--radius-sm` |
| 9 | **Settings "NEW" badge green** — `#29c785` fill | Same off-token green as item 1. | ✅ → `var(--good)` |
| 10 | **Radii drift in game editors** — pervasive `12px` container radii vs the 14px `--radius` token | Minor systemic inconsistency, but concentric nesting (12px panel inside a 14px card) is a defensible convention; mass-churning 30 files risks blind visual regressions. | ⏸ Documented, not mass-changed |
| 11 | **Status "glow-ring" shadows** — `0 0 0 3px` halos on live/status dots | Read as a second shadow vocabulary, but function as focus-ring-like state co-signals (not elevation). | ⏸ Kept as intentional co-signal |
| 12 | **Modal scrim blur** (PlaySheet/ShareResultsSheet/veil) | Blur here obscures content behind a full-screen modal/privacy layer — functional, not the decorative *panel* glass the rule targets. | ⏸ Kept as functional |
| 13 | **`JsonIcon` hardcoded hex** | Decorative file-glyph SVG art, intentionally literal. | ⏸ Kept |

### Implemented (9 of 13)
Items 1–9 above. All changes bring drifting components **back into** the existing DESIGN.md system, so no design-doc/sidecar changes were needed (the system didn't drift — the code did).

### Verification
- `npm run check` → **0 errors, 0 warnings**
- `npm test` → **909 passed (42 files)**
- `npm run build` → **success** (pre-existing chunk-size / dynamic-import warnings only)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
