### PR TITLE
Chicken Foot: full barnyard costume (countdown ribbon, pip faces, celebrations)

### DIFF
--- a/src/lib/games/chickenfoot/ChickenFootEditor.svelte
+++ b/src/lib/games/chickenfoot/ChickenFootEditor.svelte
@@ -2,27 +2,62 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
+  import { haptic } from '../../haptics';
   import { chickenfoot } from './index';
-  import { blankValue, doubleLabel, playerRoundScore, totalRounds, type ChickenFootInput } from './logic';
+  import DominoCountdown from './DominoCountdown.svelte';
+  import FeatherBurst from './FeatherBurst.svelte';
+  import DreadStamp from './DreadStamp.svelte';
+  import {
+    blankValue,
+    playerRoundScore,
+    roundPipTotal,
+    startDouble,
+    totalRounds,
+    type ChickenFootInput,
+  } from './logic';
 
   let { input = $bindable(), ctx }: { input: ChickenFootInput; ctx: RoundContext } = $props();
 
   const blankVal = $derived(blankValue(ctx.config));
   const rounds = $derived(totalRounds(ctx.config));
   const roundNum = $derived(ctx.roundIndex + 1);
+  const start = $derived(startDouble(ctx.config));
+  const pipTotal = $derived(roundPipTotal(input, ctx.players, blankVal));
+  const blocked = $derived(input.outId === null);
+  const outName = $derived(ctx.players.find((p) => p.id === input.outId)?.name ?? '');
   let showHelp = $state(false);
 
+  // Delight tokens, bumped only by a real user tap (never on mount / edit-open), so a
+  // fresh go-out flings feathers and a fresh double-blank slams the goose-egg stamp.
+  let featherTokens = $state<Record<string, number>>({});
+  let dreadTokens = $state<Record<string, number>>({});
+
   function setOut(id: string) {
-    input.outId = input.outId === id ? null : id;
-    if (input.outId === id) {
+    const turningOn = input.outId !== id;
+    input.outId = turningOn ? id : null;
+    if (turningOn) {
       input.pips[id] = 0;
       if (input.blankId === id) input.blankId = null;
+      featherTokens = { ...featherTokens, [id]: (featherTokens[id] ?? 0) + 1 };
+      haptic('tick');
     }
   }
 
   function setBlank(id: string) {
-    input.blankId = input.blankId === id ? null : id;
-    if (input.blankId === id && input.outId === id) input.outId = null;
+    const turningOn = input.blankId !== id;
+    input.blankId = turningOn ? id : null;
+    if (turningOn) {
+      if (input.outId === id) input.outId = null;
+      if (blankVal > 0) {
+        dreadTokens = { ...dreadTokens, [id]: (dreadTokens[id] ?? 0) + 1 };
+        haptic('tick');
+      }
+    }
+  }
+
+  function quickAdd(id: string, n: number) {
+    input.pips[id] = Math.max(0, (Number(input.pips[id]) || 0) + n);
+    haptic('tick');
   }
 
   function score(id: string): number {
@@ -31,14 +66,11 @@
 </script>
 
 <div class="stack">
+  <DominoCountdown {start} current={input.double} round={roundNum} total={rounds} />
+
   <div class="row spread">
-    <span class="row" style="gap: 8px">
-      <span class="pill">Round {roundNum} of {rounds}</span>
-      <span class="tile" class:blank={input.double === 0} title={doubleLabel(input.double)}>
-        <span class="half">{input.double}</span>
-        <span class="bar" aria-hidden="true"></span>
-        <span class="half">{input.double}</span>
-      </span>
+    <span class="tally" title="Total pips being dumped on the table this round">
+      🦴 <strong class="num">{pipTotal}</strong> {pipTotal === 1 ? 'pip' : 'pips'} on the table
     </span>
     <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
       Rules
@@ -47,13 +79,19 @@
 
   {#if showHelp}
     <pre class="help">{chickenfoot.help}</pre>
+  {:else if blocked}
+    <p class="hint muted">
+      🚫 No one’s out yet — tap 🐔 when someone empties their hand, or leave it unset for a blocked round.
+    </p>
   {:else}
-    <p class="hint muted">Log each hand’s leftover pips, then tap 🐔 for whoever went out.</p>
+    <p class="hint muted">🐔 {outName} went out — everyone else totals up their leftover bones.</p>
   {/if}
 
   {#each ctx.players as p (p.id)}
     {@const out = input.outId === p.id}
     <div class="prow" class:isout={out}>
+      <FeatherBurst token={featherTokens[p.id] ?? 0} />
+      <DreadStamp token={dreadTokens[p.id] ?? 0} value={blankVal} />
       <div class="row spread" style="margin-bottom: 10px">
         <span class="row" style="gap: 8px">
           <Avatar name={p.name} color={p.color} />
@@ -69,11 +107,23 @@
       </div>
 
       {#if out}
-        <div class="emptyhand">🐔 Went out — empty hand, 0 points</div>
+        <div class="emptyhand">🐔 Went out — empty hand, 0 points!</div>
       {:else}
         <div class="row spread">
           <span class="plabel">Pips left</span>
-          <Stepper bind:value={input.pips[p.id]} min={0} />
+          <Stepper bind:value={input.pips[p.id]} min={0} label={`${p.name} pips`} />
+        </div>
+        <div class="row quickadd">
+          <button type="button" class="qchip" onclick={() => quickAdd(p.id, 5)}>+5</button>
+          <button type="button" class="qchip" onclick={() => quickAdd(p.id, 10)}>+10</button>
+          <button
+            type="button"
+            class="qchip clear"
+            onclick={() => quickAdd(p.id, -(Number(input.pips[p.id]) || 0))}
+            disabled={!(Number(input.pips[p.id]) > 0)}
+          >
+            Clear
+          </button>
         </div>
       {/if}
 
@@ -96,7 +146,7 @@
             disabled={out}
             onclick={() => setBlank(p.id)}
           >
-            ⬜ Double-blank <span class="sub">(+{blankVal})</span>
+            🥚 Double-blank <span class="sub">(+{blankVal})</span>
           </button>
         {/if}
       </div>
@@ -105,30 +155,19 @@
 </div>
 
 <style>
-  /* A little domino showing the double this round is built on — the personality moment,
-     built from the surface ramp (never gold/violet, which are reserved). */
-  .tile {
+  /* Live "pips on the table" tally — the round's stakes at a glance. The 🦴 and the
+     blocked-round wording co-signal beyond colour; the number is tabular so it never
+     jitters as pips land. Never gold/violet, which the shell reserves. */
+  .tally {
     display: inline-flex;
-    align-items: stretch;
-    background: var(--surface-3);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    font-weight: 800;
-    font-variant-numeric: tabular-nums;
-    line-height: 1;
-    overflow: hidden;
-  }
-  .tile .half {
-    min-width: 22px;
-    padding: 5px 7px;
-    text-align: center;
-  }
-  .tile.blank .half {
+    align-items: center;
+    gap: 6px;
+    font-size: 0.85rem;
     color: var(--muted);
   }
-  .tile .bar {
-    width: 1px;
-    background: var(--border);
+  .tally .num {
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
   }
 
   .hint {
@@ -137,15 +176,64 @@
   }
 
   .prow {
+    position: relative;
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     padding: 12px;
   }
   /* Went-out is the good outcome (lowest pips) — co-signal it with a calm green edge,
      never color alone: the 🐔, the "empty hand" line and the 0 all say it too. */
   .prow.isout {
     border-color: color-mix(in srgb, var(--good) 45%, var(--border));
+  }
+
+  .preview {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .emptyhand {
+    color: var(--good);
+    font-weight: 700;
+    padding: 3px 0;
+  }
+
+  .plabel {
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+
+  /* Quick-add chips: dump a big hand in a couple of taps instead of many stepper nudges.
+     The stepper stays the precise control; these are the fast path. */
+  .quickadd {
+    gap: 6px;
+    margin-top: 8px;
+    justify-content: flex-end;
+  }
+  .qchip {
+    min-height: 46px;
+    min-width: 52px;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    transition: transform var(--dur-press) var(--ease-standard), background var(--dur-base) var(--ease-standard);
+  }
+  .qchip:active {
+    transform: scale(0.94);
+  }
+  .qchip.clear {
+    color: var(--muted);
+    font-weight: 600;
+  }
+  .qchip:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 
   .preview {

--- a/src/lib/games/chickenfoot/DominoCountdown.svelte
+++ b/src/lib/games/chickenfoot/DominoCountdown.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { animateMotion, prefersReducedMotion } from '../../motion';
+  import { doubleLabel, roundFlavor } from './logic';
+  import DominoFace from './DominoFace.svelte';
+
+  /**
+   * Chicken Foot's per-game costume: a countdown strip of every double from the
+   * starting double down to the dreaded double-blank, with a 🐔 that walks toward
+   * the goose egg as the rounds tick by. Pure barnyard flavor — it lives entirely
+   * inside the game editor and never touches the shared chrome.
+   *
+   * Deliberately violet-free and gold-free: Royal Violet stays on the shell's one
+   * Save action and Crown Gold on the leader, so this strip is built only from the
+   * surface ramp plus muted/semantic tints. The round number, double label and
+   * flavor name carry the meaning in text, so the walking chicken is decoration
+   * only and is skipped under reduced motion (it simply appears on the current tile).
+   */
+  let { start, current, round, total }: {
+    start: number;
+    current: number;
+    round: number;
+    total: number;
+  } = $props();
+
+  // Doubles from the starting double down to 0 (the blank). Higher doubles are
+  // already played; the current one is "here"; lower doubles are still to come.
+  const doubles = $derived(Array.from({ length: start + 1 }, (_, i) => start - i));
+  const flavor = $derived(roundFlavor(current));
+  const isBlank = $derived(current <= 0);
+  // Chicken sits centered over the current tile: (index + 0.5) / count across.
+  const idx = $derived(Math.max(0, start - current));
+  const chickPct = $derived(doubles.length > 0 ? ((idx + 0.5) / doubles.length) * 100 : 0);
+
+  let chick: HTMLSpanElement | undefined = $state();
+
+  onMount(() => {
+    if (!chick || prefersReducedMotion()) return;
+    // Strut in from the previous double with a little head-bob; the final blank
+    // round gets a bigger, more anxious flap — the goose egg looms.
+    const from = doubles.length > 0 ? Math.max(0, ((idx - 0.5) / doubles.length) * 100) : 0;
+    animateMotion(
+      chick,
+      isBlank
+        ? { left: [`${from}%`, `${chickPct}%`], rotate: [-10, 10, -6, 0], scale: [0.9, 1.2, 1] }
+        : { left: [`${from}%`, `${chickPct}%`], rotate: [-7, 5, 0] },
+      { duration: isBlank ? 0.85 : 0.55, ease: 'easeOut' },
+    );
+  });
+</script>
+
+<div class="countdown" class:blank={isBlank}>
+  <div class="head">
+    <DominoFace a={current} size="lg" label={`${doubleLabel(current)} — this round's chicken foot`} />
+    <div class="cap">
+      <span class="round">Round {round} of {total}</span>
+      <span class="name">{isBlank ? '🥚 ' : '🐔 '}{doubleLabel(current)} · {flavor}</span>
+      <span class="sub muted">
+        {isBlank ? 'the dreaded goose egg — mind the penalty' : 'counting the doubles down to the 🥚'}
+      </span>
+    </div>
+  </div>
+  <div class="track-wrap" aria-hidden="true">
+    <div class="track">
+      {#each doubles as d (d)}
+        <span
+          class="tile"
+          class:done={d > current}
+          class:here={d === current}
+          class:egg={d === 0}
+        >{d}</span>
+      {/each}
+    </div>
+    <span class="chick" bind:this={chick} style="left: {chickPct}%">{isBlank ? '🐥' : '🐔'}</span>
+  </div>
+</div>
+
+<style>
+  .countdown {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  /* The blank round foreshadows the goose egg with a restrained loss-coral edge —
+     co-signalled by the 🥚 and the "Goose Egg" name, never colour alone. */
+  .countdown.blank {
+    border-color: color-mix(in srgb, var(--bad) 45%, var(--border));
+  }
+  .cap {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .round {
+    font-size: 0.78rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+  .name {
+    font-weight: 700;
+    font-size: 1rem;
+  }
+  .sub {
+    font-size: 0.78rem;
+  }
+  .track-wrap {
+    position: relative;
+    padding-top: 20px; /* headroom for the walking chicken */
+  }
+  .track {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 3px;
+  }
+  .tile {
+    flex: 1 1 0;
+    min-width: 0;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-weight: 800;
+    font-size: 0.72rem;
+    font-variant-numeric: tabular-nums;
+  }
+  /* Already-played doubles: filled in, quietly settled. */
+  .tile.done {
+    background: var(--surface-3);
+    color: var(--text);
+    opacity: 0.6;
+  }
+  /* The double being played right now: raised and bold, marked by the chicken above. */
+  .tile.here {
+    background: var(--surface-3);
+    color: var(--text);
+    border-color: var(--text);
+    transform: scale(1.12);
+  }
+  /* The goose egg waiting at the end — dashed and ominous. */
+  .tile.egg {
+    border-style: dashed;
+    border-color: color-mix(in srgb, var(--bad) 40%, var(--border));
+  }
+  .tile.egg.here {
+    background: color-mix(in srgb, var(--bad) 12%, var(--surface-3));
+    border-color: var(--bad);
+    color: var(--text);
+  }
+  .chick {
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+    font-size: 1.15rem;
+    line-height: 1;
+    pointer-events: none;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
+  }
+</style>

--- a/src/lib/games/chickenfoot/DominoFace.svelte
+++ b/src/lib/games/chickenfoot/DominoFace.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import { pipLayout } from './logic';
+
+  /**
+   * A real domino face rendered as dot-pips — the Chicken Foot personality atom.
+   * Two halves (`a` | `b`) each draw their pips on a classic 3-column grid via the
+   * pure {@link pipLayout} helper (double-9 → 3×3, double-12 → 3×4), so the same
+   * component serves the big current-double face and the mini countdown tiles.
+   *
+   * Built entirely from the surface ramp and text/muted colors — never Royal Violet
+   * or Crown Gold, which the shell reserves for the primary action and the leader.
+   * The double-blank is the dreaded "goose egg": two empty halves rendered as a
+   * hollow, muted ghost so the 0–0 reads as ominous, not broken.
+   */
+  let {
+    a,
+    b = a,
+    size = 'lg',
+    label = '',
+  }: { a: number; b?: number; size?: 'sm' | 'lg'; label?: string } = $props();
+
+  const blank = $derived((Number(a) || 0) <= 0 && (Number(b) || 0) <= 0);
+  const halves = $derived([pipLayout(a), pipLayout(b)]);
+</script>
+
+<span
+  class="domino {size}"
+  class:blank
+  role="img"
+  aria-label={label || `Domino ${Math.max(0, a)}–${Math.max(0, b)}`}
+>
+  {#each halves as layout, i (i)}
+    {#if i === 1}<span class="bar" aria-hidden="true"></span>{/if}
+    <span class="half" style="--rows: {layout.rows}">
+      {#each layout.dots as dot (`${dot.c}-${dot.r}`)}
+        <span class="pip" style="grid-column: {dot.c + 1}; grid-row: {dot.r + 1};"></span>
+      {/each}
+    </span>
+  {/each}
+</span>
+
+<style>
+  .domino {
+    display: inline-flex;
+    align-items: stretch;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    overflow: hidden;
+    line-height: 1;
+    box-sizing: border-box;
+  }
+  .lg {
+    border-radius: var(--radius-sm);
+    --pip: 7px;
+    --pad: 8px;
+    --gap: 5px;
+  }
+  .sm {
+    border-radius: var(--radius-sm);
+    --pip: 2.5px;
+    --pad: 3px;
+    --gap: 2px;
+  }
+  .half {
+    display: grid;
+    grid-template-columns: repeat(3, var(--pip));
+    grid-template-rows: repeat(var(--rows), var(--pip));
+    gap: var(--gap);
+    align-content: center;
+    justify-content: center;
+    padding: var(--pad);
+    box-sizing: border-box;
+  }
+  .lg .half {
+    min-width: 52px;
+    min-height: 52px;
+  }
+  .sm .half {
+    min-width: 20px;
+    min-height: 20px;
+  }
+  .pip {
+    width: var(--pip);
+    height: var(--pip);
+    border-radius: 50%;
+    background: var(--text);
+    align-self: center;
+    justify-self: center;
+  }
+  .bar {
+    width: 1px;
+    background: var(--border);
+  }
+
+  /* The goose egg: a hollow, muted domino so the dreaded 0–0 reads as ominous. */
+  .blank {
+    background: color-mix(in srgb, var(--bad) 6%, var(--surface-2));
+    border-style: dashed;
+    border-color: color-mix(in srgb, var(--bad) 40%, var(--border));
+  }
+</style>

--- a/src/lib/games/chickenfoot/DreadStamp.svelte
+++ b/src/lib/games/chickenfoot/DreadStamp.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * The dread beat: when the 0–0 double-blank penalty lands on a player, a "goose
+   * egg" stamp slams down over their row. Pure delight over a sting that's already
+   * spelled out in words + number (the 🥚 toggle reads "+50" and the row preview
+   * jumps), so motion is never the only signal. `pointer-events: none`, replays
+   * whenever `token` changes, and renders nothing under reduced motion.
+   */
+  let { token = 0, value = 0 }: { token?: number; value?: number } = $props();
+
+  const reduced = prefersReducedMotion();
+</script>
+
+{#if !reduced && token > 0 && value > 0}
+  {#key token}
+    <div class="dread" aria-hidden="true">
+      <span class="stamp">🥚 +{value}</span>
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .dread {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    overflow: hidden;
+    z-index: 3;
+  }
+  .stamp {
+    font-weight: 800;
+    font-size: 1.5rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--bad);
+    padding: 4px 14px;
+    border: 2px solid var(--bad);
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--bad) 14%, var(--surface));
+    white-space: nowrap;
+    opacity: 0;
+    will-change: transform, opacity;
+    transform: rotate(-9deg);
+    animation: stamp-slam 1s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  @keyframes stamp-slam {
+    0% {
+      opacity: 0;
+      transform: rotate(-9deg) scale(2.1);
+    }
+    22% {
+      opacity: 1;
+      transform: rotate(-9deg) scale(0.92);
+    }
+    34% {
+      transform: rotate(-9deg) scale(1.04);
+    }
+    46% {
+      transform: rotate(-9deg) scale(1);
+    }
+    80% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+      transform: rotate(-9deg) scale(1);
+    }
+  }
+</style>

--- a/src/lib/games/chickenfoot/FeatherBurst.svelte
+++ b/src/lib/games/chickenfoot/FeatherBurst.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * A short flurry of feathers when a player empties their hand and goes out — the
+   * triumphant moment of a Chicken Foot round. Pure delight layered over an outcome
+   * that's already spelled out in words + number ("Went out — empty hand, 0"), so
+   * motion is never the only signal. The overlay is `pointer-events: none`, replays
+   * whenever `token` changes (a fresh go-out), and renders nothing at all under
+   * reduced motion.
+   */
+  let { token = 0 }: { token?: number } = $props();
+
+  const reduced = prefersReducedMotion();
+  const COUNT = 9;
+
+  // Deterministic pseudo-random, seeded by token so each burst looks a little
+  // different but is stable across a single render (mirrors CoinBurst/MoonRise).
+  const feathers = $derived(
+    Array.from({ length: COUNT }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      const glyphs = ['🪶', '🪶', '🐔', '🪶', '✨'];
+      return {
+        left: 50 + (rand(1) - 0.5) * 88,
+        delay: rand(2) * 0.12,
+        duration: 0.7 + rand(3) * 0.5,
+        rise: 24 + rand(4) * 34,
+        drift: (rand(5) - 0.5) * 40,
+        spin: (rand(6) - 0.5) * 260,
+        size: 0.8 + rand(7) * 0.5,
+        glyph: glyphs[Math.floor(rand(8) * glyphs.length)],
+      };
+    }),
+  );
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="feathers" aria-hidden="true">
+      {#each feathers as f, i (i)}
+        <span
+          class="feather"
+          style="
+            left: {f.left}%;
+            font-size: {f.size}rem;
+            animation-delay: {f.delay}s;
+            animation-duration: {f.duration}s;
+            --rise: {f.rise}px;
+            --drift: {f.drift}px;
+            --spin: {f.spin}deg;
+          ">{f.glyph}</span>
+      {/each}
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .feathers {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    height: 0;
+    pointer-events: none;
+    overflow: visible;
+    z-index: 2;
+  }
+  .feather {
+    position: absolute;
+    top: 0;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: feather-fly;
+    animation-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1);
+    animation-iteration-count: 1;
+    animation-fill-mode: both;
+  }
+  @keyframes feather-fly {
+    0% {
+      opacity: 0;
+      transform: translate(0, 6px) rotate(0deg) scale(0.5);
+    }
+    20% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+      transform: translate(var(--drift), calc(var(--rise) * -1)) rotate(var(--spin)) scale(1);
+    }
+  }
+</style>

--- a/src/lib/games/chickenfoot/chickenfoot.test.ts
+++ b/src/lib/games/chickenfoot/chickenfoot.test.ts
@@ -8,7 +8,10 @@ import {
   describeRound,
   doubleLabel,
   leadingDouble,
+  pipLayout,
   playerRoundScore,
+  roundFlavor,
+  roundPipTotal,
   scoreRound,
   startDouble,
   totalRounds,
@@ -160,6 +163,56 @@ describe('chicken foot · round description', () => {
   it('uses the blank label for the 0–0 round', () => {
     const r = round(input({ double: 0, outId: 'a' }), { a: 0, b: 0, c: 0 });
     expect(describeRound(r, PLAYERS)).toContain('Double-blank');
+  });
+});
+
+describe('chicken foot · display helpers', () => {
+  it('pipLayout returns exactly n dots within a 3-column grid for 0–12', () => {
+    for (let n = 0; n <= 12; n++) {
+      const layout = pipLayout(n);
+      expect(layout.dots).toHaveLength(n);
+      expect(layout.cols).toBe(3);
+      for (const { c, r } of layout.dots) {
+        expect(c).toBeGreaterThanOrEqual(0);
+        expect(c).toBeLessThan(layout.cols);
+        expect(r).toBeGreaterThanOrEqual(0);
+        expect(r).toBeLessThan(layout.rows);
+      }
+    }
+  });
+
+  it('pipLayout uses a 3×3 grid up to 9 and grows to 3×4 for 10–12', () => {
+    expect(pipLayout(9).rows).toBe(3);
+    expect(pipLayout(10).rows).toBe(4);
+    expect(pipLayout(12).rows).toBe(4);
+    expect(pipLayout(0).dots).toEqual([]);
+  });
+
+  it('pipLayout clamps junk and out-of-range input into the supported range', () => {
+    expect(pipLayout(-4).dots).toHaveLength(0);
+    expect(pipLayout(99).dots).toHaveLength(12);
+    expect(pipLayout(3.6).dots).toHaveLength(4); // rounded
+    expect(pipLayout(NaN).dots).toHaveLength(0);
+  });
+
+  it('roundFlavor gives every double a barnyard nickname, blank = the Goose Egg', () => {
+    expect(roundFlavor(0)).toBe('The Goose Egg');
+    expect(roundFlavor(9)).toBe('The Big Coop');
+    expect(roundFlavor(12)).toBe('The Whole Barnyard');
+    for (let d = 0; d <= 12; d++) {
+      expect(roundFlavor(d).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('roundPipTotal sums the pips hitting the table this round', () => {
+    // a: 12 pips, b: went out (0), c: 5 pips → 17 on the table.
+    const total = roundPipTotal(input({ pips: { a: 12, b: 3, c: 5 }, outId: 'b' }), PLAYERS, 50);
+    expect(total).toBe(17);
+  });
+
+  it('roundPipTotal folds in the double-blank penalty', () => {
+    const total = roundPipTotal(input({ pips: { a: 4, b: 0, c: 0 }, blankId: 'a' }), PLAYERS, 50);
+    expect(total).toBe(54); // 4 pips + 50 penalty
   });
 });
 

--- a/src/lib/games/chickenfoot/index.ts
+++ b/src/lib/games/chickenfoot/index.ts
@@ -11,6 +11,9 @@ export {
   totalRounds,
   doubleLabel,
   blankValue,
+  pipLayout,
+  roundFlavor,
+  roundPipTotal,
 } from './logic';
 
 export const chickenfoot: GameModule = {
@@ -75,7 +78,7 @@ export const chickenfoot: GameModule = {
     '• Everyone else adds up the pips left in their hand (a blank side = 0).',
     '• The 0–0 “double-blank” stings — it scores the penalty in Options (default 50).',
     '',
-    'Each round: log everyone’s leftover pips, tap 🐔 for who went out, and flag ⬜ whoever’s',
+    'Each round: log everyone’s leftover pips, tap 🐔 for who went out, and flag 🥚 whoever’s',
     'stuck holding the double-blank.',
   ].join('\n'),
 

--- a/src/lib/games/chickenfoot/logic.ts
+++ b/src/lib/games/chickenfoot/logic.ts
@@ -96,6 +96,85 @@ export function validateRound(
   return null;
 }
 
+/**
+ * Total pips hitting the table this round — the sum of every player's round score
+ * (leftover pips plus any double-blank penalty; the player who went out contributes 0).
+ * Pure, so the editor's live "pips on the table" tally stays testable.
+ */
+export function roundPipTotal(
+  input: ChickenFootInput,
+  players: readonly Pick<Player, 'id'>[],
+  blankVal: number,
+): number {
+  let total = 0;
+  for (const p of players) total += playerRoundScore(input, p.id, blankVal);
+  return total;
+}
+
+/**
+ * A dot layout for one domino half, on a fixed 3-column grid. Returns the grid height
+ * (`rows`) and the filled cells (`dots`, each a 0-based `{ c, r }`), so both the big
+ * current-double face and the mini countdown tiles render real pips — classic double-9
+ * (3×3) and double-12 (3×4) arrangements. Pure and deterministic, so it's unit-testable
+ * without a DOM.
+ */
+export interface PipCell {
+  c: number;
+  r: number;
+}
+export interface PipLayout {
+  cols: number;
+  rows: number;
+  dots: PipCell[];
+}
+
+const PIP_PATTERNS: Record<number, [number, number][]> = {
+  0: [],
+  1: [[1, 0]],
+  2: [[0, 0], [2, 2]],
+  3: [[0, 0], [1, 1], [2, 2]],
+  4: [[0, 0], [2, 0], [0, 2], [2, 2]],
+  5: [[0, 0], [2, 0], [1, 1], [0, 2], [2, 2]],
+  6: [[0, 0], [2, 0], [0, 1], [2, 1], [0, 2], [2, 2]],
+  7: [[0, 0], [2, 0], [0, 1], [1, 1], [2, 1], [0, 2], [2, 2]],
+  8: [[0, 0], [1, 0], [2, 0], [0, 1], [2, 1], [0, 2], [1, 2], [2, 2]],
+  9: [[0, 0], [1, 0], [2, 0], [0, 1], [1, 1], [2, 1], [0, 2], [1, 2], [2, 2]],
+  10: [[0, 0], [1, 0], [2, 0], [0, 1], [2, 1], [0, 2], [2, 2], [0, 3], [1, 3], [2, 3]],
+  11: [[0, 0], [1, 0], [2, 0], [0, 1], [2, 1], [0, 2], [1, 2], [2, 2], [0, 3], [1, 3], [2, 3]],
+  12: [[0, 0], [1, 0], [2, 0], [0, 1], [1, 1], [2, 1], [0, 2], [1, 2], [2, 2], [0, 3], [1, 3], [2, 3]],
+};
+
+/** Dot layout for a single domino half (0–12 pips), clamped to the supported range. */
+export function pipLayout(n: number): PipLayout {
+  const count = Math.max(0, Math.min(12, Math.round(Number(n) || 0)));
+  const pattern = PIP_PATTERNS[count] ?? [];
+  const rows = count >= 10 ? 4 : count <= 1 ? 1 : 3;
+  return { cols: 3, rows, dots: pattern.map(([c, r]) => ({ c, r })) };
+}
+
+/** A playful barnyard nickname for each double — the round's per-costume flavor. */
+const ROUND_FLAVORS: Record<number, string> = {
+  12: 'The Whole Barnyard',
+  11: "Rooster's Roost",
+  10: 'Ten-Gallon Cluckoff',
+  9: 'The Big Coop',
+  8: 'Hen Party',
+  7: 'Lucky Cluck',
+  6: 'Half a Dozen Eggs',
+  5: 'High-Five Feathers',
+  4: 'Four Drumsticks',
+  3: 'Three Little Chicks',
+  2: 'Two Wings',
+  1: 'The Lonely Bantam',
+  0: 'The Goose Egg',
+};
+
+/** Barnyard nickname for a leading double; the 0–0 blank is the dreaded Goose Egg. */
+export function roundFlavor(double: number): string {
+  const d = Math.max(0, Math.round(Number(double) || 0));
+  return ROUND_FLAVORS[d] ?? doubleLabel(d);
+}
+
 /** Short one-line summary for the history table, driven by the round's recorded deltas. */
 export function describeRound(
   round: Round,

--- a/src/lib/games/chickenfoot/stats.ts
+++ b/src/lib/games/chickenfoot/stats.ts
@@ -58,7 +58,7 @@ export function chickenfootStats({ games, rounds, canonical }: GameStatsInput): 
     const metrics: Metric[] = [];
     if (a.out) metrics.push({ key: 'cf_out', label: 'Went out', value: fmtInt(a.out), emoji: '🐔' });
     if (a.blanks) {
-      metrics.push({ key: 'cf_blank', label: 'Double-blank caught', value: fmtInt(a.blanks), emoji: '⬜' });
+      metrics.push({ key: 'cf_blank', label: 'Goose egg caught', value: fmtInt(a.blanks), emoji: '🥚' });
     }
     if (a.rounds) {
       metrics.push({ key: 'cf_pips', label: 'Avg pips left', value: fmtAvg(a.pips / a.rounds), emoji: '✋' });


### PR DESCRIPTION
## 🐔 Chicken Foot — Full Costume

Chicken Foot was the plainest game in the barn: the countdown of doubles that *defines* it was invisible, the current double was a tiny static `9│9` numeral, and there was zero delight for the two moments that matter — going out and getting stuck with the double-blank. This PR gives it a real per-game costume while keeping the shared chrome and **every design non-negotiable** intact. All new UI lives inside `src/lib/games/chickenfoot/`.

### What's new
- **`DominoCountdown`** — the signature strip counting the doubles down from the starting double to the dreaded double-blank, with a 🐔 that walks toward the 🥚 goose egg as rounds tick by. Hosts a big **pip-rendered domino face** for the current double. Violet/gold-free, reduced-motion safe (the chicken just appears on the current tile).
- **`DominoFace`** — real dot-pip domino faces via a pure, unit-tested `pipLayout()` helper (classic double-9 3×3, double-12 3×4). The 0–0 renders as a hollow "goose egg" ghost so the blank round reads as ominous.
- **`FeatherBurst`** — a flurry of feathers when a player empties their hand and goes out (the round's triumph).
- **`DreadStamp`** — a goose-egg penalty stamp that slams down when the double-blank lands on someone.
- **Editor** — quick-add **+5 / +10 / Clear** chips for fast big hands, a live **🦴 pips-on-the-table** tally, context-aware **blocked-round clarity**, and a barnyard microcopy refresh.

### Design guardrails held
- Royal Violet stays on the shell's one Save action; **Crown Gold never appears here** — the costume is built only from the surface ramp + semantic tints.
- Every changing number is `tabular-nums`; touch targets ≥46px; state is always co-signalled by emoji + number + text, never colour alone.
- All motion has a calm, instant reduced-motion alternative; celebrations fire only on a **real user tap**, never on mount or when re-opening a round to edit.

### Logic & tests
- New pure helpers in `logic.ts`: `pipLayout()`, `roundFlavor()`, `roundPipTotal()` — Svelte-free and covered by new vitest cases. The 🥚 goose-egg glyph is unified across editor, stats, and help.

### Validation (local)
- `npm run check` — 0 errors / 0 warnings
- `npm run build` — succeeds
- `npx vitest run` — **1035 tests passing** (46 files)