### PR TITLE
Cornhole: tactile bag-toss entry, race-to-21 lanes, and whimsy

### DIFF
--- a/src/lib/games/cornhole/BagTossRow.svelte
+++ b/src/lib/games/cornhole/BagTossRow.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  import { animateMotion } from '../../motion';
+  import { haptic } from '../../haptics';
+  import {
+    BAGS_PER_SIDE,
+    type BagState,
+    type SideThrow,
+    cycleBag,
+    slotsFromThrow,
+    throwFromSlots,
+  } from './logic';
+
+  /**
+   * One side's four-bag toss row — the tactile heart of Cornhole entry. Each of the
+   * four bags is a fixed slot you tap to climb Ground → On the board (×1) → In the
+   * hole (×3) → back to Ground, so a whole frame is entered by feel in four taps
+   * without summoning the keyboard. The bags stay put in their slots (never re-sort)
+   * so "tap this bag through its states" always hits the same bag.
+   *
+   * State is co-signalled three ways — a landing icon, a word ("Drano" / "Woody" /
+   * "Grass"), and the point value — so nothing depends on color. Motion is a small
+   * one-frame pop on the tapped bag, skipped under reduced motion.
+   */
+  let {
+    bag = $bindable(),
+    label,
+  }: { bag: SideThrow; label: string } = $props();
+
+  // A fixed, positionally-stable row of four bags. Seeded from the counts and
+  // re-synced only when the counts change from the outside (a new round, or an
+  // edited round loading) — never when our own taps write them back.
+  let slots = $state<BagState[]>(slotsFromThrow(bag, BAGS_PER_SIDE));
+  let chips = $state<(HTMLButtonElement | undefined)[]>([]);
+
+  $effect(() => {
+    const wantHole = Math.max(0, Math.trunc(Number(bag.inHole) || 0));
+    const wantBoard = Math.max(0, Math.trunc(Number(bag.onBoard) || 0));
+    const have = throwFromSlots(slots);
+    if (have.inHole !== wantHole || have.onBoard !== wantBoard) {
+      slots = slotsFromThrow(bag, BAGS_PER_SIDE);
+    }
+  });
+
+  const META: Record<BagState, { icon: string; word: string; pts: string; hint: string }> = {
+    hole: { icon: '🕳️', word: 'Drano', pts: '+3', hint: 'in the hole' },
+    board: { icon: '🫘', word: 'Woody', pts: '+1', hint: 'on the board' },
+    ground: { icon: '🌱', word: 'Grass', pts: '0', hint: 'on the ground' },
+  };
+
+  function tap(i: number) {
+    const next = [...slots];
+    next[i] = cycleBag(next[i]!);
+    slots = next;
+    const t = throwFromSlots(next);
+    bag.inHole = t.inHole;
+    bag.onBoard = t.onBoard;
+    haptic('tick');
+    const el = chips[i];
+    if (el) {
+      animateMotion(
+        el,
+        next[i] === 'hole'
+          ? { scale: [1, 1.28, 1], rotate: [0, -6, 0] }
+          : { scale: [1, 1.16, 1] },
+        { duration: 0.2, ease: 'easeOut' },
+      );
+    }
+  }
+</script>
+
+<div class="toss" role="group" aria-label={`${label} — tap each bag to place it`}>
+  {#each slots as s, i (i)}
+    {@const m = META[s]}
+    <button
+      type="button"
+      class="bag {s}"
+      bind:this={chips[i]}
+      onclick={() => tap(i)}
+      aria-label={`${label} bag ${i + 1}: ${m.hint}, ${m.pts} points. Tap to move it.`}
+    >
+      <span class="ico" aria-hidden="true">{m.icon}</span>
+      <span class="word">{m.word}</span>
+      <span class="pts">{m.pts}</span>
+    </button>
+  {/each}
+</div>
+
+<style>
+  .toss {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+  }
+  /* Each bag climbs the surface ramp as it climbs in value — depth carries the
+     "better landing" read, backed up by the icon, word, and points (never color). */
+  .bag {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    min-height: 66px;
+    padding: 8px 4px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    transition: background var(--dur-base) var(--ease-standard), border-color var(--dur-base) var(--ease-standard);
+  }
+  .bag:active {
+    transform: translateY(1px);
+  }
+  .bag:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .bag.ground {
+    background: var(--surface);
+    border-style: dashed;
+    color: var(--muted);
+  }
+  .bag.board {
+    background: var(--surface-2);
+  }
+  .bag.hole {
+    background: var(--surface-3);
+    border-color: color-mix(in srgb, var(--good) 45%, var(--border));
+  }
+  .ico {
+    font-size: 1.4rem;
+    line-height: 1;
+  }
+  .word {
+    font-size: 0.72rem;
+    font-weight: 700;
+  }
+  .pts {
+    font-size: 0.72rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--muted);
+  }
+  .bag.hole .pts {
+    color: var(--good);
+  }
+</style>

--- a/src/lib/games/cornhole/CornholeEditor.svelte
+++ b/src/lib/games/cornhole/CornholeEditor.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
-  import Stepper from '../../components/Stepper.svelte';
+  import { bumpOnChange, popIn } from '../../motion';
+  import BagTossRow from './BagTossRow.svelte';
+  import RaceToTarget from './RaceToTarget.svelte';
   import {
     BAGS_PER_SIDE,
-    IN_HOLE_POINTS,
-    ON_BOARD_POINTS,
+    bustRisk,
+    type CornholeInput,
+    isFourBagger,
     readConfig,
     scoreCornhole,
     sideRaw,
-    type CornholeInput,
+    tossFlavor,
   } from './logic';
 
   let { input = $bindable(), ctx }: { input: CornholeInput; ctx: RoundContext } = $props();
@@ -24,44 +27,93 @@
   function bag(id: string): { inHole: number; onBoard: number } {
     return input.sides[id] ?? { inHole: 0, onBoard: 0 };
   }
-  function used(id: string): number {
-    const t = bag(id);
-    return (Number(t.inHole) || 0) + (Number(t.onBoard) || 0);
-  }
-  function left(id: string): number {
-    return Math.max(0, BAGS_PER_SIDE - used(id));
-  }
   function raw(id: string): number {
     return sideRaw(bag(id));
   }
   function totalBefore(id: string): number {
     return Number(ctx.totals[id]) || 0;
   }
-  function projected(id: string): number {
-    return totalBefore(id) + (outcome.deltas[id] ?? 0);
+  function four(id: string): boolean {
+    return isFourBagger(bag(id));
   }
+
+  // Who's reigning right now (before this frame). A tie has no leader — Crown Gold
+  // only ever marks a side that's actually ahead.
+  const leaderId = $derived.by(() => {
+    const [aId, bId] = ids;
+    const ta = totalBefore(aId);
+    const tb = totalBefore(bId);
+    if (ta > tb) return aId;
+    if (tb > ta) return bId;
+    return null;
+  });
+
+  const lanes = $derived(
+    ctx.players.map((p) => ({
+      id: p.id,
+      name: p.name,
+      color: p.color,
+      total: totalBefore(p.id),
+      gain: outcome.deltas[p.id] ?? 0,
+      isLeader: p.id === leaderId,
+      danger: bustRisk(totalBefore(p.id), cfg),
+    })),
+  );
+
+  const flavor = $derived(
+    tossFlavor({
+      gainerName: gainer?.name ?? null,
+      net: outcome.net,
+      aRaw: outcome.aRaw,
+      bRaw: outcome.bRaw,
+      busted: outcome.busted,
+      fourBaggerName:
+        four(ids[0]) !== four(ids[1])
+          ? four(ids[0])
+            ? ctx.players[0]!.name
+            : ctx.players[1]!.name
+          : null,
+      bothFourBaggers: four(ids[0]) && four(ids[1]),
+      seed: ctx.roundIndex,
+    }),
+  );
+
+  // A stable key for the flavor beat, so the status line re-pops only when the
+  // narrated result actually changes (not on every keystroke of the same result).
+  const flavorKey = $derived(`${flavor.emoji}|${flavor.text}`);
 </script>
 
 <div class="stack">
-  <div class="row spread head">
-    <span class="row" style="gap: 8px">
+  <RaceToTarget {lanes} target={cfg.target} />
+
+  <div class="showdown" class:wash={!gainer} class:bust={outcome.busted}>
+    <div class="row spread head">
       <span class="pill">Round {n}</span>
-      <span class="pill">to {cfg.target}{cfg.winBy > 1 ? ` · by ${cfg.winBy}` : ''}</span>
-    </span>
-    {#if gainer}
-      <span class="row result" style="gap: 8px">
-        <span class="score-good net">🌽 {gainer.name} +{outcome.net}</span>
-        {#if outcome.busted}<span class="pill bust">💥 Bust → 15</span>{/if}
-      </span>
-    {:else}
-      <span class="muted result">🌽 Wash — no one scores</span>
-    {/if}
+      <span class="pill">to {cfg.target}{cfg.winBy > 1 ? ` · by ${cfg.winBy}` : ''}{cfg.bust ? ' · bust' : ''}</span>
+    </div>
+
+    <div class="flavor {flavor.tone}" use:bumpOnChange={flavorKey}>
+      <span class="fem" aria-hidden="true">{flavor.emoji}</span>
+      <span>{flavor.text}</span>
+    </div>
+
+    <div class="cancel" aria-hidden="true">
+      <span class="craw" class:beaten={outcome.aRaw < outcome.bRaw} class:tie={outcome.aRaw === outcome.bRaw}>{outcome.aRaw}</span>
+      <span class="cvs">⟷</span>
+      <span class="craw" class:beaten={outcome.bRaw < outcome.aRaw} class:tie={outcome.aRaw === outcome.bRaw}>{outcome.bRaw}</span>
+      <span class="carrow">→</span>
+      {#if gainer}
+        <span class="cnet">{gainer.name} keeps <strong>+{outcome.net}</strong></span>
+      {:else}
+        <span class="cnet muted">cancels to nothing</span>
+      {/if}
+    </div>
   </div>
 
   {#each ctx.players as p, i (p.id)}
     {#if i === 1}<div class="vs" aria-hidden="true">vs</div>{/if}
     <div class="side" class:scoring={outcome.gainerId === p.id}>
-      <div class="row spread" style="margin-bottom: 12px">
+      <div class="row spread shead">
         <span class="row who" style="gap: 8px">
           <Avatar name={p.name} color={p.color} />
           <span class="name">
@@ -69,36 +121,22 @@
             <strong>{p.name}</strong>
           </span>
         </span>
-        <span class="tally">
-          <span class="cur">{totalBefore(p.id)}</span>
-          <span class="arrow" aria-hidden="true">→</span>
-          <span
-            class="proj"
-            class:score-good={projected(p.id) > totalBefore(p.id)}
-            class:score-bad={projected(p.id) < totalBefore(p.id)}
-          >{projected(p.id)}{#if outcome.busted && outcome.gainerId === p.id}<span class="burst" aria-hidden="true"> 💥</span>{/if}</span>
+        <span class="frame">
+          {#if four(p.id)}
+            <span class="fourbag" use:popIn>💣 Four-bagger!</span>
+          {/if}
+          <span class="fpts">🌽 <strong>{raw(p.id)}</strong> pts</span>
         </span>
       </div>
 
-      <div class="fields">
-        <label class="f">
-          <span class="flabel">In the hole <span class="x">×{IN_HOLE_POINTS}</span></span>
-          <Stepper bind:value={input.sides[p.id].inHole} min={0} max={BAGS_PER_SIDE - (Number(bag(p.id).onBoard) || 0)} />
-        </label>
-        <label class="f">
-          <span class="flabel">On the board <span class="x">×{ON_BOARD_POINTS}</span></span>
-          <Stepper bind:value={input.sides[p.id].onBoard} min={0} max={BAGS_PER_SIDE - (Number(bag(p.id).inHole) || 0)} />
-        </label>
-      </div>
-
-      <div class="row spread meta">
-        <span class="pts">🌽 {raw(p.id)} pts this round</span>
-        <span class="left" class:score-bad={used(p.id) > BAGS_PER_SIDE}>
-          {left(p.id)} {left(p.id) === 1 ? 'bag' : 'bags'} left
-        </span>
-      </div>
+      <BagTossRow bind:bag={input.sides[p.id]} label={p.name} />
     </div>
   {/each}
+
+  <p class="hint muted">
+    Tap each bag to place it — <strong>🕳️ Drano</strong> (+3), <strong>🫘 Woody</strong> (+1),
+    or <strong>🌱 Grass</strong> (0). {BAGS_PER_SIDE} bags a side; only the higher side scores the difference.
+  </p>
 </div>
 
 <style>
@@ -106,27 +144,98 @@
     flex-wrap: wrap;
     gap: 8px;
   }
-  .result {
+
+  /* ── Cancellation showdown ── the frame's story in one glance. */
+  .showdown {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .showdown.wash {
+    border-color: color-mix(in srgb, var(--muted) 35%, var(--border));
+  }
+  .showdown.bust {
+    border-color: color-mix(in srgb, var(--bad) 45%, var(--border));
+  }
+  .flavor {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     font-weight: 700;
     font-variant-numeric: tabular-nums;
   }
-  .net {
+  .flavor .fem {
+    font-size: 1.2rem;
+  }
+  .flavor.good {
+    color: var(--good);
+  }
+  .flavor.bad {
+    color: var(--bad);
+  }
+  .flavor.muted {
+    color: var(--muted);
+  }
+  .cancel {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    font-variant-numeric: tabular-nums;
+  }
+  .craw {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 34px;
+    height: 30px;
+    padding: 0 8px;
+    border-radius: var(--radius-sm);
+    background: var(--surface-3);
     font-weight: 800;
   }
-  .bust {
-    color: var(--bad);
-    border-color: color-mix(in srgb, var(--bad) 55%, var(--border));
+  /* The lower side is cancelled out — struck through and dimmed, so the "only the
+     difference survives" rule is visible, not just asserted. */
+  .craw.beaten {
+    opacity: 0.5;
+    text-decoration: line-through;
+    text-decoration-thickness: 2px;
   }
+  .craw.tie {
+    opacity: 0.6;
+  }
+  .cvs {
+    color: var(--muted);
+    font-size: 0.8rem;
+  }
+  .carrow {
+    color: var(--muted);
+  }
+  .cnet {
+    font-weight: 700;
+  }
+  .cnet strong {
+    font-weight: 800;
+  }
+
+  /* ── Per-side entry ── */
   .side {
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     padding: 14px;
   }
-  /* The side that would score this round lifts one step up the surface ramp — depth, not a stripe. */
+  /* The side that would score this frame lifts one step up the surface ramp. */
   .side.scoring {
     background: var(--surface-3);
     border-color: color-mix(in srgb, var(--good) 45%, var(--border));
+  }
+  .shead {
+    margin-bottom: 12px;
   }
   .name {
     display: flex;
@@ -140,46 +249,24 @@
     text-transform: uppercase;
     color: var(--muted);
   }
-  .tally {
+  .frame {
     display: inline-flex;
-    align-items: baseline;
-    gap: 6px;
+    align-items: center;
+    gap: 8px;
     font-variant-numeric: tabular-nums;
-    font-weight: 700;
   }
-  .tally .cur {
-    color: var(--muted);
+  .fpts {
+    font-weight: 600;
+    font-size: 0.9rem;
   }
-  .tally .arrow {
-    color: var(--muted);
-  }
-  .tally .proj {
+  .fpts strong {
     font-weight: 800;
-    font-size: 1.15rem;
   }
-  .fields {
-    display: flex;
-    gap: 14px;
-    flex-wrap: wrap;
-  }
-  .f {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-  .flabel {
-    font-size: 0.8rem;
-    color: var(--muted);
-  }
-  .flabel .x {
-    font-weight: 700;
-    color: var(--text);
-  }
-  .meta {
-    margin-top: 12px;
-    font-size: 0.82rem;
-    color: var(--muted);
-    font-variant-numeric: tabular-nums;
+  .fourbag {
+    font-size: 0.78rem;
+    font-weight: 800;
+    color: var(--good);
+    white-space: nowrap;
   }
   .vs {
     align-self: center;
@@ -189,5 +276,10 @@
     text-transform: uppercase;
     color: var(--muted);
     margin: -4px 0;
+  }
+  .hint {
+    font-size: 0.8rem;
+    margin: 2px 2px 0;
+    line-height: 1.5;
   }
 </style>

--- a/src/lib/games/cornhole/RaceToTarget.svelte
+++ b/src/lib/games/cornhole/RaceToTarget.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+  import Avatar from '../../components/Avatar.svelte';
+
+  /**
+   * The race to the target — two lanes climbing side-by-side so the whole game is
+   * glanceable in one look: who's ahead, by how much, how far each side has to go,
+   * and (with bust on) who's edging into the danger zone where a big frame tumbles
+   * them back to 15.
+   *
+   * Crown Gold appears on exactly one thing here — the current leader's number and
+   * 👑 — honoring the Crown Gold Rule; everything else is built from the surface
+   * ramp and semantic tints. The lead is co-signalled by the 👑 and the number, so
+   * it never rides on color alone. The projected band previews this frame's swing.
+   */
+  interface Lane {
+    id: string;
+    name: string;
+    color: string;
+    total: number;
+    /** Projected point change from the frame being entered (may be negative on a bust). */
+    gain: number;
+    isLeader: boolean;
+    danger: boolean;
+  }
+
+  let { lanes, target }: { lanes: Lane[]; target: number } = $props();
+
+  const pct = (v: number) => Math.max(0, Math.min(100, (v / Math.max(1, target)) * 100));
+
+  function togo(total: number): number {
+    return Math.max(0, target - total);
+  }
+</script>
+
+<div class="race" role="group" aria-label={`Race to ${target}`}>
+  <div class="cap">
+    <span class="overline">Race to {target}</span>
+  </div>
+  {#each lanes as l (l.id)}
+    {@const projected = l.total + l.gain}
+    {@const dropping = projected < l.total}
+    <div class="lane" class:leader={l.isLeader} class:danger={l.danger}>
+      <div class="lhead">
+        <span class="who">
+          <Avatar name={l.name} color={l.color} size={22} />
+          <span class="nm">{l.name}</span>
+        </span>
+        <span class="score" class:lead={l.isLeader}>
+          {#if l.isLeader}<span class="crown" aria-hidden="true">👑</span>{/if}
+          <span class="val">{l.total}</span>
+        </span>
+      </div>
+      <div class="track">
+        <div class="fill" style="transform: scaleX({pct(Math.min(l.total, projected)) / 100})"></div>
+        {#if l.gain > 0}
+          <div
+            class="ghost gain"
+            style="left: {pct(l.total)}%; width: {pct(Math.min(projected, target)) - pct(l.total)}%"
+          ></div>
+        {:else if dropping}
+          <div
+            class="ghost drop"
+            style="left: {pct(projected)}%; width: {pct(l.total) - pct(projected)}%"
+          ></div>
+        {/if}
+        {#if l.danger}<span class="dangerEdge" aria-hidden="true"></span>{/if}
+      </div>
+      <div class="lfoot">
+        {#if l.total >= target}
+          <span class="good">🌽 at {target} — one clean frame closes it</span>
+        {:else}
+          <span class="muted"><strong class="num">{togo(l.total)}</strong> to go</span>
+        {/if}
+        {#if l.danger}<span class="warn">· 💥 bust zone</span>{/if}
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .race {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .cap {
+    display: flex;
+    justify-content: center;
+  }
+  .overline {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .lane {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 10px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
+  /* Leader gets a restrained Crown Gold wash + edge — the same scarce gold as the
+     winner row, and only ever on the side that's actually reigning. */
+  .lane.leader {
+    background: color-mix(in srgb, var(--accent) 9%, var(--surface));
+    border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+  }
+  /* Bust danger reads through the 💥 + "bust zone" words; the coral edge is a hint. */
+  .lane.danger {
+    border-color: color-mix(in srgb, var(--bad) 40%, var(--border));
+  }
+  .lhead {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .who {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .nm {
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .score {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    font-variant-numeric: tabular-nums;
+    font-weight: 800;
+  }
+  .score .val {
+    font-size: 1.15rem;
+  }
+  .score.lead .val {
+    color: var(--accent-ink);
+  }
+  .crown {
+    font-size: 0.9rem;
+  }
+  .track {
+    position: relative;
+    height: 10px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    overflow: hidden;
+  }
+  .fill {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 999px;
+    transform-origin: left center;
+    background: color-mix(in srgb, var(--text) 55%, var(--surface-3));
+    transition: transform var(--dur-base) var(--ease-standard);
+  }
+  .lane.leader .fill {
+    background: color-mix(in srgb, var(--accent) 60%, var(--surface-3));
+  }
+  .ghost {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    border-radius: 999px;
+  }
+  /* Previewed gain this frame — a lighter segment reaching ahead of the current fill. */
+  .ghost.gain {
+    background: repeating-linear-gradient(
+      45deg,
+      color-mix(in srgb, var(--good) 55%, transparent),
+      color-mix(in srgb, var(--good) 55%, transparent) 4px,
+      transparent 4px,
+      transparent 8px
+    );
+  }
+  /* Previewed bust drop — the coral band the score would recede across. */
+  .ghost.drop {
+    background: repeating-linear-gradient(
+      45deg,
+      color-mix(in srgb, var(--bad) 55%, transparent),
+      color-mix(in srgb, var(--bad) 55%, transparent) 4px,
+      transparent 4px,
+      transparent 8px
+    );
+  }
+  .dangerEdge {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 6px;
+    background: var(--bad);
+    opacity: 0.7;
+  }
+  .lfoot {
+    display: flex;
+    gap: 6px;
+    font-size: 0.78rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .lfoot .num {
+    font-weight: 800;
+    color: var(--text);
+  }
+  .lfoot .good {
+    color: var(--good);
+    font-weight: 600;
+  }
+  .lfoot .warn {
+    color: var(--bad);
+    font-weight: 600;
+  }
+</style>

--- a/src/lib/games/cornhole/cornhole.test.ts
+++ b/src/lib/games/cornhole/cornhole.test.ts
@@ -4,13 +4,21 @@ import { cornhole } from './index';
 import {
   applyBust,
   BAGS_PER_SIDE,
+  bagValue,
+  bustRisk,
   cancel,
+  type BagState,
   type CornholeConfig,
   type CornholeInput,
+  cycleBag,
+  isFourBagger,
   isWon,
   readConfig,
   scoreCornhole,
   sideRaw,
+  slotsFromThrow,
+  throwFromSlots,
+  tossFlavor,
 } from './logic';
 
 const DEFAULT: CornholeConfig = { target: 21, bust: false, winBy: 1, format: '1v1' };
@@ -200,5 +208,114 @@ describe('cornhole: module wiring', () => {
     expect(cornhole.describeRound!(round, players)).toBe('🌽 Aces +3 · 7–4');
     const washed = { input: input([1, 0], [1, 0]) } as unknown as Round;
     expect(cornhole.describeRound!(washed, players)).toMatch(/Wash/);
+  });
+});
+
+describe('cornhole: tactile bag-slot model', () => {
+  it('expands counts into a positional row — holes, then boards, then ground', () => {
+    expect(slotsFromThrow({ inHole: 2, onBoard: 1 })).toEqual(['hole', 'hole', 'board', 'ground']);
+    expect(slotsFromThrow({ inHole: 0, onBoard: 0 })).toEqual(['ground', 'ground', 'ground', 'ground']);
+    expect(slotsFromThrow({ inHole: 4, onBoard: 0 })).toEqual(['hole', 'hole', 'hole', 'hole']);
+  });
+
+  it('folds a row of slots back into in-hole / on-board counts', () => {
+    expect(throwFromSlots(['hole', 'ground', 'board', 'hole'])).toEqual({ inHole: 2, onBoard: 1 });
+    expect(throwFromSlots(['ground', 'ground', 'ground', 'ground'])).toEqual({ inHole: 0, onBoard: 0 });
+  });
+
+  it('round-trips counts through the slot model', () => {
+    for (const t of [{ inHole: 0, onBoard: 0 }, { inHole: 1, onBoard: 2 }, { inHole: 4, onBoard: 0 }, { inHole: 0, onBoard: 3 }]) {
+      expect(throwFromSlots(slotsFromThrow(t))).toEqual(t);
+    }
+  });
+
+  it('clamps junk counts and never emits more than the row length', () => {
+    expect(slotsFromThrow({ inHole: -3, onBoard: 1 })).toEqual(['board', 'ground', 'ground', 'ground']);
+    expect(slotsFromThrow(undefined)).toEqual(['ground', 'ground', 'ground', 'ground']);
+    expect(slotsFromThrow({ inHole: 9, onBoard: 9 })).toHaveLength(BAGS_PER_SIDE);
+  });
+
+  it('a tap climbs a bag in value and wraps: ground → board → hole → ground', () => {
+    expect(cycleBag('ground')).toBe('board');
+    expect(cycleBag('board')).toBe('hole');
+    expect(cycleBag('hole')).toBe('ground');
+    // Four taps on one bag returns it to where it started.
+    let s: BagState = 'ground';
+    for (let i = 0; i < 3; i++) s = cycleBag(s);
+    expect(s).toBe('ground');
+  });
+
+  it('scores each landing spot: hole 3, board 1, ground 0', () => {
+    expect(bagValue('hole')).toBe(3);
+    expect(bagValue('board')).toBe(1);
+    expect(bagValue('ground')).toBe(0);
+  });
+});
+
+describe('cornhole: four-bagger + bust risk', () => {
+  it('flags a four-bagger only when all four bags are in the hole', () => {
+    expect(isFourBagger({ inHole: 4, onBoard: 0 })).toBe(true);
+    expect(isFourBagger({ inHole: 3, onBoard: 1 })).toBe(false);
+    expect(isFourBagger({ inHole: 0, onBoard: 4 })).toBe(false);
+    expect(isFourBagger(undefined)).toBe(false);
+  });
+
+  it('bust risk lights up only within a big frame of overshooting', () => {
+    const cfg = { target: 21, bust: true };
+    expect(bustRisk(10, cfg)).toBe(true); // 10 + 12 = 22 > 21
+    expect(bustRisk(9, cfg)).toBe(false); // 9 + 12 = 21, not over
+    expect(bustRisk(21, cfg)).toBe(false); // already at the target
+    expect(bustRisk(0, cfg)).toBe(false); // miles away
+  });
+
+  it('bust risk is off without the bust rule or a target above 15', () => {
+    expect(bustRisk(18, { target: 21, bust: false })).toBe(false);
+    expect(bustRisk(14, { target: 15, bust: true })).toBe(false);
+  });
+});
+
+describe('cornhole: toss flavor (pure, deterministic)', () => {
+  const base = { net: 3, aRaw: 7, bRaw: 4, busted: false, fourBaggerName: null, bothFourBaggers: false, seed: 0 };
+
+  it('leads with the bust when a side overcooks it', () => {
+    const f = tossFlavor({ ...base, gainerName: 'Aces', busted: true });
+    expect(f.emoji).toBe('💥');
+    expect(f.tone).toBe('bad');
+    expect(f.text).toMatch(/bust/i);
+  });
+
+  it('celebrates a four-bagger', () => {
+    const f = tossFlavor({ ...base, gainerName: 'Aces', net: 12, fourBaggerName: 'Aces' });
+    expect(f.emoji).toBe('💣');
+    expect(f.tone).toBe('good');
+    expect(f.text).toMatch(/four-bagger/i);
+  });
+
+  it('washes when both sides four-bag', () => {
+    const f = tossFlavor({ ...base, gainerName: null, net: 0, fourBaggerName: null, bothFourBaggers: true });
+    expect(f.emoji).toBe('🧺');
+    expect(f.tone).toBe('muted');
+  });
+
+  it('narrates a plain wash and a total whiff', () => {
+    const wash = tossFlavor({ ...base, gainerName: null, net: 0 });
+    expect(wash.emoji).toBe('🧺');
+    expect(wash.tone).toBe('muted');
+    const whiff = tossFlavor({ ...base, gainerName: null, net: 0, aRaw: 0, bRaw: 0 });
+    expect(whiff.tone).toBe('muted');
+    expect(whiff.text).toMatch(/nothing|whiff/i);
+  });
+
+  it('narrates a normal scoring frame with the gainer and net', () => {
+    const f = tossFlavor({ ...base, gainerName: 'Bombers', net: 2 });
+    expect(f.tone).toBe('good');
+    expect(f.text).toContain('Bombers');
+    expect(f.text).toContain('+2');
+  });
+
+  it('is deterministic for the same inputs', () => {
+    const a = tossFlavor({ ...base, gainerName: 'Aces', net: 5, seed: 3 });
+    const b = tossFlavor({ ...base, gainerName: 'Aces', net: 5, seed: 3 });
+    expect(a).toEqual(b);
   });
 });

--- a/src/lib/games/cornhole/logic.ts
+++ b/src/lib/games/cornhole/logic.ts
@@ -15,6 +15,8 @@ export const ON_BOARD_POINTS = 1;
 export const BAGS_PER_SIDE = 4;
 /** Where the bust variant sends an overshooting side. */
 export const BUST_TO = 15;
+/** The most one side can rack up in a single frame — a four-bagger (4 × 3). */
+export const MAX_FRAME = BAGS_PER_SIDE * IN_HOLE_POINTS;
 
 /** One side's bags for a single round. */
 export interface SideThrow {
@@ -147,4 +149,133 @@ export function isWon(totals: Record<ID, number>, cfg: CornholeConfig): boolean 
   const top = sorted[0] ?? 0;
   const second = sorted.length > 1 ? (sorted[1] ?? 0) : -Infinity;
   return top >= cfg.target && top - second >= cfg.winBy;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UI helpers — a tactile "bag slot" model + framing flavor. Still pure and
+// Svelte-free, so the editor and the tests share the exact same logic. Nothing
+// here changes how a frame scores; it only shapes how the four bags are entered
+// and narrated.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Where a single tossed bag landed. */
+export type BagState = 'ground' | 'board' | 'hole';
+
+/** Point value of one bag by where it landed. */
+export function bagValue(s: BagState): number {
+  if (s === 'hole') return IN_HOLE_POINTS;
+  if (s === 'board') return ON_BOARD_POINTS;
+  return 0;
+}
+
+/**
+ * Expand a side's `{inHole, onBoard}` counts into an ordered row of four bag
+ * slots — holes first, then boards, then the ground. Deterministic so the same
+ * throw always paints the same row. Counts beyond four are clamped away (the
+ * editor never lets that happen, but stray data won't crash the row).
+ */
+export function slotsFromThrow(t: SideThrow | undefined, count = BAGS_PER_SIDE): BagState[] {
+  const inHole = bags(t?.inHole);
+  const onBoard = bags(t?.onBoard);
+  const slots: BagState[] = [];
+  for (let i = 0; i < count; i++) {
+    if (i < inHole) slots.push('hole');
+    else if (i < inHole + onBoard) slots.push('board');
+    else slots.push('ground');
+  }
+  return slots;
+}
+
+/** Fold a row of bag slots back into the `{inHole, onBoard}` counts the scorer reads. */
+export function throwFromSlots(slots: BagState[]): SideThrow {
+  let inHole = 0;
+  let onBoard = 0;
+  for (const s of slots) {
+    if (s === 'hole') inHole++;
+    else if (s === 'board') onBoard++;
+  }
+  return { inHole, onBoard };
+}
+
+/** Tapping a bag climbs it in value and wraps: ground → board → hole → ground. */
+export function cycleBag(s: BagState): BagState {
+  if (s === 'ground') return 'board';
+  if (s === 'board') return 'hole';
+  return 'ground';
+}
+
+/** True when a side sank all four bags in the hole — a four-bagger (worth {@link MAX_FRAME}). */
+export function isFourBagger(t: SideThrow | undefined): boolean {
+  return bags(t?.inHole) >= BAGS_PER_SIDE;
+}
+
+/**
+ * True when a side is close enough to the target that a big frame could overshoot
+ * and trip the bust rule back to {@link BUST_TO}. Only meaningful with bust on and a
+ * target above 15; drives the anticipatory "danger zone" on the race lane.
+ */
+export function bustRisk(total: number, cfg: Pick<CornholeConfig, 'target' | 'bust'>): boolean {
+  const t = Number(total) || 0;
+  return cfg.bust && cfg.target > BUST_TO && t < cfg.target && t + MAX_FRAME > cfg.target;
+}
+
+/** A narrated frame result — an emoji, a line of backyard patter, and a tone. */
+export interface FrameFlavor {
+  emoji: string;
+  text: string;
+  tone: 'good' | 'muted' | 'bad';
+}
+
+/** Deterministically pick one line from a list, rotated by `seed` (the round index). */
+function pick(list: string[], seed: number): string {
+  if (list.length === 0) return '';
+  const i = ((Math.trunc(seed) % list.length) + list.length) % list.length;
+  return list[i]!;
+}
+
+/**
+ * Turn a resolved frame into a playful, glanceable status line. Pure and
+ * deterministic (rotates variety off the round index), so the editor and tests
+ * agree on exactly what a frame says. The emoji + text always carry the meaning,
+ * so nothing here relies on color.
+ */
+export function tossFlavor(args: {
+  gainerName: string | null;
+  net: number;
+  aRaw: number;
+  bRaw: number;
+  busted: boolean;
+  fourBaggerName: string | null;
+  bothFourBaggers: boolean;
+  seed: number;
+}): FrameFlavor {
+  const { gainerName, net, aRaw, bRaw, busted, fourBaggerName, bothFourBaggers, seed } = args;
+
+  if (busted && gainerName) {
+    return { emoji: '💥', text: `${gainerName} overcooked it — bust back to ${BUST_TO}!`, tone: 'bad' };
+  }
+  if (bothFourBaggers) {
+    return { emoji: '🧺', text: 'Four-bagger each — the whole thing washes!', tone: 'muted' };
+  }
+  if (fourBaggerName && gainerName === fourBaggerName) {
+    return { emoji: '💣', text: `Four-bagger! ${fourBaggerName} sinks all four — +${net}`, tone: 'good' };
+  }
+  if (!gainerName) {
+    if (aRaw === 0 && bRaw === 0) {
+      return { emoji: '🌽', text: pick(['Nothing lands — corn in the dirt', 'Both sides whiff — no bags home'], seed), tone: 'muted' };
+    }
+    return {
+      emoji: '🧺',
+      text: pick(['Wash — bags cancel, nobody scores', 'All square — total wash', 'Even bags — it all cancels out'], seed),
+      tone: 'muted',
+    };
+  }
+
+  // A normal scoring frame — flavor scales a little with how big the swing was.
+  const line = net >= 6
+    ? pick([`${gainerName} buries it — +${net}`, `Huge frame! ${gainerName} +${net}`, `${gainerName} runs the board — +${net}`], seed)
+    : net >= 3
+      ? pick([`Drano! ${gainerName} +${net}`, `${gainerName} sinks one — +${net}`, `${gainerName} takes the frame — +${net}`], seed)
+      : pick([`That's a woody — ${gainerName} +${net}`, `${gainerName} edges it — +${net}`, `${gainerName} nudges ahead — +${net}`], seed);
+  return { emoji: '🌽', text: line, tone: 'good' };
 }


### PR DESCRIPTION
## Cornhole — Fun & UX overhaul 🌽

Cornhole scored correctly but its round editor was the plainest in the app — two abstract steppers, a "bags left" counter, and a one-line result. The signature **cancellation** rule was never *shown*, there was no **race-to-21**, and none of the brand's whimsy. This reworks the editor around the physical bag toss while keeping every bit of scoring math untouched in the Svelte-free `logic.ts`.

### What's new
- **Tactile tap-to-toss entry** (`BagTossRow.svelte`) — four bag chips per side; each tap cycles a bag **Ground (0) → 🫘 Woody (+1) → 🕳️ Drano (+3)**. Bags stay put in their slots, it's impossible to overfill, it's fast one-handed, and every chip is a labeled, keyboard/AT-accessible button with a haptic tick.
- **Race-to-21 lanes** (`RaceToTarget.svelte`) — both sides climbing toward the target in one glance, the current leader marked in **Crown Gold** (co-signalled by 👑 + number), a previewed band for the frame you're entering, and a **bust danger zone** when the bust rule is on and a side is within a big frame of overshooting.
- **Cancellation showdown** — the frame's math is now *visible*: `7 ⟷ 4 → Aces keep +3`, with the losing side struck through so "only the difference survives" is shown, not just asserted.
- **Earned whimsical moments** — a four-bagger 💣 celebration, the wash 🧺, bust dread 💥, and rotating backyard microcopy ("Drano!", "That's a woody", "Corn's in the air"). All icon + text co-signalled, never color alone.

### Logic & tests
- New **pure, dependency-free** helpers in `logic.ts` (`slotsFromThrow`, `throwFromSlots`, `cycleBag`, `bagValue`, `isFourBagger`, `bustRisk`, `tossFlavor`). The cancellation/bust/win-by scoring is unchanged.
- Added unit tests for every new helper (slot round-trips, tap cycle, four-bagger, bust-risk edges, deterministic flavor). Existing scoring tests untouched.

### Design system
Honors all non-negotiables: one Royal Violet action stays on the shell (none added here), **Crown Gold only for the leader**, depth via the surface ramp (no stacked shadows / stripes / decorative glass), `tabular-nums` on every changing number, ≥46px touch targets, state never carried by color alone, and `prefers-reduced-motion` respected throughout (all motion routed through `animateMotion`/`popIn`/`bumpOnChange`).

### Verification (local)
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — succeeds
- `npm test` — **1072 passed** (incl. new Cornhole tests)