### PR TITLE
Tally: fast quick-add counter with projected totals & target tension

### DIFF
--- a/src/lib/games/tally/TallyEditor.svelte
+++ b/src/lib/games/tally/TallyEditor.svelte
@@ -2,19 +2,330 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
-  import type { TallyInput } from './index';
+  import { haptic } from '../../haptics';
+  import { bumpOnChange, popIn } from '../../motion';
+  import {
+    deltaOf,
+    projectedTotal,
+    reachedTarget,
+    readConfig,
+    remainingToTarget,
+    targetProgress,
+    type TallyInput,
+  } from './logic';
 
   let { input = $bindable(), ctx }: { input: TallyInput; ctx: RoundContext } = $props();
+
+  const cfg = $derived(readConfig(ctx.config));
+  const round = $derived(ctx.roundIndex + 1);
+  const low = $derived(cfg.direction === 'low');
+
+  // Quick-add chips scaled to the game's point step (×1 / ×5 / ×10), so counting to a big
+  // target is a tap or two rather than a hundred nudges. The signature stepper stays for
+  // fine control and negatives (games that subtract).
+  const chipMultipliers = [1, 5, 10] as const;
+
+  function before(id: string): number {
+    return Number(ctx.totals[id]) || 0;
+  }
+  function delta(id: string): number {
+    return deltaOf(input, id);
+  }
+  function projected(id: string): number {
+    return projectedTotal(before(id), delta(id));
+  }
+  // "Good for this player" = moving toward winning: up in a high-score game, down in a
+  // low-score game. The signed number and arrow co-signal the change, so colour is never
+  // the only cue.
+  function helps(id: string): boolean {
+    const d = delta(id);
+    return d !== 0 && (low ? d < 0 : d > 0);
+  }
+  function hurts(id: string): boolean {
+    const d = delta(id);
+    return d !== 0 && (low ? d > 0 : d < 0);
+  }
+  function signed(n: number): string {
+    return n > 0 ? `+${n}` : `${n}`;
+  }
+  function remaining(id: string): number | null {
+    return remainingToTarget(projected(id), cfg.target);
+  }
+  // "Getting close" tension: within three steps of the target. Amber (a sanctioned
+  // attention colour), always paired with the 🎯 icon and the "N to go" words.
+  function closing(id: string): boolean {
+    const r = remaining(id);
+    return r != null && r <= cfg.step * 3;
+  }
+
+  function add(id: string, amount: number) {
+    input.deltas[id] = (Number(input.deltas[id]) || 0) + amount;
+    haptic('tick');
+  }
+  function reset(id: string) {
+    input.deltas[id] = 0;
+  }
+
+  // Milestone celebration: fire the win haptic the moment a player's projected total first
+  // crosses the target *this* round (they were below it before). The gold "🎯 Reached!"
+  // badge pops in on mount via use:popIn; the haptic is the tactile half. Tracked per id so
+  // stepping back below and over again re-celebrates, and an already-won player (before ≥
+  // target when the editor opens) never fake-celebrates.
+  let celebrated: Record<string, boolean> = $state({});
+  $effect(() => {
+    for (const p of ctx.players) {
+      const reached = reachedTarget(projected(p.id), cfg.target);
+      const freshCross = reached && before(p.id) < cfg.target;
+      if (freshCross && !celebrated[p.id]) {
+        celebrated[p.id] = true;
+        haptic('win');
+      } else if (!reached && celebrated[p.id]) {
+        celebrated[p.id] = false;
+      }
+    }
+  });
 </script>
 
 <div class="stack">
+  <div class="row spread head">
+    <span class="row" style="gap: 8px; flex-wrap: wrap">
+      <span class="pill">Round {round}</span>
+      <span class="pill">{low ? '⬇️ Lowest wins' : '⬆️ Highest wins'}</span>
+      {#if cfg.target > 0}
+        <span class="pill">🎯 to {cfg.target}</span>
+      {/if}
+      {#if cfg.step !== 1}
+        <span class="pill">±{cfg.step}/tap</span>
+      {/if}
+    </span>
+  </div>
+
   {#each ctx.players as p (p.id)}
-    <div class="row spread">
-      <span class="row" style="gap: 8px">
-        <Avatar name={p.name} color={p.color} />
-        <strong>{p.name}</strong>
-      </span>
-      <Stepper bind:value={input.deltas[p.id]} step={1} label={p.name} />
+    {@const pr = projected(p.id)}
+    {@const rem = remaining(p.id)}
+    {@const prog = targetProgress(pr, cfg.target)}
+    <div class="prow">
+      <div class="row spread top">
+        <span class="row who" style="gap: 8px; min-width: 0">
+          <Avatar name={p.name} color={p.color} />
+          <strong class="ellipsis">{p.name}</strong>
+        </span>
+        <span class="tally">
+          <span class="cur">{before(p.id)}</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span
+            class="proj"
+            class:score-good={helps(p.id)}
+            class:score-bad={hurts(p.id)}
+            use:bumpOnChange={pr}
+          >{pr}</span>
+          {#if delta(p.id) !== 0}
+            <span class="dchip" class:score-good={helps(p.id)} class:score-bad={hurts(p.id)}>
+              {signed(delta(p.id))}
+            </span>
+          {/if}
+        </span>
+      </div>
+
+      {#if cfg.target > 0}
+        <div class="target">
+          <div class="meter" aria-hidden="true">
+            <div
+              class="fill"
+              class:reached={reachedTarget(pr, cfg.target)}
+              style="transform: scaleX({prog ?? 0})"
+            ></div>
+          </div>
+          <div class="tstat tabnum">
+            {#if reachedTarget(pr, cfg.target)}
+              <span class="reached" use:popIn>🎯 Reached!</span>
+            {:else if rem != null}
+              <span class="togo" class:close={closing(p.id)}>🎯 {rem} to go</span>
+            {/if}
+            <span class="ratio">{pr} / {cfg.target}</span>
+          </div>
+        </div>
+      {/if}
+
+      <div class="entry">
+        <div class="chips">
+          {#each chipMultipliers as m (m)}
+            <button type="button" class="chip" onclick={() => add(p.id, cfg.step * m)}>
+              +{cfg.step * m}
+            </button>
+          {/each}
+          <button
+            type="button"
+            class="chip reset"
+            onclick={() => reset(p.id)}
+            disabled={delta(p.id) === 0}
+            aria-label={`Reset ${p.name} to no change`}
+            title="Reset to no change"
+          >↺</button>
+        </div>
+        <Stepper bind:value={input.deltas[p.id]} step={cfg.step} label={p.name} />
+      </div>
     </div>
   {/each}
 </div>
+
+<style>
+  .head {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .tally {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    flex: none;
+  }
+  .tally .cur,
+  .tally .arrow {
+    color: var(--muted);
+  }
+  .tally .proj {
+    font-weight: 800;
+    font-size: 1.2rem;
+  }
+  /* The signed round delta, restated as a chip so the change reads without relying on
+     colour: the +/− sign carries it, the tint just reinforces. */
+  .dchip {
+    font-size: 0.78rem;
+    font-weight: 700;
+    padding: 1px 7px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    color: var(--muted);
+  }
+  .score-good {
+    color: var(--good);
+  }
+  .score-bad {
+    color: var(--bad);
+  }
+  .dchip.score-good {
+    background: color-mix(in srgb, var(--good) 18%, var(--surface-3));
+  }
+  .dchip.score-bad {
+    background: color-mix(in srgb, var(--bad) 18%, var(--surface-3));
+  }
+
+  /* Target progress: a slim neutral meter that climbs the surface ramp, turning Crown Gold
+     only when the target is reached — the one moment gold is earned (this player has won). */
+  .target {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .meter {
+    height: 5px;
+    border-radius: 999px;
+    background: var(--surface);
+    overflow: hidden;
+  }
+  .fill {
+    height: 100%;
+    width: 100%;
+    border-radius: 999px;
+    transform-origin: left center;
+    background: color-mix(in srgb, var(--text) 42%, var(--surface-3));
+    transition: transform var(--dur-base, 0.18s) var(--ease-standard, ease);
+  }
+  .fill.reached {
+    background: var(--accent);
+  }
+  .tstat {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 0.8rem;
+  }
+  .tabnum {
+    font-variant-numeric: tabular-nums;
+  }
+  .togo {
+    color: var(--muted);
+    font-weight: 600;
+  }
+  .togo.close {
+    color: var(--warn);
+  }
+  .reached {
+    color: var(--accent-ink);
+    font-weight: 800;
+  }
+  .ratio {
+    color: var(--muted);
+    font-weight: 700;
+  }
+
+  .entry {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .chips {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 46px;
+    min-height: 46px;
+    padding: 0 12px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, transform var(--dur-press, 0.09s) ease;
+  }
+  .chip:hover {
+    background: var(--surface-3);
+    border-color: var(--primary);
+  }
+  .chip:active {
+    transform: scale(0.94);
+  }
+  .chip:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .chip.reset {
+    color: var(--muted);
+    font-size: 1.15rem;
+  }
+  .chip:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .chip.reset:hover:not(:disabled) {
+    color: var(--text);
+  }
+</style>

--- a/src/lib/games/tally/index.ts
+++ b/src/lib/games/tally/index.ts
@@ -1,8 +1,14 @@
 import type { GameModule, ID, Round, RoundContext } from '../../types';
 import { RoundEditor } from '../editor';
-export interface TallyInput {
-  deltas: Record<ID, number>;
-}
+import {
+  createTallyInput,
+  isTallyFinished,
+  lowerIsBetter,
+  scoreTally,
+  type TallyInput,
+} from './logic';
+
+export type { TallyInput } from './logic';
 
 export const tally: GameModule = {
   id: 'tally',
@@ -23,27 +29,40 @@ export const tally: GameModule = {
         { value: 'low', label: 'Lowest score' },
       ],
     },
-    { key: 'target', label: 'Target score to win (0 = no limit)', type: 'number', default: 0, min: 0 },
+    {
+      key: 'step',
+      label: 'Point step',
+      type: 'number',
+      default: 1,
+      min: 1,
+      help: 'The natural increment for the − / + buttons and quick-add chips (1, 5, 10…).',
+    },
+    {
+      key: 'target',
+      label: 'Target score to win (0 = no limit)',
+      type: 'number',
+      default: 0,
+      min: 0,
+      help: 'When set, the game ends the moment anyone reaches it — highest wins, or lowest for a low-score game.',
+    },
   ],
-  resolveLowerIsBetter: (c) => c.direction === 'low',
+  resolveLowerIsBetter: (c) => lowerIsBetter(c),
 
-  createRoundInput: (ctx: RoundContext): TallyInput => ({
-    deltas: Object.fromEntries(ctx.players.map((p) => [p.id, 0])),
-  }),
+  createRoundInput: (ctx: RoundContext): TallyInput =>
+    createTallyInput(ctx.players.map((p) => p.id)),
 
   validateRound: () => null,
 
-  scoreRound: (input: TallyInput): Record<ID, number> => {
-    const out: Record<ID, number> = {};
-    for (const [id, v] of Object.entries(input.deltas)) out[id] = Number(v) || 0;
-    return out;
-  },
+  scoreRound: (input: TallyInput): Record<ID, number> => scoreTally(input),
 
-  isFinished: (totals, { config }) => {
-    const target = Number(config.target) || 0;
-    if (target <= 0 || config.direction === 'low') return false;
-    return Object.values(totals).some((t) => t >= target);
-  },
+  isFinished: (totals, { config }) => isTallyFinished(totals, config),
+
+  help:
+    'Tally is the all-purpose counter for any game. Pick whether the highest or lowest ' +
+    'score wins, set a point step to match how your game scores (1s, 5s, 10s…), and an ' +
+    'optional target to end the game automatically. Each round, tap the quick-add chips or ' +
+    'the − / + buttons to log every player’s points; the board shows where the round lands ' +
+    'them before you save. Points can go negative for games that subtract.',
 
   describeRound: (round: Round) => {
     const input = round.input as TallyInput;

--- a/src/lib/games/tally/logic.ts
+++ b/src/lib/games/tally/logic.ts
@@ -1,0 +1,119 @@
+import type { ID } from '../../types';
+
+/**
+ * Tally scoring — pure, Svelte-free, fully unit-testable. `index.ts` and the editor both
+ * import from here so the exact math the game plays is the exact math the tests exercise.
+ *
+ * Tally is Score King's universal fallback counter: every round is just a per-player point
+ * delta (which may be negative — some games subtract), summed into a running total. Highest
+ * or lowest total wins, with an optional target that ends the game the moment anyone reaches
+ * it. The target is a plain end threshold in BOTH directions: for a high-score game the first
+ * to reach it is winning; for a low-score game reaching it ends the night and the LOWEST total
+ * wins (Hearts-style). That keeps "Lowest + target" a real, useful combination instead of a
+ * dead config.
+ */
+
+export type TallyDirection = 'high' | 'low';
+
+/** A round's input: each player's point change for this round, keyed by player id. */
+export interface TallyInput {
+  deltas: Record<ID, number>;
+}
+
+/** Normalized, validated config the scorer actually runs on. */
+export interface TallyConfig {
+  /** Who wins on totals: highest ('high') or lowest ('low'). */
+  direction: TallyDirection;
+  /** End-threshold score (0 = no limit). Ends the game when any total reaches it. */
+  target: number;
+  /** The natural increment for this game — drives the stepper and quick-add chips. */
+  step: number;
+}
+
+export const TALLY_DEFAULTS: TallyConfig = {
+  direction: 'high',
+  target: 0,
+  step: 1,
+};
+
+/** Read a raw, possibly-untrusted config bag into a clean {@link TallyConfig}. */
+export function readConfig(config: Record<string, unknown> | undefined): TallyConfig {
+  const c = config ?? {};
+  const target = Math.max(0, Math.trunc(Number(c.target)) || 0);
+  const step = Math.max(1, Math.trunc(Number(c.step)) || 0) || TALLY_DEFAULTS.step;
+  return {
+    direction: c.direction === 'low' ? 'low' : 'high',
+    target,
+    step,
+  };
+}
+
+/** True when the lowest total wins. */
+export function lowerIsBetter(config: Record<string, unknown> | undefined): boolean {
+  return readConfig(config).direction === 'low';
+}
+
+/** A fresh, zeroed round input for the current roster. */
+export function createTallyInput(playerIds: ID[]): TallyInput {
+  return { deltas: Object.fromEntries(playerIds.map((id) => [id, 0])) };
+}
+
+/** One player's delta for this round, coerced to a finite number (0 on garbage). */
+export function deltaOf(input: TallyInput, id: ID): number {
+  const v = Number(input?.deltas?.[id]);
+  return Number.isFinite(v) ? v : 0;
+}
+
+/** Compute per-player point deltas for the round (a pass-through of the entered deltas). */
+export function scoreTally(input: TallyInput): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of Object.keys(input?.deltas ?? {})) out[id] = deltaOf(input, id);
+  return out;
+}
+
+/**
+ * The game ends when any total reaches the target — the same "reach the threshold"
+ * rule in both directions. For a high-score game the reacher is winning; for a low-score
+ * game reaching the threshold ends the night and the lowest total wins. Off (returns
+ * false) when there is no target.
+ */
+export function isTallyFinished(
+  totals: Record<ID, number>,
+  config: Record<string, unknown> | undefined,
+): boolean {
+  const { target } = readConfig(config);
+  if (target <= 0) return false;
+  const vals = Object.values(totals);
+  return vals.length > 0 && vals.some((t) => t >= target);
+}
+
+/** A player's projected total if this round were saved as entered. */
+export function projectedTotal(before: number, delta: number): number {
+  return (Number(before) || 0) + (Number(delta) || 0);
+}
+
+/**
+ * How far a projected total is from the target, as a non-negative "N to go". Returns null
+ * when there is no target or the total has already reached it (nothing left to count down).
+ */
+export function remainingToTarget(projected: number, target: number): number | null {
+  if (!target || target <= 0) return null;
+  const remaining = target - (Number(projected) || 0);
+  return remaining > 0 ? remaining : null;
+}
+
+/** True once a projected total has reached (or passed) the target. */
+export function reachedTarget(projected: number, target: number): boolean {
+  if (!target || target <= 0) return false;
+  return (Number(projected) || 0) >= target;
+}
+
+/**
+ * Fraction (0..1) of the way a projected total is toward the target, for a progress meter.
+ * Returns null when there is no target. Clamped so an overshoot never renders past full.
+ */
+export function targetProgress(projected: number, target: number): number | null {
+  if (!target || target <= 0) return null;
+  const p = (Number(projected) || 0) / target;
+  return Math.max(0, Math.min(1, p));
+}

--- a/src/lib/games/tally/tally.test.ts
+++ b/src/lib/games/tally/tally.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round, RoundContext } from '../../types';
+import { defaultWinners } from '../../types';
+import { tally } from './index';
+import {
+  createTallyInput,
+  deltaOf,
+  isTallyFinished,
+  lowerIsBetter,
+  projectedTotal,
+  reachedTarget,
+  readConfig,
+  remainingToTarget,
+  scoreTally,
+  targetProgress,
+  type TallyInput,
+} from './logic';
+
+// ---- helpers ---------------------------------------------------------------
+
+function player(id: string, name = id): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+
+const A = player('A', 'Ada');
+const B = player('B', 'Bo');
+const C = player('C', 'Cy');
+const players = [A, B, C];
+const ids = players.map((p) => p.id);
+
+function ctx(
+  config: Record<string, unknown> = {},
+  totals: Record<ID, number> = {},
+  roundIndex = 0,
+): RoundContext {
+  return {
+    game: {} as Game,
+    players,
+    config,
+    roundIndex,
+    totals,
+    rounds: [] as Round[],
+  };
+}
+
+function input(deltas: Record<ID, number>): TallyInput {
+  return { deltas };
+}
+
+// ---- readConfig ------------------------------------------------------------
+
+describe('readConfig', () => {
+  it('defaults to high / no target / step 1', () => {
+    expect(readConfig(undefined)).toEqual({ direction: 'high', target: 0, step: 1 });
+    expect(readConfig({})).toEqual({ direction: 'high', target: 0, step: 1 });
+  });
+
+  it('reads direction, target and step', () => {
+    expect(readConfig({ direction: 'low', target: 100, step: 5 })).toEqual({
+      direction: 'low',
+      target: 100,
+      step: 5,
+    });
+  });
+
+  it('coerces and floors messy values, clamps step to >= 1', () => {
+    expect(readConfig({ direction: 'sideways', target: -50, step: 0 })).toEqual({
+      direction: 'high',
+      target: 0,
+      step: 1,
+    });
+    expect(readConfig({ target: '10', step: '2.9' })).toEqual({
+      direction: 'high',
+      target: 10,
+      step: 2,
+    });
+    expect(readConfig({ step: 'garbage' }).step).toBe(1);
+  });
+
+  it('lowerIsBetter reflects the direction', () => {
+    expect(lowerIsBetter({ direction: 'low' })).toBe(true);
+    expect(lowerIsBetter({ direction: 'high' })).toBe(false);
+    expect(lowerIsBetter(undefined)).toBe(false);
+  });
+});
+
+// ---- input + scoring -------------------------------------------------------
+
+describe('createTallyInput / scoreTally', () => {
+  it('creates a zeroed delta for every player', () => {
+    expect(createTallyInput(ids)).toEqual({ deltas: { A: 0, B: 0, C: 0 } });
+  });
+
+  it('passes entered deltas straight through', () => {
+    expect(scoreTally(input({ A: 5, B: -3, C: 0 }))).toEqual({ A: 5, B: -3, C: 0 });
+  });
+
+  it('coerces garbage deltas to 0 without dropping the player', () => {
+    const out = scoreTally({ deltas: { A: Number.NaN, B: '7' as unknown as number, C: 4 } });
+    expect(out).toEqual({ A: 0, B: 7, C: 4 });
+  });
+
+  it('deltaOf reads a single finite delta or 0', () => {
+    expect(deltaOf(input({ A: 9 }), 'A')).toBe(9);
+    expect(deltaOf(input({}), 'A')).toBe(0);
+    expect(deltaOf({ deltas: { A: Number.NaN } }, 'A')).toBe(0);
+  });
+});
+
+// ---- finish / target -------------------------------------------------------
+
+describe('isTallyFinished', () => {
+  it('is off when there is no target', () => {
+    expect(isTallyFinished({ A: 999 }, { target: 0 })).toBe(false);
+    expect(isTallyFinished({ A: 999 }, {})).toBe(false);
+  });
+
+  it('ends a high-score game when anyone reaches the target', () => {
+    expect(isTallyFinished({ A: 40, B: 99 }, { direction: 'high', target: 100 })).toBe(false);
+    expect(isTallyFinished({ A: 40, B: 100 }, { direction: 'high', target: 100 })).toBe(true);
+    expect(isTallyFinished({ A: 40, B: 101 }, { direction: 'high', target: 100 })).toBe(true);
+  });
+
+  it('also ends a LOW-score game when anyone reaches the threshold (Hearts-style)', () => {
+    // The previously-dead combo: reaching the threshold ends the night, lowest wins.
+    expect(isTallyFinished({ A: 30, B: 99 }, { direction: 'low', target: 100 })).toBe(false);
+    expect(isTallyFinished({ A: 30, B: 100 }, { direction: 'low', target: 100 })).toBe(true);
+  });
+
+  it('never finishes an empty board', () => {
+    expect(isTallyFinished({}, { target: 50 })).toBe(false);
+  });
+});
+
+// ---- editor helpers --------------------------------------------------------
+
+describe('editor helpers', () => {
+  it('projectedTotal adds delta onto the running total', () => {
+    expect(projectedTotal(20, 5)).toBe(25);
+    expect(projectedTotal(20, -8)).toBe(12);
+    expect(projectedTotal(Number.NaN as unknown as number, 5)).toBe(5);
+  });
+
+  it('remainingToTarget counts down, and is null once reached or with no target', () => {
+    expect(remainingToTarget(70, 100)).toBe(30);
+    expect(remainingToTarget(100, 100)).toBeNull();
+    expect(remainingToTarget(120, 100)).toBeNull();
+    expect(remainingToTarget(50, 0)).toBeNull();
+  });
+
+  it('reachedTarget flips at or above the target only when one is set', () => {
+    expect(reachedTarget(99, 100)).toBe(false);
+    expect(reachedTarget(100, 100)).toBe(true);
+    expect(reachedTarget(150, 100)).toBe(true);
+    expect(reachedTarget(150, 0)).toBe(false);
+  });
+
+  it('targetProgress is a clamped 0..1 fraction, null without a target', () => {
+    expect(targetProgress(0, 100)).toBe(0);
+    expect(targetProgress(50, 100)).toBe(0.5);
+    expect(targetProgress(150, 100)).toBe(1);
+    expect(targetProgress(-10, 100)).toBe(0);
+    expect(targetProgress(50, 0)).toBeNull();
+  });
+});
+
+// ---- module wiring ---------------------------------------------------------
+
+describe('tally module', () => {
+  it('exposes the expected identity and config fields', () => {
+    expect(tally.id).toBe('tally');
+    const keys = (tally.configFields ?? []).map((f) => f.key);
+    expect(keys).toEqual(['direction', 'step', 'target']);
+    expect(tally.help).toBeTruthy();
+  });
+
+  it('resolveLowerIsBetter follows the direction config', () => {
+    expect(tally.resolveLowerIsBetter?.({ direction: 'low' })).toBe(true);
+    expect(tally.resolveLowerIsBetter?.({ direction: 'high' })).toBe(false);
+  });
+
+  it('createRoundInput seeds a zeroed delta per seated player', () => {
+    expect(tally.createRoundInput(ctx())).toEqual({ deltas: { A: 0, B: 0, C: 0 } });
+  });
+
+  it('scoreRound and isFinished route through the pure logic', () => {
+    expect(tally.scoreRound(input({ A: 3, B: 0, C: -1 }), ctx())).toEqual({ A: 3, B: 0, C: -1 });
+    expect(
+      tally.isFinished?.({ A: 100 }, { config: { target: 100 }, roundCount: 1, playerCount: 3 }),
+    ).toBe(true);
+  });
+
+  it('picks the highest or lowest total as winner by direction', () => {
+    const totals = { A: 40, B: 90, C: 12 };
+    expect(defaultWinners(tally, totals, { direction: 'high' })).toEqual(['B']);
+    expect(defaultWinners(tally, totals, { direction: 'low' })).toEqual(['C']);
+  });
+
+  it('describeRound summarises the non-zero deltas', () => {
+    const round = { input: input({ A: 5, B: 0, C: -2 }) } as unknown as Round;
+    expect(tally.describeRound?.(round, players)).toBe('+5 / -2');
+    const empty = { input: input({ A: 0, B: 0, C: 0 }) } as unknown as Round;
+    expect(tally.describeRound?.(empty, players)).toBe('no change');
+  });
+});


### PR DESCRIPTION
## What & why

Tally is Score King's universal fallback counter — the module that gets used most — yet it was the **blandest editor in the app**: a bare list of one stepper per player, with a half-broken target and no personality or tests. This PR turns it into the app's fastest, most delightful scorer while keeping the chrome identical game-to-game.

## Changes

**Speed & tactility**
- **Configurable "Point step"** config (1/5/10…) drives the stepper and a new **quick-add chip row** scaled to it (×1 / ×5 / ×10), so counting to a big target is a tap or two instead of a hundred nudges. The signature stepper stays for fine control and negatives (games that subtract).
- **Live current → projected totals** per player. The round delta is co-signalled by its **+/− sign, an arrow, and a tint** (never colour alone), with a number bump on every change. In a low-score game "good" correctly means moving *down*.

**Target that finally works**
- The optional target is now a real **end threshold in both directions** — it ends the game the moment anyone reaches it. Previously it was silently ignored for low-score games (Hearts-style low wins now works).
- **Target-approach tension**: a slim neutral progress meter, **"N to go"** (amber when closing in), and a Crown-Gold **"🎯 Reached!"** pulse + win-haptic the instant a player crosses the target.

**Craft & correctness**
- Extracted pure, Svelte-free **`logic.ts`** (`readConfig` / `scoreTally` / `isTallyFinished` + editor helpers) and added **`tally.test.ts`** — the module previously had **no tests**.
- Added in-game **help** copy.

## Design guardrails honoured
- One Royal Violet action per screen (Save round) — quick-add chips are neutral surface chips.
- **Crown Gold** appears only at the target-reached (winner) moment; progress/tension uses neutral + Caution Amber, always co-signalled with icon + text.
- `tabular-nums` on every number, ≥46px touch targets, `prefers-reduced-motion` respected throughout. Nested-card 12px radius matches the sibling Uno/Cornhole editors for cross-game consistency.

## Verification (local)
- `npm run check` → 0 errors, 0 warnings
- `npm run build` → success
- `npm test` → **999/999 pass** (27 in tally + registry)