### PR TITLE
Mobile one-handed ergonomics: >=46px targets, safe-area, sticky Save round

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -255,8 +255,8 @@
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    min-height: 40px;
-    padding: 0 16px;
+    min-height: 46px;
+    padding: 0 18px;
     border-radius: 999px;
     border: 1px solid var(--border);
     background: var(--surface-3);

--- a/src/app.css
+++ b/src/app.css
@@ -103,6 +103,22 @@ html[data-contrast] .btn:focus-visible {
 
 * { box-sizing: border-box; }
 
+/* Kill the 300ms tap delay and double-tap-to-zoom on interactive controls so
+   rapid one-handed score entry (steppers, toggles, tabs) responds instantly and
+   never accidentally zooms the board mid-round. */
+button,
+a,
+input,
+select,
+label,
+.btn,
+.iconbtn,
+.pill,
+[role="radio"],
+[role="button"] {
+  touch-action: manipulation;
+}
+
 html, body { margin: 0; padding: 0; }
 
 body {
@@ -218,14 +234,15 @@ tbody tr:last-child td { border-bottom: none; }
 .app {
   max-width: var(--maxw);
   margin: 0 auto;
-  padding: 0 14px calc(96px + env(safe-area-inset-bottom));
+  padding: 0 calc(14px + env(safe-area-inset-right)) calc(96px + env(safe-area-inset-bottom))
+    calc(14px + env(safe-area-inset-left));
 }
 
 .appbar {
   position: sticky; top: 0; z-index: 20;
   display: flex; align-items: center; justify-content: space-between;
   gap: 10px;
-  padding: 12px 14px calc(12px);
+  padding: 12px calc(14px + env(safe-area-inset-right)) 12px calc(14px + env(safe-area-inset-left));
   padding-top: calc(12px + env(safe-area-inset-top));
   background: color-mix(in srgb, var(--bg) 86%, transparent);
   backdrop-filter: blur(10px);
@@ -239,15 +256,16 @@ tbody tr:last-child td { border-bottom: none; }
 .tabbar {
   position: fixed; left: 0; right: 0; bottom: 0; z-index: 30;
   display: flex; justify-content: space-around;
-  padding: 8px 6px calc(8px + env(safe-area-inset-bottom));
+  padding: 8px calc(6px + env(safe-area-inset-right)) calc(8px + env(safe-area-inset-bottom))
+    calc(6px + env(safe-area-inset-left));
   background: color-mix(in srgb, var(--bg) 92%, transparent);
   backdrop-filter: blur(12px);
   border-top: 1px solid var(--border);
 }
 .tabbar a {
-  display: flex; flex-direction: column; align-items: center; gap: 2px;
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 2px;
   font-size: 0.7rem; color: var(--muted); text-decoration: none;
-  padding: 4px 10px; border-radius: var(--radius-chip); min-width: 56px;
+  padding: 4px 10px; border-radius: var(--radius-chip); min-width: 56px; min-height: 46px;
 }
 .tabbar a.active { color: var(--text); background: var(--surface-2); }
 .tabbar a .ico { font-size: 1.2rem; line-height: 1; }
@@ -365,7 +383,7 @@ tbody tr:last-child td { border-bottom: none; }
 }
 .toast-action {
   flex: none;
-  min-height: 38px; padding: 0 16px;
+  min-height: 44px; padding: 0 16px;
   border-radius: 999px; border: 1px solid var(--border);
   background: var(--surface); color: var(--text);
   font-weight: 700; font-size: 0.9rem; cursor: pointer;

--- a/src/lib/components/PlayerSelect.svelte
+++ b/src/lib/components/PlayerSelect.svelte
@@ -67,7 +67,8 @@
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    padding: 7px 12px 7px 8px;
+    min-height: 46px;
+    padding: 7px 14px 7px 10px;
     border-radius: 999px;
     border: 1px solid var(--border);
     background: var(--surface-2);

--- a/src/lib/games/hearts/HeartsEditor.svelte
+++ b/src/lib/games/hearts/HeartsEditor.svelte
@@ -57,6 +57,7 @@
   }
   .toggle {
     flex: 1;
+    min-height: 46px;
     padding: 9px;
     border: 1px solid var(--border);
     border-radius: 10px;

--- a/src/pages/Court.svelte
+++ b/src/pages/Court.svelte
@@ -356,8 +356,8 @@
     margin: 0 2px 8px;
   }
   .chip {
-    min-height: 40px;
-    padding: 6px 12px;
+    min-height: 46px;
+    padding: 6px 14px;
     border: 1px solid var(--border);
     border-radius: 999px;
     background: var(--surface);

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -563,7 +563,7 @@
         {#if draftError}
           <p class="entry-error" role="alert">⚠️ {draftError}</p>
         {/if}
-        <button class="btn primary block" onclick={saveRound} disabled={!!draftError}>Save round</button>
+        <button class="btn primary block save-round" onclick={saveRound} disabled={!!draftError}>Save round</button>
       </div>
     {:else}
       <div class="card center" style="margin-top: 12px">All {maxR} rounds played.</div>
@@ -710,6 +710,22 @@
     align-items: center;
     margin-top: 18px;
     margin-bottom: 8px;
+  }
+  /* Sticky round-entry commit: the single Royal Violet action stays pinned in the
+     thumb zone (just above the bottom tab bar) so a tall editor with many players
+     can never push "Save round" below the fold. It rides normally when the card
+     already fits; on desktop the tab bar is gone, so it returns to inline flow. */
+  .save-round {
+    position: sticky;
+    bottom: calc(74px + env(safe-area-inset-bottom));
+    z-index: 6;
+    box-shadow: var(--shadow);
+  }
+  @media (min-width: 900px) {
+    .save-round {
+      position: static;
+      box-shadow: none;
+    }
   }
   /* Inline round-entry error: an assertive alert co-signalled with ⚠️ and words
      (never colour alone) so an invalid round is clear before Save is even tapped.

--- a/src/pages/History.svelte
+++ b/src/pages/History.svelte
@@ -557,8 +557,8 @@
   }
   .grouphead .small-icon {
     flex: none;
-    width: 38px;
-    height: 38px;
+    width: 46px;
+    height: 46px;
     font-size: 0.95rem;
   }
   .avstack {
@@ -614,7 +614,7 @@
   }
   .actions {
     flex: none;
-    gap: 6px;
+    gap: 8px;
   }
   .sm {
     font-size: 0.85rem;
@@ -640,7 +640,7 @@
       gap: 8px;
     }
     .actions {
-      gap: 4px;
+      gap: 6px;
     }
   }
 </style>


### PR DESCRIPTION
## Critique 11 — Mobile one-handed ergonomics & touch targets

Audited `src/` through the lens of dim-light, one-handed, game-night phone use: thumb-reach of primary actions, ≥46px touch targets, spacing between tap targets, safe-area insets, sticky action bars, and scroll-vs-fixed behavior during round entry. All DESIGN.md non-negotiables respected (one Royal Violet primary per screen, Crown Gold untouched, surface ramp, tabular-nums, reduced-motion).

### Critique items (title · why it matters · fix)

1. **Bottom tab bar targets under 46px** — the most-tapped chrome computed to ~40px tall, failing the ≥46px non-negotiable and the "built for thumbs" claim. → `min-height:46px` + centered. **Implemented.**
2. **App bar + tab bar ignore left/right safe-area** — rotate a notched phone and nav/content hug the notch. → added `env(safe-area-inset-left/right)` to app bar, tab bar, and the content column. **Implemented.**
3. **Player-select chips ~38px tall** — a frequent setup tap, easy to mis-hit in dim light. → `min-height:46px`. **Implemented.**
4. **Court lens/sort filter chips 40px** — below target on a control row you flick through often. → `min-height:46px`. **Implemented.**
5. **History "Name this crew" ✎ icon 38px** — icon-only control under the minimum. → 46×46. **Implemented.**
6. **Privacy "Hide scores" pill 40px** — one-handed veil control below target. → `min-height:46px`. **Implemented.**
7. **Undo toast action 38px** — the only way to reverse a destructive delete, and it's time-limited. → bumped to 44px. **Implemented.**
8. **"Save round" primary not pinned to the thumb zone** — the app's heartbeat. A tall editor (many players) pushes the single Royal Violet Save button below the fold, forcing a reach/scroll to commit every round. → made Save a **sticky thumb-zone action** just above the tab bar (returns to inline flow on desktop where the tab bar is gone). **Implemented.**
9. **Hearts round-entry toggles (♠Q/♦J) ~42px** — round-entry toggles under target. → `min-height:46px`. **Implemented.**
10. **No `touch-action: manipulation`** — 300ms tap delay + double-tap-to-zoom fire during rapid stepper/toggle entry, occasionally zooming the board mid-round. → applied to interactive controls globally. **Implemented.**
11. **History share/archive/delete icons only 4–6px apart** — a destructive 🗑 sits one mis-tap from archive. → widened gap to 8px (6px on narrow screens). **Implemented.**
12. **Play-screen Delete-game is icon-only 🗑 in the top-right corner** — the hardest corner to reach one-handed, for a destructive action. It is 46px and undoable, so left as-is this pass; **documented** as a placement critique (candidate: relocate near Abandon at the bottom).

### Implemented: 11 of 12

### Local verification
- `npm run check` → 0 errors, 0 warnings
- `npm test` → 909 passed (42 files)
- `npm run build` → success (pre-existing chunk/dynamic-import warnings only)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
