### PR TITLE
Codenames: spy-fantasy series scoreboard, assassin reveal & fast teams

### DIFF
--- a/src/lib/games/codenames/AssassinReveal.svelte
+++ b/src/lib/games/codenames/AssassinReveal.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * Codenames' most dramatic beat: the losing team touches the 💀 assassin and the
+   * game ends instantly. This overlay dramatizes that single tap — the black
+   * assassin card flips up dead-centre, a dark wash blows the losing team's cover,
+   * and shards scatter. Pure delight layered over a result that's already spelled
+   * out by the ending toggle + the winner panel (so motion is never the only
+   * signal). The overlay is `pointer-events: none`, replays whenever `token`
+   * changes, and renders nothing at all under reduced motion — the toggle and
+   * banner are the calm, instant alternative.
+   */
+  let { token = 0 }: { token?: number } = $props();
+
+  const reduced = prefersReducedMotion();
+  const SHARD_COUNT = 12;
+
+  // Deterministic pseudo-random seeded by token (mirrors the Avalon reveal).
+  const shards = $derived(
+    Array.from({ length: SHARD_COUNT }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      const glyphs = ['💀', '✕', '·', '▪', '✦'];
+      return {
+        left: 28 + rand(1) * 44,
+        top: 34 + rand(2) * 26,
+        delay: 0.34 + rand(3) * 0.2,
+        duration: 0.5 + rand(4) * 0.5,
+        spread: (rand(5) - 0.5) * 150,
+        rise: 16 + rand(6) * 46,
+        size: 0.5 + rand(7) * 0.8,
+        glyph: glyphs[Math.floor(rand(8) * glyphs.length)],
+      };
+    }),
+  );
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="reveal" aria-hidden="true">
+      <div class="wash"></div>
+      <span class="card">💀</span>
+      <div class="shards">
+        {#each shards as s, i (i)}
+          <span
+            class="shard"
+            style="
+              left: {s.left}%;
+              top: {s.top}%;
+              font-size: {s.size}rem;
+              animation-delay: {s.delay}s;
+              animation-duration: {s.duration}s;
+              --spread: {s.spread}px;
+              --rise: {s.rise}px;
+            ">{s.glyph}</span>
+        {/each}
+      </div>
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .reveal {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    border-radius: 14px;
+    z-index: 3;
+  }
+  .wash {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    /* The assassin steals the game — a dark, ominous scrim. Never Crown Gold. */
+    background:
+      radial-gradient(120% 90% at 50% 46%, rgba(0, 0, 0, 0.72), transparent 70%);
+    animation: wash 1.6s ease-out both;
+  }
+  .card {
+    position: absolute;
+    left: 50%;
+    top: 44%;
+    font-size: 2.6rem;
+    line-height: 1;
+    opacity: 0;
+    transform: translate(-50%, -50%);
+    will-change: transform, opacity;
+    filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.6));
+    animation: card-flip 1.1s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  .shards {
+    position: absolute;
+    inset: 0;
+  }
+  .shard {
+    position: absolute;
+    line-height: 1;
+    color: var(--text);
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: shard-fly;
+    animation-timing-function: ease-out;
+    animation-fill-mode: both;
+  }
+
+  @keyframes wash {
+    0% { opacity: 0; }
+    28% { opacity: 1; }
+    100% { opacity: 0; }
+  }
+  /* The black card snaps up out of the grid, spins on its face, then settles. */
+  @keyframes card-flip {
+    0% { opacity: 0; transform: translate(-50%, -50%) rotateY(90deg) scale(0.6); }
+    30% { opacity: 1; transform: translate(-50%, -50%) rotateY(0deg) scale(1.08); }
+    58% { opacity: 1; transform: translate(-50%, -50%) rotateY(0deg) scale(1); }
+    100% { opacity: 0; transform: translate(-50%, -50%) rotateY(0deg) scale(1.16); }
+  }
+  @keyframes shard-fly {
+    0% { opacity: 0; transform: translate(0, 0) scale(0.5); }
+    30% { opacity: 1; }
+    100% { opacity: 0; transform: translate(var(--spread), calc(var(--rise) * -1)) scale(1); }
+  }
+</style>

--- a/src/lib/games/codenames/CodenamesEditor.svelte
+++ b/src/lib/games/codenames/CodenamesEditor.svelte
@@ -1,97 +1,267 @@
 <script lang="ts">
   import type { ID, RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
+  import { haptic } from '../../haptics';
+  import AssassinReveal from './AssassinReveal.svelte';
   import {
     TEAMS,
     TEAM_META,
     teamCounts,
     tally,
+    seriesState,
+    streak,
+    balanceTeams,
+    swapTeams,
+    shuffleTeams,
+    codeword,
     type CodenamesInput,
     type Team,
   } from './logic';
 
   let { input = $bindable(), ctx }: { input: CodenamesInput; ctx: RoundContext } = $props();
 
+  // Backfill the optional spymaster desks for rounds saved before they existed.
+  if (input.spymasters == null) input.spymasters = { red: null, blue: null };
+
   const trackAssassin = $derived(ctx.config.trackAssassin !== false);
+  const winTarget = $derived(Math.max(0, Math.round(Number(ctx.config.winTarget) || 0)));
   const playerIds = $derived(ctx.players.map((p) => p.id));
   const counts = $derived(teamCounts(input.teams, playerIds));
   const prior = $derived(tally(ctx.rounds));
   const priorGames = $derived(prior.red + prior.blue);
+  const series = $derived(seriesState(prior, winTarget));
+  const run = $derived(streak(ctx.rounds));
+  const word = $derived(codeword(ctx.game.id));
   /** Round 0 has no carried teams, so the roster is front-and-centre; later it tucks away. */
   const setupOpen = $derived(ctx.roundIndex === 0);
+  let showSpies = $state(false);
 
   function teamOf(id: ID): Team {
     return input.teams[id] === 'blue' ? 'blue' : 'red';
   }
+  const redPlayers = $derived(ctx.players.filter((p) => teamOf(p.id) === 'red'));
+  const bluePlayers = $derived(ctx.players.filter((p) => teamOf(p.id) === 'blue'));
+
+  // A stable 5×5 agent grid for the spy motif: 9 red · 8 blue · 7 neutral · 1 assassin,
+  // arranged by a game-seeded shuffle so it's the same board all match. Pure decoration.
+  const grid = $derived.by(() => {
+    const kinds = [
+      ...Array(9).fill('red'),
+      ...Array(8).fill('blue'),
+      ...Array(7).fill('neutral'),
+      'assassin',
+    ];
+    let h = 0;
+    const s = String(ctx.game.id);
+    for (let i = 0; i < s.length; i++) h = (Math.imul(h, 31) + s.charCodeAt(i)) | 0;
+    const rand = () => {
+      h = (Math.imul(h, 1103515245) + 12345) | 0;
+      return ((h >>> 0) % 1000) / 1000;
+    };
+    for (let i = kinds.length - 1; i > 0; i--) {
+      const j = Math.floor(rand() * (i + 1));
+      [kinds[i], kinds[j]] = [kinds[j], kinds[i]];
+    }
+    return kinds;
+  });
+
+  // Series pips per side: `target` slots, filled up to the games that side has banked.
+  const redPips = $derived(
+    series.target > 0 ? Array.from({ length: series.target }, (_, i) => i < prior.red) : [],
+  );
+  const bluePips = $derived(
+    series.target > 0 ? Array.from({ length: series.target }, (_, i) => i < prior.blue) : [],
+  );
+
+  // The assassin's-reveal fires when the ending flips to 💀 with a winner set (never on mount).
+  let strikeToken = $state(0);
+  let strikePrimed = false;
+  let lastAssassin = false;
+  $effect(() => {
+    const isAssassin = input.ending === 'assassin' && input.winner !== null;
+    if (!strikePrimed) {
+      strikePrimed = true;
+      lastAssassin = isAssassin;
+      return;
+    }
+    if (isAssassin && !lastAssassin) {
+      strikeToken += 1;
+      haptic('win');
+    }
+    lastAssassin = isAssassin;
+  });
+
+  function pickWinner(t: Team) {
+    input.winner = t;
+    haptic('tick');
+  }
+  function setEnding(e: CodenamesInput['ending']) {
+    input.ending = e;
+    haptic('tick');
+  }
   function flip(id: ID) {
-    input.teams[id] = teamOf(id) === 'red' ? 'blue' : 'red';
+    input.teams = { ...input.teams, [id]: teamOf(id) === 'red' ? 'blue' : 'red' };
+    // A player leaving a desk can't keep running it.
+    if (input.spymasters?.red === id || input.spymasters?.blue === id) {
+      input.spymasters = {
+        red: input.spymasters.red === id ? null : (input.spymasters?.red ?? null),
+        blue: input.spymasters.blue === id ? null : (input.spymasters?.blue ?? null),
+      };
+    }
+    haptic('tick');
+  }
+  function doBalance() {
+    input.teams = balanceTeams(playerIds);
+    input.spymasters = { red: null, blue: null };
+    haptic('save');
+  }
+  function doSwap() {
+    input.teams = swapTeams(input.teams);
+    input.spymasters = { red: input.spymasters?.blue ?? null, blue: input.spymasters?.red ?? null };
+    haptic('save');
+  }
+  function doShuffle() {
+    input.teams = shuffleTeams(playerIds);
+    input.spymasters = { red: null, blue: null };
+    haptic('save');
+  }
+  function setSpy(team: Team, id: ID) {
+    const cur = input.spymasters ?? { red: null, blue: null };
+    input.spymasters = { ...cur, [team]: cur[team] === id ? null : id };
+    haptic('tick');
   }
 </script>
 
 <div class="stack">
-  <div class="tallybar" class:first={priorGames === 0}>
-    {#if priorGames > 0}
-      <span class="tlabel">Match so far</span>
-      <span class="tscore" aria-label="Red {prior.red}, Blue {prior.blue}">
-        <span class="tteam">🔴 {prior.red}</span>
-        <span class="tdash" aria-hidden="true">–</span>
-        <span class="tteam">{prior.blue} 🔵</span>
-      </span>
-    {:else}
-      <span class="tlabel">🕵️ First game of the match</span>
+  <!-- Series scoreboard — the Red vs Blue head-to-head, dramatized. -->
+  <div class="series" class:tense={(series.matchPoint || series.decider) && !series.over}>
+    <div class="grid" aria-hidden="true">
+      {#each grid as k, i (i)}
+        <span class="tile {k}"></span>
+      {/each}
+    </div>
+    <div class="series-body">
+      <div class="row spread head">
+        <span class="over">🕵️ Codeword · {word}</span>
+        <span class="over muted">
+          {#if series.target > 0}Best of {series.target * 2 - 1}{:else}Open match{/if}
+        </span>
+      </div>
+
+      {#if priorGames > 0}
+        <div class="hh" aria-label="Red {prior.red}, Blue {prior.blue}">
+          <span class="side red" class:ahead={series.leader === 'red'}>
+            <span class="semoji" aria-hidden="true">🔴</span>
+            <span class="snum tnum">{prior.red}</span>
+          </span>
+          <span class="dash" aria-hidden="true">–</span>
+          <span class="side blue" class:ahead={series.leader === 'blue'}>
+            <span class="snum tnum">{prior.blue}</span>
+            <span class="semoji" aria-hidden="true">🔵</span>
+          </span>
+        </div>
+        {#if series.leader}
+          <p class="lead-line">
+            {TEAM_META[series.leader].emoji} <strong>{TEAM_META[series.leader].label}</strong> leads the match
+          </p>
+        {:else}
+          <p class="lead-line muted">All square — {prior.red} apiece</p>
+        {/if}
+      {:else}
+        <p class="firstline">🎙️ First game of the match — spymasters, give your clues.</p>
+      {/if}
+
+      {#if series.target > 0}
+        <div class="pips" aria-hidden="true">
+          <span class="prow red">{#each redPips as on, i (i)}<i class:on></i>{/each}</span>
+          <span class="pspacer"></span>
+          <span class="prow blue">{#each bluePips as on, i (i)}<i class:on></i>{/each}</span>
+        </div>
+      {/if}
+
+      {#if run.team && run.length >= 2}
+        <p class="streak" aria-live="polite">
+          {TEAM_META[run.team].emoji} <strong>{TEAM_META[run.team].label}</strong> on a
+          <span class="tnum">{run.length}</span>-game run 🔥
+        </p>
+      {/if}
+
+      {#if !series.over && (series.matchPoint || series.decider)}
+        <p class="matchpoint" aria-live="polite">
+          {#if series.decider}
+            🎯 <strong>Decider</strong> — the next game takes the series.
+          {:else if series.leader}
+            🎯 <strong>{TEAM_META[series.leader].label} match point</strong> — one game from the crown.
+          {/if}
+        </p>
+      {/if}
+    </div>
+  </div>
+
+  <!-- The stage hosts the hero winner choice, the ending, and the assassin reveal overlay. -->
+  <div class="stage">
+    <AssassinReveal token={strikeToken} />
+
+    <div class="field">
+      <span class="flabel">Who cracked the grid?</span>
+      <div class="winner" role="group" aria-label="Winning team">
+        {#each TEAMS as t (t)}
+          <button
+            type="button"
+            class="teamwin {t}"
+            class:on={input.winner === t}
+            aria-pressed={input.winner === t}
+            onclick={() => pickWinner(t)}
+          >
+            <span class="wemoji" aria-hidden="true">{TEAM_META[t].emoji}</span>
+            <span class="wname">{TEAM_META[t].label}</span>
+            <span class="wtag">{input.winner === t ? '✓ agents found' : 'tap if they won'}</span>
+          </button>
+        {/each}
+      </div>
+    </div>
+
+    {#if trackAssassin}
+      <div class="field">
+        <span class="flabel">How did it end?</span>
+        <div class="ending" role="group" aria-label="How the game ended">
+          <button
+            type="button"
+            class="endbtn agents"
+            class:on={input.ending === 'agents'}
+            aria-pressed={input.ending === 'agents'}
+            onclick={() => setEnding('agents')}
+          >
+            🎉 Found all agents
+          </button>
+          <button
+            type="button"
+            class="endbtn assassin"
+            class:on={input.ending === 'assassin'}
+            aria-pressed={input.ending === 'assassin'}
+            onclick={() => setEnding('assassin')}
+          >
+            💀 Assassin
+          </button>
+        </div>
+        {#if input.ending === 'assassin'}
+          <p class="hint">💀 The losing team touched the assassin — cover blown, instant loss.</p>
+        {/if}
+      </div>
     {/if}
   </div>
 
-  <div class="field">
-    <span class="flabel">Who won this game?</span>
-    <div class="winner" role="group" aria-label="Winning team">
-      {#each TEAMS as t (t)}
-        <button
-          type="button"
-          class="teamwin {t}"
-          class:on={input.winner === t}
-          aria-pressed={input.winner === t}
-          onclick={() => (input.winner = t)}
-        >
-          <span class="wemoji" aria-hidden="true">{TEAM_META[t].emoji}</span>
-          <span class="wname">{TEAM_META[t].label}</span>
-          <span class="wtag">{input.winner === t ? '✓ won' : 'tap if they won'}</span>
-        </button>
-      {/each}
+  {#snippet quickAssign()}
+    <div class="quick" role="group" aria-label="Quick team assignment">
+      <button type="button" class="qbtn" onclick={doShuffle}>🔀 Shuffle</button>
+      <button type="button" class="qbtn" onclick={doBalance}>⚖️ Balance</button>
+      <button type="button" class="qbtn" onclick={doSwap}>⇄ Swap sides</button>
     </div>
-  </div>
-
-  {#if trackAssassin}
-    <div class="field">
-      <span class="flabel">How did it end?</span>
-      <div class="ending" role="group" aria-label="How the game ended">
-        <button
-          type="button"
-          class="endbtn agents"
-          class:on={input.ending === 'agents'}
-          aria-pressed={input.ending === 'agents'}
-          onclick={() => (input.ending = 'agents')}
-        >
-          🎉 Found all agents
-        </button>
-        <button
-          type="button"
-          class="endbtn assassin"
-          class:on={input.ending === 'assassin'}
-          aria-pressed={input.ending === 'assassin'}
-          onclick={() => (input.ending = 'assassin')}
-        >
-          💀 Assassin
-        </button>
-      </div>
-      {#if input.ending === 'assassin'}
-        <p class="hint">💀 The losing team revealed the assassin — an instant loss.</p>
-      {/if}
-    </div>
-  {/if}
+  {/snippet}
 
   {#snippet roster()}
     <div class="stack roster">
+      {@render quickAssign()}
       {#each ctx.players as p (p.id)}
         {@const team = teamOf(p.id)}
         <div class="prow">
@@ -128,6 +298,40 @@
       {@render roster()}
     </details>
   {/if}
+
+  <!-- Optional: log who ran each spymaster desk, for the spymaster win-rate stat. -->
+  <details class="teams-details spies" bind:open={showSpies}>
+    <summary>
+      <span>🎙️ Spymasters</span>
+      <span class="summ">
+        {#if input.spymasters?.red || input.spymasters?.blue}logged · tap to edit{:else}optional{/if}
+      </span>
+    </summary>
+    <div class="spybody">
+      {#each TEAMS as t (t)}
+        {@const roster = t === 'red' ? redPlayers : bluePlayers}
+        <div class="spyrow">
+          <span class="spylabel {t}">{TEAM_META[t].emoji} {TEAM_META[t].label}</span>
+          {#if roster.length === 0}
+            <span class="muted small">No one on this team yet</span>
+          {:else}
+            <div class="chips">
+              {#each roster as p (p.id)}
+                <button
+                  type="button"
+                  class="chip {t}"
+                  class:on={input.spymasters?.[t] === p.id}
+                  aria-pressed={input.spymasters?.[t] === p.id}
+                  onclick={() => setSpy(t, p.id)}
+                >{p.name}</button>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/each}
+      <p class="muted small">The spymaster gives one-word clues — logging them unlocks a win-rate stat.</p>
+    </div>
+  </details>
 </div>
 
 <style>
@@ -142,37 +346,165 @@
     font-weight: 600;
   }
 
-  /* Match tally */
-  .tallybar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    padding: 10px 14px;
+  /* ── Series scoreboard ─────────────────────────────────────────────── */
+  .series {
+    position: relative;
+    overflow: hidden;
+    padding: 12px 14px;
     background: var(--surface-2);
     border: 1px solid var(--border);
     border-radius: var(--radius);
   }
-  .tallybar.first {
-    justify-content: center;
+  .series.tense {
+    border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
   }
-  .tlabel {
-    font-size: 0.85rem;
+  .series-body {
+    position: relative;
+    z-index: 1;
+  }
+  /* The 5×5 agent grid motif — a faint spy costume behind the score. Decoration only. */
+  .grid {
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 2px;
+    width: 62px;
+    opacity: 0.16;
+    pointer-events: none;
+    z-index: 0;
+  }
+  .tile {
+    aspect-ratio: 1;
+    background: var(--muted);
+  }
+  .tile.red {
+    background: #e5484d;
+  }
+  .tile.blue {
+    background: #4c7dff;
+  }
+  .tile.neutral {
+    background: #c9b458;
+  }
+  .tile.assassin {
+    background: #1b1b1f;
+  }
+  .head {
+    margin-bottom: 4px;
+  }
+  .over {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text);
+  }
+  .over.muted {
     color: var(--muted);
-    font-weight: 600;
   }
-  .tscore {
+  .hh {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    padding: 2px 0;
+  }
+  .side {
     display: inline-flex;
     align-items: center;
-    gap: 10px;
-    font-weight: 700;
-    font-variant-numeric: tabular-nums;
+    gap: 8px;
+    opacity: 0.72;
   }
-  .tdash {
+  .side.ahead {
+    opacity: 1;
+  }
+  .snum {
+    font-size: 2rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+  .side.ahead .snum {
+    text-shadow: 0 0 1px currentColor;
+  }
+  .side.red {
+    color: #e5484d;
+  }
+  .side.blue {
+    color: #4c7dff;
+  }
+  .semoji {
+    font-size: 1rem;
+  }
+  .dash {
+    color: var(--muted);
+    font-weight: 700;
+  }
+  .lead-line,
+  .firstline {
+    margin: 6px 0 0;
+    text-align: center;
+    font-size: 0.9rem;
+  }
+  .lead-line.muted,
+  .firstline {
     color: var(--muted);
   }
 
-  /* Winner chooser — the hero choice */
+  .pips {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 8px;
+  }
+  .prow {
+    display: inline-flex;
+    gap: 5px;
+  }
+  .prow i {
+    width: 9px;
+    height: 9px;
+    border-radius: 999px;
+    border: 1.5px solid currentColor;
+    opacity: 0.4;
+  }
+  .prow i.on {
+    opacity: 1;
+    background: currentColor;
+  }
+  .prow.red {
+    color: #e5484d;
+  }
+  .prow.blue {
+    color: #4c7dff;
+  }
+  .pspacer {
+    width: 1px;
+    height: 14px;
+    background: var(--border);
+  }
+
+  .streak,
+  .matchpoint {
+    margin: 8px 0 0;
+    text-align: center;
+    font-size: 0.85rem;
+    color: var(--text);
+  }
+  .matchpoint {
+    font-weight: 600;
+  }
+
+  /* ── Winner + ending stage (hosts the assassin reveal) ─────────────── */
+  .stage {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
   .winner {
     display: flex;
     gap: 10px;
@@ -271,7 +603,36 @@
     line-height: 1.4;
   }
 
-  /* Team roster */
+  /* ── Fast team assignment ──────────────────────────────────────────── */
+  .quick {
+    display: flex;
+    gap: 8px;
+  }
+  .qbtn {
+    flex: 1 1 0;
+    min-height: 40px;
+    padding: 8px 6px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-3);
+    color: var(--text);
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .qbtn:hover {
+    border-color: var(--primary);
+  }
+  .qbtn:active {
+    transform: translateY(1px);
+  }
+  .qbtn:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+
+  /* ── Team roster ───────────────────────────────────────────────────── */
   .roster {
     gap: 8px;
   }
@@ -361,10 +722,70 @@
     padding-bottom: 12px;
   }
 
+  /* ── Spymaster log ─────────────────────────────────────────────────── */
+  .spybody {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-bottom: 12px;
+  }
+  .spyrow {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .spylabel {
+    font-weight: 700;
+    font-size: 0.85rem;
+  }
+  .spylabel.red {
+    color: #e5484d;
+  }
+  .spylabel.blue {
+    color: #4c7dff;
+  }
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .chip {
+    --tc: #e5484d;
+    min-height: 38px;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--text);
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .chip.blue {
+    --tc: #4c7dff;
+  }
+  .chip.on {
+    border-color: var(--tc);
+    background: color-mix(in srgb, var(--tc) 16%, var(--surface));
+  }
+  .chip:active {
+    transform: translateY(1px);
+  }
+  .chip:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .small {
+    font-size: 0.8rem;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .teamwin,
     .endbtn,
-    .teamtog {
+    .teamtog,
+    .qbtn,
+    .chip {
       transition: none;
     }
   }

--- a/src/lib/games/codenames/codenames.test.ts
+++ b/src/lib/games/codenames/codenames.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import type { Game, ID, Player, Round, RoundContext } from '../../types';
 import {
+  balanceTeams,
   carryTeams,
+  codeword,
   createInput,
   defaultTeams,
   describe as summarize,
@@ -9,12 +11,17 @@ import {
   otherTeam,
   pickWinners,
   score,
+  seriesState,
+  shuffleTeams,
+  streak,
+  swapTeams,
   tally,
   teamCounts,
   validate,
   type CodenamesInput,
   type Team,
 } from './logic';
+import { codenamesStats } from './stats';
 
 // ── fixtures ────────────────────────────────────────────────────────────────
 const player = (id: string): Player => ({ id, name: id.toUpperCase(), color: '#7c5cff', createdAt: 0 });
@@ -24,7 +31,8 @@ const input = (
   teams: Record<ID, Team>,
   winner: Team | null = null,
   ending: CodenamesInput['ending'] = 'agents',
-): CodenamesInput => ({ teams, winner, ending });
+  spymasters?: CodenamesInput['spymasters'],
+): CodenamesInput => ({ teams, winner, ending, ...(spymasters ? { spymasters } : {}) });
 
 const round = (index: number, inp: CodenamesInput): Round => ({
   id: `r${index}`,
@@ -208,5 +216,175 @@ describe('a full match', () => {
     expect(totals).toEqual({ a: 2, b: 2, c: 1 });
     expect(pickWinners(totals).sort()).toEqual(['a', 'b']);
     expect(matchOver(totals, 2)).toBe(true);
+  });
+});
+
+// ── seriesState ─────────────────────────────────────────────────────────────
+describe('seriesState', () => {
+  it('is an open head-to-head with no target', () => {
+    const s = seriesState({ red: 3, blue: 1 }, 0);
+    expect(s).toMatchObject({ target: 0, leader: 'red', matchPoint: false, decider: false, over: false });
+  });
+  it('reports a level series with no leader', () => {
+    expect(seriesState({ red: 2, blue: 2 }, 4).leader).toBeNull();
+  });
+  it('flags match point one game from the target', () => {
+    const s = seriesState({ red: 2, blue: 0 }, 3);
+    expect(s).toMatchObject({ leader: 'red', redNeeded: 1, blueNeeded: 3, matchPoint: true, decider: false, over: false });
+  });
+  it('flags a decider when both sides need one', () => {
+    const s = seriesState({ red: 2, blue: 2 }, 3);
+    expect(s).toMatchObject({ matchPoint: true, decider: true, over: false });
+  });
+  it('reports the series as over once a side reaches the target', () => {
+    const s = seriesState({ red: 3, blue: 1 }, 3);
+    expect(s).toMatchObject({ over: true, matchPoint: false, decider: false });
+  });
+  it('sanitises a junk target', () => {
+    expect(seriesState({ red: 1, blue: 0 }, Number.NaN).target).toBe(0);
+    expect(seriesState({ red: 1, blue: 0 }, -4).target).toBe(0);
+  });
+});
+
+// ── streak ──────────────────────────────────────────────────────────────────
+describe('streak', () => {
+  it('is empty with no resolved games', () => {
+    expect(streak([])).toEqual({ team: null, length: 0 });
+    expect(streak([round(0, input({ a: 'red', b: 'blue' }, null))])).toEqual({ team: null, length: 0 });
+  });
+  it('counts the current run and resets on a side change', () => {
+    const rounds = [
+      round(0, input({ a: 'red', b: 'blue' }, 'blue')),
+      round(1, input({ a: 'red', b: 'blue' }, 'red')),
+      round(2, input({ a: 'red', b: 'blue' }, 'red')),
+    ];
+    expect(streak(rounds)).toEqual({ team: 'red', length: 2 });
+  });
+  it('reads in play order regardless of array order and skips unresolved rounds', () => {
+    const rounds = [
+      round(2, input({ a: 'red', b: 'blue' }, 'blue')),
+      round(0, input({ a: 'red', b: 'blue' }, 'blue')),
+      round(1, input({ a: 'red', b: 'blue' }, null)),
+    ];
+    expect(streak(rounds)).toEqual({ team: 'blue', length: 2 });
+  });
+});
+
+// ── fast team assignment ──────────────────────────────────────────────────────
+describe('balanceTeams', () => {
+  it('matches the alternating default split', () => {
+    expect(balanceTeams(['a', 'b', 'c', 'd'])).toEqual(defaultTeams(['a', 'b', 'c', 'd']));
+  });
+});
+
+describe('swapTeams', () => {
+  it('flips every side', () => {
+    expect(swapTeams({ a: 'red', b: 'blue', c: 'red' })).toEqual({ a: 'blue', b: 'red', c: 'blue' });
+  });
+  it('repairs a corrupt entry to a valid side', () => {
+    expect(swapTeams({ a: 'green' as unknown as Team })).toEqual({ a: 'red' });
+  });
+});
+
+describe('shuffleTeams', () => {
+  it('is deterministic under an injected RNG and stays balanced', () => {
+    const ids = ['a', 'b', 'c', 'd', 'e'];
+    const seq = [0.9, 0.1, 0.7, 0.3, 0.5];
+    let i = 0;
+    const rand = () => seq[i++ % seq.length];
+    const out = shuffleTeams(ids, rand);
+    const counts = teamCounts(out, ids);
+    expect(Math.abs(counts.red - counts.blue)).toBeLessThanOrEqual(1);
+    // Same RNG sequence → same assignment.
+    i = 0;
+    expect(shuffleTeams(ids, () => seq[i++ % seq.length])).toEqual(out);
+  });
+  it('assigns every player a valid side', () => {
+    const ids = ['a', 'b', 'c'];
+    const out = shuffleTeams(ids, () => 0);
+    expect(Object.keys(out).sort()).toEqual(ids);
+    for (const id of ids) expect(['red', 'blue']).toContain(out[id]);
+  });
+});
+
+// ── codeword ──────────────────────────────────────────────────────────────────
+describe('codeword', () => {
+  it('is deterministic for the same seed', () => {
+    expect(codeword('g1')).toBe(codeword('g1'));
+    expect(codeword(42)).toBe(codeword(42));
+  });
+  it('returns an uppercase word from the list', () => {
+    const w = codeword('anything');
+    expect(w).toMatch(/^[A-Z]+$/);
+  });
+});
+
+// ── spymasters are non-scoring ────────────────────────────────────────────────
+describe('optional spymasters', () => {
+  const ids = ['a', 'b', 'c'];
+  const spies = { red: 'a', blue: 'c' };
+  it('does not change scoring', () => {
+    const withSpies = input({ a: 'red', b: 'red', c: 'blue' }, 'red', 'agents', spies);
+    const without = input({ a: 'red', b: 'red', c: 'blue' }, 'red');
+    expect(score(withSpies, ids)).toEqual(score(without, ids));
+  });
+  it('does not change validation', () => {
+    expect(validate(input({ a: 'red', b: 'blue' }, 'red', 'agents', { red: 'a', blue: 'b' }), ['a', 'b'])).toBeNull();
+  });
+});
+
+// ── stats ─────────────────────────────────────────────────────────────────────
+const game = (id = 'g', config: Record<string, unknown> = {}): Game => ({
+  id,
+  type: 'codenames',
+  config,
+  playerIds: [],
+  status: 'active',
+  createdAt: 0,
+  roundCount: 0,
+});
+const statsInput = (rounds: Round[], ps: Player[] = players('a', 'b', 'c', 'd')) => ({
+  games: [game()],
+  rounds,
+  players: ps,
+  canonical: (id: ID) => id,
+});
+
+describe('codenamesStats', () => {
+  it('surfaces the longest win streak (min 2)', () => {
+    const rounds = [
+      round(0, input({ a: 'red', b: 'blue' }, 'red')),
+      round(1, input({ a: 'red', b: 'blue' }, 'red')),
+      round(2, input({ a: 'red', b: 'blue' }, 'red')),
+      round(3, input({ a: 'red', b: 'blue' }, 'blue')),
+    ];
+    const { global } = codenamesStats(statsInput(rounds));
+    const streakMetric = global?.find((m) => m.key === 'cn_streak');
+    expect(streakMetric?.value).toContain('3 in a row');
+    expect(streakMetric?.value).toContain('🔴');
+  });
+  it('omits the streak metric when no side wins twice running', () => {
+    const rounds = [
+      round(0, input({ a: 'red', b: 'blue' }, 'red')),
+      round(1, input({ a: 'red', b: 'blue' }, 'blue')),
+    ];
+    const { global } = codenamesStats(statsInput(rounds));
+    expect(global?.some((m) => m.key === 'cn_streak')).toBe(false);
+  });
+  it('computes spymaster win rate only when logged', () => {
+    const rounds = [
+      round(0, input({ a: 'red', b: 'blue' }, 'red', 'agents', { red: 'a', blue: 'b' })),
+      round(1, input({ a: 'red', b: 'blue' }, 'blue', 'agents', { red: 'a', blue: 'b' })),
+    ];
+    const { perPlayer } = codenamesStats(statsInput(rounds));
+    const aSpy = perPlayer?.['a']?.find((m) => m.key === 'cn_spymaster');
+    expect(aSpy?.value).toBe('50%');
+    expect(aSpy?.sub).toContain('1/2');
+  });
+  it('omits spymaster metrics when no desks were logged', () => {
+    const rounds = [round(0, input({ a: 'red', b: 'blue' }, 'red'))];
+    const { perPlayer } = codenamesStats(statsInput(rounds));
+    const hasSpy = Object.values(perPlayer ?? {}).some((ms) => ms.some((m) => m.key === 'cn_spymaster'));
+    expect(hasSpy).toBe(false);
   });
 });

--- a/src/lib/games/codenames/logic.ts
+++ b/src/lib/games/codenames/logic.ts
@@ -19,6 +19,12 @@ export type Team = 'red' | 'blue';
 /** How a game ended — the two iconic Codenames outcomes. */
 export type Ending = 'agents' | 'assassin';
 
+/** Optional record of who ran each spymaster desk this game (flavour + stats only). */
+export interface Spymasters {
+  red: ID | null;
+  blue: ID | null;
+}
+
 export interface CodenamesInput {
   /**
    * Each player's team for this game. Persisted per-round and carried forward by
@@ -30,6 +36,12 @@ export interface CodenamesInput {
   winner: Team | null;
   /** `agents` = winners found all their agents; `assassin` = losers hit the assassin. */
   ending: Ending;
+  /**
+   * Who gave the one-word clues for each side, if the table logged it. Purely
+   * optional — never required, never affects scoring or validation — and only
+   * powers the spymaster win-rate stat. Absent on rounds saved before it existed.
+   */
+  spymasters?: Spymasters;
 }
 
 export const TEAMS: readonly Team[] = ['red', 'blue'];
@@ -167,3 +179,126 @@ export function describe(input: CodenamesInput): string {
   if (input.ending === 'assassin') out += ' · 💀 assassin';
   return out;
 }
+
+// ── Series drama ────────────────────────────────────────────────────────────
+
+export interface SeriesState {
+  /** Best-of target (games to win). 0 = open-ended, no series. */
+  target: number;
+  /** The side currently ahead in banked games, or null when level. */
+  leader: Team | null;
+  /** Games each side still needs to clinch the series (0 once reached). */
+  redNeeded: number;
+  blueNeeded: number;
+  /** A side sits one game from taking the series (best-of only, not yet over). */
+  matchPoint: boolean;
+  /** Both sides are one game away — the next game decides it. */
+  decider: boolean;
+  /** The series has already been clinched. */
+  over: boolean;
+}
+
+/**
+ * The state of a best-of series from the games banked so far. Drives the series
+ * pips and the "match point / decider" tension line. With no target (0) it stays
+ * an open-ended head-to-head: a leader is still surfaced, but nothing is a match
+ * point and it's never "over".
+ */
+export function seriesState(counts: Record<Team, number>, winTarget: number): SeriesState {
+  const target = Math.max(0, Math.round(Number(winTarget) || 0));
+  const red = Math.max(0, Number(counts.red) || 0);
+  const blue = Math.max(0, Number(counts.blue) || 0);
+  const leader: Team | null = red === blue ? null : red > blue ? 'red' : 'blue';
+
+  if (target <= 0) {
+    return { target: 0, leader, redNeeded: 0, blueNeeded: 0, matchPoint: false, decider: false, over: false };
+  }
+  const redNeeded = Math.max(0, target - red);
+  const blueNeeded = Math.max(0, target - blue);
+  const over = redNeeded === 0 || blueNeeded === 0;
+  const matchPoint = !over && (redNeeded === 1 || blueNeeded === 1);
+  const decider = !over && redNeeded === 1 && blueNeeded === 1;
+  return { target, leader, redNeeded, blueNeeded, matchPoint, decider, over };
+}
+
+export interface Streak {
+  /** The team riding the current streak, or null when there's no run yet. */
+  team: Team | null;
+  /** How many games in a row that team has won (0 when none). */
+  length: number;
+}
+
+/**
+ * The current win streak: how many games in a row the most-recent winner has
+ * taken. Reads the rounds in play order and stops at the first side-change, so a
+ * fresh loss resets the run. Unresolved rounds are skipped.
+ */
+export function streak(rounds: Round[]): Streak {
+  const winners: Team[] = [];
+  const ordered = [...rounds].sort((a, b) => a.index - b.index);
+  for (const r of ordered) {
+    const w = (r.input as CodenamesInput | undefined)?.winner;
+    if (isTeam(w)) winners.push(w);
+  }
+  if (winners.length === 0) return { team: null, length: 0 };
+  const team = winners[winners.length - 1];
+  let length = 0;
+  for (let i = winners.length - 1; i >= 0; i--) {
+    if (winners[i] === team) length += 1;
+    else break;
+  }
+  return { team, length };
+}
+
+// ── Fast team assignment ────────────────────────────────────────────────────
+
+/** Balanced split by seat order (alternating). Alias of {@link defaultTeams}. */
+export function balanceTeams(playerIds: ID[]): Record<ID, Team> {
+  return defaultTeams(playerIds);
+}
+
+/** Flip every player to the other side — swap Red ⇄ Blue wholesale. */
+export function swapTeams(teams: Record<ID, Team>): Record<ID, Team> {
+  const out: Record<ID, Team> = {};
+  for (const [id, t] of Object.entries(teams)) {
+    out[id] = isTeam(t) ? otherTeam(t) : 'red';
+  }
+  return out;
+}
+
+/**
+ * A random *balanced* split: shuffle the roster, then deal alternately so the
+ * teams differ by at most one. RNG is injectable so tests are deterministic.
+ */
+export function shuffleTeams(
+  playerIds: ID[],
+  rand: () => number = Math.random,
+): Record<ID, Team> {
+  const shuffled = [...playerIds];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return defaultTeams(shuffled);
+}
+
+// ── Spymaster flavour ───────────────────────────────────────────────────────
+
+/**
+ * A deterministic, family-friendly spy "codeword" for a game, seeded so the same
+ * game always shows the same word (pure flavour on the panel — never state).
+ */
+export function codeword(seed: number | string): string {
+  const words = [
+    'NIGHTFALL', 'COBRA', 'ECHO', 'LANTERN', 'MIRAGE', 'FALCON', 'CIPHER', 'VELVET',
+    'DOMINO', 'GLACIER', 'ORCHID', 'THUNDER', 'SPARROW', 'JACKAL', 'HALO', 'RIPTIDE',
+  ];
+  let h = 2166136261;
+  const s = String(seed);
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return words[Math.abs(h) % words.length];
+}
+

--- a/src/lib/games/codenames/stats.ts
+++ b/src/lib/games/codenames/stats.ts
@@ -1,13 +1,18 @@
 import type { ID } from '../../types';
 import type { CodenamesInput, Team } from './logic';
+import { TEAM_META } from './logic';
 import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
-import { fmtInt } from '../../stats/format';
+import { fmtInt, fmtPct } from '../../stats/format';
 
 interface CodenamesAgg {
   /** Games lost because this player's team hit the assassin. */
   assassinLosses: number;
   /** Games won by finding all agents (no assassin drama). */
   cleanWins: number;
+  /** Games this player ran a spymaster desk (either side). */
+  spymasterGames: number;
+  /** Of those, how many their team won. */
+  spymasterWins: number;
 }
 
 function isTeam(value: unknown): value is Team {
@@ -29,7 +34,7 @@ export function codenamesStats({
   const get = (id: ID): CodenamesAgg => {
     let a = per.get(id);
     if (!a) {
-      a = { assassinLosses: 0, cleanWins: 0 };
+      a = { assassinLosses: 0, cleanWins: 0, spymasterGames: 0, spymasterWins: 0 };
       per.set(id, a);
     }
     return a;
@@ -38,8 +43,15 @@ export function codenamesStats({
   const teamWins: Record<Team, number> = { red: 0, blue: 0 };
   let assassinGames = 0;
 
-  for (const r of rounds) {
-    if (!gameIds.has(r.gameId)) continue;
+  // Longest run of consecutive wins per side, in the order games were recorded.
+  const ordered = [...rounds]
+    .filter((r) => gameIds.has(r.gameId))
+    .sort((a, b) => a.createdAt - b.createdAt || a.index - b.index);
+  const longestRun: Record<Team, number> = { red: 0, blue: 0 };
+  let runTeam: Team | null = null;
+  let runLen = 0;
+
+  for (const r of ordered) {
     const input = r.input as CodenamesInput | undefined;
     if (!input?.teams || !isTeam(input.winner)) continue;
 
@@ -48,6 +60,14 @@ export function codenamesStats({
     teamWins[winner] += 1;
     if (byAssassin) assassinGames += 1;
 
+    // Track the running streak per side.
+    if (runTeam === winner) runLen += 1;
+    else {
+      runTeam = winner;
+      runLen = 1;
+    }
+    if (runLen > longestRun[winner]) longestRun[winner] = runLen;
+
     for (const [pid, team] of Object.entries(input.teams)) {
       if (!isTeam(team)) continue;
       const a = get(canonical(pid));
@@ -55,6 +75,18 @@ export function codenamesStats({
         if (!byAssassin) a.cleanWins += 1;
       } else if (byAssassin) {
         a.assassinLosses += 1;
+      }
+    }
+
+    // Optional spymaster desks: credit whoever ran each side.
+    const spies = input.spymasters;
+    if (spies) {
+      for (const side of ['red', 'blue'] as Team[]) {
+        const pid = spies[side];
+        if (pid == null) continue;
+        const a = get(canonical(pid));
+        a.spymasterGames += 1;
+        if (side === winner) a.spymasterWins += 1;
       }
     }
   }
@@ -78,6 +110,15 @@ export function codenamesStats({
         emoji: '💀',
       });
     }
+    if (a.spymasterGames > 0) {
+      metrics.push({
+        key: 'cn_spymaster',
+        label: 'Spymaster win rate',
+        value: fmtPct(a.spymasterWins / a.spymasterGames),
+        sub: `${fmtInt(a.spymasterWins)}/${fmtInt(a.spymasterGames)} as spymaster`,
+        emoji: '🎙️',
+      });
+    }
     if (metrics.length) perPlayer[id] = metrics;
   }
 
@@ -97,6 +138,19 @@ export function codenamesStats({
       label: 'Assassin endings',
       value: fmtInt(assassinGames),
       emoji: '💀',
+    });
+  }
+  // Best win streak — surface the longer of the two sides' runs (min 2 to be a "streak").
+  const bestStreakTeam: Team = longestRun.red >= longestRun.blue ? 'red' : 'blue';
+  const bestStreak = longestRun[bestStreakTeam];
+  if (bestStreak >= 2) {
+    const meta = TEAM_META[bestStreakTeam];
+    global.push({
+      key: 'cn_streak',
+      label: 'Longest win streak',
+      value: `${meta.emoji} ${fmtInt(bestStreak)} in a row`,
+      sub: `${meta.label} team’s best run`,
+      emoji: '🔥',
     });
   }
 


### PR DESCRIPTION
## 🕵️ Codenames glow-up — Full Spy Fantasy

Turns the Codenames Red-vs-Blue **tracker** into a dramatic, whimsical spy experience — while keeping the app chrome **identical** to every other game and leaving scoring/validation semantics **unchanged**. All personality lives in the Codenames module (`CodenamesEditor.svelte`, new `AssassinReveal.svelte`, `logic.ts`, `stats.ts`).

### What's new
- **Series scoreboard** — a big `tabular-nums` 🔴 n – n 🔵 head-to-head, best-of **series pips**, a **match-point / decider** tension line (`aria-live`), a **win-streak** flame ("🔴 3 in a row 🔥"), a subtle **5×5 agent-grid motif**, and a deterministic spy **codeword** flourish.
- **💀 Assassin reveal** (`AssassinReveal.svelte`) — a dramatic overlay that replays when a game flips to an assassin ending, fired via a token `$effect` + `haptic('win')`. Renders **nothing under reduced motion**, and is never the only signal (the ending toggle + winner panel still spell it out).
- **Fast team assignment** — 🔀 Shuffle · ⚖️ Balance · ⇄ Swap quick actions (seeded, testable RNG in `logic.ts`).
- **Optional spymaster log** — a collapsed `<details>`, never required, that unlocks a **spymaster win-rate** stat.
- **Richer stats** — longest win streak per team + spymaster win rate per player.

### Design non-negotiables honored
- **Red vs Blue always carries a non-color cue** (emoji 🔴/🔵 + "Red"/"Blue" label + text) for colour-blind players.
- **No Crown Gold** anywhere in the module — the leader is emphasized via opacity + text, leaving `#ffd166` reserved for the shell's crown/winner.
- Shell keeps its single **Royal Violet** primary action ("Save round"); the editor adds no second violet fill.
- Depth via the surface ramp, ≥46px touch targets, `tabular-nums` on every changing number, and `prefers-reduced-motion` respected.
- New pure helpers (`seriesState`, `streak`, `balanceTeams`, `swapTeams`, `shuffleTeams`, `codeword`) live in Svelte-free `logic.ts` and are fully unit-tested.

> Note: the iconic Codenames board colors used in the grid motif / scoreboard accents are intentional, domain-specific, and always paired with emoji+label cues.

### Verification (local)
- `npm run check` → 0 errors, 0 warnings
- `npm test` → **1057 passed** (49 in codenames, incl. new coverage for all helpers + stats)
- `npm run build` → success

No shell files (GamePlay, Scoreboard, tab bar) or other games were touched.