### PR TITLE
Avalon: vote track (the Hammer), signature animations & Night Briefing

### DIFF
--- a/src/lib/games/avalon/AssassinReveal.svelte
+++ b/src/lib/games/avalon/AssassinReveal.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * Avalon's signature beat: when Good completes three quests, the Assassin gets one shot at
+   * Merlin. This overlay dramatizes that single guess — a dagger sweeps across the stage and
+   * strikes. On a `found` hit the strike lands blood-red and Evil steals the game; on a miss
+   * the blade glances off a shield and Good holds. Pure delight layered over a result that is
+   * already spelled out in the banner text + the winning-team tally, so motion is never the
+   * only signal. The overlay is `pointer-events: none`, replays whenever `token` changes, and
+   * renders nothing at all under reduced motion — the banner is the calm, instant alternative.
+   */
+  let { token = 0, found = false }: { token?: number; found?: boolean } = $props();
+
+  const reduced = prefersReducedMotion();
+  const SPARK_COUNT = 10;
+
+  // Deterministic pseudo-random seeded by token (mirrors CoinBurst / MoonRise).
+  const sparks = $derived(
+    Array.from({ length: SPARK_COUNT }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      const hitGlyphs = found ? ['🩸', '✦', '✧', '·'] : ['✦', '✧', '⋆', '·'];
+      return {
+        left: 30 + rand(1) * 40,
+        bottom: 30 + rand(2) * 30,
+        delay: 0.42 + rand(3) * 0.18,
+        duration: 0.5 + rand(4) * 0.5,
+        spread: (rand(5) - 0.5) * 120,
+        rise: 20 + rand(6) * 44,
+        size: 0.5 + rand(7) * 0.7,
+        glyph: hitGlyphs[Math.floor(rand(8) * hitGlyphs.length)],
+      };
+    }),
+  );
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="reveal" class:found aria-hidden="true">
+      <div class="wash"></div>
+      <span class="target">{found ? '🧙' : '🛡️'}</span>
+      <span class="dagger">🗡️</span>
+      <div class="sparks">
+        {#each sparks as s, i (i)}
+          <span
+            class="spark"
+            style="
+              left: {s.left}%;
+              bottom: {s.bottom}%;
+              font-size: {s.size}rem;
+              animation-delay: {s.delay}s;
+              animation-duration: {s.duration}s;
+              --spread: {s.spread}px;
+              --rise: {s.rise}px;
+            ">{s.glyph}</span>
+        {/each}
+      </div>
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .reveal {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    border-radius: 14px;
+    z-index: 3;
+  }
+  .wash {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    /* Miss → a calm violet/good glow; hit → the Loss-Coral steal. Never Crown Gold. */
+    background:
+      radial-gradient(120% 90% at 50% 60%, color-mix(in srgb, var(--good) 30%, transparent), transparent 70%);
+    animation: wash 1.5s ease-out both;
+  }
+  .reveal.found .wash {
+    background:
+      radial-gradient(120% 90% at 50% 55%, color-mix(in srgb, var(--bad) 40%, transparent), transparent 72%);
+    animation-duration: 1.7s;
+  }
+  .target {
+    position: absolute;
+    left: 50%;
+    top: 46%;
+    font-size: 2rem;
+    line-height: 1;
+    opacity: 0;
+    transform: translate(-50%, -50%);
+    will-change: transform, opacity;
+    animation: target-beat 1.5s ease-out both;
+  }
+  .dagger {
+    position: absolute;
+    top: 44%;
+    font-size: 2.1rem;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.5));
+    animation: dagger-sweep 0.85s cubic-bezier(0.4, 0, 0.2, 1) both;
+  }
+  .sparks {
+    position: absolute;
+    inset: 0;
+  }
+  .spark {
+    position: absolute;
+    line-height: 1;
+    color: var(--text);
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: spark-fly;
+    animation-timing-function: ease-out;
+    animation-fill-mode: both;
+  }
+
+  @keyframes wash {
+    0% { opacity: 0; }
+    32% { opacity: 1; }
+    100% { opacity: 0; }
+  }
+  /* Blade sweeps in from the left, pauses at the target, then drives through on the strike. */
+  @keyframes dagger-sweep {
+    0% { opacity: 0; left: -12%; transform: rotate(-20deg) scale(0.9); }
+    35% { opacity: 1; left: 42%; transform: rotate(-8deg) scale(1); }
+    58% { left: 46%; transform: rotate(-8deg) scale(1.08); }
+    100% { opacity: 0; left: 52%; transform: rotate(6deg) scale(1.18); }
+  }
+  @keyframes target-beat {
+    0% { opacity: 0; transform: translate(-50%, -50%) scale(0.7); }
+    30% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+    58% { opacity: 1; transform: translate(-50%, -50%) scale(1.14); }
+    100% { opacity: 0; transform: translate(-50%, -50%) scale(1); }
+  }
+  @keyframes spark-fly {
+    0% { opacity: 0; transform: translate(0, 0) scale(0.5); }
+    30% { opacity: 1; }
+    100% { opacity: 0; transform: translate(var(--spread), calc(var(--rise) * -1)) scale(1); }
+  }
+</style>

--- a/src/lib/games/avalon/AvalonEditor.svelte
+++ b/src/lib/games/avalon/AvalonEditor.svelte
@@ -2,12 +2,20 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
+  import { haptic } from '../../haptics';
+  import AssassinReveal from './AssassinReveal.svelte';
   import {
+    HAMMER,
     MAX_QUESTS,
     clinch,
     decidedBefore,
+    effectiveTeamSize,
     expectedWinnerCount,
+    isHammer,
+    knowledgeHints,
     outcomeOf,
+    rejectsOf,
+    resolutionOf,
     roleList,
     roleSetup,
     tallyBefore,
@@ -19,7 +27,13 @@
 
   let { input = $bindable(), ctx }: { input: AvalonInput; ctx: RoundContext } = $props();
 
-  let showRoles = $state(false);
+  // Backfill optional fields for rounds saved before the vote track / council existed.
+  if (input.rejects == null) input.rejects = 0;
+  if (input.team == null) input.team = [];
+  if (input.leaderId === undefined) input.leaderId = null;
+
+  let showBriefing = $state(false);
+  let showCouncil = $state(false);
 
   const players = $derived(ctx.players);
   const playerCount = $derived(players.length);
@@ -31,6 +45,7 @@
     oberon: !!ctx.config.oberon,
   });
   const roles = $derived(roleList(playerCount, cfg));
+  const hints = $derived(knowledgeHints(cfg));
 
   const before = $derived(tallyBefore(ctx.rounds, ctx.roundIndex, setup));
   const decided = $derived(decidedBefore(before));
@@ -41,8 +56,13 @@
     setup.questTeams[ctx.roundIndex] ?? setup.questTeams[MAX_QUESTS - 1] ?? 3,
   );
 
+  const rejects = $derived(rejectsOf(input));
+  const hammer = $derived(isHammer(input));
+  const team = $derived(input.team ?? []);
+  const size = $derived(effectiveTeamSize(input));
+
   const outcome = $derived<Outcome>(outcomeOf(input, twoFail));
-  const clinchedBy = $derived<Side | null>(decided ? null : clinch(before, outcome));
+  const clinchedBy = $derived<Side | null>(decided ? null : clinch(before, resolutionOf(input, twoFail)));
   const sideKnown = $derived(
     clinchedBy === 'evil' || (clinchedBy === 'good' && input.assassinFoundMerlin !== null),
   );
@@ -50,6 +70,11 @@
     !clinchedBy ? null : sideKnown ? winningSide(clinchedBy, input.assassinFoundMerlin) : null,
   );
   const expectedWinners = $derived(finalSide ? expectedWinnerCount(setup, finalSide) : 0);
+
+  // Match point: a side sitting on two quests is one away from the crown. Co-signalled in text.
+  const goodMatch = $derived(before.successes === 2);
+  const evilMatch = $derived(before.fails === 2);
+  const suddenDeath = $derived(goodMatch && evilMatch);
 
   type PipState = Outcome | 'current' | 'future';
   const pips = $derived.by(() => {
@@ -61,22 +86,26 @@
       } else {
         const r = ctx.rounds.find((x) => x.index === i);
         const inp = r?.input as AvalonInput | undefined;
-        if (r && inp) state = outcomeOf(inp, setup.twoFailQuests[i] ?? false);
+        if (r && inp) state = resolutionOf(inp, setup.twoFailQuests[i] ?? false) === 'success' ? 'success' : 'fail';
       }
       list.push({ n: i + 1, state });
     }
     return list;
   });
 
-  // Keep the fail count within the team once the team size shrinks.
+  // Keep the fail count within the team once the team (or its size) shrinks.
   $effect(() => {
-    const ts = Number(input.teamSize) || 0;
+    const ts = size;
     if ((Number(input.fails) || 0) > ts) input.fails = ts;
   });
 
-  // Reset resolution when it no longer applies, and drop stale winners whenever the
-  // winning side changes — but never on first mount, so editing a saved clinch keeps
-  // its recorded team.
+  // When a roster is logged, it becomes the single source of truth for the team size.
+  $effect(() => {
+    if (team.length > 0 && input.teamSize !== team.length) input.teamSize = team.length;
+  });
+
+  // Reset resolution when it no longer applies, and drop stale winners whenever the winning
+  // side changes — but never on first mount, so editing a saved clinch keeps its recorded team.
   let primed = false;
   let lastSide: Side | null = null;
   $effect(() => {
@@ -95,11 +124,39 @@
     }
   });
 
+  // The Assassin's-strike reveal fires when the guess lands (null → hit/miss), never on mount.
+  let strikeToken = $state(0);
+  let strikeFound = $state(false);
+  let strikePrimed = false;
+  let lastGuess: boolean | null = null;
+  $effect(() => {
+    const g = clinchedBy === 'good' ? input.assassinFoundMerlin : null;
+    if (!strikePrimed) {
+      strikePrimed = true;
+      lastGuess = g;
+      return;
+    }
+    if (g !== null && g !== lastGuess) {
+      strikeFound = g;
+      strikeToken += 1;
+      haptic('win');
+    }
+    lastGuess = g;
+  });
+
   function markSuccess() {
     input.fails = 0;
+    haptic('tick');
   }
   function markFail() {
     if ((Number(input.fails) || 0) < requiredFails) input.fails = requiredFails;
+    haptic('tick');
+  }
+  function setRejects(n: number) {
+    const next = Math.max(0, Math.min(HAMMER, n));
+    if (next === rejects) return;
+    input.rejects = next;
+    haptic(next >= HAMMER ? 'save' : 'tick');
   }
   function setAssassin(found: boolean) {
     input.assassinFoundMerlin = found;
@@ -109,11 +166,21 @@
     input.winners = input.winners.includes(id)
       ? input.winners.filter((x) => x !== id)
       : [...input.winners, id];
+    haptic('tick');
+  }
+  function setLeader(id: string) {
+    input.leaderId = input.leaderId === id ? null : id;
+    haptic('tick');
+  }
+  function toggleAboard(id: string) {
+    const next = team.includes(id) ? team.filter((x) => x !== id) : [...team, id];
+    input.team = next;
+    haptic('tick');
   }
 </script>
 
 <div class="stack">
-  <div class="panel track">
+  <div class="panel track" class:tense={(goodMatch || evilMatch) && !decided}>
     <div class="row spread">
       <span class="muted small">Quest track</span>
       <span class="tally tnum">
@@ -131,31 +198,52 @@
           class:fail={p.state === 'fail'}
         >
           <span class="pn tnum">Q{p.n}</span>
-          <span class="pmark" aria-hidden="true">
-            {#if p.state === 'success'}✓{:else if p.state === 'fail'}✗{:else if p.state === 'current'}●{:else}·{/if}
-          </span>
+          {#key p.state}
+            <span class="pmark" class:stamp={p.state === 'success' || p.state === 'fail'} aria-hidden="true">
+              {#if p.state === 'success'}✓{:else if p.state === 'fail'}✗{:else if p.state === 'current'}●{:else}·{/if}
+            </span>
+          {/key}
         </div>
       {/each}
     </div>
+    {#if !decided && (goodMatch || evilMatch)}
+      <p class="matchpoint small" aria-live="polite">
+        {#if suddenDeath}
+          ⚔️ <strong>Sudden death</strong> — the next quest decides Avalon.
+        {:else if goodMatch}
+          🛡️ <strong>Good match point</strong> — one more success and the realm is saved.
+        {:else}
+          🗡️ <strong>Evil match point</strong> — one more fail and Mordred wins.
+        {/if}
+      </p>
+    {/if}
   </div>
 
   <div class="panel">
-    <button class="rowbtn" type="button" onclick={() => (showRoles = !showRoles)} aria-expanded={showRoles}>
+    <button class="rowbtn" type="button" onclick={() => (showBriefing = !showBriefing)} aria-expanded={showBriefing}>
       <span class="row" style="gap: 8px">
         <span aria-hidden="true">🎭</span>
-        <span><strong>{playerCount} players</strong> · 🛡️ {setup.good} Good · 🗡️ {setup.evil} Evil</span>
+        <span><strong>{playerCount} at the round table</strong> · 🛡️ {setup.good} Good · 🗡️ {setup.evil} Evil</span>
       </span>
-      <span class="muted small">{showRoles ? 'Hide' : 'Roles'}</span>
+      <span class="muted small">{showBriefing ? 'Hide' : 'Briefing'}</span>
     </button>
-    {#if showRoles}
-      <div class="roles">
-        {#each roles as r (r.name + r.emoji)}
-          <span class="pill role" class:good={r.side === 'good'} class:evil={r.side === 'evil'}>
-            {r.emoji} {r.name}{#if r.note}<span class="muted"> · {r.note}</span>{/if}
-          </span>
-        {/each}
+    {#if showBriefing}
+      <div class="briefing">
+        <p class="brief-lead small muted">🌙 Douse the lights — here's who wakes, and who they see.</p>
+        <div class="roles">
+          {#each roles as r (r.name + r.emoji)}
+            <span class="pill role" class:good={r.side === 'good'} class:evil={r.side === 'evil'}>
+              {r.emoji} {r.name}{#if r.note}<span class="muted"> · {r.note}</span>{/if}
+            </span>
+          {/each}
+        </div>
+        <ul class="hints">
+          {#each hints as h (h)}
+            <li>{h}</li>
+          {/each}
+        </ul>
         <p class="muted small teams">
-          Team sizes by quest: {setup.questTeams.join(' · ')}{#if twoFail || setup.twoFailQuests.some(Boolean)} · Quest 4 needs 2 fails{/if}
+          Team sizes by quest: {setup.questTeams.join(' · ')}{#if setup.twoFailQuests.some(Boolean)} · Quest 4 needs 2 fails{/if}
         </p>
       </div>
     {/if}
@@ -174,46 +262,129 @@
         <span class="muted small">Suggested team {suggestedTeam}{#if twoFail} · needs 2 fails{/if}</span>
       </div>
 
-      <div class="row spread field">
-        <span>On the quest</span>
-        <Stepper bind:value={input.teamSize} min={2} max={playerCount} />
-      </div>
-
-      <div class="otoggles">
-        <button
-          type="button"
-          class="otoggle success"
-          class:on={outcome === 'success'}
-          aria-pressed={outcome === 'success'}
-          onclick={markSuccess}
-        >
-          <span class="oi score-good" aria-hidden="true">✓</span> Succeeded
-        </button>
-        <button
-          type="button"
-          class="otoggle fail"
-          class:on={outcome === 'fail'}
-          aria-pressed={outcome === 'fail'}
-          onclick={markFail}
-        >
-          <span class="oi score-bad" aria-hidden="true">✗</span> Failed
-        </button>
-      </div>
-
-      {#if outcome === 'fail'}
-        <div class="row spread field">
-          <span>Fail cards revealed</span>
-          <Stepper bind:value={input.fails} min={requiredFails} max={input.teamSize} />
+      <!-- The vote track: rejected proposals stack up toward the Hammer. -->
+      <div class="votetrack" class:hammered={hammer}>
+        <div class="row spread">
+          <span class="vt-lbl">🗳️ Vote track <span class="muted small">· rejected proposals</span></span>
+          <span class="pill tnum" class:score-bad={hammer}>{rejects}/{HAMMER}</span>
         </div>
-      {:else if twoFail}
-        <p class="muted small hint">On Quest 4 a single Fail still succeeds — it takes two.</p>
+        <div class="vbeads" role="group" aria-label="Rejected proposals this quest">
+          {#each Array(HAMMER) as _, i (i)}
+            <button
+              type="button"
+              class="vbead"
+              class:filled={i < rejects}
+              class:doom={i === HAMMER - 1}
+              aria-pressed={i < rejects}
+              aria-label={`${i + 1} rejected proposal${i === 0 ? '' : 's'}`}
+              onclick={() => setRejects(i + 1 === rejects ? i : i + 1)}
+            >{i === HAMMER - 1 ? '🔨' : (i < rejects ? '✗' : '·')}</button>
+          {/each}
+        </div>
+        {#if hammer}
+          <p class="hammer-call">🔨 <strong>The Hammer falls!</strong> Five proposals rejected — Evil seizes Avalon.</p>
+        {/if}
+      </div>
+
+      {#if !hammer}
+        {#if team.length === 0}
+          <div class="row spread field">
+            <span>On the quest</span>
+            <Stepper bind:value={input.teamSize} min={2} max={playerCount} />
+          </div>
+        {:else}
+          <div class="row spread field">
+            <span>🚣 {team.length} aboard <span class="muted small">· from the council</span></span>
+          </div>
+        {/if}
+
+        <div class="otoggles">
+          <button
+            type="button"
+            class="otoggle success"
+            class:on={outcome === 'success'}
+            aria-pressed={outcome === 'success'}
+            onclick={markSuccess}
+          >
+            <span class="oi score-good" aria-hidden="true">✓</span> Succeeded
+          </button>
+          <button
+            type="button"
+            class="otoggle fail"
+            class:on={outcome === 'fail'}
+            aria-pressed={outcome === 'fail'}
+            onclick={markFail}
+          >
+            <span class="oi score-bad" aria-hidden="true">✗</span> Sabotaged
+          </button>
+        </div>
+
+        {#if outcome === 'fail'}
+          <div class="row spread field">
+            <span>🗡️ Fail cards revealed</span>
+            <Stepper bind:value={input.fails} min={requiredFails} max={size} />
+          </div>
+        {:else if twoFail}
+          <p class="muted small hint">On Quest 4 a single Fail still succeeds — treachery needs two.</p>
+        {/if}
+      {/if}
+
+      <!-- Optional council log: who led, who sailed. Never required — the tool stays fast. -->
+      <button class="rowbtn council-toggle" type="button" onclick={() => (showCouncil = !showCouncil)} aria-expanded={showCouncil}>
+        <span class="row" style="gap: 8px">
+          <span aria-hidden="true">👑</span>
+          <span>Record the council <span class="muted small">· optional</span></span>
+        </span>
+        <span class="muted small">{showCouncil ? 'Hide' : 'Log'}</span>
+      </button>
+      {#if showCouncil}
+        <div class="council">
+          <div class="csec">
+            <span class="muted small">👑 Quest leader</span>
+            <div class="chips">
+              {#each players as p (p.id)}
+                <button
+                  type="button"
+                  class="chip"
+                  class:on={input.leaderId === p.id}
+                  aria-pressed={input.leaderId === p.id}
+                  onclick={() => setLeader(p.id)}
+                >
+                  <Avatar name={p.name} color={p.color} size={24} />
+                  <span class="cn">{p.name}</span>
+                  {#if input.leaderId === p.id}<span class="ck" aria-hidden="true">👑</span>{/if}
+                </button>
+              {/each}
+            </div>
+          </div>
+          <div class="csec">
+            <span class="muted small">🚣 Who sailed? <span class="muted">· sets the team size</span></span>
+            <div class="chips">
+              {#each players as p (p.id)}
+                <button
+                  type="button"
+                  class="chip"
+                  class:on={team.includes(p.id)}
+                  aria-pressed={team.includes(p.id)}
+                  onclick={() => toggleAboard(p.id)}
+                >
+                  <Avatar name={p.name} color={p.color} size={24} />
+                  <span class="cn">{p.name}</span>
+                  {#if team.includes(p.id)}<span class="ck" aria-hidden="true">✓</span>{/if}
+                </button>
+              {/each}
+            </div>
+          </div>
+        </div>
       {/if}
     </div>
 
     {#if clinchedBy}
       <div class="panel resolve">
+        <AssassinReveal token={strikeToken} found={strikeFound} />
+
         {#if clinchedBy === 'good'}
-          <p class="rhead">🛡️ Good completed three quests! The Assassin gets one shot at Merlin.</p>
+          <p class="rhead">🛡️ Good completed three quests! The Assassin rises for one shot at Merlin.</p>
           <div class="atoggles">
             <button
               type="button"
@@ -222,7 +393,7 @@
               aria-pressed={input.assassinFoundMerlin === false}
               onclick={() => setAssassin(false)}
             >
-              🎯 Missed
+              🛡️ Missed
             </button>
             <button
               type="button"
@@ -234,6 +405,8 @@
               🗡️ Found Merlin
             </button>
           </div>
+        {:else if hammer}
+          <p class="rhead">🔨 The Hammer fell — the Minions of Mordred take Avalon without a fight.</p>
         {:else}
           <p class="rhead">🗡️ Evil sank three quests — the Minions of Mordred win.</p>
         {/if}
@@ -294,6 +467,10 @@
     display: flex;
     flex-direction: column;
     gap: 10px;
+    transition: border-color 0.2s ease;
+  }
+  .track.tense {
+    border-color: color-mix(in srgb, var(--primary) 55%, var(--border));
   }
   .tally {
     display: inline-flex;
@@ -341,6 +518,20 @@
     color: var(--text);
     box-shadow: inset 0 0 0 1px var(--primary);
   }
+  /* A quest resolving stamps its ✓/✗ in — decoration over a mark that's already there. */
+  .pmark.stamp {
+    display: inline-block;
+    animation: stamp 0.34s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  @keyframes stamp {
+    0% { transform: scale(1.9) rotate(-14deg); opacity: 0; }
+    55% { transform: scale(0.86) rotate(4deg); opacity: 1; }
+    100% { transform: scale(1) rotate(0deg); opacity: 1; }
+  }
+  .matchpoint {
+    margin: 0;
+    color: var(--text);
+  }
 
   .rowbtn {
     width: 100%;
@@ -357,11 +548,16 @@
     text-align: left;
     padding: 0;
   }
+  .briefing {
+    margin-top: 10px;
+  }
+  .brief-lead {
+    margin: 0 0 8px;
+  }
   .roles {
     display: flex;
     flex-wrap: wrap;
     gap: 6px;
-    margin-top: 10px;
   }
   .role.good {
     border-color: color-mix(in srgb, var(--good) 45%, var(--border));
@@ -369,9 +565,23 @@
   .role.evil {
     border-color: color-mix(in srgb, var(--bad) 45%, var(--border));
   }
+  .hints {
+    list-style: none;
+    margin: 10px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .hints li {
+    font-size: 0.86rem;
+    line-height: 1.4;
+    color: var(--text);
+    padding-left: 2px;
+  }
   .teams {
     width: 100%;
-    margin: 8px 0 0;
+    margin: 10px 0 0;
   }
 
   .entry {
@@ -387,6 +597,56 @@
   }
   .hint {
     margin: 0;
+  }
+
+  .votetrack {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    transition: border-color 0.2s ease, background 0.2s ease;
+  }
+  .votetrack.hammered {
+    border-color: var(--bad);
+    background: color-mix(in srgb, var(--bad) 12%, var(--surface));
+  }
+  .vt-lbl {
+    font-weight: 700;
+  }
+  .vbeads {
+    display: flex;
+    gap: 6px;
+  }
+  .vbead {
+    flex: 1 1 0;
+    min-height: 40px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface-2);
+    color: var(--muted);
+    font-weight: 800;
+    cursor: pointer;
+    line-height: 1;
+  }
+  .vbead.filled {
+    border-color: var(--bad);
+    color: var(--bad);
+    background: color-mix(in srgb, var(--bad) 16%, var(--surface));
+  }
+  .vbead.doom {
+    font-size: 1.05rem;
+  }
+  .vbead.doom.filled {
+    background: color-mix(in srgb, var(--bad) 30%, var(--surface));
+    color: var(--text);
+  }
+  .hammer-call {
+    margin: 0;
+    font-size: 0.86rem;
+    line-height: 1.4;
   }
 
   .otoggles {
@@ -419,10 +679,27 @@
     background: color-mix(in srgb, var(--bad) 16%, var(--surface));
   }
 
+  .council-toggle {
+    border-top: 1px solid var(--border);
+    padding-top: 12px;
+  }
+  .council {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .csec {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
   .resolve {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: 10px;
+    overflow: hidden;
   }
   .rhead {
     margin: 0;
@@ -454,6 +731,8 @@
     font-weight: 700;
     border: 1px solid var(--border);
     background: var(--surface);
+    position: relative;
+    z-index: 2;
   }
   .banner.good {
     border-color: var(--good);
@@ -493,5 +772,20 @@
 
   .done {
     margin: 0;
+  }
+
+  .vbead:focus-visible,
+  .otoggle:focus-visible,
+  .toggle:focus-visible,
+  .chip:focus-visible,
+  .rowbtn:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pmark.stamp {
+      animation: none;
+    }
   }
 </style>

--- a/src/lib/games/avalon/avalon.test.ts
+++ b/src/lib/games/avalon/avalon.test.ts
@@ -1,16 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import type { ID, Round } from '../../types';
 import {
+  HAMMER,
   MAX_PLAYERS,
   MIN_PLAYERS,
   clampPlayers,
   clinch,
   decidedBefore,
   describeAvalon,
+  effectiveTeamSize,
   expectedWinnerCount,
+  isHammer,
   isResolved,
+  knowledgeHints,
   outcomeOf,
   pickAvalonWinners,
+  rejectsOf,
+  resolutionOf,
   roleList,
   roleSetup,
   scoreAvalon,
@@ -22,7 +28,16 @@ import {
 } from './logic';
 
 function inp(partial: Partial<AvalonInput> = {}): AvalonInput {
-  return { fails: 0, teamSize: 3, assassinFoundMerlin: null, winners: [], ...partial };
+  return {
+    fails: 0,
+    teamSize: 3,
+    assassinFoundMerlin: null,
+    winners: [],
+    rejects: 0,
+    leaderId: null,
+    team: [],
+    ...partial,
+  };
 }
 
 function mkRound(index: number, input: AvalonInput): Round {
@@ -338,5 +353,146 @@ describe('describeAvalon', () => {
   it('handles a round with no recorded input', () => {
     const r: Round = { id: 'x', gameId: 'g', index: 0, input: undefined, deltas: {}, createdAt: 0 };
     expect(describeAvalon(r, 5)).toBe('Quest 1');
+  });
+
+  it('narrates the vote track on a completed quest', () => {
+    expect(describeAvalon(mkRound(0, inp({ fails: 0, rejects: 2 })), 5)).toBe(
+      'Quest 1 ✓ succeeded · 2 rejected proposals',
+    );
+    expect(describeAvalon(mkRound(1, inp({ fails: 1, rejects: 1 })), 5)).toBe(
+      'Quest 2 ✗ failed · 1 fail · 1 rejected proposal',
+    );
+  });
+
+  it('narrates the Hammer falling', () => {
+    const r = mkRound(2, inp({ rejects: HAMMER, winners: ['p4', 'p5'] }));
+    const out = describeAvalon(r, 5);
+    expect(out).toContain('🔨 the Hammer');
+    expect(out).toContain('Evil seizes it');
+  });
+});
+
+describe('rejectsOf & isHammer', () => {
+  it('clamps the vote track to 0…HAMMER', () => {
+    expect(rejectsOf({ rejects: 3 })).toBe(3);
+    expect(rejectsOf({ rejects: -2 })).toBe(0);
+    expect(rejectsOf({ rejects: 99 })).toBe(HAMMER);
+    expect(rejectsOf({})).toBe(0);
+    expect(rejectsOf({ rejects: 2.6 })).toBe(3);
+  });
+  it('flags the Hammer only at HAMMER rejections', () => {
+    expect(isHammer({ rejects: HAMMER - 1 })).toBe(false);
+    expect(isHammer({ rejects: HAMMER })).toBe(true);
+    expect(isHammer({ rejects: HAMMER + 3 })).toBe(true);
+    expect(isHammer({})).toBe(false);
+  });
+});
+
+describe('resolutionOf', () => {
+  it('resolves success/fail from the fail cards', () => {
+    expect(resolutionOf({ fails: 0, rejects: 0 }, false)).toBe('success');
+    expect(resolutionOf({ fails: 1, rejects: 0 }, false)).toBe('fail');
+    expect(resolutionOf({ fails: 1, rejects: 0 }, true)).toBe('success');
+    expect(resolutionOf({ fails: 2, rejects: 0 }, true)).toBe('fail');
+  });
+  it('lets the Hammer override the mission entirely', () => {
+    expect(resolutionOf({ fails: 0, rejects: HAMMER }, false)).toBe('hammer');
+    expect(resolutionOf({ fails: 2, rejects: HAMMER }, false)).toBe('hammer');
+  });
+});
+
+describe('effectiveTeamSize', () => {
+  it('prefers a logged roster, else the stepper size', () => {
+    expect(effectiveTeamSize({ team: ['a', 'b'], teamSize: 4 })).toBe(2);
+    expect(effectiveTeamSize({ team: [], teamSize: 4 })).toBe(4);
+    expect(effectiveTeamSize({ teamSize: 3 })).toBe(3);
+  });
+});
+
+describe('the Hammer (vote track) end-to-end', () => {
+  it('clinches Evil immediately, regardless of the tally', () => {
+    expect(clinch({ successes: 0, fails: 0 }, 'hammer')).toBe('evil');
+    expect(clinch({ successes: 2, fails: 0 }, 'hammer')).toBe('evil');
+  });
+
+  it('counts a Hammer quest as a fail in the running tally', () => {
+    const setup = roleSetup(5);
+    const rounds = [mkRound(0, inp({ rejects: HAMMER }))];
+    expect(tallyBefore(rounds, 1, setup)).toEqual({ successes: 0, fails: 1 });
+  });
+
+  it('requires the Evil team recorded with no Assassin step', () => {
+    // A Hammer on the very first quest hands Evil the game — 2 Evil at 5 players.
+    const draft = inp({ rejects: HAMMER, winners: ['p4', 'p5'] });
+    expect(validateAvalon(draft, [], 0, seats(5))).toBeNull();
+    const wrong = inp({ rejects: HAMMER, winners: ['p4'] });
+    expect(validateAvalon(wrong, [], 0, seats(5))).toMatch(/2 Evil/);
+  });
+
+  it('does not ask for the Assassin guess on a Hammer', () => {
+    const draft = inp({ rejects: HAMMER, winners: [] });
+    // Should complain about the Evil team, never about the Assassin.
+    expect(validateAvalon(draft, [], 0, seats(5))).toMatch(/2 Evil/);
+    expect(validateAvalon(draft, [], 0, seats(5))).not.toMatch(/Assassin/);
+  });
+
+  it('scores the recorded Evil team on a Hammer', () => {
+    const draft = inp({ rejects: HAMMER, winners: ['p4', 'p5'] });
+    const deltas = scoreAvalon(draft, [], 0, seats(5));
+    expect(deltas).toEqual({ p1: 0, p2: 0, p3: 0, p4: 1, p5: 1 });
+  });
+});
+
+describe('validateAvalon — council (leader & team)', () => {
+  it('rejects a leader who is not seated', () => {
+    expect(validateAvalon(inp({ teamSize: 2, leaderId: 'zzz' }), [], 0, seats(5))).toMatch(
+      /leader is not in this game/,
+    );
+    expect(validateAvalon(inp({ teamSize: 2, leaderId: 'p1' }), [], 0, seats(5))).toBeNull();
+  });
+
+  it('rejects a logged team with outsiders, duplicates, or a bad size', () => {
+    expect(validateAvalon(inp({ team: ['p1', 'zzz'] }), [], 0, seats(5))).toMatch(
+      /not in this game/,
+    );
+    expect(validateAvalon(inp({ team: ['p1', 'p1'] }), [], 0, seats(5))).toMatch(/twice/);
+    expect(validateAvalon(inp({ team: ['p1'] }), [], 0, seats(5))).toMatch(/between 2 and 5/);
+  });
+
+  it('accepts a logged team and lets it drive the fail bound', () => {
+    // Two aboard → fails may not exceed 2 even though the stepper size says 5.
+    expect(validateAvalon(inp({ team: ['p1', 'p2'], teamSize: 5, fails: 3 }), [], 0, seats(5))).toMatch(
+      /fails must be between 0 and the team size \(2\)/,
+    );
+    expect(validateAvalon(inp({ team: ['p1', 'p2'], teamSize: 5, fails: 1 }), [], 0, seats(5))).toBeNull();
+  });
+});
+
+describe('knowledgeHints', () => {
+  const noRoles: RolesConfig = { percival: false, morgana: false, mordred: false, oberon: false };
+
+  it('always names Merlin and the Assassin', () => {
+    const hints = knowledgeHints(noRoles).join('\n');
+    expect(hints).toContain('Merlin');
+    expect(hints).toContain('Assassin');
+  });
+
+  it('hides a Mordred-in-play caveat only when Mordred is on', () => {
+    expect(knowledgeHints(noRoles).join('\n')).not.toContain('except Mordred');
+    expect(knowledgeHints({ ...noRoles, mordred: true }).join('\n')).toContain('except Mordred');
+  });
+
+  it('adds a Percival line that names Morgana when both are on', () => {
+    expect(knowledgeHints({ ...noRoles, percival: true }).some((h) => h.includes('Percival'))).toBe(
+      true,
+    );
+    expect(
+      knowledgeHints({ ...noRoles, percival: true, morgana: true }).join('\n'),
+    ).toContain('can’t tell');
+  });
+
+  it('adds a lone-Oberon line only when Oberon is on', () => {
+    expect(knowledgeHints(noRoles).some((h) => h.includes('Oberon'))).toBe(false);
+    expect(knowledgeHints({ ...noRoles, oberon: true }).some((h) => h.includes('Oberon'))).toBe(true);
   });
 });

--- a/src/lib/games/avalon/index.ts
+++ b/src/lib/games/avalon/index.ts
@@ -71,7 +71,7 @@ export const avalon: GameModule = {
   createRoundInput: (ctx: RoundContext): AvalonInput => {
     const setup = roleSetup(ctx.players.length);
     const teamSize = setup.questTeams[ctx.roundIndex] ?? setup.questTeams[MAX_QUESTS - 1] ?? 3;
-    return { fails: 0, teamSize, assassinFoundMerlin: null, winners: [] };
+    return { fails: 0, teamSize, assassinFoundMerlin: null, winners: [], rejects: 0, leaderId: null, team: [] };
   },
 
   validateRound: (input: AvalonInput, ctx: RoundContext) =>
@@ -94,8 +94,11 @@ export const avalon: GameModule = {
     'Success/Fail cards — any single Fail sinks the quest (Quest 4 needs TWO Fails at 7+ players).',
     'Record how many Fails were revealed; the tracker marks the quest ✓ or ✗.',
     '',
+    'Before a team sails, the table votes on it. Log rejected proposals on the vote track —',
+    '🔨 five rejections in one quest is the Hammer, and Evil seizes the game outright.',
+    '',
     '🛡️ Good wins by succeeding 3 quests — then the Assassin may name Merlin: if correct,',
-    '🗡️ Evil steals the win. Evil wins outright by failing 3 quests.',
+    '🗡️ Evil steals the win. Evil wins outright by failing 3 quests (or dropping the Hammer).',
     '',
     'At the clinch, tap everyone on the winning side to record the result.',
   ].join('\n'),

--- a/src/lib/games/avalon/logic.ts
+++ b/src/lib/games/avalon/logic.ts
@@ -21,6 +21,8 @@ import type { ID, Round } from '../../types';
 
 export type Side = 'good' | 'evil';
 export type Outcome = 'success' | 'fail';
+/** A quest either succeeds, fails on the mission, or is never run because the vote track maxed out ("the Hammer"). */
+export type Resolution = Outcome | 'hammer';
 
 /** The draft recorded for one quest (round). Resolution fields matter only on the clinching quest. */
 export interface AvalonInput {
@@ -32,6 +34,16 @@ export interface AvalonInput {
   assassinFoundMerlin: boolean | null;
   /** Resolution: the members of the winning side (drives `pickWinners`). */
   winners: ID[];
+  /**
+   * Vote track — rejected team proposals *before* a team was approved this quest (0–5).
+   * `HAMMER` (5) rejections is "the Hammer": Evil wins the game outright, no quest is run.
+   * Optional + defensively defaulted so games saved before the vote track still load.
+   */
+  rejects?: number;
+  /** Who led the approved team (or held the hammer). Optional flavour/tracking; `null` when unset. */
+  leaderId?: ID | null;
+  /** The approved quest team. When non-empty it drives the team size; optional to log. */
+  team?: ID[];
 }
 
 /** Optional-role toggles (reference only — they never change the Good/Evil head counts). */
@@ -69,6 +81,8 @@ export const MAX_PLAYERS = 10;
 export const MAX_QUESTS = 5;
 /** Quests a side must win to end the quest phase. */
 export const QUESTS_TO_WIN = 3;
+/** Rejected team proposals in a single quest that hand the game to Evil ("the Hammer"). */
+export const HAMMER = 5;
 
 /** Evil (Minions of Mordred) head count by player count; the rest are Good. */
 const EVIL_BY_COUNT: Record<number, number> = { 5: 2, 6: 2, 7: 3, 8: 3, 9: 3, 10: 4 };
@@ -130,7 +144,36 @@ export function outcomeOf(input: Pick<AvalonInput, 'fails'>, twoFail: boolean): 
   return fails >= (twoFail ? 2 : 1) ? 'fail' : 'success';
 }
 
-/** Successes/fails recorded across the quests *before* `roundIndex` (the ones that count so far). */
+/** Rejected proposals recorded on the vote track this quest, clamped to 0…`HAMMER`. */
+export function rejectsOf(input: Pick<AvalonInput, 'rejects'>): number {
+  const r = Math.round(Number(input.rejects) || 0);
+  return Math.max(0, Math.min(HAMMER, r));
+}
+
+/** True when the vote track maxed out — five proposals rejected — and the Hammer fell. */
+export function isHammer(input: Pick<AvalonInput, 'rejects'>): boolean {
+  return rejectsOf(input) >= HAMMER;
+}
+
+/**
+ * How a quest resolved: the Hammer (vote track maxed → no mission) takes precedence over the
+ * Success/Fail cards, since the team never actually goes.
+ */
+export function resolutionOf(input: Pick<AvalonInput, 'fails' | 'rejects'>, twoFail: boolean): Resolution {
+  return isHammer(input) ? 'hammer' : outcomeOf(input, twoFail);
+}
+
+/** The team that went on the quest: the tapped roster when logged, else the stepper's team size. */
+export function effectiveTeamSize(input: Pick<AvalonInput, 'team' | 'teamSize'>): number {
+  const team = input.team ?? [];
+  return team.length > 0 ? team.length : Number(input.teamSize) || 0;
+}
+
+/**
+ * Successes/fails recorded across the quests *before* `roundIndex` (the ones that count so far).
+ * A Hammer quest counts as a fail here so the tally still reflects Evil's decided advantage —
+ * though in practice the Hammer ends the game on its own quest, so no later quest is ever entered.
+ */
 export function tallyBefore(rounds: Round[], roundIndex: number, setup: RoleSetup): Tally {
   let successes = 0;
   let fails = 0;
@@ -139,16 +182,17 @@ export function tallyBefore(rounds: Round[], roundIndex: number, setup: RoleSetu
     const inp = r.input as AvalonInput | undefined;
     if (!inp) continue;
     const twoFail = setup.twoFailQuests[r.index] ?? false;
-    if (outcomeOf(inp, twoFail) === 'fail') fails++;
-    else successes++;
+    if (resolutionOf(inp, twoFail) === 'success') successes++;
+    else fails++;
   }
   return { successes, fails };
 }
 
-/** Which side (if any) reaches three quests once `outcome` is applied to `before`. */
-export function clinch(before: Tally, outcome: Outcome): Side | null {
-  if (outcome === 'success' && before.successes + 1 >= QUESTS_TO_WIN) return 'good';
-  if (outcome === 'fail' && before.fails + 1 >= QUESTS_TO_WIN) return 'evil';
+/** Which side (if any) reaches three quests — or seizes the Hammer — once `resolution` is applied. */
+export function clinch(before: Tally, resolution: Resolution): Side | null {
+  if (resolution === 'hammer') return 'evil';
+  if (resolution === 'success' && before.successes + 1 >= QUESTS_TO_WIN) return 'good';
+  if (resolution === 'fail' && before.fails + 1 >= QUESTS_TO_WIN) return 'evil';
   return null;
 }
 
@@ -187,17 +231,36 @@ export function validateAvalon(
   const questNo = roundIndex + 1;
   if (questNo > MAX_QUESTS) return `Avalon is at most ${MAX_QUESTS} quests.`;
 
-  const teamSize = Number(input.teamSize) || 0;
-  if (teamSize < 2 || teamSize > n) {
-    return `Quest ${questNo}: team size must be between 2 and ${n}.`;
+  const seats = new Set(playerIds);
+  const team = input.team ?? [];
+  if (team.length) {
+    for (const t of team) {
+      if (!seats.has(t)) return 'The quest team includes someone who is not in this game.';
+    }
+    if (new Set(team).size !== team.length) return 'A player is listed twice on the quest team.';
+    if (team.length < 2 || team.length > n) {
+      return `Quest ${questNo}: the quest team must have between 2 and ${n} players.`;
+    }
   }
-  const fails = Number(input.fails) || 0;
-  if (fails < 0 || fails > teamSize) {
-    return `Quest ${questNo}: fails must be between 0 and the team size (${teamSize}).`;
+  if (input.leaderId != null && !seats.has(input.leaderId)) {
+    return 'The quest leader is not in this game.';
   }
 
   const twoFail = setup.twoFailQuests[roundIndex] ?? false;
-  const clinchedBy = clinch(before, outcomeOf(input, twoFail));
+  const hammer = isHammer(input);
+
+  if (!hammer) {
+    const teamSize = effectiveTeamSize(input);
+    if (teamSize < 2 || teamSize > n) {
+      return `Quest ${questNo}: team size must be between 2 and ${n}.`;
+    }
+    const fails = Number(input.fails) || 0;
+    if (fails < 0 || fails > teamSize) {
+      return `Quest ${questNo}: fails must be between 0 and the team size (${teamSize}).`;
+    }
+  }
+
+  const clinchedBy = clinch(before, resolutionOf(input, twoFail));
   if (clinchedBy) {
     if (
       clinchedBy === 'good' &&
@@ -206,7 +269,6 @@ export function validateAvalon(
       return 'Good reached three quests — record the Assassin’s guess at Merlin.';
     }
     const side = winningSide(clinchedBy, input.assassinFoundMerlin);
-    const seats = new Set(playerIds);
     const winners = input.winners ?? [];
     for (const w of winners) {
       if (!seats.has(w)) return 'The winning team includes someone who is not in this game.';
@@ -236,7 +298,7 @@ export function scoreAvalon(
   const setup = roleSetup(playerIds.length);
   const before = tallyBefore(rounds, roundIndex, setup);
   const twoFail = setup.twoFailQuests[roundIndex] ?? false;
-  if (!clinch(before, outcomeOf(input, twoFail))) return out;
+  if (!clinch(before, resolutionOf(input, twoFail))) return out;
 
   const winners = new Set(input.winners ?? []);
   for (const id of playerIds) out[id] = winners.has(id) ? 1 : 0;
@@ -253,7 +315,7 @@ export function pickAvalonWinners(totals: Record<ID, number>): ID[] {
   return Object.keys(totals).filter((id) => (Number(totals[id]) || 0) > 0);
 }
 
-/** One-line history summary for a quest, narrating the finale on the clinching round. */
+/** One-line history summary for a quest, narrating the leader, vote track, and finale. */
 export function describeAvalon(round: Round, playerCount: number): string {
   const inp = round.input as AvalonInput | undefined;
   const qn = round.index + 1;
@@ -261,22 +323,63 @@ export function describeAvalon(round: Round, playerCount: number): string {
 
   const setup = roleSetup(playerCount);
   const twoFail = setup.twoFailQuests[round.index] ?? false;
-  const outcome = outcomeOf(inp, twoFail);
+  const resolution = resolutionOf(inp, twoFail);
+  const rejects = rejectsOf(inp);
   const fails = Number(inp.fails) || 0;
-  const base =
-    outcome === 'success'
-      ? `Quest ${qn} ✓ succeeded`
-      : `Quest ${qn} ✗ failed · ${fails} fail${fails === 1 ? '' : 's'}`;
+
+  let base: string;
+  if (resolution === 'hammer') {
+    base = `Quest ${qn} 🔨 the Hammer — ${HAMMER} proposals rejected`;
+  } else if (resolution === 'success') {
+    base = `Quest ${qn} ✓ succeeded`;
+  } else {
+    base = `Quest ${qn} ✗ failed · ${fails} fail${fails === 1 ? '' : 's'}`;
+  }
+  // The vote track is worth narrating even on a completed quest — a knife-edge win reads well.
+  if (resolution !== 'hammer' && rejects > 0) {
+    base += ` · ${rejects} rejected proposal${rejects === 1 ? '' : 's'}`;
+  }
 
   const winners = inp.winners ?? [];
   if (winners.length) {
-    const clinchedBy: Side = outcome === 'fail' ? 'evil' : 'good';
+    const clinchedBy: Side = resolution === 'success' ? 'good' : 'evil';
     const side = winningSide(clinchedBy, inp.assassinFoundMerlin);
     let finale: string;
     if (side === 'good') finale = '🛡️ Good prevails';
+    else if (resolution === 'hammer') finale = '🗡️ Evil seizes it — the Hammer falls';
     else if (clinchedBy === 'good') finale = '🗡️ Evil steals it — Assassin found Merlin';
     else finale = '🗡️ Evil triumphs';
     return `${base} · ${finale}`;
   }
   return base;
+}
+
+/**
+ * Whimsical "who sees whom" hints for the night briefing, derived purely from the active
+ * optional-role toggles. Pure + unit-testable; the editor just renders these lines.
+ */
+export function knowledgeHints(cfg: RolesConfig): string[] {
+  const lines: string[] = [];
+  lines.push(
+    cfg.mordred
+      ? '🧙 Merlin sees every Minion of Mordred — except Mordred himself.'
+      : '🧙 Merlin sees every Minion of Mordred.',
+  );
+  if (cfg.percival) {
+    lines.push(
+      cfg.morgana
+        ? '🔎 Percival sees Merlin & Morgana — but can’t tell which is the true seer.'
+        : '🔎 Percival sees Merlin’s glow and can shield the wise one.',
+    );
+  }
+  lines.push(
+    cfg.oberon
+      ? '😈 The Minions know each other in the dark — all but lone Oberon.'
+      : '😈 The Minions of Mordred know one another in the dark.',
+  );
+  if (cfg.oberon) {
+    lines.push('👁️ Oberon skulks alone — unknown to his fellow Evil, and blind to them.');
+  }
+  lines.push('🗡️ If Good completes three quests, the Assassin gets one shot to name Merlin.');
+  return lines;
 }

--- a/src/lib/games/avalon/stats.ts
+++ b/src/lib/games/avalon/stats.ts
@@ -1,7 +1,7 @@
 import type { ID, Round } from '../../types';
 import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
 import { fmtPct } from '../../stats/format';
-import { outcomeOf, roleSetup, winningSide, type AvalonInput, type Side } from './logic';
+import { resolutionOf, roleSetup, winningSide, type AvalonInput, type Side } from './logic';
 
 interface Agg {
   goodGames: number;
@@ -57,13 +57,13 @@ export function avalonStats({ games, rounds, canonical }: GameStatsInput): GameS
       const inp = r.input as AvalonInput | undefined;
       if (!inp) continue;
       const twoFail = setup.twoFailQuests[r.index] ?? false;
-      const outcome = outcomeOf(inp, twoFail);
+      const res = resolutionOf(inp, twoFail);
       questsPlayed += 1;
-      if (outcome === 'fail') questFails += 1;
+      if (res !== 'success') questFails += 1;
 
       const winners = inp.winners ?? [];
       if (winners.length) {
-        const clinchedBy: Side = outcome === 'fail' ? 'evil' : 'good';
+        const clinchedBy: Side = res === 'success' ? 'good' : 'evil';
         const side = winningSide(clinchedBy, inp.assassinFoundMerlin);
         resolution = {
           winners: new Set(winners.map(canonical)),


### PR DESCRIPTION
## Avalon gets quest-board tension and hidden-role drama

Improves the **Avalon** game module end-to-end — more faithful to the real rules, more fun to run at the table — without touching the shared app chrome. Personality lives in emoji, copy, accent moments, and animation only.

### 🗳️ Vote track — "the Hammer" (a real, currently-missing core rule)
- New optional `AvalonInput` fields: `leaderId`, `team` (approved roster), `rejects` (0–5 rejected proposals this quest).
- **5 rejected proposals in one quest = instant Evil win** via a new `resolutionOf() -> 'success' | 'fail' | 'hammer'`, wired through `clinch` / `tallyBefore` / `scoreAvalon` / `validateAvalon`.
- All new fields are defensively defaulted, so games saved before this change still load.

### 🎭 Signature animations
- **`AssassinReveal`** overlay at the Good clinch: a dagger-strike Evil *steal* vs a Good *hold* — the iconic Assassin's-gambit moment.
- **Quest-reveal ✓/✗ stamp** on resolve, plus **match-point / sudden-death** tension styling when a side sits at 2.

### 🕯️ Night Briefing + polish
- `knowledgeHints(cfg)` (pure) drives a whimsical who-sees-whom setup helper derived from the role toggles.
- Always-visible reject pips with the Hammer callout; an optional **Council** (leader picker + who-sailed roster).
- Playful medieval microcopy and tasteful **haptics** at key beats.

### ✅ Design non-negotiables honored
- Identical chrome; Royal Violet = one primary action; **Crown Gold reserved for leader/winner** (the Assassin steal uses Loss-Coral, not gold).
- Surface ramp for depth, `tabular-nums`, ≥46px targets, never color-alone, `prefers-reduced-motion` + haptic gating throughout.

### 🧪 Testing (local only)
- Extended `avalon.test.ts`: `resolutionOf`, hammer clinch/score/validate, `effectiveTeamSize`, `knowledgeHints`, enriched `describeAvalon`.
- **59 Avalon tests green**, **full suite 1018 green**, `npm run check` clean (0 errors/0 warnings), `npm run build` succeeds.

All rules stay in Svelte-free `logic.ts`; the editor remains a thin renderer.