### PR TITLE
Blood on the Clocktower: Storyteller Grimoire, private role reveal & gothic day/night animations

### DIFF
--- a/src/lib/games/botc/BotcEditor.svelte
+++ b/src/lib/games/botc/BotcEditor.svelte
@@ -2,16 +2,29 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
+  import { haptic } from '../../haptics';
   import { botc } from './index';
+  import PhaseSky from './PhaseSky.svelte';
+  import ExecutionToll from './ExecutionToll.svelte';
+  import TownVerdict from './TownVerdict.svelte';
+  import RoleReveal from './RoleReveal.svelte';
+  import type { RevealData } from './RoleReveal.svelte';
   import type { BotcInput, Nomination, Team } from './logic';
   import {
     aliveCount,
+    demonStatus,
+    evilKnowledge,
+    evilWinsIn,
+    ghostVotesLeft,
+    isDemonRole,
     phaseEmoji,
     phaseKind,
     phaseLabel,
     roleTeam,
+    roleType,
     rolesFor,
     teamCount,
+    teamOfType,
     voteThreshold,
   } from './logic';
 
@@ -23,11 +36,29 @@
   const label = $derived(phaseLabel(ctx.roundIndex));
   const emoji = $derived(phaseEmoji(ctx.roundIndex));
   const alive = $derived(aliveCount(input.states));
+  const dead = $derived(ctx.players.length - alive);
   const threshold = $derived(voteThreshold(alive));
   const goodN = $derived(teamCount(input.states, 'good'));
   const evilN = $derived(teamCount(input.states, 'evil'));
+  const ghosts = $derived(ghostVotesLeft(input.states));
+  const demonState = $derived(demonStatus(input.states));
+  const evilIn = $derived(evilWinsIn(input.states));
 
   let showGuide = $state(false);
+  let expanded = $state<Record<string, boolean>>({});
+  let reveal = $state<RevealData | null>(null);
+
+  // Animation tokens — bumping one replays its overlay (each is reduced-motion-safe).
+  let skyToken = $state(0);
+  let tollToken = $state(0);
+  let verdictToken = $state(0);
+  let verdictTeam = $state<Team>('good');
+
+  // Open each phase with its dusk↔dawn sky (once per editor mount / phase).
+  $effect(() => {
+    ctx.roundIndex;
+    skyToken += 1;
+  });
 
   const nameOf = (id: string | null): string =>
     ctx.players.find((p) => p.id === id)?.name ?? '—';
@@ -36,18 +67,63 @@
     const st = input.states[id];
     st.alive = !st.alive;
     if (st.alive) st.ghostUsed = false;
+    haptic('tick');
   }
   function setTeam(id: string, team: Team) {
-    input.states[id].team = team;
+    const st = input.states[id];
+    st.team = team;
+    if (team === 'good') st.isDemon = false; // the Demon is always evil
+    haptic('tick');
   }
   function onRole(id: string, value: string) {
     const st = input.states[id];
     st.role = value;
-    const t = roleTeam(value, script);
-    if (t) st.team = t;
+    // Auto-follow a known role: a Demon marks the Demon; any other known role
+    // clears it. Off-script text leaves the Storyteller's manual flags alone.
+    if (isDemonRole(value, script)) {
+      st.team = 'evil';
+      st.isDemon = true;
+    } else {
+      const t = roleType(value, script);
+      if (t) {
+        st.team = teamOfType(t);
+        st.isDemon = false;
+      } else {
+        const rt = roleTeam(value, script);
+        if (rt) st.team = rt;
+      }
+    }
+  }
+  function toggleDemon(id: string) {
+    const st = input.states[id];
+    st.isDemon = !st.isDemon;
+    if (st.isDemon) st.team = 'evil';
+    haptic('tick');
   }
   function toggleGhost(id: string) {
     input.states[id].ghostUsed = !input.states[id].ghostUsed;
+    haptic('tick');
+  }
+  function toggleNotes(id: string) {
+    expanded[id] = !expanded[id];
+  }
+
+  function openReveal(id: string) {
+    const p = ctx.players.find((x) => x.id === id);
+    const st = input.states[id];
+    if (!p || !st) return;
+    const k = evilKnowledge(input.states, id);
+    const demonName = k.demonId && k.demonId !== id ? nameOf(k.demonId) : null;
+    reveal = {
+      name: p.name,
+      color: p.color,
+      role: st.role,
+      team: st.team,
+      isDemon: !!st.isDemon,
+      fellowEvil: k.fellowEvil.filter((eid) => eid !== k.demonId).map((eid) => nameOf(eid)),
+      demonName,
+    };
+    haptic('tick');
   }
 
   function addNomination() {
@@ -57,8 +133,21 @@
   function removeNomination(target: Nomination) {
     input.nominations = input.nominations.filter((n) => n !== target);
   }
+  function toggleExecuted(nom: Nomination) {
+    nom.executed = !nom.executed;
+    if (nom.executed) {
+      tollToken += 1;
+      haptic('save');
+    }
+  }
   function setResult(team: Team) {
-    input.result = input.result === team ? null : team;
+    const next = input.result === team ? null : team;
+    input.result = next;
+    if (next) {
+      verdictTeam = next;
+      verdictToken += 1;
+      haptic('win');
+    }
   }
 </script>
 
@@ -68,175 +157,248 @@
   {/each}
 </datalist>
 
-<div class="stack">
-  <!-- Phase header -->
-  <div class="phase">
-    <span class="phase-name">{emoji} {label}</span>
-    <span class="row" style="gap: 6px">
-      <span class="pill">🌿 {alive} alive</span>
-      <span class="pill">😇 {goodN} · 😈 {evilN}</span>
+<div class="stage">
+  <PhaseSky token={skyToken} {kind} />
+
+  <div class="stack">
+    <!-- Town Square — the Storyteller's glance -->
+    <div class="phase">
+      <span class="phase-name">{emoji} {label}</span>
       <button type="button" class="btn small ghost" onclick={() => (showGuide = !showGuide)}>
         {showGuide ? 'Hide' : 'Guide'}
       </button>
-    </span>
-  </div>
+    </div>
 
-  {#if showGuide}
-    <pre class="help">{botc.help}</pre>
-  {/if}
+    <div class="square" role="group" aria-label="Town at a glance">
+      <span class="stat"><span class="sn">{alive}</span> alive</span>
+      <span class="dot" aria-hidden="true">·</span>
+      <span class="stat">💀 <span class="sn">{dead}</span> dead</span>
+      <span class="dot" aria-hidden="true">·</span>
+      <span class="stat">😇 <span class="sn">{goodN}</span></span>
+      <span class="stat">😈 <span class="sn">{evilN}</span></span>
+      {#if ghosts > 0}
+        <span class="dot" aria-hidden="true">·</span>
+        <span class="stat">🗳️ <span class="sn">{ghosts}</span> ghost {ghosts === 1 ? 'vote' : 'votes'}</span>
+      {/if}
+    </div>
 
-  <p class="hint">
-    {#if kind === 'night'}
-      🌙 Resolve the night in secret, then tap a player to mark who died.
-    {:else}
-      ☀️ Town talks, nominates, and votes — log the block below.
+    <!-- Win-condition nudges (hints only — your word is final) -->
+    {#if demonState === 'fallen'}
+      <p class="nudge good">🌅 The Demon has fallen — Good wins.</p>
+    {:else if demonState === 'alive'}
+      <p class="nudge">🕯️ Good wins the moment the Demon dies.</p>
     {/if}
-  </p>
-
-  <!-- Roster -->
-  {#each ctx.players as p (p.id)}
-    {@const st = input.states[p.id]}
-    {#if st}
-      <div class="prow" class:dead={!st.alive}>
-        <div class="row spread">
-          <span class="who">
-            <Avatar name={p.name} color={p.color} size={28} />
-            <strong class="nm">{p.name}</strong>
-          </span>
-          <button
-            type="button"
-            class="life"
-            class:isdead={!st.alive}
-            aria-pressed={!st.alive}
-            onclick={() => toggleAlive(p.id)}
-          >
-            {st.alive ? '🌿 Alive' : '💀 Dead'}
-          </button>
-        </div>
-
-        <div class="controls">
-          <input
-            class="role"
-            type="text"
-            list="botc-roles"
-            placeholder="Character…"
-            aria-label={`${p.name}'s character`}
-            value={st.role}
-            oninput={(e) => onRole(p.id, e.currentTarget.value)}
-          />
-          <div class="team" role="group" aria-label={`${p.name}'s team`}>
-            <button type="button" class:on={st.team === 'good'} onclick={() => setTeam(p.id, 'good')}>
-              😇 Good
-            </button>
-            <button type="button" class:on={st.team === 'evil'} onclick={() => setTeam(p.id, 'evil')}>
-              😈 Evil
-            </button>
-          </div>
-        </div>
-
-        {#if !st.alive}
-          <button
-            type="button"
-            class="ghostvote"
-            class:used={st.ghostUsed}
-            aria-pressed={st.ghostUsed}
-            onclick={() => toggleGhost(p.id)}
-          >
-            🗳️ Ghost vote {st.ghostUsed ? 'used' : 'available'}
-          </button>
-        {/if}
-      </div>
+    {#if evilIn > 0 && evilIn <= 2}
+      <p class="nudge evil">😈 Evil wins with {evilIn} more {evilIn === 1 ? 'death' : 'deaths'} — 2 left alive.</p>
+    {:else if alive <= 2 && ctx.players.length > 2}
+      <p class="nudge evil">😈 Only two stand — Evil takes the town.</p>
     {/if}
-  {/each}
 
-  <!-- Day: nominations & votes -->
-  {#if kind === 'day'}
-    <div class="noms">
-      <div class="row spread">
-        <span class="section-lbl">Nominations &amp; votes</span>
-        <span class="pill">Majority: {threshold}</span>
-      </div>
+    {#if showGuide}
+      <pre class="help">{botc.help}</pre>
+    {/if}
 
-      {#each input.nominations as nom (nom)}
-        {@const reaches = (Number(nom.votes) || 0) >= threshold}
-        <div class="nom" class:executed={nom.executed}>
-          <div class="nom-line">
-            <select bind:value={nom.nomineeId} aria-label="Nominated player">
-              <option value={null}>— on the block —</option>
-              {#each ctx.players as p (p.id)}
-                <option value={p.id}>{p.name}</option>
-              {/each}
-            </select>
+    <p class="hint">
+      {#if kind === 'night'}
+        🌙 Resolve the night in secret, then tap a seat to mark who died.
+      {:else}
+        ☀️ Dawn breaks — the town talks, nominates, and votes. Log the block below.
+      {/if}
+    </p>
+
+    <!-- The Grimoire: one card per seat, in circle order -->
+    {#each ctx.players as p, i (p.id)}
+      {@const st = input.states[p.id]}
+      {#if st}
+        <div class="prow" class:dead={!st.alive} class:demon={st.isDemon}>
+          <div class="row spread top">
+            <span class="who">
+              <span class="seat" aria-label={`Seat ${i + 1}`}>{i + 1}</span>
+              <Avatar name={p.name} color={p.color} size={26} />
+              <strong class="nm">{p.name}</strong>
+              {#if st.isDemon}<span class="dtag" title="The Demon">😈</span>{/if}
+            </span>
             <button
               type="button"
-              class="rm"
-              aria-label="Remove nomination"
-              title="Remove"
-              onclick={() => removeNomination(nom)}
-            >✕</button>
+              class="life"
+              class:isdead={!st.alive}
+              aria-pressed={!st.alive}
+              onclick={() => toggleAlive(p.id)}
+            >
+              {st.alive ? '🌿 Alive' : '💀 Dead'}
+            </button>
           </div>
-          <div class="nom-line by">
-            <span class="by-lbl">by</span>
-            <select bind:value={nom.nominatorId} aria-label="Nominating player">
-              <option value={null}>— nominator (optional) —</option>
-              {#each ctx.players as p (p.id)}
-                <option value={p.id}>{p.name}</option>
-              {/each}
-            </select>
+
+          <div class="controls">
+            <input
+              class="role"
+              type="text"
+              list="botc-roles"
+              placeholder="Character…"
+              aria-label={`${p.name}'s character`}
+              value={st.role}
+              oninput={(e) => onRole(p.id, e.currentTarget.value)}
+            />
+            <div class="team" role="group" aria-label={`${p.name}'s team`}>
+              <button type="button" class:on={st.team === 'good'} onclick={() => setTeam(p.id, 'good')}>
+                😇 Good
+              </button>
+              <button type="button" class:on={st.team === 'evil'} onclick={() => setTeam(p.id, 'evil')}>
+                😈 Evil
+              </button>
+            </div>
           </div>
-          <div class="row spread nom-tally">
-            <span class="votes-lbl">
-              Votes
-              <span class="reach" class:hit={reaches}>{reaches ? '· reaches majority' : `· needs ${threshold}`}</span>
-            </span>
-            <span class="row" style="gap: 10px">
-              <Stepper bind:value={nom.votes} min={0} max={ctx.players.length} />
+
+          <div class="acts">
+            <button type="button" class="act" onclick={() => openReveal(p.id)}>🎭 Reveal</button>
+            <button
+              type="button"
+              class="act"
+              class:on={st.isDemon}
+              aria-pressed={st.isDemon}
+              onclick={() => toggleDemon(p.id)}
+            >😈 Demon</button>
+            <button
+              type="button"
+              class="act"
+              class:on={expanded[p.id]}
+              aria-expanded={!!expanded[p.id]}
+              onclick={() => toggleNotes(p.id)}
+            >📝 Notes</button>
+            {#if !st.alive}
               <button
                 type="button"
-                class="exec"
-                class:on={nom.executed}
-                aria-pressed={nom.executed}
-                onclick={() => (nom.executed = !nom.executed)}
-              >⚖️ Executed</button>
-            </span>
+                class="act ghostvote"
+                class:used={st.ghostUsed}
+                aria-pressed={st.ghostUsed}
+                onclick={() => toggleGhost(p.id)}
+              >🗳️ Ghost {st.ghostUsed ? 'used' : 'ready'}</button>
+            {/if}
           </div>
+
+          {#if expanded[p.id]}
+            <div class="notes">
+              <input
+                class="note-in"
+                type="text"
+                list="botc-roles"
+                placeholder="Suspected as… (who they might be)"
+                aria-label={`${p.name}'s suspected role`}
+                bind:value={st.suspect}
+              />
+              <input
+                class="note-in"
+                type="text"
+                placeholder="Reminder (poisoned, drunk, red herring…)"
+                aria-label={`${p.name}'s reminder`}
+                bind:value={st.reminder}
+              />
+            </div>
+          {/if}
         </div>
-      {/each}
+      {/if}
+    {/each}
 
-      <button type="button" class="btn block ghost add" onclick={addNomination}>
-        ＋ Add nomination
-      </button>
-    </div>
-  {/if}
+    <!-- Day: nominations & votes -->
+    {#if kind === 'day'}
+      <div class="noms">
+        <ExecutionToll token={tollToken} />
+        <div class="row spread">
+          <span class="section-lbl">Nominations &amp; votes</span>
+          <span class="pill">Majority: {threshold}</span>
+        </div>
 
-  <!-- Result recorder -->
-  <div class="result">
-    <span class="section-lbl">End the game</span>
-    <div class="result-btns">
-      <button type="button" class="res good" class:on={input.result === 'good'} aria-pressed={input.result === 'good'} onclick={() => setResult('good')}>
-        😇 Good wins
-      </button>
-      <button type="button" class="res evil" class:on={input.result === 'evil'} aria-pressed={input.result === 'evil'} onclick={() => setResult('evil')}>
-        😈 Evil wins
-      </button>
-    </div>
-    {#if input.result}
-      <p class="recorded">
-        🏁 {input.result === 'good' ? 'Good' : 'Evil'} recorded — Save round, then <strong>Finish &amp; record winner</strong>.
-      </p>
+        {#each input.nominations as nom (nom)}
+          {@const reaches = (Number(nom.votes) || 0) >= threshold}
+          <div class="nom" class:executed={nom.executed}>
+            <div class="nom-line">
+              <select bind:value={nom.nomineeId} aria-label="Nominated player">
+                <option value={null}>— on the block —</option>
+                {#each ctx.players as p (p.id)}
+                  <option value={p.id}>{p.name}</option>
+                {/each}
+              </select>
+              <button
+                type="button"
+                class="rm"
+                aria-label="Remove nomination"
+                title="Remove"
+                onclick={() => removeNomination(nom)}
+              >✕</button>
+            </div>
+            <div class="nom-line by">
+              <span class="by-lbl">by</span>
+              <select bind:value={nom.nominatorId} aria-label="Nominating player">
+                <option value={null}>— nominator (optional) —</option>
+                {#each ctx.players as p (p.id)}
+                  <option value={p.id}>{p.name}</option>
+                {/each}
+              </select>
+            </div>
+            <div class="row spread nom-tally">
+              <span class="votes-lbl">
+                Votes
+                <span class="reach" class:hit={reaches}>{reaches ? '· reaches majority' : `· needs ${threshold}`}</span>
+              </span>
+              <span class="row" style="gap: 10px">
+                <Stepper bind:value={nom.votes} min={0} max={ctx.players.length} />
+                <button
+                  type="button"
+                  class="exec"
+                  class:on={nom.executed}
+                  aria-pressed={nom.executed}
+                  onclick={() => toggleExecuted(nom)}
+                >⚖️ Executed</button>
+              </span>
+            </div>
+          </div>
+        {/each}
+
+        <button type="button" class="btn block ghost add" onclick={addNomination}>
+          ＋ Add nomination
+        </button>
+      </div>
     {/if}
-  </div>
 
-  <input
-    class="note"
-    type="text"
-    placeholder="Storyteller note (optional)…"
-    aria-label="Storyteller note"
-    bind:value={input.note}
-  />
+    <!-- Result recorder -->
+    <div class="result">
+      <TownVerdict token={verdictToken} team={verdictTeam} />
+      <span class="section-lbl">End the game</span>
+      <div class="result-btns">
+        <button type="button" class="res good" class:on={input.result === 'good'} aria-pressed={input.result === 'good'} onclick={() => setResult('good')}>
+          😇 Good wins
+        </button>
+        <button type="button" class="res evil" class:on={input.result === 'evil'} aria-pressed={input.result === 'evil'} onclick={() => setResult('evil')}>
+          😈 Evil wins
+        </button>
+      </div>
+      {#if input.result}
+        <p class="recorded">
+          🏁 {input.result === 'good' ? 'Good' : 'Evil'} recorded — Save round, then <strong>Finish &amp; record winner</strong>.
+        </p>
+      {/if}
+    </div>
+
+    <input
+      class="note"
+      type="text"
+      placeholder="Storyteller note for this phase (optional)…"
+      aria-label="Storyteller note"
+      bind:value={input.note}
+    />
+  </div>
 </div>
 
+<RoleReveal {reveal} onclose={() => (reveal = null)} />
+
 <style>
+  .stage {
+    position: relative;
+  }
+  .stack {
+    position: relative;
+    z-index: 1;
+  }
   .phase {
     display: flex;
     align-items: center;
@@ -248,6 +410,53 @@
     font-weight: 800;
     font-size: 1.05rem;
   }
+
+  /* Town Square — the glance line */
+  .square {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px 8px;
+    padding: 8px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  .stat {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--text);
+  }
+  .sn {
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+  .dot {
+    color: var(--muted);
+  }
+
+  .nudge {
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text);
+    padding: 8px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
+  .nudge.good {
+    color: var(--good);
+    border-color: color-mix(in srgb, var(--good) 45%, var(--border));
+  }
+  .nudge.evil {
+    color: var(--bad);
+    border-color: color-mix(in srgb, var(--bad) 45%, var(--border));
+  }
+
   .hint {
     margin: 0;
     color: var(--muted);
@@ -257,7 +466,7 @@
     white-space: pre-wrap;
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     padding: 12px;
     font-size: 0.82rem;
     line-height: 1.5;
@@ -269,20 +478,39 @@
   .prow {
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     padding: 12px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
   }
   .prow.dead {
     background: var(--surface);
+  }
+  .prow.demon {
+    border-color: color-mix(in srgb, var(--bad) 40%, var(--border));
+  }
+  .top {
+    align-items: center;
   }
   .who {
     display: inline-flex;
     align-items: center;
     gap: 8px;
     min-width: 0;
+  }
+  .seat {
+    flex: none;
+    display: grid;
+    place-items: center;
+    width: 22px;
+    height: 22px;
+    border-radius: var(--radius-sm);
+    background: var(--surface-3);
+    color: var(--muted);
+    font-size: 0.78rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
   }
   .nm {
     overflow: hidden;
@@ -291,6 +519,11 @@
   }
   .prow.dead .nm {
     color: var(--muted);
+  }
+  .dtag {
+    flex: none;
+    font-size: 0.9rem;
+    line-height: 1;
   }
 
   .life {
@@ -331,7 +564,7 @@
     min-height: 38px;
     padding: 0 12px;
     border: 0;
-    border-radius: 7px;
+    border-radius: var(--radius-sm);
     background: transparent;
     color: var(--muted);
     font-weight: 700;
@@ -343,21 +576,46 @@
     color: var(--text);
   }
 
-  .ghostvote {
-    align-self: flex-start;
+  /* Per-seat secondary actions */
+  .acts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .act {
     min-height: 38px;
     padding: 0 12px;
-    border: 1px dashed var(--border);
+    border: 1px solid var(--border);
     border-radius: 999px;
     background: transparent;
     color: var(--muted);
     font-weight: 600;
+    font-size: 0.85rem;
     cursor: pointer;
+    white-space: nowrap;
   }
-  .ghostvote.used {
+  .act.on {
+    border-style: solid;
+    color: var(--text);
+    background: var(--surface-3);
+  }
+  .act.ghostvote {
+    border-style: dashed;
+  }
+  .act.ghostvote.used {
     border-style: solid;
     color: var(--text);
     background: var(--surface-2);
+  }
+
+  .notes {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding-top: 2px;
+  }
+  .note-in {
+    font-size: 0.85rem;
   }
 
   .section-lbl {
@@ -370,6 +628,7 @@
 
   .noms,
   .result {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: 10px;
@@ -379,7 +638,7 @@
   .nom {
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     padding: 10px;
     display: flex;
     flex-direction: column;
@@ -477,7 +736,7 @@
 
   .life:focus-visible,
   .team button:focus-visible,
-  .ghostvote:focus-visible,
+  .act:focus-visible,
   .rm:focus-visible,
   .exec:focus-visible,
   .res:focus-visible {
@@ -487,7 +746,7 @@
 
   .life,
   .team button,
-  .ghostvote,
+  .act,
   .exec,
   .res {
     transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
@@ -495,7 +754,7 @@
   @media (prefers-reduced-motion: reduce) {
     .life,
     .team button,
-    .ghostvote,
+    .act,
     .exec,
     .res {
       transition: none;

--- a/src/lib/games/botc/ExecutionToll.svelte
+++ b/src/lib/games/botc/ExecutionToll.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * The toll of the bell: when the town executes a nominee, a single bell swings
+   * over the block and a skull drops beneath a somber Loss-Coral wash. A localized
+   * beat, not a full-screen takeover — the execution is already spelled out by the
+   * pressed "Executed" state + the history line, so motion is never the only
+   * signal. `pointer-events: none`, replays whenever `token` changes, and renders
+   * nothing under reduced motion.
+   */
+  let { token = 0 }: { token?: number } = $props();
+
+  const reduced = prefersReducedMotion();
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="toll" aria-hidden="true">
+      <div class="wash"></div>
+      <span class="bell">🔔</span>
+      <span class="skull">💀</span>
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .toll {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    border-radius: 14px;
+    z-index: 2;
+    display: grid;
+    place-items: center;
+  }
+  .wash {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    background: radial-gradient(90% 120% at 50% 40%, color-mix(in srgb, var(--bad) 30%, transparent), transparent 70%);
+    animation: toll-wash 1.1s ease-out both;
+  }
+  .bell {
+    position: absolute;
+    top: 8%;
+    font-size: 1.9rem;
+    line-height: 1;
+    opacity: 0;
+    transform-origin: 50% 0;
+    will-change: transform, opacity;
+    animation: bell-swing 1.1s ease-out both;
+  }
+  .skull {
+    position: absolute;
+    top: 34%;
+    font-size: 1.8rem;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.5));
+    animation: skull-drop 1.1s cubic-bezier(0.4, 0, 0.2, 1) both;
+  }
+  @keyframes toll-wash {
+    0% { opacity: 0; }
+    30% { opacity: 1; }
+    100% { opacity: 0; }
+  }
+  @keyframes bell-swing {
+    0% { opacity: 0; transform: rotate(-26deg); }
+    22% { opacity: 1; transform: rotate(22deg); }
+    44% { transform: rotate(-16deg); }
+    64% { transform: rotate(12deg); }
+    82% { transform: rotate(-6deg); }
+    100% { opacity: 0; transform: rotate(0deg); }
+  }
+  @keyframes skull-drop {
+    0% { opacity: 0; transform: translateY(-14px) scale(0.7); }
+    38% { opacity: 1; transform: translateY(0) scale(1.12); }
+    70% { opacity: 1; transform: translateY(0) scale(1); }
+    100% { opacity: 0; transform: translateY(10px) scale(1); }
+  }
+</style>

--- a/src/lib/games/botc/PhaseSky.svelte
+++ b/src/lib/games/botc/PhaseSky.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * The clocktower's heartbeat: each phase opens with a dusk↔dawn wash over the
+   * editor. On a 🌙 night the sky cools, a moon rises and stars twinkle up; on a
+   * ☀️ day the sky warms, the sun climbs and rays fan out. Pure atmosphere layered
+   * over the phase header, which already names the phase in words + emoji, so the
+   * sky is never the only signal. Mirrors Hearts' MoonRise: `pointer-events: none`,
+   * replays whenever `token` changes (a new phase), and renders nothing at all
+   * under reduced motion — the header is the calm, instant alternative.
+   */
+  let { token = 0, kind = 'night' }: { token?: number; kind?: 'night' | 'day' } = $props();
+
+  const reduced = prefersReducedMotion();
+  const COUNT = 14;
+
+  // Deterministic pseudo-random seeded by token (mirrors MoonRise / CoinBurst).
+  const motes = $derived(
+    Array.from({ length: COUNT }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      const night = ['✦', '✧', '⋆', '·', '✦'];
+      const day = ['·', '✧', '⋆', '·'];
+      const glyphs = kind === 'night' ? night : day;
+      return {
+        left: rand(1) * 100,
+        bottom: rand(2) * 66,
+        delay: rand(3) * 0.4,
+        duration: 0.9 + rand(4) * 0.7,
+        rise: 24 + rand(5) * 58,
+        size: 0.5 + rand(6) * 0.65,
+        glyph: glyphs[Math.floor(rand(7) * glyphs.length)],
+      };
+    }),
+  );
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="sky-wrap" class:day={kind === 'day'} aria-hidden="true">
+      <div class="wash"></div>
+      <div class="motes">
+        {#each motes as m, i (i)}
+          <span
+            class="mote"
+            style="
+              left: {m.left}%;
+              bottom: {m.bottom}%;
+              font-size: {m.size}rem;
+              animation-delay: {m.delay}s;
+              animation-duration: {m.duration}s;
+              --rise: {m.rise}px;
+            ">{m.glyph}</span>
+        {/each}
+      </div>
+      <span class="orb">{kind === 'night' ? '🌙' : '☀️'}</span>
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .sky-wrap {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    border-radius: 14px;
+    z-index: 1;
+  }
+  .wash {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    /* Night: a cool violet dusk. Day: a warm dawn — semantic warmth, never Crown Gold. */
+    background:
+      radial-gradient(120% 80% at 50% 118%, color-mix(in srgb, var(--primary) 30%, transparent), transparent 68%),
+      linear-gradient(to top, color-mix(in srgb, var(--primary) 14%, transparent), transparent 55%);
+    animation: sky-wash 1.5s ease-out both;
+  }
+  .sky-wrap.day .wash {
+    background:
+      radial-gradient(120% 80% at 50% 118%, color-mix(in srgb, var(--warn) 26%, transparent), transparent 68%),
+      linear-gradient(to top, color-mix(in srgb, var(--warn) 12%, transparent), transparent 55%);
+  }
+  .motes {
+    position: absolute;
+    inset: 0;
+  }
+  .mote {
+    position: absolute;
+    line-height: 1;
+    color: var(--text);
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: mote-rise;
+    animation-timing-function: ease-out;
+    animation-fill-mode: both;
+  }
+  .orb {
+    position: absolute;
+    left: 50%;
+    bottom: 0;
+    font-size: 2.2rem;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    filter: drop-shadow(0 0 12px color-mix(in srgb, var(--primary) 55%, transparent));
+    animation: orb-rise 1.5s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  .sky-wrap.day .orb {
+    filter: drop-shadow(0 0 14px color-mix(in srgb, var(--warn) 60%, transparent));
+  }
+  @keyframes sky-wash {
+    0% { opacity: 0; }
+    28% { opacity: 1; }
+    100% { opacity: 0; }
+  }
+  @keyframes mote-rise {
+    0% { opacity: 0; transform: translateY(6px) scale(0.6); }
+    30% { opacity: 0.9; }
+    100% { opacity: 0; transform: translateY(calc(var(--rise) * -1)) scale(1); }
+  }
+  @keyframes orb-rise {
+    0% { opacity: 0; transform: translate(-50%, 38px) scale(0.7); }
+    35% { opacity: 1; transform: translate(-50%, -16px) scale(1.05); }
+    75% { opacity: 0.9; transform: translate(-50%, -22px) scale(1); }
+    100% { opacity: 0; transform: translate(-50%, -28px) scale(1); }
+  }
+</style>

--- a/src/lib/games/botc/RoleReveal.svelte
+++ b/src/lib/games/botc/RoleReveal.svelte
@@ -1,0 +1,242 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+  import Avatar from '../../components/Avatar.svelte';
+
+  /**
+   * The digital role token. The Storyteller taps a seat and hands the phone over;
+   * this full-screen private card shows that player ONLY their own character — a
+   * two-step reveal (a "pass to {name}" cover first) keeps the next player from
+   * peeking. An evil player also learns their fellow evil and who the Demon is,
+   * exactly as they would on the first night. Honors the privacy principle: the
+   * Grimoire's true roles never share a screen with the person being revealed to.
+   *
+   * The flip is decorative — the card content carries all meaning — so under
+   * reduced motion it simply crossfades. Escape or the "hand it back" button
+   * closes it and returns the Storyteller to the Grimoire.
+   */
+  export interface RevealData {
+    name: string;
+    color: string;
+    role: string;
+    team: 'good' | 'evil';
+    isDemon: boolean;
+    /** Names of the other evil seats (evil viewer only). */
+    fellowEvil: string[];
+    /** The Demon's name, if flagged (evil viewer only). */
+    demonName: string | null;
+  }
+
+  let { reveal, onclose }: { reveal: RevealData | null; onclose: () => void } = $props();
+
+  const reduced = prefersReducedMotion();
+  let shown = $state(false);
+
+  // A fresh reveal always starts hidden behind the "pass the phone" cover.
+  $effect(() => {
+    reveal;
+    shown = false;
+  });
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === 'Escape') onclose();
+  }
+</script>
+
+<svelte:window onkeydown={reveal ? onKey : undefined} />
+
+{#if reveal}
+  <div class="scrim" role="dialog" aria-modal="true" aria-label={`${reveal.name}'s character`}>
+    {#if !shown}
+      <div class="cover" class:still={reduced}>
+        <span class="hush" aria-hidden="true">🤫</span>
+        <p class="pass">Pass the phone to</p>
+        <span class="who">
+          <Avatar name={reveal.name} color={reveal.color} size={28} />
+          <strong class="wname">{reveal.name}</strong>
+        </span>
+        <p class="sub">Everyone else, look away.</p>
+        <button type="button" class="btn primary block reveal-btn" onclick={() => (shown = true)}>
+          🎭 Reveal my character
+        </button>
+        <button type="button" class="btn block ghost" onclick={onclose}>Cancel</button>
+      </div>
+    {:else}
+      <div class="card" class:evil={reveal.team === 'evil'} class:still={reduced}>
+        <span class="badge" aria-hidden="true">{reveal.team === 'evil' ? '😈' : '🕯️'}</span>
+        <p class="youare">You are</p>
+        <strong class="role">{reveal.role || 'Not assigned yet'}</strong>
+        <span class="team-lbl">
+          {#if reveal.isDemon}
+            😈 The Demon
+          {:else if reveal.team === 'evil'}
+            😈 Evil — Minion
+          {:else}
+            😇 Good — you serve the town
+          {/if}
+        </span>
+
+        {#if reveal.team === 'evil'}
+          <div class="intel">
+            {#if reveal.demonName}
+              <p class="intel-line"><span class="ilabel">The Demon</span> <span class="iname">{reveal.demonName}</span></p>
+            {/if}
+            {#if reveal.fellowEvil.length}
+              <p class="intel-line">
+                <span class="ilabel">Your evil</span>
+                <span class="iname">{reveal.fellowEvil.join(', ')}</span>
+              </p>
+            {:else if !reveal.demonName}
+              <p class="intel-line muted">No other evil flagged in the Grimoire yet.</p>
+            {/if}
+          </div>
+        {:else}
+          <p class="flavor">Sleep well — and trust no one. 🌙</p>
+        {/if}
+
+        <button type="button" class="btn primary block" onclick={onclose}>👀 Hide &amp; hand it back</button>
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    display: grid;
+    place-items: center;
+    padding: 20px;
+    background: color-mix(in srgb, var(--bg) 82%, black);
+    backdrop-filter: blur(6px);
+  }
+  .cover,
+  .card {
+    width: min(360px, 100%);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 24px 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    text-align: center;
+  }
+  .card {
+    animation: flip-in 0.4s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  .cover {
+    animation: fade-in 0.25s ease-out both;
+  }
+  .card.still,
+  .cover.still {
+    animation: fade-in 0.2s ease-out both;
+  }
+
+  .hush {
+    font-size: 2.4rem;
+    line-height: 1;
+  }
+  .pass {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+  .who {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .wname {
+    font-size: 1.25rem;
+    font-weight: 800;
+  }
+  .sub {
+    margin: 0 0 6px;
+    color: var(--muted);
+    font-size: 0.82rem;
+  }
+  .reveal-btn {
+    margin-top: 4px;
+  }
+
+  .badge {
+    font-size: 2.6rem;
+    line-height: 1;
+    filter: drop-shadow(0 0 14px color-mix(in srgb, var(--good) 45%, transparent));
+  }
+  .card.evil .badge {
+    filter: drop-shadow(0 0 14px color-mix(in srgb, var(--bad) 45%, transparent));
+  }
+  .youare {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+  }
+  .role {
+    font-size: 1.6rem;
+    font-weight: 800;
+    line-height: 1.15;
+  }
+  .team-lbl {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .flavor {
+    margin: 4px 0 8px;
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+  .intel {
+    width: 100%;
+    margin: 6px 0 8px;
+    padding: 10px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .intel-line {
+    margin: 0;
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 0.9rem;
+  }
+  .intel-line.muted {
+    justify-content: center;
+    color: var(--muted);
+    font-size: 0.82rem;
+  }
+  .ilabel {
+    color: var(--muted);
+  }
+  .iname {
+    font-weight: 700;
+    text-align: right;
+  }
+
+  @keyframes fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+  @keyframes flip-in {
+    0% { opacity: 0; transform: perspective(700px) rotateY(-90deg) scale(0.94); }
+    60% { opacity: 1; transform: perspective(700px) rotateY(8deg) scale(1); }
+    100% { opacity: 1; transform: perspective(700px) rotateY(0deg) scale(1); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .card,
+    .cover {
+      animation: fade-in 0.2s ease-out both;
+    }
+  }
+</style>

--- a/src/lib/games/botc/TownVerdict.svelte
+++ b/src/lib/games/botc/TownVerdict.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * The verdict on the town. When a winner is recorded a gothic reveal washes the
+   * editor: Good breaks into a 🌅 dawn (the Demon has fallen) under a Win-Green
+   * glow; Evil falls into a 🌑 blood-moon eclipse under a Loss-Coral wash. Pure
+   * delight over a result already spelled out by the pressed Good/Evil button and
+   * the banner copy, so motion is never the only signal — and never Crown Gold,
+   * which belongs to the leader/winner tally alone. `pointer-events: none`,
+   * replays on `token`, silent under reduced motion.
+   */
+  let { token = 0, team = 'good' }: { token?: number; team?: 'good' | 'evil' } = $props();
+
+  const reduced = prefersReducedMotion();
+  const COUNT = 12;
+
+  const sparks = $derived(
+    Array.from({ length: COUNT }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      const good = ['✦', '✧', '⋆', '·'];
+      const evil = ['🩸', '✦', '·', '⋆'];
+      const glyphs = team === 'evil' ? evil : good;
+      return {
+        left: 24 + rand(1) * 52,
+        bottom: 26 + rand(2) * 34,
+        delay: 0.28 + rand(3) * 0.2,
+        duration: 0.7 + rand(4) * 0.6,
+        spread: (rand(5) - 0.5) * 150,
+        rise: 24 + rand(6) * 52,
+        size: 0.5 + rand(7) * 0.7,
+        glyph: glyphs[Math.floor(rand(8) * glyphs.length)],
+      };
+    }),
+  );
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="verdict" class:evil={team === 'evil'} aria-hidden="true">
+      <div class="wash"></div>
+      <span class="orb">{team === 'evil' ? '🌑' : '🌅'}</span>
+      <div class="sparks">
+        {#each sparks as s, i (i)}
+          <span
+            class="spark"
+            style="
+              left: {s.left}%;
+              bottom: {s.bottom}%;
+              font-size: {s.size}rem;
+              animation-delay: {s.delay}s;
+              animation-duration: {s.duration}s;
+              --spread: {s.spread}px;
+              --rise: {s.rise}px;
+            ">{s.glyph}</span>
+        {/each}
+      </div>
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .verdict {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    border-radius: 14px;
+    z-index: 3;
+  }
+  .wash {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    background: radial-gradient(120% 90% at 50% 60%, color-mix(in srgb, var(--good) 32%, transparent), transparent 70%);
+    animation: verdict-wash 1.6s ease-out both;
+  }
+  .verdict.evil .wash {
+    background: radial-gradient(120% 90% at 50% 55%, color-mix(in srgb, var(--bad) 40%, transparent), transparent 72%);
+    animation-duration: 1.8s;
+  }
+  .orb {
+    position: absolute;
+    left: 50%;
+    top: 46%;
+    font-size: 2.3rem;
+    line-height: 1;
+    opacity: 0;
+    transform: translate(-50%, -50%);
+    will-change: transform, opacity;
+    filter: drop-shadow(0 0 12px color-mix(in srgb, var(--good) 55%, transparent));
+    animation: orb-beat 1.6s ease-out both;
+  }
+  .verdict.evil .orb {
+    filter: drop-shadow(0 0 12px color-mix(in srgb, var(--bad) 55%, transparent));
+  }
+  .sparks {
+    position: absolute;
+    inset: 0;
+  }
+  .spark {
+    position: absolute;
+    line-height: 1;
+    color: var(--text);
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: spark-fly;
+    animation-timing-function: ease-out;
+    animation-fill-mode: both;
+  }
+  @keyframes verdict-wash {
+    0% { opacity: 0; }
+    30% { opacity: 1; }
+    100% { opacity: 0; }
+  }
+  @keyframes orb-beat {
+    0% { opacity: 0; transform: translate(-50%, -50%) scale(0.6); }
+    30% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+    58% { opacity: 1; transform: translate(-50%, -50%) scale(1.16); }
+    100% { opacity: 0; transform: translate(-50%, -50%) scale(1); }
+  }
+  @keyframes spark-fly {
+    0% { opacity: 0; transform: translate(0, 0) scale(0.5); }
+    30% { opacity: 1; }
+    100% { opacity: 0; transform: translate(var(--spread), calc(var(--rise) * -1)) scale(1); }
+  }
+</style>

--- a/src/lib/games/botc/botc.test.ts
+++ b/src/lib/games/botc/botc.test.ts
@@ -4,8 +4,13 @@ import {
   aliveCount,
   aliveTeamCount,
   carryRoster,
+  demonStatus,
   describe as describePhase,
+  evilKnowledge,
+  evilWinsIn,
+  ghostVotesLeft,
   initialRoster,
+  isDemonRole,
   isResolved,
   phaseEmoji,
   phaseKind,
@@ -13,6 +18,7 @@ import {
   phaseNumber,
   pickWinners,
   roleTeam,
+  roleType,
   rolesFor,
   scoreRound,
   scriptRef,
@@ -107,6 +113,14 @@ describe('carryRoster — persists role/team/alive/ghost between phases', () => 
     expect(next.B).toEqual(state());
   });
 
+  it('carries the Grimoire notes (demon, reminder, suspect) forward', () => {
+    const prev = { A: state({ role: 'Imp', team: 'evil', isDemon: true, reminder: 'red herring', suspect: 'Fortune Teller' }) };
+    const next = carryRoster(prev, ['A']);
+    expect(next.A.isDemon).toBe(true);
+    expect(next.A.reminder).toBe('red herring');
+    expect(next.A.suspect).toBe('Fortune Teller');
+  });
+
   it('seats a brand-new player fresh (defensive)', () => {
     const next = carryRoster({ A: state({ team: 'evil' }) }, ['A', 'C']);
     expect(next.C).toEqual(state());
@@ -149,6 +163,66 @@ describe('counts & the vote threshold', () => {
     expect(voteThreshold(6)).toBe(3);
     expect(voteThreshold(1)).toBe(1);
     expect(voteThreshold(0)).toBe(0);
+  });
+});
+
+// ── Grimoire nudges (demon, ghost votes, evil-at-2, evil knowledge) ──────────
+
+describe('ghostVotesLeft — dead players who still hold a ghost vote', () => {
+  it('counts unspent ghost votes among the dead only', () => {
+    const states = {
+      A: state({ alive: true }),
+      B: state({ alive: false, ghostUsed: false }),
+      C: state({ alive: false, ghostUsed: true }),
+      D: state({ alive: false, ghostUsed: false }),
+    };
+    expect(ghostVotesLeft(states)).toBe(2);
+    expect(ghostVotesLeft({ A: state() })).toBe(0);
+  });
+});
+
+describe('demonStatus — the Demon’s fate for the Good-wins nudge', () => {
+  it('is unmarked until a Demon is flagged', () => {
+    expect(demonStatus({ A: state(), B: state({ team: 'evil' }) })).toBe('unmarked');
+  });
+
+  it('is alive while any flagged Demon lives', () => {
+    expect(demonStatus({ A: state({ team: 'evil', isDemon: true }), B: state() })).toBe('alive');
+  });
+
+  it('is fallen once every flagged Demon is dead', () => {
+    expect(demonStatus({ A: state({ team: 'evil', isDemon: true, alive: false }), B: state() })).toBe('fallen');
+  });
+});
+
+describe('evilWinsIn — deaths remaining until only two are left alive', () => {
+  it('counts the living above the two-player floor', () => {
+    expect(evilWinsIn({ A: state(), B: state(), C: state(), D: state() })).toBe(2);
+    expect(evilWinsIn({ A: state(), B: state() })).toBe(0);
+    expect(evilWinsIn({ A: state(), B: state({ alive: false }) })).toBe(0);
+  });
+});
+
+describe('evilKnowledge — the first-night reveal for an evil seat', () => {
+  const states = {
+    A: state({ team: 'evil', isDemon: true }),
+    B: state({ team: 'evil' }),
+    C: state({ team: 'good' }),
+  };
+
+  it('shows a Minion their fellow evil and the Demon (excluding themselves)', () => {
+    expect(evilKnowledge(states, 'B')).toEqual({ fellowEvil: ['A'], demonId: 'A' });
+  });
+
+  it('shows the Demon their Minions', () => {
+    expect(evilKnowledge(states, 'A')).toEqual({ fellowEvil: ['B'], demonId: 'A' });
+  });
+
+  it('returns no Demon when none is flagged', () => {
+    expect(evilKnowledge({ A: state({ team: 'evil' }), B: state({ team: 'evil' }) }, 'A')).toEqual({
+      fellowEvil: ['B'],
+      demonId: null,
+    });
   });
 });
 
@@ -266,6 +340,21 @@ describe('script & role reference (data only)', () => {
     expect(roleTeam('Poisoner', 'tb')).toBe('evil');
     expect(roleTeam('Not A Role', 'tb')).toBeNull();
     expect(roleTeam('', 'tb')).toBeNull();
+  });
+
+  it('exposes a known role’s type, else null', () => {
+    expect(roleType('Imp', 'tb')).toBe('demon');
+    expect(roleType('Poisoner', 'tb')).toBe('minion');
+    expect(roleType('Butler', 'tb')).toBe('outsider');
+    expect(roleType('Chef', 'tb')).toBe('townsfolk');
+    expect(roleType('Nope', 'tb')).toBeNull();
+  });
+
+  it('flags a demon role for the auto-marker (case-insensitive)', () => {
+    expect(isDemonRole('imp', 'tb')).toBe(true);
+    expect(isDemonRole('Vortox', 'snv')).toBe(true);
+    expect(isDemonRole('Poisoner', 'tb')).toBe(false);
+    expect(isDemonRole('', 'tb')).toBe(false);
   });
 
   it('falls back to Trouble Brewing for an unknown script', () => {

--- a/src/lib/games/botc/logic.ts
+++ b/src/lib/games/botc/logic.ts
@@ -23,6 +23,15 @@ export interface PlayerState {
   alive: boolean;
   /** A dead player spends their single ghost vote once — tracked, never enforced. */
   ghostUsed: boolean;
+  /**
+   * The Demon, in the Storyteller's Grimoire. Optional and auto-set when a
+   * demon-type role is typed; drives the "Good wins when the Demon dies" nudge.
+   */
+  isDemon?: boolean;
+  /** Private Storyteller reminder token ("poisoned", "drunk", "red herring"). */
+  reminder?: string;
+  /** The Storyteller's read: who they think this seat is (or could be). */
+  suspect?: string;
 }
 
 /** A single day-phase nomination and its vote tally. */
@@ -77,9 +86,10 @@ export function initialRoster(playerIds: ID[]): Record<ID, PlayerState> {
 }
 
 /**
- * Carry a roster forward into the next phase — roles, teams, alive/dead and
- * ghost-vote status persist, so the Storyteller only edits what changed. New
- * seats (defensive) start fresh; a cloned object keeps rounds independent.
+ * Carry a roster forward into the next phase — roles, teams, alive/dead, the
+ * ghost-vote status and the Storyteller's Grimoire notes (demon, reminder,
+ * suspect) persist, so only what changed needs editing. New seats (defensive)
+ * start fresh; a cloned object keeps rounds independent.
  */
 export function carryRoster(
   prev: Record<ID, PlayerState> | undefined,
@@ -89,7 +99,15 @@ export function carryRoster(
   for (const id of playerIds) {
     const p = prev?.[id];
     out[id] = p
-      ? { role: p.role, team: p.team, alive: p.alive, ghostUsed: p.ghostUsed }
+      ? {
+          role: p.role,
+          team: p.team,
+          alive: p.alive,
+          ghostUsed: p.ghostUsed,
+          isDemon: p.isDemon,
+          reminder: p.reminder,
+          suspect: p.suspect,
+        }
       : freshState();
   }
   return out;
@@ -113,6 +131,56 @@ export function aliveTeamCount(states: Record<ID, PlayerState>, team: Team): num
  */
 export function voteThreshold(alive: number): number {
   return Math.ceil(Math.max(0, alive) / 2);
+}
+
+/** Ghost votes still in the town: dead players who haven't spent theirs. */
+export function ghostVotesLeft(states: Record<ID, PlayerState>): number {
+  return Object.values(states).filter((s) => !s.alive && !s.ghostUsed).length;
+}
+
+/** Whether the Demon is unmarked, still among the living, or has fallen. */
+export type DemonState = 'unmarked' | 'alive' | 'fallen';
+
+/**
+ * The Demon's fate at a glance, for the "Good wins the moment the Demon dies"
+ * nudge. `unmarked` when the Storyteller hasn't flagged a Demon yet; `alive`
+ * while any flagged Demon lives; `fallen` once every flagged Demon is dead.
+ */
+export function demonStatus(states: Record<ID, PlayerState>): DemonState {
+  const demons = Object.values(states).filter((s) => s.isDemon);
+  if (demons.length === 0) return 'unmarked';
+  return demons.some((s) => s.alive) ? 'alive' : 'fallen';
+}
+
+/**
+ * How many more deaths until only two players remain alive — the point Evil
+ * wins. Zero means the town is already at (or below) the floor.
+ */
+export function evilWinsIn(states: Record<ID, PlayerState>): number {
+  return Math.max(0, aliveCount(states) - 2);
+}
+
+/** What an evil player learns on the first night: their team and the Demon. */
+export interface EvilKnowledge {
+  /** Other evil seats (excludes the viewer). */
+  fellowEvil: ID[];
+  /** The flagged Demon's seat, if any (may be the viewer themselves). */
+  demonId: ID | null;
+}
+
+/**
+ * The fellow-evil + Demon info surfaced in a minion/demon's private reveal.
+ * Pure so it can be unit-tested; the editor only renders what it returns.
+ */
+export function evilKnowledge(
+  states: Record<ID, PlayerState>,
+  selfId: ID,
+): EvilKnowledge {
+  const ids = Object.keys(states);
+  return {
+    fellowEvil: ids.filter((id) => id !== selfId && states[id]?.team === 'evil'),
+    demonId: ids.find((id) => states[id]?.isDemon) ?? null,
+  };
 }
 
 // ── Scoring / winners ─────────────────────────────────────────────────────
@@ -274,8 +342,19 @@ export function rolesFor(script: string | undefined): RoleRef[] {
 
 /** Team a known role belongs to (case-insensitive), or null if off-script. */
 export function roleTeam(role: string, script: string | undefined): Team | null {
+  const type = roleType(role, script);
+  return type ? teamOfType(type) : null;
+}
+
+/** Type of a known role (case-insensitive), or null if it's off-script. */
+export function roleType(role: string, script: string | undefined): RoleType | null {
   const key = role.trim().toLowerCase();
   if (!key) return null;
   const hit = rolesFor(script).find((r) => r.name.toLowerCase() === key);
-  return hit ? teamOfType(hit.type) : null;
+  return hit ? hit.type : null;
+}
+
+/** True when a typed role is a known Demon on the script — auto-marks the Demon. */
+export function isDemonRole(role: string, script: string | undefined): boolean {
+  return roleType(role, script) === 'demon';
 }


### PR DESCRIPTION
## Blood on the Clocktower — critique & improvements

BotC is the most theatrical game in Score King (dusk↔dawn, executions, the Demon's fall, up to 20 seats) but its module was the flattest: no thematic animation, a long one-handed roster scroll with no glanceable summary, and no awareness of the win conditions it exists to track. This PR leans into BotC's gothic day/night storyteller personality through **emoji, copy, accent moments, and animation** — never by restyling the shared shell.

### ✨ Signature animations (reduced-motion-safe, token-seeded, `pointer-events: none`)
- **PhaseSky** — a dusk↔dawn wash on each phase change: moon rises + stars on 🌙 nights, sun climbs + rays on ☀️ days.
- **ExecutionToll** — a localized bell-toll 🔔 + skull-drop 💀 beat when a nominee is marked executed.
- **TownVerdict** — the win reveal: Good = 🌅 sunrise (the Demon has fallen), Evil = 🌑 blood-moon eclipse.

### 📖 The Grimoire (Storyteller's master board)
- Glanceable **Town Square** header — alive/dead, 😇/😈 split, 🗳️ ghost votes remaining.
- **Seat numbers** in circle order + tighter rows built for the big table (up to 20 seats).
- Per-seat true **character** (autocomplete → auto team + Demon detect), optional **Demon** marker, and a collapsible **suspected-role map** + **reminder** tokens (poisoned / drunk / red herring).
- **Win-condition nudges** (Demon status, Evil's 2-alive floor) — hints only; the Storyteller's word is final.

### 🎭 Pass-the-phone private role reveal (`RoleReveal.svelte`)
- Full-screen two-step token: a "pass the phone to {name}" cover, then that player's character **only**.
- Evil players also learn their fellow evil + who the Demon is, exactly as on the first night.
- Honors the privacy principle — the Grimoire's true roles never share a screen with the person being revealed to.

### 🧠 Logic (pure, unit-tested)
- `PlayerState` gains backward-compatible `isDemon` / `reminder` / `suspect` (all carried forward).
- New helpers: `ghostVotesLeft`, `demonStatus`, `evilWinsIn`, `evilKnowledge`, `roleType`, `isDemonRole` — fully covered in `botc.test.ts`.

### Design compliance
Royal Violet stays the single primary action owned by the play screen (editor body is violet-free; the reveal overlay is a separate surface). Crown Gold is untouched — animations use `--good` / `--bad` / `--primary` / `--warn` washes only. Depth via the surface ramp, `tabular-nums` on every changing number, ≥46px on primary targets, no color-only state (always co-signalled with emoji/text), and `prefers-reduced-motion` fully honored.

### Local verification
- `npm run check` — 0 errors, 0 warnings
- `npm test` — 46 files, **1029 tests passing**
- `npm run build` — succeeds (PWA generated)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>