### PR TITLE
Skull King: bounty builder, pirate whimsy & tests

### DIFF
--- a/src/lib/games/skullking/CoinBurst.svelte
+++ b/src/lib/games/skullking/CoinBurst.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * A short treasure pop layered over a player's bounty control. Pure delight on
+   * top of a bounty total that's already shown in words + number, so motion is
+   * never the only signal. Renders nothing under reduced motion, is
+   * `pointer-events: none`, and replays whenever `token` changes (a new capture)
+   * — a small cascade for a big haul, a couple of coins for a modest one.
+   */
+  let {
+    /** Bump this to replay the burst (e.g. the running bounty total). */
+    token = 0,
+    /** Bigger, more coins for a significant capture. */
+    big = false,
+  }: { token?: number; big?: boolean } = $props();
+
+  const reduced = prefersReducedMotion();
+  const count = $derived(big ? 10 : 5);
+
+  const coins = $derived(
+    Array.from({ length: count }, (_, i) => {
+      const rand = (n: number) => ((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1 + 1) % 1;
+      const glyphs = ['🪙', '🪙', '💰', '✨'];
+      return {
+        left: 50 + (rand(1) - 0.5) * (big ? 120 : 70),
+        delay: rand(2) * 0.12,
+        duration: 0.7 + rand(3) * 0.5,
+        rise: 26 + rand(4) * (big ? 40 : 22),
+        drift: (rand(5) - 0.5) * 30,
+        spin: (rand(6) - 0.5) * 220,
+        size: 0.85 + rand(7) * (big ? 0.7 : 0.4),
+        glyph: glyphs[Math.floor(rand(8) * glyphs.length)],
+      };
+    }),
+  );
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="coins" aria-hidden="true">
+      {#each coins as c, i (i)}
+        <span
+          class="coin"
+          style="
+            left: {c.left}%;
+            font-size: {c.size}rem;
+            animation-delay: {c.delay}s;
+            animation-duration: {c.duration}s;
+            --rise: {c.rise}px;
+            --drift: {c.drift}px;
+            --spin: {c.spin}deg;
+          ">{c.glyph}</span>
+      {/each}
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .coins {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 0;
+    pointer-events: none;
+    overflow: visible;
+    z-index: 2;
+  }
+  .coin {
+    position: absolute;
+    bottom: 0;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: coin-pop;
+    animation-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1);
+    animation-iteration-count: 1;
+    animation-fill-mode: both;
+  }
+  @keyframes coin-pop {
+    0% {
+      opacity: 0;
+      transform: translate(0, 4px) rotate(0deg) scale(0.5);
+    }
+    18% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+      transform: translate(var(--drift), calc(var(--rise) * -1)) rotate(var(--spin)) scale(1);
+    }
+  }
+</style>

--- a/src/lib/games/skullking/SkullKingEditor.svelte
+++ b/src/lib/games/skullking/SkullKingEditor.svelte
@@ -2,29 +2,106 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
-  import { scoreRow, skullking, type SKInput } from './index';
+  import { haptic } from '../../haptics';
+  import { skullking } from './index';
+  import VoyageRibbon from './VoyageRibbon.svelte';
+  import CoinBurst from './CoinBurst.svelte';
+  import {
+    BONUS_VALUES,
+    BOUNTY_LIMITS,
+    bountyTotal,
+    emptyBounty,
+    outcomeLabel,
+    readConfig,
+    scoreRow,
+    type SKBounty,
+    type SKInput,
+  } from './logic';
 
   let { input = $bindable(), ctx }: { input: SKInput; ctx: RoundContext } = $props();
 
   const n = $derived(ctx.roundIndex + 1);
-  const requireBid = $derived(ctx.config.bonusesRequireBid !== false);
-  const won = $derived(
-    ctx.players.reduce((a, p) => a + (Number(input.rows[p.id]?.actual) || 0), 0),
+  const total = $derived(readConfig(ctx.config).rounds);
+  const requireBid = $derived(readConfig(ctx.config).bonusesRequireBid);
+  const won = $derived(ctx.players.reduce((a, p) => a + (Number(input.rows[p.id]?.actual) || 0), 0));
+  const bidSum = $derived(ctx.players.reduce((a, p) => a + (Number(input.rows[p.id]?.bid) || 0), 0));
+  const bidRead = $derived(
+    bidSum === n ? '⚖️ dead even' : bidSum > n ? '🌊 over-bid seas' : '🍃 tricks to spare',
   );
+
   let showHelp = $state(false);
+  let open = $state<Record<string, boolean>>({});
+  let tokens = $state<Record<string, number>>({});
+  let bigHaul = $state<Record<string, boolean>>({});
+  const prevBounty: Record<string, number> = {};
+  let ready = false;
+
+  const bountyOf = $derived(
+    Object.fromEntries(ctx.players.map((p) => [p.id, bountyTotal(input.rows[p.id]?.bounty)])),
+  );
+
+  // Legacy rounds saved before the builder carry only a numeric `bonus`; seed a
+  // structured bounty (with that number preserved as a manual entry) so nothing
+  // is lost and every capture stays editable. Also primes the burst baseline so
+  // pre-existing bounty doesn't fire coins on open.
+  $effect(() => {
+    if (ready) return;
+    for (const p of ctx.players) {
+      const row = input.rows[p.id];
+      if (!row) continue;
+      if (!row.bounty) row.bounty = { ...emptyBounty(), manual: Number(row.bonus) || 0 };
+      prevBounty[p.id] = bountyTotal(row.bounty);
+    }
+    ready = true;
+  });
+
+  // Keep the numeric `bonus` mirror in sync with the structured bounty, so
+  // history summaries and stats that read `bonus` stay correct.
+  $effect(() => {
+    for (const p of ctx.players) {
+      const row = input.rows[p.id];
+      if (row?.bounty) row.bonus = bountyTotal(row.bounty);
+    }
+  });
+
+  // Treasure pop whenever a player's bounty climbs — a small cascade for a big
+  // capture (≥ a Pirate) or a growing hoard. Skipped wholesale under reduced
+  // motion inside CoinBurst.
+  $effect(() => {
+    if (!ready) return;
+    for (const p of ctx.players) {
+      const cur = bountyOf[p.id] ?? 0;
+      const prev = prevBounty[p.id] ?? 0;
+      if (cur > prev) {
+        tokens = { ...tokens, [p.id]: (tokens[p.id] ?? 0) + 1 };
+        bigHaul = { ...bigHaul, [p.id]: cur - prev >= BONUS_VALUES.pirate || cur >= 40 };
+        haptic('tick');
+      }
+      prevBounty[p.id] = cur;
+    }
+  });
 
   function preview(id: string): number {
     return scoreRow(input.rows[id], n, requireBid);
   }
+  function toggleTray(id: string) {
+    open = { ...open, [id]: !open[id] };
+  }
+  function flip(b: SKBounty, key: 'jollyRoger' | 'mermaidCatchesSK' | 'skOverMermaid') {
+    b[key] = !b[key];
+  }
+  const signed = (v: number) => (v >= 0 ? `+${v}` : `${v}`);
 </script>
 
 <div class="stack">
-  <div class="row spread">
-    <span class="pill">Round {n} · {n} {n === 1 ? 'trick' : 'tricks'}</span>
-    <span class="row" style="gap: 8px">
-      <span class="pill" class:score-bad={won > n}>won {won}/{n}</span>
+  <VoyageRibbon round={n} {total} />
+
+  <div class="row spread wrap">
+    <span class="pill" class:score-bad={won > n}>🃏 won {won}/{n}</span>
+    <span class="row wrap" style="gap: 8px">
+      <span class="pill" title="Total tricks bid vs. tricks available">🗣️ bids {bidSum} · {bidRead}</span>
       <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
-        Bonuses
+        Bounty guide
       </button>
     </span>
   </div>
@@ -35,24 +112,77 @@
 
   {#each ctx.players as p (p.id)}
     {@const row = input.rows[p.id]}
+    {@const b = row.bounty ?? emptyBounty()}
+    {@const oc = outcomeLabel(row, n)}
+    {@const pts = preview(p.id)}
     <div class="prow">
       <div class="row spread" style="margin-bottom: 10px">
         <span class="row" style="gap: 8px">
           <Avatar name={p.name} color={p.color} />
           <strong>{p.name}</strong>
         </span>
-        <span
-          class="preview"
-          class:score-good={preview(p.id) >= 0}
-          class:score-bad={preview(p.id) < 0}
-        >
-          {preview(p.id) >= 0 ? '+' : ''}{preview(p.id)}
+        <span class="preview-wrap">
+          <span class="preview" class:score-good={pts >= 0} class:score-bad={pts < 0}>
+            {signed(pts)}
+          </span>
+          <span
+            class="outcome"
+            class:score-good={oc.kind === 'hit' || oc.kind === 'zero'}
+            class:score-bad={oc.kind === 'miss'}
+          >
+            {oc.emoji} {oc.label}
+          </span>
         </span>
       </div>
+
       <div class="fields">
         <label class="f">Bid<Stepper bind:value={row.bid} min={0} max={n} label={`${p.name} bid`} /></label>
         <label class="f">Won<Stepper bind:value={row.actual} min={0} max={n} label={`${p.name} won`} /></label>
-        <label class="f">Bonus<input type="number" step="10" bind:value={row.bonus} /></label>
+      </div>
+
+      <div class="bounty">
+        <button
+          type="button"
+          class="bounty-toggle"
+          class:has={bountyOf[p.id] > 0}
+          aria-expanded={!!open[p.id]}
+          onclick={() => toggleTray(p.id)}
+        >
+          <span>🪙 Bounty</span>
+          <span class="btot">{signed(bountyOf[p.id] ?? 0)}</span>
+          <span class="chev" class:up={open[p.id]} aria-hidden="true">▾</span>
+        </button>
+        <CoinBurst token={tokens[p.id] ?? 0} big={bigHaul[p.id]} />
+
+        {#if open[p.id]}
+          <div class="tray">
+            <div class="counters">
+              <label class="cf">
+                <span>🎴 14s <em>+{BONUS_VALUES.fourteen} ea</em></span>
+                <Stepper bind:value={b.fourteens} min={0} max={BOUNTY_LIMITS.fourteens} label={`${p.name} fourteens`} />
+              </label>
+              <label class="cf">
+                <span>⚔️ Pirates caught <em>+{BONUS_VALUES.pirate} ea</em></span>
+                <Stepper bind:value={b.pirates} min={0} max={BOUNTY_LIMITS.pirates} label={`${p.name} pirates`} />
+              </label>
+            </div>
+            <div class="chips">
+              <button type="button" class="chip" class:on={b.jollyRoger} onclick={() => flip(b, 'jollyRoger')}>
+                🏴‍☠️ Jolly Roger <span class="cv">+{BONUS_VALUES.jollyRoger}</span>
+              </button>
+              <button type="button" class="chip" class:on={b.mermaidCatchesSK} onclick={() => flip(b, 'mermaidCatchesSK')}>
+                🧜‍♀️ Mermaid nabs Skull King <span class="cv">+{BONUS_VALUES.mermaidCatchesSK}</span>
+              </button>
+              <button type="button" class="chip" class:on={b.skOverMermaid} onclick={() => flip(b, 'skOverMermaid')}>
+                👑 Skull King eats Mermaid <span class="cv">+{BONUS_VALUES.skOverMermaid}</span>
+              </button>
+            </div>
+            <label class="manual">
+              <span>🧰 Other (house rules)</span>
+              <input type="number" step="10" bind:value={b.manual} aria-label={`${p.name} other bounty`} />
+            </label>
+          </div>
+        {/if}
       </div>
     </div>
   {/each}
@@ -77,12 +207,128 @@
     font-size: 0.78rem;
     color: var(--muted);
   }
-  .f input {
-    width: 84px;
+  .preview-wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
   }
   .preview {
     font-weight: 800;
+    font-size: 1.05rem;
     font-variant-numeric: tabular-nums;
+  }
+  .outcome {
+    font-size: 0.74rem;
+    font-weight: 700;
+    color: var(--muted);
+    text-align: right;
+  }
+  .bounty {
+    position: relative;
+    margin-top: 12px;
+  }
+  .bounty-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    min-height: 46px;
+    padding: 8px 12px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+    font-size: 0.9rem;
+  }
+  .bounty-toggle.has {
+    border-color: var(--primary);
+  }
+  .btot {
+    margin-left: auto;
+    font-variant-numeric: tabular-nums;
+    color: var(--muted);
+  }
+  .bounty-toggle.has .btot {
+    color: var(--text);
+  }
+  .chev {
+    transition: transform var(--dur-base) var(--ease-standard);
+    color: var(--muted);
+  }
+  .chev.up {
+    transform: rotate(180deg);
+  }
+  .tray {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 10px;
+    padding: 12px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+  }
+  .counters {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  .cf {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.8rem;
+    color: var(--text);
+  }
+  .cf em {
+    color: var(--muted);
+    font-style: normal;
+    font-size: 0.74rem;
+  }
+  .chips {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .chip {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 9px 12px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+    text-align: left;
+  }
+  .chip .cv {
+    margin-left: auto;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .chip.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .chip.on .cv {
+    color: rgba(255, 255, 255, 0.85);
+  }
+  .manual {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .manual input {
+    width: 110px;
   }
   .help {
     white-space: pre-wrap;

--- a/src/lib/games/skullking/VoyageRibbon.svelte
+++ b/src/lib/games/skullking/VoyageRibbon.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { animateMotion, prefersReducedMotion } from '../../motion';
+  import { legName } from './logic';
+
+  /**
+   * Skull King's per-game "costume": a 10-leg voyage strip with a ship that sails
+   * to the current round. Pure Skull King flavor — it lives entirely inside the
+   * game editor and never touches the shared chrome. The round number and leg
+   * name carry the meaning in text, so the sailing animation is decoration only
+   * and is fully skipped under reduced motion (the ship simply appears at its leg).
+   */
+  let { round, total }: { round: number; total: number } = $props();
+
+  const legs = $derived(Array.from({ length: total }, (_, i) => i + 1));
+  const name = $derived(legName(round, total));
+  const isFinal = $derived(round === total);
+  // Ship sits centered over the current leg: (index + 0.5) / total across the track.
+  const shipPct = $derived(total > 0 ? ((round - 0.5) / total) * 100 : 0);
+
+  let ship: HTMLSpanElement | undefined = $state();
+
+  onMount(() => {
+    if (!ship || prefersReducedMotion()) return;
+    // Sail in from the previous leg with a gentle bob, then a bigger flourish on
+    // the final round — the Skull King's Gauntlet deserves a flag-raising beat.
+    const from = total > 0 ? Math.max(0, ((round - 1.5) / total) * 100) : 0;
+    animateMotion(
+      ship,
+      isFinal
+        ? { left: [`${from}%`, `${shipPct}%`], rotate: [-8, 8, -4, 0], scale: [0.9, 1.25, 1] }
+        : { left: [`${from}%`, `${shipPct}%`], rotate: [-6, 4, 0] },
+      { duration: isFinal ? 0.9 : 0.6, ease: 'easeOut' },
+    );
+  });
+</script>
+
+<div class="voyage" class:final={isFinal}>
+  <div class="cap">
+    <span class="leg">Leg {round} of {total}</span>
+    <span class="name">{isFinal ? '💀 ' : ''}{name}{isFinal ? ' 👑' : ''}</span>
+  </div>
+  <div class="sea" aria-hidden="true">
+    <div class="track">
+      {#each legs as l (l)}
+        <span class="dot" class:done={l < round} class:here={l === round}></span>
+      {/each}
+    </div>
+    <span class="ship" bind:this={ship} style="left: {shipPct}%">{isFinal ? '🏴‍☠️' : '⛵'}</span>
+  </div>
+</div>
+
+<style>
+  .voyage {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+  }
+  .voyage.final {
+    border-color: var(--primary);
+  }
+  .cap {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .leg {
+    font-size: 0.78rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+  .name {
+    font-weight: 700;
+    font-size: 0.92rem;
+    text-align: right;
+  }
+  .sea {
+    position: relative;
+    height: 26px;
+  }
+  .track {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 2px;
+  }
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+  }
+  .dot.done {
+    background: var(--primary);
+    border-color: var(--primary);
+    opacity: 0.55;
+  }
+  .dot.here {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 22%, transparent);
+  }
+  .ship {
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 1.25rem;
+    line-height: 1;
+    pointer-events: none;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
+  }
+</style>

--- a/src/lib/games/skullking/index.ts
+++ b/src/lib/games/skullking/index.ts
@@ -1,36 +1,24 @@
 import type { GameModule, ID, Round, RoundContext } from '../../types';
 import { RoundEditor } from '../editor';
 import { skullkingStats } from './stats';
+import {
+  effectiveBonus,
+  emptyBounty,
+  readConfig,
+  scoreRow,
+  validateSkullKing,
+  type SKInput,
+  type SKRow,
+} from './logic';
 
-export interface SKRow {
-  bid: number;
-  actual: number;
-  bonus: number;
-}
-export interface SKInput {
-  rows: Record<ID, SKRow>;
-}
-
-/** Score a single player's row. Round n has n tricks. */
-export function scoreRow(row: SKRow, n: number, bonusesRequireBid: boolean): number {
-  const bid = Number(row.bid) || 0;
-  const actual = Number(row.actual) || 0;
-  const made = actual === bid;
-  let pts: number;
-  if (bid === 0) {
-    pts = made ? 10 * n : -10 * n;
-  } else {
-    pts = made ? 20 * bid : -10 * Math.abs(actual - bid);
-  }
-  const bonus = Number(row.bonus) || 0;
-  if (bonus && (!bonusesRequireBid || made)) pts += bonus;
-  return pts;
-}
+// Re-exported so existing importers (the editor, stats) keep a single entry point
+// even though the pure model now lives in ./logic.
+export { scoreRow, type SKInput, type SKRow };
 
 export const skullking: GameModule = {
   id: 'skullking',
   name: 'Skull King',
-  tagline: 'Bid your tricks. Hunt the bonuses.',
+  tagline: 'Bid your tricks. Hunt the bounty.',
   emoji: '🏴‍☠️',
   keywords: ['trick taking', 'pirate', 'bidding', 'cards'],
   minPlayers: 2,
@@ -45,28 +33,20 @@ export const skullking: GameModule = {
     },
   ],
 
-  maxRounds: (config) => Number(config.rounds) || 10,
+  maxRounds: (config) => readConfig(config).rounds,
 
   createRoundInput: (ctx: RoundContext): SKInput => ({
-    rows: Object.fromEntries(ctx.players.map((p) => [p.id, { bid: 0, actual: 0, bonus: 0 }])),
+    rows: Object.fromEntries(
+      ctx.players.map((p) => [p.id, { bid: 0, actual: 0, bonus: 0, bounty: emptyBounty() }]),
+    ),
   }),
 
-  validateRound: (input: SKInput, ctx: RoundContext): string | null => {
-    const n = ctx.roundIndex + 1;
-    let won = 0;
-    for (const p of ctx.players) {
-      const row = input.rows[p.id];
-      if (row.bid < 0 || row.bid > n) return `${p.name}: bid must be between 0 and ${n}.`;
-      if (row.actual < 0 || row.actual > n) return `${p.name}: tricks won must be between 0 and ${n}.`;
-      won += Number(row.actual) || 0;
-    }
-    if (won > n) return `Total tricks won (${won}) can't exceed the ${n} available this round.`;
-    return null;
-  },
+  validateRound: (input: SKInput, ctx: RoundContext): string | null =>
+    validateSkullKing(input, ctx),
 
   scoreRound: (input: SKInput, ctx: RoundContext): Record<ID, number> => {
     const n = ctx.roundIndex + 1;
-    const requireBid = ctx.config.bonusesRequireBid !== false;
+    const requireBid = readConfig(ctx.config).bonusesRequireBid;
     const out: Record<ID, number> = {};
     for (const p of ctx.players) out[p.id] = scoreRow(input.rows[p.id], n, requireBid);
     return out;
@@ -77,7 +57,9 @@ export const skullking: GameModule = {
     return players
       .map((p) => {
         const r = input.rows[p.id];
-        return r ? `${p.name} ${r.bid}/${r.actual}` : '';
+        if (!r) return '';
+        const treasure = effectiveBonus(r) > 0 ? ' 🪙' : '';
+        return `${p.name} ${r.bid}/${r.actual}${treasure}`;
       })
       .filter(Boolean)
       .join(' · ');
@@ -88,13 +70,13 @@ export const skullking: GameModule = {
     'Hit your bid: 20 × bid. Bid 0 and succeed: 10 × round number.',
     'Miss a bid of 1+: −10 per trick over/under. Miss a 0 bid: −10 × round number.',
     '',
-    'Typical bonuses (enter in the Bonus field):',
-    '• +10 for each 14 you capture (yellow/purple/green/black)',
+    'Bounty (tap the 🪙 builder — it does the math for you):',
+    '• +10 for each 14 you capture (yellow/green/purple)',
     '• +20 for capturing the black 14 (Jolly Roger)',
     '• +30 Skull King captures each Pirate',
     '• +40 each Mermaid captures the Skull King',
     '• +50 Skull King over Mermaid',
-    'Bonuses vary by edition — confirm your set.',
+    'Bounties vary by edition — the Other field covers house rules.',
   ].join('\n'),
 
   stats: skullkingStats,

--- a/src/lib/games/skullking/logic.ts
+++ b/src/lib/games/skullking/logic.ts
@@ -1,0 +1,194 @@
+import type { ID, RoundContext } from '../../types';
+
+/**
+ * Pure, Svelte-free Skull King scoring. Kept isolated from the editor so the
+ * whole bid/trick/bounty model is independently unit-testable and safe for the
+ * engine (and stats) to import. No I/O, no DOM.
+ */
+
+/** The five capture bounties, straight from the game's own reference (2021 edition). */
+export const BONUS_VALUES = {
+  /** Each standard 14 (yellow / green / purple) you capture. */
+  fourteen: 10,
+  /** The black 14 — the Jolly Roger. */
+  jollyRoger: 20,
+  /** Each Pirate the Skull King captures. */
+  pirate: 30,
+  /** A Mermaid capturing the Skull King. */
+  mermaidCatchesSK: 40,
+  /** The Skull King capturing a Mermaid. */
+  skOverMermaid: 50,
+} as const;
+
+/** How many of each capture there can plausibly be in one trick/round. */
+export const BOUNTY_LIMITS = {
+  /** Three coloured 14s (yellow, green, purple). */
+  fourteens: 3,
+  /** Five Pirates in a standard deck (Tigress can play as a sixth). */
+  pirates: 6,
+} as const;
+
+/** A structured breakdown of a player's captured bounty for one round. */
+export interface SKBounty {
+  /** Count of standard (coloured) 14s captured. */
+  fourteens: number;
+  /** Captured the black 14 (Jolly Roger). */
+  jollyRoger: boolean;
+  /** Count of Pirates the player's Skull King captured. */
+  pirates: number;
+  /** A Mermaid captured this player's Skull King. */
+  mermaidCatchesSK: boolean;
+  /** This player's Skull King captured a Mermaid. */
+  skOverMermaid: boolean;
+  /** Edition-variance / house-rule extra, entered by hand. */
+  manual: number;
+}
+
+export interface SKRow {
+  bid: number;
+  actual: number;
+  /**
+   * Effective bonus total for the round — the single value scoring uses. Kept as
+   * a plain number so rounds saved before the structured builder existed still
+   * score and render unchanged.
+   */
+  bonus: number;
+  /**
+   * Structured breakdown behind {@link bonus}. Optional: legacy rounds omit it and
+   * fall back to their numeric {@link bonus} (surfaced as a manual entry in the UI).
+   */
+  bounty?: SKBounty;
+}
+
+export interface SKInput {
+  rows: Record<ID, SKRow>;
+}
+
+export interface SKConfig {
+  rounds: number;
+  bonusesRequireBid: boolean;
+}
+
+/** A fresh, empty structured bounty. */
+export function emptyBounty(): SKBounty {
+  return {
+    fourteens: 0,
+    jollyRoger: false,
+    pirates: 0,
+    mermaidCatchesSK: false,
+    skOverMermaid: false,
+    manual: 0,
+  };
+}
+
+/** Sum a structured bounty into points. */
+export function bountyTotal(b: SKBounty | undefined): number {
+  if (!b) return 0;
+  const fourteens = Math.max(0, Math.trunc(Number(b.fourteens) || 0));
+  const pirates = Math.max(0, Math.trunc(Number(b.pirates) || 0));
+  const manual = Math.trunc(Number(b.manual) || 0);
+  return (
+    fourteens * BONUS_VALUES.fourteen +
+    (b.jollyRoger ? BONUS_VALUES.jollyRoger : 0) +
+    pirates * BONUS_VALUES.pirate +
+    (b.mermaidCatchesSK ? BONUS_VALUES.mermaidCatchesSK : 0) +
+    (b.skOverMermaid ? BONUS_VALUES.skOverMermaid : 0) +
+    manual
+  );
+}
+
+/**
+ * The bonus points a row contributes — the structured bounty when present,
+ * otherwise the row's stored numeric {@link SKRow.bonus} (legacy rounds).
+ */
+export function effectiveBonus(row: SKRow): number {
+  return row.bounty ? bountyTotal(row.bounty) : Number(row.bonus) || 0;
+}
+
+/** Read + coerce the game config. */
+export function readConfig(config: Record<string, unknown>): SKConfig {
+  const rounds = Math.max(1, Math.min(10, Math.trunc(Number(config.rounds) || 10)));
+  return { rounds, bonusesRequireBid: config.bonusesRequireBid !== false };
+}
+
+/** Whether a row's bid was met exactly. */
+export function madeBid(row: SKRow): boolean {
+  return (Number(row.actual) || 0) === (Number(row.bid) || 0);
+}
+
+/** Score a single player's row. Round n has n tricks. */
+export function scoreRow(row: SKRow, n: number, bonusesRequireBid: boolean): number {
+  const bid = Number(row.bid) || 0;
+  const actual = Number(row.actual) || 0;
+  const made = actual === bid;
+  let pts: number;
+  if (bid === 0) {
+    pts = made ? 10 * n : -10 * n;
+  } else {
+    pts = made ? 20 * bid : -10 * Math.abs(actual - bid);
+  }
+  const bonus = effectiveBonus(row);
+  if (bonus && (!bonusesRequireBid || made)) pts += bonus;
+  return pts;
+}
+
+/** Null when valid, otherwise a human-readable error. */
+export function validateSkullKing(input: SKInput, ctx: RoundContext): string | null {
+  const n = ctx.roundIndex + 1;
+  let won = 0;
+  for (const p of ctx.players) {
+    const row = input.rows[p.id];
+    if (!row) continue;
+    if (row.bid < 0 || row.bid > n) return `${p.name}: bid must be between 0 and ${n}.`;
+    if (row.actual < 0 || row.actual > n)
+      return `${p.name}: tricks won must be between 0 and ${n}.`;
+    won += Number(row.actual) || 0;
+  }
+  if (won > n) return `Total tricks won (${won}) can't exceed the ${n} available this round.`;
+  return null;
+}
+
+/** A short thematic read on how a row's bid is landing, for at-a-glance delight. */
+export interface SKOutcome {
+  /** 'hit' met the bid, 'zero' survived a 0-bid, 'miss' blew it, 'idle' bid 0 with nothing yet. */
+  kind: 'hit' | 'zero' | 'miss' | 'idle';
+  label: string;
+  emoji: string;
+}
+
+export function outcomeLabel(row: SKRow, n: number): SKOutcome {
+  const bid = Number(row.bid) || 0;
+  const actual = Number(row.actual) || 0;
+  const made = actual === bid;
+  if (bid === 0 && actual === 0) {
+    // A pledged-and-standing zero bid: still clean, worth 10 × round if it holds.
+    return { kind: 'idle', label: `Sworn to take none · +${10 * n} if it holds`, emoji: '🫙' };
+  }
+  if (made && bid === 0) return { kind: 'zero', label: 'Slipped away clean!', emoji: '🕊️' };
+  if (made) return { kind: 'hit', label: 'Nailed the bid!', emoji: '🎯' };
+  const off = Math.abs(actual - bid);
+  if (bid === 0) return { kind: 'miss', label: 'Oath broken — overboard', emoji: '🌊' };
+  return {
+    kind: 'miss',
+    label: `Off by ${off} — walk the plank`,
+    emoji: '🪝',
+  };
+}
+
+/** A thematic name for each leg of the 10-round voyage. */
+export function legName(n: number, total: number): string {
+  if (n === total) return "The Skull King's Gauntlet";
+  const names = [
+    'Setting Sail',
+    'Open Water',
+    'Rough Seas',
+    'Hidden Cove',
+    'Cannon Fire',
+    'The Kraken Stirs',
+    'Ghost Ship',
+    'Treasure Isle',
+    'The Reckoning',
+    'Final Plunder',
+  ];
+  return names[n - 1] ?? `Leg ${n}`;
+}

--- a/src/lib/games/skullking/skullking.test.ts
+++ b/src/lib/games/skullking/skullking.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from 'vitest';
+import type { Game, Player, Round, RoundContext } from '../../types';
+import { skullking } from './index';
+import { skullkingStats } from './stats';
+import {
+  BONUS_VALUES,
+  bountyTotal,
+  effectiveBonus,
+  emptyBounty,
+  legName,
+  madeBid,
+  outcomeLabel,
+  readConfig,
+  scoreRow,
+  validateSkullKing,
+  type SKBounty,
+  type SKInput,
+  type SKRow,
+} from './logic';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+function row(bid: number, actual: number, extra: Partial<SKRow> = {}): SKRow {
+  return { bid, actual, bonus: 0, ...extra };
+}
+function bounty(over: Partial<SKBounty> = {}): SKBounty {
+  return { ...emptyBounty(), ...over };
+}
+function player(id: string): Player {
+  return { id, name: id.toUpperCase(), color: '#7c5cff', createdAt: 0 };
+}
+const P2 = ['a', 'b'].map(player);
+function ctxFor(players: Player[], config: Record<string, unknown>, roundIndex: number): RoundContext {
+  return { game: { id: 'g' } as never, players, config, roundIndex, totals: {}, rounds: [] };
+}
+
+// ── config ───────────────────────────────────────────────────────────────
+describe('readConfig', () => {
+  it('applies defaults', () => {
+    expect(readConfig({})).toEqual({ rounds: 10, bonusesRequireBid: true });
+  });
+  it('coerces and clamps rounds to 1..10', () => {
+    expect(readConfig({ rounds: '5' }).rounds).toBe(5);
+    expect(readConfig({ rounds: 99 }).rounds).toBe(10);
+    expect(readConfig({ rounds: 3 }).rounds).toBe(3);
+    expect(readConfig({ rounds: 0 }).rounds).toBe(10); // 0 is falsy → default 10
+  });
+  it('treats bonusesRequireBid only false as off', () => {
+    expect(readConfig({ bonusesRequireBid: false }).bonusesRequireBid).toBe(false);
+    expect(readConfig({ bonusesRequireBid: undefined }).bonusesRequireBid).toBe(true);
+  });
+});
+
+// ── bounty maths ────────────────────────────────────────────────────────────
+describe('bountyTotal', () => {
+  it('is zero for an empty bounty', () => {
+    expect(bountyTotal(emptyBounty())).toBe(0);
+    expect(bountyTotal(undefined)).toBe(0);
+  });
+  it('sums each capture at its documented value', () => {
+    expect(bountyTotal(bounty({ fourteens: 3 }))).toBe(30);
+    expect(bountyTotal(bounty({ jollyRoger: true }))).toBe(20);
+    expect(bountyTotal(bounty({ pirates: 2 }))).toBe(60);
+    expect(bountyTotal(bounty({ mermaidCatchesSK: true }))).toBe(40);
+    expect(bountyTotal(bounty({ skOverMermaid: true }))).toBe(50);
+    expect(bountyTotal(bounty({ manual: 15 }))).toBe(15);
+  });
+  it('adds captures together', () => {
+    const b = bounty({ fourteens: 2, jollyRoger: true, pirates: 1, skOverMermaid: true, manual: 5 });
+    expect(bountyTotal(b)).toBe(20 + 20 + 30 + 50 + 5);
+  });
+  it('clamps negative/fractional counts', () => {
+    expect(bountyTotal(bounty({ fourteens: -3, pirates: 1.9 }))).toBe(30);
+  });
+});
+
+describe('effectiveBonus', () => {
+  it('prefers the structured bounty when present', () => {
+    expect(effectiveBonus(row(1, 1, { bonus: 999, bounty: bounty({ pirates: 1 }) }))).toBe(30);
+  });
+  it('falls back to the legacy numeric bonus', () => {
+    expect(effectiveBonus(row(1, 1, { bonus: 40 }))).toBe(40);
+  });
+});
+
+// ── row scoring ─────────────────────────────────────────────────────────────
+describe('scoreRow', () => {
+  it('pays 20 × bid for a met positive bid', () => {
+    expect(scoreRow(row(3, 3), 5, true)).toBe(60);
+  });
+  it('pays 10 × round for a met zero bid', () => {
+    expect(scoreRow(row(0, 0), 7, true)).toBe(70);
+  });
+  it('charges 10 × round for a missed zero bid', () => {
+    expect(scoreRow(row(0, 2), 7, true)).toBe(-70);
+  });
+  it('charges 10 per trick off for a missed positive bid', () => {
+    expect(scoreRow(row(3, 1), 5, true)).toBe(-20);
+    expect(scoreRow(row(2, 5), 5, true)).toBe(-30);
+  });
+  it('adds bounty only when the bid is met and gating is on', () => {
+    expect(scoreRow(row(2, 2, { bounty: bounty({ pirates: 1 }) }), 5, true)).toBe(40 + 30);
+    expect(scoreRow(row(2, 1, { bounty: bounty({ pirates: 1 }) }), 5, true)).toBe(-10);
+  });
+  it('adds bounty even on a miss when gating is off', () => {
+    expect(scoreRow(row(2, 1, { bounty: bounty({ pirates: 1 }) }), 5, false)).toBe(-10 + 30);
+  });
+  it('honours the legacy numeric bonus', () => {
+    expect(scoreRow(row(1, 1, { bonus: 20 }), 3, true)).toBe(20 + 20);
+  });
+});
+
+describe('madeBid', () => {
+  it('is true only on an exact match', () => {
+    expect(madeBid(row(2, 2))).toBe(true);
+    expect(madeBid(row(2, 3))).toBe(false);
+  });
+});
+
+// ── outcome labels ───────────────────────────────────────────────────────────
+describe('outcomeLabel', () => {
+  it('reads a standing zero bid as idle', () => {
+    expect(outcomeLabel(row(0, 0), 4).kind).toBe('idle');
+  });
+  it('celebrates a met positive bid', () => {
+    expect(outcomeLabel(row(3, 3), 5).kind).toBe('hit');
+  });
+  it('flags a busted bid as a miss', () => {
+    expect(outcomeLabel(row(3, 1), 5).kind).toBe('miss');
+    expect(outcomeLabel(row(0, 2), 5).kind).toBe('miss');
+  });
+});
+
+describe('legName', () => {
+  it('names the final round the Gauntlet', () => {
+    expect(legName(10, 10)).toBe("The Skull King's Gauntlet");
+  });
+  it('names earlier legs', () => {
+    expect(legName(1, 10)).toBe('Setting Sail');
+  });
+});
+
+// ── validation ──────────────────────────────────────────────────────────────
+describe('validateSkullKing', () => {
+  const hand = (rows: Record<string, SKRow>): SKInput => ({ rows });
+  it('accepts a legal round', () => {
+    expect(validateSkullKing(hand({ a: row(2, 2), b: row(1, 1) }), ctxFor(P2, {}, 2))).toBeNull();
+  });
+  it('rejects a bid above the round number', () => {
+    expect(validateSkullKing(hand({ a: row(4, 0), b: row(0, 0) }), ctxFor(P2, {}, 2))).toMatch(
+      /bid must be between 0 and 3/,
+    );
+  });
+  it('rejects tricks that exceed the round', () => {
+    expect(validateSkullKing(hand({ a: row(0, 4), b: row(0, 0) }), ctxFor(P2, {}, 2))).toMatch(
+      /tricks won must be between 0 and 3/,
+    );
+  });
+  it('rejects a table that wins more tricks than exist', () => {
+    expect(validateSkullKing(hand({ a: row(2, 2), b: row(2, 2) }), ctxFor(P2, {}, 2))).toMatch(
+      /can't exceed the 3 available/,
+    );
+  });
+});
+
+// ── module wiring ─────────────────────────────────────────────────────────────
+describe('skullking module', () => {
+  it('has the expected identity and bounds', () => {
+    expect(skullking.id).toBe('skullking');
+    expect(skullking.minPlayers).toBe(2);
+    expect(skullking.maxPlayers).toBe(8);
+    expect(skullking.configFields?.map((f) => f.key)).toEqual(['rounds', 'bonusesRequireBid']);
+  });
+  it('caps rounds via config', () => {
+    expect(skullking.maxRounds!({ rounds: 7 }, 4)).toBe(7);
+    expect(skullking.maxRounds!({}, 4)).toBe(10);
+  });
+  it('seeds a fresh structured bounty per player', () => {
+    const input = skullking.createRoundInput(ctxFor(P2, {}, 0)) as SKInput;
+    expect(Object.keys(input.rows)).toEqual(['a', 'b']);
+    expect(input.rows.a).toEqual({ bid: 0, actual: 0, bonus: 0, bounty: emptyBounty() });
+  });
+  it('scores a whole round through the module', () => {
+    const input: SKInput = {
+      rows: { a: row(2, 2, { bounty: bounty({ jollyRoger: true }) }), b: row(0, 1) },
+    };
+    const deltas = skullking.scoreRound(input, ctxFor(P2, {}, 4));
+    expect(deltas).toEqual({ a: 40 + 20, b: -50 });
+  });
+  it('describeRound marks a banked bounty with treasure', () => {
+    const r: Round = {
+      id: 'r',
+      gameId: 'g',
+      index: 0,
+      input: { rows: { a: row(1, 1, { bounty: bounty({ pirates: 1 }) }), b: row(0, 0) } },
+      deltas: {},
+      createdAt: 0,
+    };
+    expect(skullking.describeRound!(r, P2)).toBe('A 1/1 🪙 · B 0/0');
+  });
+});
+
+// ── stats ─────────────────────────────────────────────────────────────────────
+describe('skullkingStats', () => {
+  const game: Game = {
+    id: 'g',
+    type: 'skullking',
+    config: {},
+    playerIds: ['a'],
+    status: 'finished',
+    createdAt: 0,
+    roundCount: 2,
+  };
+  function asRound(index: number, input: SKInput): Round {
+    return { id: `r${index}`, gameId: 'g', index, input, deltas: {}, createdAt: 0 };
+  }
+
+  it('derives accuracy, boldness, zero-bid and haul metrics', () => {
+    const rounds = [
+      asRound(0, { rows: { a: row(1, 1, { bounty: bounty({ pirates: 1 }) }) } }),
+      asRound(1, { rows: { a: row(0, 0) } }),
+    ];
+    const { perPlayer } = skullkingStats({
+      games: [game],
+      rounds,
+      players: [player('a')],
+      canonical: (id) => id,
+    });
+    const metrics = perPlayer!.a;
+    const keys = metrics.map((m) => m.key);
+    expect(keys).toContain('sk_acc');
+    expect(keys).toContain('sk_bold');
+    expect(keys).toContain('sk_zero');
+    expect(keys).toContain('sk_haul');
+    expect(metrics.find((m) => m.key === 'sk_haul')!.value).toBe('30');
+  });
+
+  it('counts a legacy numeric bonus toward the haul', () => {
+    const rounds = [asRound(0, { rows: { a: row(2, 2, { bonus: 40 }) } })];
+    const { perPlayer } = skullkingStats({
+      games: [game],
+      rounds,
+      players: [player('a')],
+      canonical: (id) => id,
+    });
+    expect(perPlayer!.a.find((m) => m.key === 'sk_bonus')!.value).toBe('40');
+  });
+});
+
+// keep BONUS_VALUES referenced so the contract is asserted, not just imported.
+describe('BONUS_VALUES', () => {
+  it('matches the reference sheet', () => {
+    expect(BONUS_VALUES).toEqual({
+      fourteen: 10,
+      jollyRoger: 20,
+      pirate: 30,
+      mermaidCatchesSK: 40,
+      skOverMermaid: 50,
+    });
+  });
+});

--- a/src/lib/games/skullking/stats.ts
+++ b/src/lib/games/skullking/stats.ts
@@ -1,5 +1,5 @@
 import type { ID } from '../../types';
-import type { SKInput } from './index';
+import { effectiveBonus, type SKInput, type SKRow } from './logic';
 import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
 import { fmtInt, fmtPct } from '../../stats/format';
 
@@ -9,6 +9,8 @@ interface SKAgg {
   zero: number;
   zeroMade: number;
   bonus: number;
+  bidSum: number;
+  bestHaul: number;
 }
 
 /**
@@ -22,7 +24,7 @@ export function skullkingStats({ games, rounds, canonical }: GameStatsInput): Ga
   const get = (id: ID): SKAgg => {
     let a = per.get(id);
     if (!a) {
-      a = { bids: 0, made: 0, zero: 0, zeroMade: 0, bonus: 0 };
+      a = { bids: 0, made: 0, zero: 0, zeroMade: 0, bonus: 0, bidSum: 0, bestHaul: 0 };
       per.set(id, a);
     }
     return a;
@@ -38,12 +40,15 @@ export function skullkingStats({ games, rounds, canonical }: GameStatsInput): Ga
       const actual = Number(row.actual) || 0;
       const made = actual === bid;
       a.bids += 1;
+      a.bidSum += bid;
       if (made) a.made += 1;
       if (bid === 0) {
         a.zero += 1;
         if (made) a.zeroMade += 1;
       }
-      a.bonus += Number(row.bonus) || 0;
+      const haul = effectiveBonus(row as SKRow);
+      a.bonus += haul;
+      if (haul > a.bestHaul) a.bestHaul = haul;
     }
   }
 
@@ -56,12 +61,16 @@ export function skullkingStats({ games, rounds, canonical }: GameStatsInput): Ga
     const metrics: Metric[] = [];
     if (a.bids) {
       metrics.push({ key: 'sk_acc', label: 'Bid accuracy', value: fmtPct(a.made / a.bids), emoji: '🎯' });
+      metrics.push({ key: 'sk_bold', label: 'Avg bid', value: (a.bidSum / a.bids).toFixed(1), emoji: '🦜' });
     }
     if (a.zero) {
       metrics.push({ key: 'sk_zero', label: 'Zero-bid success', value: `${a.zeroMade}/${a.zero}`, emoji: '🥚' });
     }
     if (a.bonus) {
-      metrics.push({ key: 'sk_bonus', label: 'Bonus hunted', value: fmtInt(a.bonus), emoji: '💰' });
+      metrics.push({ key: 'sk_bonus', label: 'Bounty hunted', value: fmtInt(a.bonus), emoji: '💰' });
+    }
+    if (a.bestHaul) {
+      metrics.push({ key: 'sk_haul', label: 'Biggest haul', value: fmtInt(a.bestHaul), emoji: '🪙' });
     }
     if (metrics.length) perPlayer[id] = metrics;
   }


### PR DESCRIPTION
## What & why

Skull King was the thinnest of the trick-taking family. Its biggest flaw: **bonus scoring was raw mental math** — a bare number input where the scorekeeper had to remember every bonus value, sum them in their head, and type a total (exactly the bookkeeping the product promises to erase). It also had **zero tests** and almost no pirate personality.

## Changes

### 🏴‍☠️ Bounty Builder (the flagship fix)
- Replaces the raw `bonus` number field with a structured, tappable builder: steppers for **14s** (+10 ea) and **Pirates caught** (+30 ea), plus toggle chips for **Jolly Roger** (+20), **Mermaid nabs Skull King** (+40), and **Skull King eats Mermaid** (+50), with an **Other** field for house rules.
- Auto-computes the bounty — no more mental math.
- **Backward compatible:** the numeric `bonus` is kept as a mirror, and legacy rounds seed their old value into the Other field so nothing is lost and everything stays editable.

### 🎉 Pirate whimsy (all reduced-motion safe)
- **Voyage ribbon:** a 10-leg track with a ship that sails to the current round; final round becomes "The Skull King's Gauntlet" with an extra flourish.
- **Coin bursts** when a player's bounty climbs (bigger cascade for a big capture).
- **Thematic bid outcome labels** ("Nailed the bid!", "Slipped away clean!", "walk the plank") co-signed with text + emoji, never color alone.
- **Bids-vs-tricks tension read** in the header (over-bid / dead even / tricks to spare).
- Every animation routes through `animateMotion`/`prefersReducedMotion`, honoring the app Motion setting and OS `prefers-reduced-motion`.

### 🧪 Quality
- Extracted pure model into `logic.ts` (Svelte-free, unit-testable).
- New `skullking.test.ts` — **34 tests** covering scoring, bounty math, legacy fallback, validation, outcome labels, module wiring, and stats.
- Enriched stats (avg bid 🦜, biggest haul 🪙); `describeRound` marks banked bounty with 🪙.

## Design compliance
Chrome untouched — all new pieces live in `src/lib/games/skullking/`. Royal Violet only for the one active/selected state (matching Spades), **no Crown Gold**, `tabular-nums` on changing numbers, ≥46px targets, state co-signed by text/icon/sign.

## Verification (local)
- `npm run check` → 0 errors / 0 warnings
- `npm test` → **955 passed** (was 921; +34 new)
- `npm run build` → success