### PR TITLE
Hearts: moon meter, live previews, and a shoot-the-moon celebration

### DIFF
--- a/src/lib/games/hearts/HeartsEditor.svelte
+++ b/src/lib/games/hearts/HeartsEditor.svelte
@@ -2,63 +2,258 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
-  import type { HeartsInput } from './index';
+  import { haptic } from '../../haptics';
+  import { hearts } from './index';
+  import HeartsMeter from './HeartsMeter.svelte';
+  import MoonRise from './MoonRise.svelte';
+  import {
+    HEARTS_TOTAL,
+    heartsRemaining,
+    heartsTotal,
+    outcomeFor,
+    previewDelta,
+    readConfig,
+    shooter,
+    type HeartsInput,
+  } from './logic';
 
   let { input = $bindable(), ctx }: { input: HeartsInput; ctx: RoundContext } = $props();
 
-  const variantJack = $derived(!!ctx.config.variantJack);
-  const total = $derived(
-    Object.values(input.hearts).reduce((a, b) => a + (Number(b) || 0), 0),
+  const cfg = $derived(readConfig(ctx.config));
+  const variantJack = $derived(cfg.variantJack);
+  const ids = $derived(ctx.players.map((p) => p.id));
+
+  const placed = $derived(heartsTotal(input));
+  const remaining = $derived(heartsRemaining(input));
+  const moon = $derived(shooter(input));
+  const moonName = $derived(ctx.players.find((p) => p.id === moon)?.name ?? '');
+  const swing = $derived(
+    cfg.moonRule === 'subtract' ? `${moonName} takes −26` : 'everyone else takes +26',
   );
 
+  const previews = $derived(
+    Object.fromEntries(ids.map((id) => [id, previewDelta(input, id, ids, ctx.config)])),
+  );
+  const outcomes = $derived(
+    Object.fromEntries(ids.map((id) => [id, outcomeFor(input, id, ids, ctx.config)])),
+  );
+
+  let showHelp = $state(false);
+  let moonToken = $state(0);
+  let prevMoon: string | null = null;
+  let ready = false;
+
+  // Prime the moon baseline on first render so re-opening a round that already
+  // holds a moon doesn't fire the celebration on mount — only a fresh sweep does.
+  $effect(() => {
+    if (!ready) {
+      prevMoon = moon;
+      ready = true;
+      return;
+    }
+    if (moon && moon !== prevMoon) {
+      moonToken += 1;
+      haptic('win');
+    }
+    prevMoon = moon;
+  });
+
+  const signed = (v: number) => (v > 0 ? `+${v}` : v < 0 ? `−${Math.abs(v)}` : '0');
+
   function setQueen(id: string) {
-    input.queen = input.queen === id ? null : id;
+    const on = input.queen !== id;
+    input.queen = on ? id : null;
+    if (on) haptic('tick'); // a small beat of dread as the Lady lands
   }
   function setJack(id: string) {
     input.jack = input.jack === id ? null : id;
+    haptic('tick');
+  }
+  function takeRest(id: string) {
+    if (remaining <= 0) return;
+    input.hearts[id] = Math.min(HEARTS_TOTAL, (Number(input.hearts[id]) || 0) + remaining);
+    haptic('tick');
+  }
+  function shootMoon(id: string) {
+    for (const p of ctx.players) input.hearts[p.id] = p.id === id ? HEARTS_TOTAL : 0;
+    input.queen = id;
   }
 </script>
 
-<div class="stack">
-  <div class="row spread">
-    <span class="muted">Tap to assign the ♠Q{variantJack ? ' and ♦J' : ''}.</span>
-    <span class="pill" class:score-bad={total !== 13}>♥ {total}/13</span>
+<div class="stack sky-stage">
+  <MoonRise token={moonToken} />
+
+  <HeartsMeter {placed} moonReady={!!moon} />
+
+  <div class="row spread wrap">
+    <span class="muted hint">Fewer points is better — dodge the ♥ and the ♠Q.</span>
+    <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+      {showHelp ? 'Hide rules' : 'How to play'}
+    </button>
   </div>
 
+  {#if showHelp}
+    <pre class="help">{hearts.help}</pre>
+  {/if}
+
+  {#if moon}
+    <div class="moon-banner" role="status">
+      <span class="ic" aria-hidden="true">🌙</span>
+      <span><strong>{moonName} is shooting the moon!</strong> — {swing}.</span>
+    </div>
+  {/if}
+
   {#each ctx.players as p (p.id)}
-    <div class="prow">
-      <div class="row spread" style="margin-bottom: 8px">
-        <span class="row" style="gap: 8px">
+    {@const isShooter = moon === p.id}
+    {@const tookLady = !moon && input.queen === p.id}
+    {@const oc = outcomes[p.id]}
+    {@const pts = previews[p.id]}
+    <div class="prow" class:shooter={isShooter} class:lady={tookLady}>
+      <div class="row spread" style="margin-bottom: 10px">
+        <span class="row" style="gap: 8px; min-width: 0">
           <Avatar name={p.name} color={p.color} />
-          <strong>{p.name}</strong>
+          <strong class="pname">{p.name}</strong>
         </span>
-        <Stepper bind:value={input.hearts[p.id]} min={0} max={13} label={`${p.name} hearts`} />
+        <span class="preview-wrap">
+          <span
+            class="preview"
+            class:score-good={pts <= 0}
+            class:score-bad={pts > 0}
+          >{signed(pts)}</span>
+          <span
+            class="outcome"
+            class:score-good={oc.kind === 'clean' || oc.kind === 'moon'}
+            class:score-bad={oc.kind === 'lady' || (oc.kind === 'points' && pts > 0)}
+          >{oc.emoji} {oc.label}</span>
+        </span>
       </div>
-      <div class="row" style="gap: 8px">
-        <button type="button" class="toggle" class:on={input.queen === p.id} onclick={() => setQueen(p.id)}>
-          ♠Q <span class="sub">(13)</span>
+
+      <div class="row" style="gap: 10px; align-items: center">
+        <Stepper bind:value={input.hearts[p.id]} min={0} max={13} label={`${p.name} hearts`} />
+        <button
+          type="button"
+          class="btn small ghost grow"
+          onclick={() => takeRest(p.id)}
+          disabled={remaining <= 0}
+          title="Give every unplaced heart to {p.name}"
+        >
+          ♥ Took the rest{remaining > 0 ? ` (${remaining})` : ''}
+        </button>
+      </div>
+
+      <div class="cards">
+        <button
+          type="button"
+          class="toggle queen"
+          class:on={input.queen === p.id}
+          aria-pressed={input.queen === p.id}
+          onclick={() => setQueen(p.id)}
+        >
+          <span class="glyph">♠Q</span>
+          <span class="sub">the Lady · +13</span>
         </button>
         {#if variantJack}
-          <button type="button" class="toggle jack" class:on={input.jack === p.id} onclick={() => setJack(p.id)}>
-            ♦J <span class="sub">(−10)</span>
+          <button
+            type="button"
+            class="toggle jack"
+            class:on={input.jack === p.id}
+            aria-pressed={input.jack === p.id}
+            onclick={() => setJack(p.id)}
+          >
+            <span class="glyph">♦J</span>
+            <span class="sub">−10</span>
           </button>
         {/if}
+        <button
+          type="button"
+          class="toggle moon-btn"
+          class:on={isShooter}
+          onclick={() => shootMoon(p.id)}
+          title="{p.name} took all 13 hearts and the ♠Q"
+        >
+          <span class="glyph">🌙</span>
+          <span class="sub">shoot</span>
+        </button>
       </div>
     </div>
   {/each}
 </div>
 
 <style>
+  .sky-stage {
+    position: relative;
+  }
+  .hint {
+    font-size: 0.85rem;
+  }
+  .moon-banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border: 1px solid var(--primary);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--primary) 12%, var(--surface-2));
+    font-size: 0.92rem;
+  }
+  .moon-banner .ic {
+    font-size: 1.3rem;
+    line-height: 1;
+  }
   .prow {
+    position: relative;
+    z-index: 0;
     background: var(--surface-2);
     border: 1px solid var(--border);
     border-radius: 12px;
     padding: 12px;
   }
+  .prow.lady {
+    border-color: color-mix(in srgb, var(--bad) 55%, var(--border));
+    background: color-mix(in srgb, var(--bad) 8%, var(--surface-2));
+  }
+  .prow.shooter {
+    border-color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 10%, var(--surface-2));
+  }
+  .pname {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .preview-wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+    flex: none;
+  }
+  .preview {
+    font-weight: 800;
+    font-size: 1.1rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .outcome {
+    font-size: 0.74rem;
+    font-weight: 700;
+    color: var(--muted);
+    text-align: right;
+    white-space: nowrap;
+  }
+  .cards {
+    display: flex;
+    gap: 8px;
+    margin-top: 10px;
+  }
   .toggle {
     flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
     min-height: 46px;
-    padding: 9px;
+    padding: 6px 9px;
     border: 1px solid var(--border);
     border-radius: 10px;
     background: var(--surface);
@@ -66,16 +261,49 @@
     cursor: pointer;
     font-weight: 700;
   }
+  .toggle .glyph {
+    font-size: 0.98rem;
+    line-height: 1.1;
+  }
   .toggle .sub {
     color: var(--muted);
     font-weight: 500;
+    font-size: 0.72rem;
   }
-  .toggle.on {
-    background: var(--primary);
-    border-color: var(--primary-strong);
-    color: #fff;
+  /* The Lady is the bad card — dread reads in semantic coral, never gold. */
+  .toggle.queen.on {
+    background: color-mix(in srgb, var(--bad) 20%, var(--surface));
+    border-color: var(--bad);
+    color: var(--text);
   }
-  .toggle.on .sub {
-    color: rgba(255, 255, 255, 0.8);
+  .toggle.queen.on .sub {
+    color: color-mix(in srgb, var(--bad) 85%, var(--text));
+  }
+  /* The Jack is the good card — a calm green nod when claimed. */
+  .toggle.jack.on {
+    background: color-mix(in srgb, var(--good) 20%, var(--surface));
+    border-color: var(--good);
+    color: var(--text);
+  }
+  .toggle.jack.on .sub {
+    color: color-mix(in srgb, var(--good) 80%, var(--text));
+  }
+  .toggle.moon-btn.on {
+    background: color-mix(in srgb, var(--primary) 22%, var(--surface));
+    border-color: var(--primary);
+  }
+  .toggle.moon-btn.on .sub {
+    color: color-mix(in srgb, var(--primary) 85%, var(--text));
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
   }
 </style>

--- a/src/lib/games/hearts/HeartsMeter.svelte
+++ b/src/lib/games/hearts/HeartsMeter.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+  import { HEARTS_TOTAL } from './logic';
+
+  /**
+   * Hearts' per-game "costume": a slim ribbon at the top of the round editor that
+   * reads the 13 hearts as a waxing moon. As hearts get handed out the moon fills
+   * (🌑 → 🌕); the count and the "left to place" copy carry the real meaning, so
+   * the glyph is reinforcement, never the only signal. When one player is holding
+   * every heart *and* the Queen, the ribbon flips to its charged "Set for a moon
+   * shot" state. Pure flavor — it lives entirely inside the editor and never
+   * touches the shared chrome. No animation, so nothing to gate for reduced motion.
+   */
+  let {
+    placed = 0,
+    moonReady = false,
+  }: { placed?: number; moonReady?: boolean } = $props();
+
+  const left = $derived(Math.max(0, HEARTS_TOTAL - placed));
+  const over = $derived(placed > HEARTS_TOTAL);
+
+  // Map hearts placed (0..13) onto the eight lunar glyphs, waxing to full.
+  const PHASES = ['🌑', '🌒', '🌒', '🌓', '🌓', '🌔', '🌔', '🌕'];
+  const phase = $derived(
+    moonReady || placed >= HEARTS_TOTAL
+      ? '🌕'
+      : PHASES[Math.min(PHASES.length - 1, Math.round((placed / HEARTS_TOTAL) * (PHASES.length - 1)))],
+  );
+
+  const pct = $derived(Math.min(100, (placed / HEARTS_TOTAL) * 100));
+
+  const caption = $derived(
+    moonReady
+      ? 'Set for a moon shot'
+      : over
+        ? `${placed - HEARTS_TOTAL} too many hearts`
+        : left === 0
+          ? 'All 13 hearts placed'
+          : `${left} heart${left === 1 ? '' : 's'} left to place`,
+  );
+</script>
+
+<div class="meter" class:ready={moonReady} class:over>
+  <span class="moon" aria-hidden="true">{phase}</span>
+  <div class="body">
+    <div class="cap">
+      <span class="label">{caption}</span>
+      <span class="count">{placed}/{HEARTS_TOTAL} ♥</span>
+    </div>
+    <div class="track" aria-hidden="true">
+      <div class="fill" style="transform: scaleX({pct / 100})"></div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .meter {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+  }
+  .meter.ready {
+    border-color: var(--primary);
+  }
+  .meter.over {
+    border-color: color-mix(in srgb, var(--bad) 60%, var(--border));
+  }
+  .moon {
+    font-size: 1.5rem;
+    line-height: 1;
+    flex: none;
+  }
+  .body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .cap {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .label {
+    font-weight: 700;
+    font-size: 0.9rem;
+  }
+  .meter.ready .label {
+    color: var(--primary);
+  }
+  .meter.over .label {
+    color: var(--bad);
+  }
+  .count {
+    font-size: 0.8rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+  .track {
+    height: 6px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    overflow: hidden;
+  }
+  .fill {
+    height: 100%;
+    width: 100%;
+    transform-origin: left center;
+    border-radius: 999px;
+    background: var(--primary);
+    transition: transform var(--dur-base, 180ms) var(--ease-standard, ease);
+  }
+  .meter.over .fill {
+    background: var(--bad);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .fill {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/games/hearts/MoonRise.svelte
+++ b/src/lib/games/hearts/MoonRise.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * The big moment: when a player shoots the moon, a brief moonrise washes the
+   * whole editor and a starfield sweeps up behind the rows. Pure delight layered
+   * over a swing that's already spelled out in words + numbers (the banner and the
+   * flipped preview), so motion is never the only signal. The overlay is
+   * `pointer-events: none`, replays whenever `token` changes (a fresh moon), and
+   * renders nothing at all under reduced motion — the banner and preview swing are
+   * the calm, instant alternative shown by the editor either way.
+   */
+  let { token = 0 }: { token?: number } = $props();
+
+  const reduced = prefersReducedMotion();
+  const STAR_COUNT = 16;
+
+  // Deterministic pseudo-random, seeded by token so each moon looks a little
+  // different but is stable across a single render (mirrors CoinBurst).
+  const stars = $derived(
+    Array.from({ length: STAR_COUNT }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      const glyphs = ['✦', '✧', '⋆', '·', '✦'];
+      return {
+        left: rand(1) * 100,
+        bottom: rand(2) * 70,
+        delay: rand(3) * 0.4,
+        duration: 0.9 + rand(4) * 0.7,
+        rise: 30 + rand(5) * 60,
+        size: 0.55 + rand(6) * 0.7,
+        glyph: glyphs[Math.floor(rand(7) * glyphs.length)],
+      };
+    }),
+  );
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="moonrise" aria-hidden="true">
+      <div class="sky"></div>
+      <div class="stars">
+        {#each stars as s, i (i)}
+          <span
+            class="star"
+            style="
+              left: {s.left}%;
+              bottom: {s.bottom}%;
+              font-size: {s.size}rem;
+              animation-delay: {s.delay}s;
+              animation-duration: {s.duration}s;
+              --rise: {s.rise}px;
+            ">{s.glyph}</span>
+        {/each}
+      </div>
+      <span class="moon">🌕</span>
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .moonrise {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    border-radius: 14px;
+    z-index: 1;
+  }
+  .sky {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    background:
+      radial-gradient(120% 80% at 50% 120%, color-mix(in srgb, var(--primary) 34%, transparent), transparent 70%),
+      linear-gradient(to top, color-mix(in srgb, var(--primary) 16%, transparent), transparent 55%);
+    animation: sky-wash 1.5s ease-out both;
+  }
+  .stars {
+    position: absolute;
+    inset: 0;
+  }
+  .star {
+    position: absolute;
+    line-height: 1;
+    color: var(--text);
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: twinkle-rise;
+    animation-timing-function: ease-out;
+    animation-fill-mode: both;
+  }
+  .moon {
+    position: absolute;
+    left: 50%;
+    bottom: 0;
+    font-size: 2.4rem;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    filter: drop-shadow(0 0 12px color-mix(in srgb, var(--primary) 60%, transparent));
+    animation: moon-rise 1.5s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  @keyframes sky-wash {
+    0% { opacity: 0; }
+    28% { opacity: 1; }
+    100% { opacity: 0; }
+  }
+  @keyframes twinkle-rise {
+    0% { opacity: 0; transform: translateY(6px) scale(0.6); }
+    30% { opacity: 0.9; }
+    100% { opacity: 0; transform: translateY(calc(var(--rise) * -1)) scale(1); }
+  }
+  @keyframes moon-rise {
+    0% { opacity: 0; transform: translate(-50%, 40px) scale(0.7); }
+    35% { opacity: 1; transform: translate(-50%, -18px) scale(1.05); }
+    75% { opacity: 0.9; transform: translate(-50%, -24px) scale(1); }
+    100% { opacity: 0; transform: translate(-50%, -30px) scale(1); }
+  }
+</style>

--- a/src/lib/games/hearts/hearts.test.ts
+++ b/src/lib/games/hearts/hearts.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import type { Player } from '../../types';
+import { hearts } from './index';
+import {
+  HEARTS_TOTAL,
+  baseDelta,
+  emptyInput,
+  heartsRemaining,
+  heartsTotal,
+  isFinished,
+  outcomeFor,
+  previewDelta,
+  readConfig,
+  scoreRound,
+  shooter,
+  validateRound,
+  type HeartsInput,
+} from './logic';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+function player(id: string): Player {
+  return { id, name: id.toUpperCase(), color: '#7c5cff', createdAt: 0 };
+}
+const P4 = ['a', 'b', 'c', 'd'].map(player);
+const IDS = P4.map((p) => p.id);
+
+function input(
+  hearts: Record<string, number>,
+  queen: string | null = null,
+  jack: string | null = null,
+): HeartsInput {
+  return { hearts, queen, jack };
+}
+
+// ── config ───────────────────────────────────────────────────────────────
+describe('readConfig', () => {
+  it('applies defaults', () => {
+    expect(readConfig({})).toEqual({ endScore: 100, variantJack: false, moonRule: 'add26' });
+  });
+  it('reads overrides and clamps moonRule to a known value', () => {
+    expect(readConfig({ endScore: 50, variantJack: true, moonRule: 'subtract' })).toEqual({
+      endScore: 50,
+      variantJack: true,
+      moonRule: 'subtract',
+    });
+    expect(readConfig({ moonRule: 'nonsense' }).moonRule).toBe('add26');
+  });
+});
+
+// ── heart bookkeeping ──────────────────────────────────────────────────────
+describe('heart tallies', () => {
+  it('emptyInput seeds every player at zero hearts', () => {
+    expect(emptyInput(IDS)).toEqual({
+      hearts: { a: 0, b: 0, c: 0, d: 0 },
+      queen: null,
+      jack: null,
+    });
+  });
+  it('totals and remaining hearts', () => {
+    const i = input({ a: 5, b: 3, c: 0, d: 1 });
+    expect(heartsTotal(i)).toBe(9);
+    expect(heartsRemaining(i)).toBe(4);
+  });
+  it('remaining never goes negative', () => {
+    expect(heartsRemaining(input({ a: 20 }))).toBe(0);
+  });
+});
+
+// ── validation ─────────────────────────────────────────────────────────────
+describe('validateRound', () => {
+  it('nudges toward 13 when hearts are short', () => {
+    const msg = validateRound(input({ a: 5, b: 3, c: 0, d: 0 }, 'a'), P4, {});
+    expect(msg).toMatch(/5 more hearts/);
+  });
+  it('flags too many hearts', () => {
+    const msg = validateRound(input({ a: 10, b: 5, c: 0, d: 0 }, 'a'), P4, {});
+    expect(msg).toMatch(/2 too many/);
+  });
+  it('requires the Queen to be assigned', () => {
+    const msg = validateRound(input({ a: 13, b: 0, c: 0, d: 0 }, null), P4, {});
+    expect(msg).toMatch(/Queen of Spades/);
+  });
+  it('requires the Jack under the Omnibus variant', () => {
+    const i = input({ a: 13, b: 0, c: 0, d: 0 }, 'a', null);
+    expect(validateRound(i, P4, { variantJack: true })).toMatch(/Jack of Diamonds/);
+    expect(validateRound(i, P4, { variantJack: false })).toBeNull();
+  });
+  it('passes a well-formed round', () => {
+    expect(validateRound(input({ a: 4, b: 4, c: 4, d: 1 }, 'd'), P4, {})).toBeNull();
+  });
+});
+
+// ── scoring ──────────────────────────────────────────────────────────────
+describe('scoreRound', () => {
+  it('adds hearts and the Queen (+13)', () => {
+    const out = scoreRound(input({ a: 4, b: 4, c: 4, d: 1 }, 'd'), IDS, {});
+    expect(out).toEqual({ a: 4, b: 4, c: 4, d: 14 });
+    // 26 points distributed in all.
+    expect(Object.values(out).reduce((x, y) => x + y, 0)).toBe(26);
+  });
+
+  it('applies the Omnibus Jack (−10) only when enabled', () => {
+    const i = input({ a: 4, b: 4, c: 4, d: 1 }, 'd', 'a');
+    expect(scoreRound(i, IDS, { variantJack: true })).toEqual({ a: -6, b: 4, c: 4, d: 14 });
+    // Ignored when the variant is off.
+    expect(scoreRound(i, IDS, { variantJack: false })).toEqual({ a: 4, b: 4, c: 4, d: 14 });
+  });
+
+  it('12 hearts + the Queen is NOT a moon', () => {
+    const i = input({ a: 12, b: 1, c: 0, d: 0 }, 'a');
+    expect(shooter(i)).toBeNull();
+    expect(scoreRound(i, IDS, {})).toEqual({ a: 25, b: 1, c: 0, d: 0 });
+  });
+
+  it('shoots the moon: everyone else +26 (add26)', () => {
+    const i = input({ a: 13, b: 0, c: 0, d: 0 }, 'a');
+    expect(shooter(i)).toBe('a');
+    expect(scoreRound(i, IDS, { moonRule: 'add26' })).toEqual({ a: 0, b: 26, c: 26, d: 26 });
+  });
+
+  it('shoots the moon: shooter −26 (subtract)', () => {
+    const i = input({ a: 13, b: 0, c: 0, d: 0 }, 'a');
+    expect(scoreRound(i, IDS, { moonRule: 'subtract' })).toEqual({ a: -26, b: 0, c: 0, d: 0 });
+  });
+
+  it('a moon ignores the Jack for the shooter under add26', () => {
+    const i = input({ a: 13, b: 0, c: 0, d: 0 }, 'a', 'a');
+    expect(scoreRound(i, IDS, { moonRule: 'add26', variantJack: true })).toEqual({
+      a: 0,
+      b: 26,
+      c: 26,
+      d: 26,
+    });
+  });
+});
+
+// ── previews & outcomes ────────────────────────────────────────────────────
+describe('previews', () => {
+  it('baseDelta ignores the moon reversal; previewDelta honors it', () => {
+    const i = input({ a: 13, b: 0, c: 0, d: 0 }, 'a');
+    expect(baseDelta(i, 'a', readConfig({}))).toBe(26);
+    expect(previewDelta(i, 'a', IDS, {})).toBe(0);
+    expect(previewDelta(i, 'b', IDS, {})).toBe(26);
+  });
+
+  it('outcomeFor classifies clean, lady, moon and mooned', () => {
+    const clean = input({ a: 0, b: 5, c: 7, d: 1 }, 'd');
+    expect(outcomeFor(clean, 'a', IDS, {}).kind).toBe('clean');
+    expect(outcomeFor(clean, 'd', IDS, {}).kind).toBe('lady');
+
+    const moon = input({ a: 13, b: 0, c: 0, d: 0 }, 'a');
+    expect(outcomeFor(moon, 'a', IDS, {}).kind).toBe('moon');
+    expect(outcomeFor(moon, 'b', IDS, {}).kind).toBe('points');
+  });
+});
+
+// ── end condition ──────────────────────────────────────────────────────────
+describe('isFinished', () => {
+  it('ends when a player reaches the end score', () => {
+    expect(isFinished({ a: 100, b: 40 }, {})).toBe(true);
+    expect(isFinished({ a: 99, b: 40 }, {})).toBe(false);
+    expect(isFinished({ a: 55, b: 40 }, { endScore: 50 })).toBe(true);
+  });
+});
+
+// ── module wiring ──────────────────────────────────────────────────────────
+describe('hearts module', () => {
+  it('delegates validate/score/finish to the shared logic', () => {
+    const ctx = {
+      game: {} as never,
+      players: P4,
+      config: {},
+      roundIndex: 0,
+      totals: {},
+      rounds: [],
+    };
+    const i = input({ a: 13, b: 0, c: 0, d: 0 }, 'a');
+    expect(hearts.validateRound(i, ctx)).toBeNull();
+    expect(hearts.scoreRound(i, ctx)).toEqual({ a: 0, b: 26, c: 26, d: 26 });
+    expect(hearts.isFinished!({ a: 100 }, { config: {}, roundCount: 3, playerCount: 4 })).toBe(true);
+  });
+
+  it('createRoundInput seeds every seat', () => {
+    const ctx = {
+      game: {} as never,
+      players: P4,
+      config: {},
+      roundIndex: 0,
+      totals: {},
+      rounds: [],
+    };
+    expect(hearts.createRoundInput(ctx)).toEqual(emptyInput(IDS));
+    expect(HEARTS_TOTAL).toBe(13);
+  });
+
+  it('describeRound summarizes a moon and an ordinary round', () => {
+    const moon = { input: input({ a: 13, b: 0, c: 0, d: 0 }, 'a') } as never;
+    expect(hearts.describeRound!(moon, P4)).toMatch(/shot the moon/);
+    const ordinary = { input: input({ a: 4, b: 4, c: 4, d: 1 }, 'd', 'a') } as never;
+    expect(hearts.describeRound!(ordinary, P4)).toMatch(/♠Q D · ♦J A/);
+  });
+});

--- a/src/lib/games/hearts/index.ts
+++ b/src/lib/games/hearts/index.ts
@@ -1,19 +1,16 @@
 import type { GameModule, ID, Round, RoundContext } from '../../types';
 import { RoundEditor } from '../editor';
 import { heartsStats } from './stats';
+import {
+  emptyInput,
+  isFinished as heartsFinished,
+  scoreRound as scoreHearts,
+  shooter,
+  validateRound as validateHearts,
+  type HeartsInput,
+} from './logic';
 
-export interface HeartsInput {
-  hearts: Record<ID, number>;
-  queen: ID | null;
-  jack: ID | null;
-}
-
-function shooter(input: HeartsInput): ID | null {
-  for (const [id, h] of Object.entries(input.hearts)) {
-    if (h === 13 && input.queen === id) return id;
-  }
-  return null;
-}
+export type { HeartsInput, HeartsConfig, MoonRule } from './logic';
 
 export const hearts: GameModule = {
   id: 'hearts',
@@ -31,6 +28,7 @@ export const hearts: GameModule = {
       label: 'Jack of Diamonds = −10 (Omnibus variant)',
       type: 'boolean',
       default: false,
+      help: 'Adds one good card worth grabbing: whoever takes the ♦J shaves 10 off their round.',
     },
     {
       key: 'moonRule',
@@ -41,62 +39,49 @@ export const hearts: GameModule = {
         { value: 'add26', label: 'Everyone else +26' },
         { value: 'subtract', label: 'Shooter −26' },
       ],
+      help: 'Take all 13 hearts and the ♠Q to shoot the moon and flip the round on its head.',
     },
   ],
 
-  createRoundInput: (ctx: RoundContext): HeartsInput => ({
-    hearts: Object.fromEntries(ctx.players.map((p) => [p.id, 0])),
-    queen: null,
-    jack: null,
-  }),
+  createRoundInput: (ctx: RoundContext): HeartsInput =>
+    emptyInput(ctx.players.map((p) => p.id)),
 
-  validateRound: (input: HeartsInput, ctx: RoundContext): string | null => {
-    const total = Object.values(input.hearts).reduce((a, b) => a + (Number(b) || 0), 0);
-    if (total !== 13) return `Hearts must total 13 (currently ${total}).`;
-    if (!input.queen) return 'Assign the Queen of Spades (♠Q) to whoever took it.';
-    if (ctx.config.variantJack && !input.jack) {
-      return 'Assign the Jack of Diamonds (♦J) to whoever took it.';
-    }
-    return null;
-  },
+  validateRound: (input: HeartsInput, ctx: RoundContext): string | null =>
+    validateHearts(input, ctx.players, ctx.config),
 
-  scoreRound: (input: HeartsInput, ctx: RoundContext): Record<ID, number> => {
-    const variantJack = !!ctx.config.variantJack;
-    const moonRule = ctx.config.moonRule ?? 'add26';
-    const base: Record<ID, number> = {};
-    for (const p of ctx.players) {
-      const id = p.id;
-      base[id] =
-        (Number(input.hearts[id]) || 0) +
-        (input.queen === id ? 13 : 0) -
-        (variantJack && input.jack === id ? 10 : 0);
-    }
-    const moon = shooter(input);
-    if (!moon) return base;
+  scoreRound: (input: HeartsInput, ctx: RoundContext): Record<ID, number> =>
+    scoreHearts(input, ctx.players.map((p) => p.id), ctx.config),
 
-    const out: Record<ID, number> = {};
-    for (const p of ctx.players) {
-      if (moonRule === 'subtract') {
-        out[p.id] = p.id === moon ? -26 : base[p.id];
-      } else {
-        out[p.id] = p.id === moon ? 0 : base[p.id] + 26;
-      }
-    }
-    return out;
-  },
-
-  isFinished: (totals, { config }) => {
-    const end = Number(config.endScore) || 100;
-    return Object.values(totals).some((t) => t >= end);
-  },
+  isFinished: (totals, { config }) => heartsFinished(totals, config),
 
   describeRound: (round: Round, players): string => {
     const input = round.input as HeartsInput;
     const name = (id: ID | null) => players.find((p) => p.id === id)?.name ?? '?';
     const moon = shooter(input);
     if (moon) return `🌙 ${name(moon)} shot the moon`;
-    return `♠Q: ${name(input.queen)}`;
+    const parts: string[] = [`♠Q ${name(input.queen)}`];
+    if (input.jack) parts.push(`♦J ${name(input.jack)}`);
+    return parts.join(' · ');
   },
+
+  help: [
+    'Hearts is a dodging game: lowest score wins. Every round hands out 26 penalty',
+    'points — 13 hearts (♥ = 1 each) and the Queen of Spades (♠Q = 13). Take as few',
+    'as you can.',
+    '',
+    'Each round: give every heart to whoever took it (they must total 13), then tap',
+    'the ♠Q onto whoever got stuck with her.',
+    '',
+    '🌙 Shoot the moon: take ALL 13 hearts AND the ♠Q in one round. Instead of eating',
+    '26, you flip it — either everyone else takes +26, or you take −26 (set in setup).',
+    'A huge, risky swing: miss it by one heart and you just took the whole load.',
+    '',
+    '♦J Omnibus (optional): the Jack of Diamonds is a good card — whoever takes it',
+    'shaves 10 points off their round.',
+    '',
+    'The game ends when someone reaches the end score (100 by default). Lowest total',
+    'at that moment wins the crown.',
+  ].join('\n'),
 
   stats: heartsStats,
 

--- a/src/lib/games/hearts/logic.ts
+++ b/src/lib/games/hearts/logic.ts
@@ -1,0 +1,204 @@
+import type { ID } from '../../types';
+
+/**
+ * Hearts scoring — pure, Svelte-free. Everything the module, its editor, and its
+ * tests need to turn a recorded round into per-player point deltas lives here.
+ *
+ * Each round distributes the 13 hearts (♥ = 1 pt each) plus the Queen of Spades
+ * (♠Q = 13 pts) — 26 penalty points in all. Lower is better: you're dodging
+ * points, not chasing them. "Shooting the moon" is the reversal — take *all* 26
+ * (every heart and the Queen) and, instead of eating 26, you either hand everyone
+ * else 26 or subtract 26 from yourself. The optional Omnibus variant adds the
+ * Jack of Diamonds (♦J = −10), a good card worth grabbing.
+ */
+
+export interface HeartsInput {
+  /** Hearts taken this round, by player id. Must sum to 13 for a valid round. */
+  hearts: Record<ID, number>;
+  /** Who took the Queen of Spades (♠Q, +13). */
+  queen: ID | null;
+  /** Who took the Jack of Diamonds (♦J, −10) — Omnibus variant only. */
+  jack: ID | null;
+}
+
+export type MoonRule = 'add26' | 'subtract';
+
+export interface HeartsConfig {
+  endScore: number;
+  variantJack: boolean;
+  moonRule: MoonRule;
+}
+
+export const DEFAULT_CONFIG: HeartsConfig = {
+  endScore: 100,
+  variantJack: false,
+  moonRule: 'add26',
+};
+
+/** Points in play each round: 13 hearts + the ♠Q. */
+export const HEARTS_TOTAL = 13;
+export const QUEEN_POINTS = 13;
+export const JACK_POINTS = 10;
+export const MOON_POINTS = 26;
+
+function numOr(v: unknown, fallback: number): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function readConfig(config: Record<string, unknown> = {}): HeartsConfig {
+  const moon = config.moonRule === 'subtract' ? 'subtract' : 'add26';
+  return {
+    endScore: numOr(config.endScore, DEFAULT_CONFIG.endScore),
+    variantJack: !!config.variantJack,
+    moonRule: moon,
+  };
+}
+
+/** A fresh, empty round with every player on zero hearts and no cards claimed. */
+export function emptyInput(playerIds: readonly ID[]): HeartsInput {
+  return {
+    hearts: Object.fromEntries(playerIds.map((id) => [id, 0])),
+    queen: null,
+    jack: null,
+  };
+}
+
+/** Hearts placed so far this round. */
+export function heartsTotal(input: HeartsInput): number {
+  return Object.values(input.hearts).reduce((a, b) => a + (numOr(b, 0) || 0), 0);
+}
+
+/** Hearts still waiting to be assigned (never negative). */
+export function heartsRemaining(input: HeartsInput): number {
+  return Math.max(0, HEARTS_TOTAL - heartsTotal(input));
+}
+
+/**
+ * Who shot the moon this round: took every heart (all 13) *and* the Queen.
+ * Returns their id, or null when nobody swept the board.
+ */
+export function shooter(input: HeartsInput): ID | null {
+  for (const [id, h] of Object.entries(input.hearts)) {
+    if ((numOr(h, 0) || 0) === HEARTS_TOTAL && input.queen === id) return id;
+  }
+  return null;
+}
+
+/**
+ * The raw penalty a single player takes this round *before* any moon reversal:
+ * their hearts, plus 13 if they hold the Queen, minus 10 if they hold the Jack
+ * (Omnibus only). This is the number to preview per row while entering.
+ */
+export function baseDelta(
+  input: HeartsInput,
+  id: ID,
+  cfg: HeartsConfig,
+): number {
+  return (
+    (numOr(input.hearts[id], 0) || 0) +
+    (input.queen === id ? QUEEN_POINTS : 0) -
+    (cfg.variantJack && input.jack === id ? JACK_POINTS : 0)
+  );
+}
+
+/**
+ * Per-player point deltas for a round, applying the moon reversal when someone
+ * swept the board. Pure — the module's `scoreRound` delegates straight to this.
+ */
+export function scoreRound(
+  input: HeartsInput,
+  playerIds: readonly ID[],
+  config: Record<string, unknown>,
+): Record<ID, number> {
+  const cfg = readConfig(config);
+  const base: Record<ID, number> = {};
+  for (const id of playerIds) base[id] = baseDelta(input, id, cfg);
+
+  const moon = shooter(input);
+  if (!moon) return base;
+
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) {
+    if (cfg.moonRule === 'subtract') {
+      out[id] = id === moon ? -MOON_POINTS : base[id];
+    } else {
+      out[id] = id === moon ? 0 : base[id] + MOON_POINTS;
+    }
+  }
+  return out;
+}
+
+/**
+ * The delta a single player will take this round *after* the moon reversal — the
+ * exact number to preview next to their name as the round is entered.
+ */
+export function previewDelta(
+  input: HeartsInput,
+  id: ID,
+  playerIds: readonly ID[],
+  config: Record<string, unknown>,
+): number {
+  return scoreRound(input, playerIds, config)[id] ?? 0;
+}
+
+/** Validate a round. Null when good, else a friendly, specific message. */
+export function validateRound(
+  input: HeartsInput,
+  players: readonly { id: ID; name: string }[],
+  config: Record<string, unknown>,
+): string | null {
+  const cfg = readConfig(config);
+  const total = heartsTotal(input);
+  if (total !== HEARTS_TOTAL) {
+    const left = HEARTS_TOTAL - total;
+    return left > 0
+      ? `${left} more heart${left === 1 ? '' : 's'} to place (hearts must total 13).`
+      : `That's ${-left} too many hearts (they must total 13).`;
+  }
+  if (!input.queen) return 'Assign the Queen of Spades (♠Q) to whoever took her.';
+  if (cfg.variantJack && !input.jack) {
+    return 'Assign the Jack of Diamonds (♦J) to whoever took it.';
+  }
+  return null;
+}
+
+export type OutcomeKind = 'moon' | 'lady' | 'clean' | 'points';
+
+export interface Outcome {
+  kind: OutcomeKind;
+  emoji: string;
+  label: string;
+}
+
+/**
+ * A one-glance read of how a player fared this round, for the outcome tag beside
+ * their preview. Co-signals with the numeric delta (never color alone): a moon,
+ * eating the Lady, a spotless dodge, or an ordinary points haul.
+ */
+export function outcomeFor(
+  input: HeartsInput,
+  id: ID,
+  playerIds: readonly ID[],
+  config: Record<string, unknown>,
+): Outcome {
+  const moon = shooter(input);
+  if (moon) {
+    return id === moon
+      ? { kind: 'moon', emoji: '🌙', label: 'shot the moon' }
+      : { kind: 'points', emoji: '☄️', label: 'mooned' };
+  }
+  const delta = previewDelta(input, id, playerIds, config);
+  if (input.queen === id) return { kind: 'lady', emoji: '💔', label: 'took the Lady' };
+  if (delta <= 0) return { kind: 'clean', emoji: '😇', label: 'clean' };
+  return { kind: 'points', emoji: '♥️', label: `+${delta}` };
+}
+
+/** True when any player has reached the end score and the game can wrap. */
+export function isFinished(
+  totals: Record<ID, number>,
+  config: Record<string, unknown>,
+): boolean {
+  const end = readConfig(config).endScore;
+  return Object.values(totals).some((t) => t >= end);
+}

--- a/src/lib/games/hearts/stats.ts
+++ b/src/lib/games/hearts/stats.ts
@@ -1,5 +1,5 @@
 import type { ID } from '../../types';
-import type { HeartsInput } from './index';
+import { shooter, type HeartsInput } from './logic';
 import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
 import { fmtPct } from '../../stats/format';
 
@@ -8,14 +8,6 @@ interface HeartsAgg {
   queens: number;
   clean: number;
   rounds: number;
-}
-
-/** Who shot the moon this round (took all 13 hearts + the ♠Q), by original id. */
-function moonShooter(input: HeartsInput): ID | null {
-  for (const [id, h] of Object.entries(input.hearts)) {
-    if ((Number(h) || 0) === 13 && input.queen === id) return id;
-  }
-  return null;
 }
 
 /**
@@ -48,7 +40,7 @@ export function heartsStats({ games, rounds, canonical }: GameStatsInput): GameS
       const points = (Number(h) || 0) + (tookQueen ? 13 : 0);
       if (points === 0) a.clean += 1;
     }
-    const moon = moonShooter(input);
+    const moon = shooter(input);
     if (moon) get(canonical(moon)).moons += 1;
   }
 


### PR DESCRIPTION
## Hearts — full costume makeover

Gives the **Hearts** module a proper per-game costume while keeping the app chrome identical. All flavor lives inside the game's own editor + logic/costume files; the shared shell is untouched.

### Foundation
- **Refactored scoring into a Svelte-free `logic.ts`** — Hearts was the only card game with inline scoring and **no tests**. Now it matches the repo convention (Spades, Skull King, …).
- **New `hearts.test.ts`** (22 cases): 13-heart validation, Queen +13, Omnibus ♦J −10, both moon rules (others +26 / shooter −26), the 12-hearts-plus-Queen non-moon edge, end-score finish, and module wiring. Saved-round deltas are unchanged.

### Fun / UX
- **Live per-player preview** — each row shows the points it'll take this round with good/bad framing + an outcome tag (😇 clean · 💔 took the Lady · 🌙 moon), reinforcing that lower is better.
- **HeartsMeter ribbon** — a waxing-moon “N of 13 hearts placed / M left” strip that flips to **🌕 Set for a moon shot** when someone holds the whole board.
- **MoonRise celebration** — the big moment: a brief full-editor moonrise wash + starfield sweep behind the rows, a **SHOOTING THE MOON** banner, and the preview flips to the dramatic swing. Fully skipped under reduced motion (banner + swing remain); light `win` haptic.
- **Queen-of-Spades dread** in semantic coral (never gold), a green nod for the good ♦J, plus one-tap **“Took the rest”** and **🌙 “Shoot”** helpers for fast entry.
- **Help text**, a richer `describeRound`, and whimsical microcopy throughout.

### Design guardrails honored
One Royal Violet primary action (Save round); **no Crown Gold** in the editor (dread is semantic coral); every changing number is `tabular-nums`; touch targets ≥46px (36px `small` variant only where the system sanctions it); all animation reduced-motion-safe; app chrome unchanged.

### Local verification
- `npm run check` — 0 errors / 0 warnings
- `npm test` — 977 passed (incl. new Hearts suite)
- `npm run build` — succeeds

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>