### PR TITLE
Critique 14: Micro-interactions, motion & delight

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
+  import { fly } from 'svelte/transition';
+  import { prefersReducedMotion } from './lib/motion';
   import { pathStore, parseRoute, link, titleForRoute } from './lib/router';
   import { toast } from './lib/stores/toast';
   import { settings } from './lib/stores/settings';
@@ -34,11 +36,24 @@
       return;
     }
     announce(title.split(' · ')[0]);
+    playRouteTransition();
     void (async () => {
       await tick();
       mainEl?.focus();
     })();
   });
+
+  // Retrigger the quick content crossfade on each navigation by removing and
+  // re-adding the class on the next frame. Purely decorative: the reduced-motion
+  // CSS collapses the animation to nothing, and navigation never waits on it.
+  function playRouteTransition() {
+    const el = mainEl;
+    if (!el) return;
+    el.classList.remove('route-in');
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => el.classList.add('route-in'));
+    });
+  }
 
   // Which primary nav item is active — shared by the mobile tab bar and the
   // desktop sidebar rail so both stay in lockstep.
@@ -80,6 +95,11 @@
   $effect(() => {
     if (veiled) veilBtn?.focus();
   });
+
+  // Toast slide-up: rises from the thumb zone so an Undo affordance draws the eye
+  // without a jarring pop. Reduced motion collapses it to an instant appearance
+  // (duration 0), so the toast still shows — it just doesn't travel.
+  const toastFly = $derived(prefersReducedMotion() ? { duration: 0 } : { y: 16, duration: 220 });
 </script>
 
 {#snippet navLinks()}
@@ -183,11 +203,13 @@
 </div>
 
 {#if $toast}
-  <div class="toast" role="status" aria-live="polite" aria-atomic="true">
-    <span>{$toast.message}</span>
-    {#if $toast.action}
-      <button class="toast-action" onclick={$toast.action.run}>{$toast.action.label}</button>
-    {/if}
+  <div class="toast-host">
+    <div class="toast" role="status" aria-live="polite" aria-atomic="true" in:fly={toastFly} out:fly={toastFly}>
+      <span>{$toast.message}</span>
+      {#if $toast.action}
+        <button class="toast-action" onclick={$toast.action.run}>{$toast.action.label}</button>
+      {/if}
+    </div>
   </div>
 {/if}
 

--- a/src/app.css
+++ b/src/app.css
@@ -14,6 +14,17 @@
   --card-gap: 6px;
   --maxw: 760px;
 
+  /* Motion tokens (mirror .impeccable/design.json). Fast and functional — the
+     whole system stays inside the 150–250ms "conveys state, never choreography"
+     budget. One place to tune timing so the chrome moves as one. */
+  --dur-press: 0.05s;   /* button press-down */
+  --dur-fast: 0.12s;    /* tile lift, small state shifts */
+  --dur-base: 0.15s;    /* default hover/state color transitions */
+  --dur-slow: 0.24s;    /* page/route crossfade — top of the budget */
+  --dur-flash: 0.9s;    /* round-saved confirmation pulse */
+  --ease-out: cubic-bezier(0.22, 0.61, 0.36, 1);
+  --ease-standard: ease;
+
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   font-size: calc(100% * var(--font-scale, 1));
   line-height: 1.5;
@@ -152,7 +163,7 @@ button, input, select { font: inherit; }
   color: var(--text);
   cursor: pointer;
   font-weight: 600;
-  transition: transform 0.05s ease, background 0.15s ease, border-color 0.15s ease;
+  transition: transform var(--dur-press) var(--ease-standard), background var(--dur-base) var(--ease-standard), border-color var(--dur-base) var(--ease-standard);
   user-select: none;
 }
 .btn:hover { background: var(--surface-3); }
@@ -336,8 +347,12 @@ tbody tr:last-child td { border-bottom: none; }
   border: 1px solid var(--border); border-radius: var(--radius);
   background: var(--surface); color: var(--text); cursor: pointer;
   box-shadow: var(--shadow);
+  transition: transform var(--dur-fast) var(--ease-out), border-color var(--dur-fast) var(--ease-standard);
 }
-.gametile:hover { border-color: var(--primary); text-decoration: none; transform: translateY(-1px); transition: 0.12s; }
+.gametile:hover { border-color: var(--primary); text-decoration: none; transform: translateY(-1px); }
+/* Tap gives the same 1px press-down as buttons so picking a game feels tactile,
+   not just hover-reactive (hover doesn't exist on the phone this is built for). */
+.gametile:active { transform: translateY(1px); }
 .gametile .emoji { font-size: 2rem; }
 .gametile .name { font-weight: 700; }
 .gametile .tag { font-size: 0.8rem; color: var(--muted); }
@@ -347,6 +362,19 @@ tbody tr:last-child td { border-bottom: none; }
 .section-title { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); margin: 18px 4px 8px; }
 
 .empty { text-align: center; color: var(--muted); padding: 32px 16px; }
+
+/* Route transition: a quick, quiet crossfade played on the scroll stage each time
+   the route changes. Applied by toggling `.route-in` on <main> (no remount, so
+   focus/scroll handling is untouched). Stays at the top of the motion budget and
+   is purely decorative — navigation completes instantly whether or not it plays,
+   and the global reduced-motion rules settle it to nothing. */
+.app.route-in {
+  animation: route-in var(--dur-slow) var(--ease-out);
+}
+@keyframes route-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
 
 .sr-only {
   position: absolute; width: 1px; height: 1px;
@@ -371,15 +399,24 @@ tbody tr:last-child td { border-bottom: none; }
 }
 @keyframes sk-shimmer { 100% { transform: translateX(100%); } }
 
+/* The toast rides in a full-width fixed host so its own transform is free for the
+   fly transition; the host handles centering and stays click-through except on
+   the toast itself. */
+.toast-host {
+  position: fixed; left: 0; right: 0;
+  bottom: calc(86px + env(safe-area-inset-bottom));
+  display: flex; justify-content: center;
+  padding: 0 12px;
+  z-index: 70; pointer-events: none;
+}
 .toast {
-  position: fixed; left: 50%; bottom: calc(86px + env(safe-area-inset-bottom));
-  transform: translateX(-50%);
   display: flex; align-items: center; gap: 14px;
   max-width: min(92vw, 420px);
   background: var(--surface-3); color: var(--text);
   border: 1px solid var(--border); border-radius: 999px;
-  padding: 8px 8px 8px 18px; box-shadow: var(--shadow); z-index: 70;
+  padding: 8px 8px 8px 18px; box-shadow: var(--shadow);
   font-size: 0.9rem;
+  pointer-events: auto;
 }
 .toast-action {
   flex: none;

--- a/src/lib/components/ReplicaBoard.svelte
+++ b/src/lib/components/ReplicaBoard.svelte
@@ -9,6 +9,7 @@
   import { resolveLower } from '../types';
   import { getModule } from '../games/registry';
   import { computeTotals } from '../scoring';
+  import { haptic } from '../haptics';
   import { showToast } from '../stores/toast';
   import {
     liveReplica,
@@ -122,6 +123,7 @@
     if (n > seenRoundCount) {
       const landed = replica.rounds[n - 1];
       if (landed) flashRow(landed.id);
+      haptic('save');
       if (sending && n > sentAtRoundCount) clearSending();
     }
     seenRoundCount = n;

--- a/src/lib/components/Scoreboard.svelte
+++ b/src/lib/components/Scoreboard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ID, Player } from '../types';
   import { standings, leaders } from '../scoring';
+  import { bumpOnChange, popIn } from '../motion';
   import Avatar from './Avatar.svelte';
 
   let {
@@ -58,14 +59,14 @@
             {#if p}<Avatar name={p.name} color={p.color} size={24} decorative />{p.name}{/if}
             {#if youId && s.playerId === youId}<span class="you">You</span>{/if}
             {#if winnerSet.has(s.playerId)}
-              <span aria-hidden="true" title="Winner">🏆</span><span class="sr-only">Winner</span>
+              <span aria-hidden="true" title="Winner" use:popIn>🏆</span><span class="sr-only">Winner</span>
             {:else if leaderSet.has(s.playerId)}
-              <span aria-hidden="true" title="Leading">👑</span><span class="sr-only">Leading</span>
+              <span aria-hidden="true" title="Leading" use:popIn>👑</span><span class="sr-only">Leading</span>
             {/if}
           </span>
         </td>
         <td class="num" class:lead={isGold(s.playerId)}>
-          <span class="total">{s.total}</span>
+          <span class="total" use:bumpOnChange={s.total}>{s.total}</span>
           {#if leaderSet.size && !leaderSet.has(s.playerId) && !winnerSet.has(s.playerId)}
             <span class="gap">{behind} back</span>
           {:else if singleLeader && leaderSet.has(s.playerId) && winnerSet.size === 0 && ranked.length > 1}

--- a/src/lib/components/Segmented.svelte
+++ b/src/lib/components/Segmented.svelte
@@ -84,10 +84,13 @@
     font: inherit;
     font-weight: 700;
     cursor: pointer;
-    transition: background 0.15s ease, color 0.15s ease;
+    transition: background var(--dur-base) var(--ease-standard), color var(--dur-base) var(--ease-standard), transform var(--dur-press) var(--ease-standard);
   }
   .seg:hover {
     color: var(--text);
+  }
+  .seg:active {
+    transform: translateY(1px);
   }
   .seg.on {
     background: var(--primary);

--- a/src/lib/components/Stepper.svelte
+++ b/src/lib/components/Stepper.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { clamp } from '../util';
+  import { haptic } from '../haptics';
+  import { animateMotion } from '../motion';
 
   let {
     value = $bindable(0),
@@ -17,10 +19,14 @@
   const incLabel = $derived(label ? `Increase ${label}` : 'Increase');
 
   function dec() {
-    value = clamp((Number(value) || 0) - step, min, max);
+    const next = clamp((Number(value) || 0) - step, min, max);
+    if (next !== value) haptic('tick');
+    value = next;
   }
   function inc() {
-    value = clamp((Number(value) || 0) + step, min, max);
+    const next = clamp((Number(value) || 0) + step, min, max);
+    if (next !== value) haptic('tick');
+    value = next;
   }
   // Keyboard users can type straight into the field; clamp on change so a typed
   // value can't slip past the bounds the − / + buttons enforce.
@@ -28,15 +34,30 @@
     if (value == null || Number.isNaN(Number(value))) return;
     value = clamp(Number(value), min, max);
   }
+
+  // A one-frame "bump" retriggered whenever the value changes, so the number
+  // gives a tiny tactile-looking nudge under the thumb. Driven through
+  // animateMotion so it retriggers reliably and auto-skips under reduced motion.
+  let inputEl: HTMLInputElement | undefined = $state();
+  let firstRun = true;
+  $effect(() => {
+    void value;
+    if (firstRun) {
+      firstRun = false;
+      return;
+    }
+    if (inputEl) animateMotion(inputEl, { scale: [1, 1.12, 1] }, { duration: 0.14, ease: 'easeOut' });
+  });
 </script>
 
 <div class="stepper">
-  <button type="button" class="iconbtn" onclick={dec} disabled={value <= min} aria-label={decLabel}>
+  <button type="button" class="iconbtn step-btn" onclick={dec} disabled={value <= min} aria-label={decLabel}>
     −
   </button>
   <input
     type="number"
     bind:value
+    bind:this={inputEl}
     {min}
     {max}
     {step}
@@ -44,7 +65,7 @@
     aria-label={fieldLabel}
     onchange={clampTyped}
   />
-  <button type="button" class="iconbtn" onclick={inc} disabled={value >= max} aria-label={incLabel}>
+  <button type="button" class="iconbtn step-btn" onclick={inc} disabled={value >= max} aria-label={incLabel}>
     +
   </button>
 </div>
@@ -69,5 +90,13 @@
     -webkit-appearance: none;
     appearance: none;
     margin: 0;
+  }
+  /* Press feedback on the ± buttons: a subtle scale-in so the signature control
+     feels physical under the thumb (hover doesn't exist on the target phone). */
+  .step-btn {
+    transition: transform var(--dur-press) var(--ease-standard), background var(--dur-base) var(--ease-standard);
+  }
+  .step-btn:active {
+    transform: scale(0.92);
   }
 </style>

--- a/src/lib/components/WinnerCelebration.svelte
+++ b/src/lib/components/WinnerCelebration.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../motion';
+
+  /**
+   * A one-shot confetti burst for the winner moment. Pure delight layered over a
+   * banner that already announces the win in words + 🏆 (so motion is never the
+   * only signal). It renders nothing at all under reduced motion, plays exactly
+   * once, and is `pointer-events: none` so it never blocks the Play again / Share
+   * actions underneath. Gold leads the mix — a win is the one place Crown Gold
+   * gets to celebrate.
+   */
+  let {
+    /** How many pieces to scatter. Kept modest so it reads as a flourish, not a screen-filler. */
+    count = 16,
+  }: { count?: number } = $props();
+
+  const reduced = prefersReducedMotion();
+
+  // A small, deterministic scatter so every win feels lively but never chaotic.
+  const pieces = $derived(
+    Array.from({ length: count }, (_, i) => {
+      const rand = (n: number) => ((Math.sin(i * 12.9898 + n * 78.233) * 43758.5453) % 1 + 1) % 1;
+      const palette = ['var(--accent)', 'var(--accent)', 'var(--primary)', 'var(--good)', 'var(--bad)'];
+      return {
+        left: 6 + rand(1) * 88, // vw-ish %, kept off the edges
+        delay: rand(2) * 0.25,
+        duration: 1.1 + rand(3) * 0.8,
+        drift: (rand(4) - 0.5) * 90, // px horizontal drift
+        spin: 180 + rand(5) * 540,
+        size: 7 + rand(6) * 7,
+        color: palette[Math.floor(rand(7) * palette.length)],
+        round: rand(8) > 0.6,
+      };
+    }),
+  );
+</script>
+
+{#if !reduced}
+  <div class="confetti" aria-hidden="true">
+    {#each pieces as p, i (i)}
+      <span
+        class="piece"
+        class:round={p.round}
+        style="
+          left: {p.left}%;
+          width: {p.size}px;
+          height: {p.size * 0.6}px;
+          background: {p.color};
+          animation-delay: {p.delay}s;
+          animation-duration: {p.duration}s;
+          --drift: {p.drift}px;
+          --spin: {p.spin}deg;
+        "
+      ></span>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .confetti {
+    position: absolute;
+    inset: -8px 0 auto 0;
+    height: 0;
+    pointer-events: none;
+    overflow: visible;
+    z-index: 1;
+  }
+  .piece {
+    position: absolute;
+    top: 0;
+    border-radius: 2px;
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: confetti-fall;
+    animation-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1);
+    animation-iteration-count: 1;
+    animation-fill-mode: both;
+  }
+  .piece.round {
+    border-radius: 50%;
+  }
+  @keyframes confetti-fall {
+    0% {
+      opacity: 0;
+      transform: translate(0, -6px) rotate(0deg) scale(0.6);
+    }
+    12% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+      transform: translate(var(--drift), 120px) rotate(var(--spin)) scale(1);
+    }
+  }
+</style>

--- a/src/lib/haptics.test.ts
+++ b/src/lib/haptics.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { haptic, hapticsSupported } from './haptics';
+import { settings } from './stores/settings';
+
+/**
+ * The haptics helper must be a good table citizen: buzz on the right moments, but
+ * only when the user hasn't opted out (setting or reduced-motion) and the device
+ * can actually vibrate. These tests pin that three-way gate so a future change
+ * can't start buzzing phones that asked for quiet.
+ */
+describe('haptic', () => {
+  const original = Object.getOwnPropertyDescriptor(navigator, 'vibrate');
+  let vibrate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vibrate = vi.fn(() => true);
+    Object.defineProperty(navigator, 'vibrate', { value: vibrate, configurable: true });
+    // Default settings: haptics on, motion 'full' so reduced-motion never gates.
+    settings.update((s) => ({ ...s, haptics: true, motion: 'full' }));
+  });
+
+  afterEach(() => {
+    if (original) Object.defineProperty(navigator, 'vibrate', original);
+    else delete (navigator as unknown as { vibrate?: unknown }).vibrate;
+    settings.update((s) => ({ ...s, haptics: true, motion: 'system' }));
+  });
+
+  it('vibrates for a known pattern when enabled and supported', () => {
+    haptic('save');
+    expect(vibrate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when the haptics setting is off', () => {
+    settings.update((s) => ({ ...s, haptics: false }));
+    haptic('save');
+    expect(vibrate).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when motion is reduced', () => {
+    settings.update((s) => ({ ...s, motion: 'reduce' }));
+    haptic('win');
+    expect(vibrate).not.toHaveBeenCalled();
+  });
+
+  it('never throws if vibrate rejects', () => {
+    vibrate.mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    expect(() => haptic('tick')).not.toThrow();
+  });
+
+  it('reports support based on navigator.vibrate', () => {
+    expect(hapticsSupported()).toBe(true);
+    delete (navigator as unknown as { vibrate?: unknown }).vibrate;
+    expect(hapticsSupported()).toBe(false);
+  });
+});

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -1,0 +1,49 @@
+import { get } from 'svelte/store';
+import { settings } from './stores/settings';
+import { prefersReducedMotion } from './motion';
+
+/**
+ * Tasteful, opt-out haptic feedback for the moments that matter at the table —
+ * a saved round, an undo, a win. Kept deliberately tiny: a game-night helper
+ * should feel physical when you commit a score, never buzz for decoration.
+ *
+ * Every buzz is gated three ways so it can never surprise or annoy:
+ *   1. the in-app `haptics` setting (default on, one toggle in Accessibility),
+ *   2. the reduced-motion preference (a physical buzz is motion too), and
+ *   3. actual `navigator.vibrate` support (absent on desktop and iOS Safari).
+ *
+ * Patterns are short and distinct so a saved round and a win don't feel the same.
+ */
+export type HapticPattern = 'tick' | 'save' | 'win' | 'undo';
+
+const PATTERNS: Record<HapticPattern, number | number[]> = {
+  tick: 8, // a single light nudge for a stepper ±
+  save: 18, // a firm "it landed" for a saved round
+  win: [22, 40, 22, 40, 60], // a celebratory triple-tap for a win
+  undo: [10, 30, 10], // a gentle double for a reversal
+};
+
+function canVibrate(): boolean {
+  return typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function';
+}
+
+/**
+ * Fire a haptic pattern if the user hasn't turned haptics or motion off and the
+ * device supports vibration. Safe to call unconditionally from any interaction —
+ * it no-ops everywhere it shouldn't run.
+ */
+export function haptic(pattern: HapticPattern): void {
+  if (!canVibrate()) return;
+  if (prefersReducedMotion()) return;
+  if (get(settings).haptics === false) return;
+  try {
+    navigator.vibrate(PATTERNS[pattern]);
+  } catch {
+    // A rejected/broken vibrate must never break score entry.
+  }
+}
+
+/** True when the current device can produce haptics at all — for gating UI copy. */
+export function hapticsSupported(): boolean {
+  return canVibrate();
+}

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -65,3 +65,35 @@ export function animateMotion(...args: Parameters<typeof animate>): AnimateContr
   if (prefersReducedMotion()) return skippedAnimation();
   return animate(...args);
 }
+
+/**
+ * Svelte action: give an element a quick scale "bump" whenever the bound value
+ * changes — never on mount. Perfect for a score total that updates in place, so
+ * the eye is drawn to the number that moved without any layout shift or colour
+ * change (the number itself still carries the state). Auto-skips under reduced
+ * motion via {@link animateMotion}.
+ */
+export function bumpOnChange(node: HTMLElement, value: unknown) {
+  let prev = value;
+  return {
+    update(next: unknown) {
+      if (Object.is(next, prev)) return;
+      prev = next;
+      animateMotion(node, { scale: [1, 1.18, 1] }, { duration: 0.18, ease: 'easeOut' });
+    },
+  };
+}
+
+/**
+ * Svelte action: a small celebratory pop when an element first appears — used
+ * for the leader 👑 and winner 🏆 as they mount, so a change of reign gets a
+ * beat of delight. Motion-only decoration (the icon + text carry the meaning),
+ * so it's fully skipped under reduced motion.
+ */
+export function popIn(node: HTMLElement) {
+  animateMotion(
+    node,
+    { scale: [0.4, 1.25, 1], rotate: [-12, 4, 0] },
+    { duration: 0.42, ease: 'easeOut' },
+  );
+}

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -33,6 +33,8 @@ export interface Settings {
   colorBlind: boolean;
   /** Hold a screen wake lock while a game is being played. */
   keepAwake: boolean;
+  /** Tasteful vibration feedback on save/undo/win where the device supports it. */
+  haptics: boolean;
   /** Blur scores with a tap-to-reveal veil after the phone is set down. */
   privacyGuard: boolean;
   /** Let the Daily Crown & Court surface playful roasts/rivalries, not just flexes. */
@@ -111,6 +113,7 @@ export const PORTABLE_SETTING_KEYS = [
   'keepAwake',
   'privacyGuard',
   'roastMode',
+  'haptics',
   'catalogFavorites',
   'catalogHidden',
   'gamePresets',
@@ -167,6 +170,7 @@ const defaults: Settings = {
   keepAwake: false,
   privacyGuard: false,
   roastMode: true,
+  haptics: true,
   catalogFavorites: [],
   catalogHidden: [],
   gamePresets: [],
@@ -325,6 +329,7 @@ export const GAMEPLAY_SETTING_KEYS = [
   'keepAwake',
   'privacyGuard',
   'roastMode',
+  'haptics',
 ] as const satisfies readonly PortableSettingKey[];
 
 /** True when any key in `keys` currently differs from its factory default. */

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -22,12 +22,14 @@
   import { navigate, link, absoluteUrl } from '../lib/router';
   import { showToast, showActionToast } from '../lib/stores/toast';
   import { announce } from '../lib/stores/announcer';
+  import { haptic } from '../lib/haptics';
   import { relativeTime, generateJoinCode, rosterFor } from '../lib/util';
   import { settings } from '../lib/stores/settings';
   import { leadMember } from '../lib/stores/identity';
   import { enableWakeLock, disableWakeLock } from '../lib/wakelock';
   import Scoreboard from '../lib/components/Scoreboard.svelte';
   import Avatar from '../lib/components/Avatar.svelte';
+  import WinnerCelebration from '../lib/components/WinnerCelebration.svelte';
   import PlaySheet from '../lib/components/PlaySheet.svelte';
   import ShareResultsSheet from '../lib/components/ShareResultsSheet.svelte';
   import BackLink from '../lib/components/BackLink.svelte';
@@ -217,6 +219,7 @@
     const newest = rounds[rounds.length - 1];
     if (newest) {
       pulseRow(newest.id);
+      haptic('save');
       announce(`Round ${newest.index + 1} saved. ${leaderSummary()}`);
     }
   }
@@ -279,6 +282,7 @@
         await load();
         publish();
       });
+      haptic('undo');
     });
   }
 
@@ -293,6 +297,7 @@
       .map((wid) => plist.find((p) => p.id === wid)?.name ?? '?')
       .join(' and ');
     if (names) {
+      haptic('win');
       announce(`Game finished. ${names} ${(game?.winnerIds?.length ?? 0) > 1 ? 'tie for the win' : 'wins'}.`);
     }
   }
@@ -327,6 +332,7 @@
     showActionToast('Game deleted', 'Undo', async () => {
       await restoreGame(gameSnap, roundsSnap);
       navigate(`/play/${gameSnap.id}`);
+      haptic('undo');
     });
   }
 
@@ -525,7 +531,10 @@
   <Scoreboard players={orderedPlayers} {totals} lowerIsBetter={lower} winners={game.winnerIds ?? []} youId={$leadMember?.id} />
 
   {#if game.status === 'finished'}
-    <div class="card center banner">🏆 {winnerNames || 'Nobody'} {(game.winnerIds?.length ?? 0) > 1 ? 'tie!' : 'wins!'}</div>
+    <div class="card center banner winner-banner">
+      <WinnerCelebration />
+      <span class="banner-text">🏆 {winnerNames || 'Nobody'} {(game.winnerIds?.length ?? 0) > 1 ? 'tie!' : 'wins!'}</span>
+    </div>
     <button class="btn block" style="margin-top: 12px" onclick={() => (shareOpen = true)}>
       📤 Share results
     </button>
@@ -753,6 +762,31 @@
     font-weight: 800;
     background: color-mix(in srgb, var(--accent) 22%, var(--surface));
     border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+  }
+  /* The winner banner is the celebration stage: it hosts the one-shot confetti
+     (positioned relative so the pieces rain from its top edge) and gives itself a
+     single gentle pop as it mounts. It only ever mounts when a game finishes, so
+     the entrance plays exactly once; reduced motion collapses it to a static card
+     and the confetti component renders nothing. The 🏆 + "wins!" text always
+     carries the outcome, so none of this is state-by-motion. */
+  .winner-banner {
+    position: relative;
+    overflow: visible;
+    animation: winner-pop 0.5s var(--ease-out, cubic-bezier(0.22, 0.61, 0.36, 1)) both;
+  }
+  .banner-text {
+    position: relative;
+    z-index: 2;
+  }
+  @keyframes winner-pop {
+    0% { transform: scale(0.94); opacity: 0; }
+    55% { transform: scale(1.03); opacity: 1; }
+    100% { transform: scale(1); opacity: 1; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .winner-banner {
+      animation: none;
+    }
   }
   .scroll {
     overflow-x: auto;

--- a/src/pages/GameplaySettings.svelte
+++ b/src/pages/GameplaySettings.svelte
@@ -6,14 +6,16 @@
     GAMEPLAY_SETTING_KEYS,
   } from '../lib/stores/settings';
   import { isWakeLockSupported } from '../lib/wakelock';
+  import { hapticsSupported } from '../lib/haptics';
   import BackLink from '../lib/components/BackLink.svelte';
   import Switch from '../lib/components/Switch.svelte';
 
   const wakeSupported = isWakeLockSupported();
+  const canHaptics = hapticsSupported();
 
   const canReset = $derived(differsFromDefaults($settings, GAMEPLAY_SETTING_KEYS));
 
-  function setBool(key: 'keepAwake' | 'privacyGuard' | 'roastMode', v: boolean) {
+  function setBool(key: 'keepAwake' | 'privacyGuard' | 'roastMode' | 'haptics', v: boolean) {
     settings.update((s) => ({ ...s, [key]: v }));
   }
 </script>
@@ -50,6 +52,22 @@
     <span class="muted sm">Blurs the board when you set the phone down, so a passer-by can’t read the scores. Tap to reveal.</span>
   </span>
   <Switch checked={$settings.privacyGuard} onchange={(v) => setBool('privacyGuard', v)} />
+</label>
+
+<label class="card sw-row row spread">
+  <span class="meta">
+    <span class="name">Haptic feedback</span>
+    <span class="muted sm">
+      {canHaptics
+        ? 'A gentle buzz when a round saves, an undo fires, or someone wins. Follows your Reduced-motion setting.'
+        : 'This device doesn’t support vibration.'}
+    </span>
+  </span>
+  <Switch
+    checked={$settings.haptics}
+    disabled={!canHaptics}
+    onchange={(v) => setBool('haptics', v)}
+  />
 </label>
 
 <div class="section-title">Personality</div>


### PR DESCRIPTION
## Critique 14 — Micro-interactions, Motion & Delight

Audited Score King through the lens of **motion & delight**, expressing the *Whimsical, Easy, Game-Night Energy* personality through motion while keeping the shared chrome identical game-to-game and honoring `prefers-reduced-motion` everywhere. Every animation has a non-animated fallback, uses the design.json motion budget (150–250ms), and never conveys state by motion alone.

### Critique items (title · why it matters · fix)

1. **No shared motion tokens** — durations/easings were magic numbers (0.05/0.12/0.15/0.9s) scattered across files; design.json defines motion tokens but the CSS had none. → **Added** `--dur-*` / `--ease-*` custom properties in `app.css`, adopted across the shared chrome.
2. **Toast pops in/out abruptly** — the Undo toast (a named DESIGN.md feedback moment) had no entrance/exit. → **Added** a `fly` slide-up in/out, reduced-motion falls back to instant.
3. **No haptics** — the brief asks for tasteful haptics where available; none existed. → **Added** `haptics.ts` gated three ways (new portable `haptics` setting + reduced-motion + `navigator.vibrate` support), wired into save/undo/win/stepper on host **and** guest boards, with a Gameplay-settings toggle and unit tests.
4. **Winner moment was static** — the 🏆 banner just appeared. → **Added** a one-shot confetti burst + gentle banner pop (Crown Gold is allowed to celebrate here), co-signalled by the existing trophy + "wins!" text; renders nothing under reduced motion.
5. **Score totals swapped instantly** — no score-change transition. → **Added** a subtle scale "bump" on a player's total when it changes (`bumpOnChange` action) — the number itself still carries the state.
6. **Lead change uncelebrated** — the 👑 just moved. → **Added** a `popIn` pop as the leader crown / winner trophy mounts.
7. **Route/tab changes were instant** — no route transition. → **Added** a quick content crossfade on navigation via a class toggle on `<main>` (no remount, focus/scroll handling untouched).
8. **Stepper ± had no tactile feedback** — the signature control felt flat. → **Added** a press scale on the ± buttons + a value bump + a haptic tick.
9. **GameTile had no press feedback** — hover lifted but tap didn't (and the phone has no hover). → **Added** a `:active` press using the shared token.
10. **Segmented switch was abrupt** — → **Added** token-based transitions + a press affordance.
11. **Save gave no cross-device confirmation on haptic-capable phones** — → save haptic fires for host and guest when a round lands, alongside the existing green row pulse.
12. **Reduced-motion audit** — every new animation routes through the `animateMotion` boundary or a CSS reduced-motion fallback, so nothing new buzzes or moves when the user (or OS) asks for calm.

### Implemented
All 12 items above are implemented in this PR.

### Files
- `src/app.css` — motion tokens, route-transition keyframe, toast host restructure, gametile press.
- `src/lib/motion.ts` — `bumpOnChange` + `popIn` reusable actions.
- `src/lib/haptics.ts` (+ `haptics.test.ts`) — gated haptics helper.
- `src/lib/components/WinnerCelebration.svelte` — reduced-motion-safe confetti.
- `src/lib/components/{Scoreboard,Stepper,Segmented,ReplicaBoard}.svelte` — micro-interactions + haptics.
- `src/pages/{GamePlay,GameplaySettings}.svelte` — celebration wiring, haptics wiring, settings toggle.
- `src/App.svelte` — toast transition + route crossfade.
- `src/lib/stores/settings.ts` — new portable `haptics` preference.

### Design non-negotiables respected
One Royal Violet primary per screen (unchanged), Crown Gold reserved for leader/winner (celebration confetti is the sanctioned exception), surface-ramp depth, one Soft Lift shadow, tabular-nums, ≥46px targets, state never by color/motion alone, `prefers-reduced-motion` honored, and **identical chrome game-to-game** — all delight rides on top of the shared shell.

### Local checks
- `npm run check` — 0 errors, 0 warnings
- `npm test` — **921 passing** (+5 new haptics tests)
- `npm run build` — clean
