### PR TITLE
Make Euchre more fun: big-moment celebrations, race-to-10 peg track, role clarity

### DIFF
--- a/src/lib/games/euchre/EuchreEditor.svelte
+++ b/src/lib/games/euchre/EuchreEditor.svelte
@@ -1,15 +1,28 @@
 <script lang="ts">
   import type { Player, RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
+  import { prefersReducedMotion } from '../../motion';
   import { euchre } from './index';
-  import { handPoints, optionsFromConfig, type EuchreInput, type HandResult, type TeamIndex } from './logic';
+  import {
+    celebrationFor,
+    leadingTeam,
+    optionsFromConfig,
+    targetFromConfig,
+    teamTotals,
+    toTarget,
+    type EuchreInput,
+    type HandResult,
+    type TeamIndex,
+  } from './logic';
 
   let { input = $bindable(), ctx }: { input: EuchreInput; ctx: RoundContext } = $props();
 
   let showRules = $state(false);
+  const reduced = prefersReducedMotion();
 
   const byId = $derived(new Map(ctx.players.map((p) => [p.id, p])));
   const opts = $derived(optionsFromConfig(ctx.config));
+  const target = $derived(targetFromConfig(ctx.config));
 
   function members(idx: TeamIndex): Player[] {
     return (input.teams[idx] ?? [])
@@ -23,26 +36,40 @@
 
   const makerMembers = $derived(input.maker == null ? [] : members(input.maker));
 
+  // Race to the barn: team totals BEFORE this hand, and who's out front.
+  const scores = $derived(teamTotals(input.teams, ctx.totals));
+  const leader = $derived(leadingTeam(scores));
+
+  // Role each team is playing this hand, once a caller is picked.
+  function role(idx: TeamIndex): 'makers' | 'defenders' | null {
+    if (input.maker == null) return null;
+    return input.maker === idx ? 'makers' : 'defenders';
+  }
+
   const results: { value: HandResult; emoji: string; label: string; hint: string }[] = [
     { value: 'made', emoji: '✋', label: 'Made', hint: '3–4' },
     { value: 'march', emoji: '🧹', label: 'March', hint: 'all 5' },
     { value: 'euchred', emoji: '🚫', label: 'Euchred', hint: 'set' },
   ];
 
-  const preview = $derived.by(() => {
-    if (input.maker == null || input.result == null) return null;
+  // The staged drama for the chosen hand — emoji, copy, points, and whether it's a
+  // "big" moment worth a flourish. Team names are composed here from the module logic.
+  const cel = $derived(
+    input.maker == null || input.result == null
+      ? null
+      : celebrationFor(input.result, input.alone, opts),
+  );
+  const scoringTeam = $derived.by(() => {
+    if (input.maker == null || input.result == null) return '';
     const makerIdx = input.maker;
     const defIdx = (makerIdx === 0 ? 1 : 0) as TeamIndex;
-    const p = handPoints(input.result, input.alone, opts);
-    const lone = input.alone ? ' alone' : '';
-    if (input.result === 'euchred') {
-      return { text: `${teamLabel(defIdx)} euchre ${teamLabel(makerIdx)}`, pts: p.defenders };
-    }
-    if (input.result === 'march') {
-      return { text: `${teamLabel(makerIdx)}${lone} march`, pts: p.maker };
-    }
-    return { text: `${teamLabel(makerIdx)}${lone} make it`, pts: p.maker };
+    return input.result === 'euchred' ? teamLabel(defIdx) : teamLabel(makerIdx);
   });
+  // Replays the flourish whenever the recorded outcome changes.
+  const celKey = $derived(`${input.maker}-${input.result}-${input.alone}`);
+  const celClass = $derived(
+    cel?.tone === 'euchred' ? 'stamp' : cel?.lone ? 'howl' : cel?.tone === 'march' ? 'sweep' : '',
+  );
 
   function setMaker(idx: TeamIndex) {
     input.maker = idx;
@@ -73,11 +100,43 @@
     <pre class="help">{euchre.help}</pre>
   {/if}
 
+  <div class="race" aria-label="Race to {target}">
+    {#each [0, 1] as idx (idx)}
+      {@const ti = idx as TeamIndex}
+      {@const s = scores[ti]}
+      {@const ahead = leader === ti}
+      <div class="racerow" class:lead={ahead}>
+        <div class="racetop">
+          <span class="racename">
+            {#if ahead}<span class="crown" aria-hidden="true">👑</span>{/if}
+            {teamLabel(ti)}
+          </span>
+          <span class="racescore" class:lead={ahead}>{s}</span>
+        </div>
+        {#if target <= 16}
+          <div class="pips" aria-hidden="true">
+            {#each Array(target) as _, i (i)}
+              <span class="pip" class:on={i < s} class:gold={ahead && i < s}></span>
+            {/each}
+          </div>
+        {:else}
+          <div class="bar" aria-hidden="true">
+            <span class="fill" class:gold={ahead} style="width: {Math.min(100, (s / target) * 100)}%"></span>
+          </div>
+        {/if}
+        <span class="tobarn">
+          {#if s >= target}🏁 at the barn{:else}{toTarget(s, target)} to the barn{/if}
+        </span>
+      </div>
+    {/each}
+  </div>
+
   <div class="field">
     <div class="qlabel">Who called it up?</div>
     <div class="teams">
       {#each [0, 1] as idx (idx)}
         {@const ti = idx as TeamIndex}
+        {@const r = role(ti)}
         <button
           type="button"
           class="teambtn"
@@ -85,7 +144,9 @@
           aria-pressed={input.maker === ti}
           onclick={() => setMaker(ti)}
         >
-          <span class="teamtag">Team {idx + 1}</span>
+          <span class="teamtag" class:makers={r === 'makers'} class:defenders={r === 'defenders'}>
+            {r === 'makers' ? 'Makers' : r === 'defenders' ? 'Defenders' : `Team ${idx + 1}`}
+          </span>
           <span class="avatars">
             {#each members(ti) as p (p.id)}
               <Avatar name={p.name} color={p.color} size={26} />
@@ -95,39 +156,6 @@
         </button>
       {/each}
     </div>
-  </div>
-
-  <div class="field">
-    <button
-      type="button"
-      class="alonebtn"
-      class:on={input.alone}
-      aria-pressed={input.alone}
-      onclick={toggleAlone}
-    >
-      🐺 Going alone
-    </button>
-    {#if input.alone}
-      {#if input.maker == null}
-        <div class="muted hint" style="margin-top: 8px">Pick the calling team first.</div>
-      {:else}
-        <div class="qlabel" style="margin-top: 10px">Who went alone?</div>
-        <div class="who">
-          {#each makerMembers as p (p.id)}
-            <button
-              type="button"
-              class="whobtn"
-              class:on={input.alonePlayer === p.id}
-              aria-pressed={input.alonePlayer === p.id}
-              onclick={() => setAlonePlayer(p.id)}
-            >
-              <Avatar name={p.name} color={p.color} size={24} />
-              {p.name}
-            </button>
-          {/each}
-        </div>
-      {/if}
-    {/if}
   </div>
 
   <div class="field">
@@ -149,10 +177,49 @@
     </div>
   </div>
 
-  <div class="preview" class:ready={!!preview}>
-    {#if preview}
-      <span class="ptext">{preview.text}</span>
-      <strong class="pts score-good">+{preview.pts}</strong>
+  <div class="field">
+    <button
+      type="button"
+      class="alonebtn"
+      class:on={input.alone}
+      aria-pressed={input.alone}
+      onclick={toggleAlone}
+    >
+      🐺 Going alone
+    </button>
+    {#if input.alone}
+      {#if input.maker == null}
+        <div class="muted hint" style="margin-top: 8px">Pick the calling team first.</div>
+      {:else}
+        <div class="qlabel" style="margin-top: 10px">Who braved it alone?</div>
+        <div class="who">
+          {#each makerMembers as p (p.id)}
+            <button
+              type="button"
+              class="whobtn"
+              class:on={input.alonePlayer === p.id}
+              aria-pressed={input.alonePlayer === p.id}
+              onclick={() => setAlonePlayer(p.id)}
+            >
+              <Avatar name={p.name} color={p.color} size={24} />
+              {p.name}
+            </button>
+          {/each}
+        </div>
+      {/if}
+    {/if}
+  </div>
+
+  <div class="preview" class:ready={!!cel} class:big={cel?.big}>
+    {#if cel}
+      {#key celKey}
+        <span class="cel-emoji" class:animate={cel.big && !reduced} class:sweep={celClass === 'sweep'} class:howl={celClass === 'howl'} class:stamp={celClass === 'stamp'} aria-hidden="true">{cel.emoji}</span>
+      {/key}
+      <span class="cel-copy">
+        <span class="cel-head">{cel.headline}</span>
+        <span class="cel-cheer">{scoringTeam} · {cel.cheer}</span>
+      </span>
+      <strong class="pts score-good">+{cel.points}</strong>
     {:else}
       <span class="muted">Pick the calling team and the result.</span>
     {/if}
@@ -172,6 +239,87 @@
     color: var(--muted);
     margin-bottom: 8px;
   }
+
+  /* Race to the barn — the euchre costume on top of the shared scoreboard. */
+  .race {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+  }
+  .racerow {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .racetop {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .racename {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 700;
+    min-width: 0;
+  }
+  .crown {
+    font-size: 0.95rem;
+    line-height: 1;
+  }
+  .racescore {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .racescore.lead {
+    color: var(--accent-ink);
+  }
+  .pips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+  .pip {
+    width: 10px;
+    height: 10px;
+    border-radius: var(--radius-pill, 999px);
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+  }
+  .pip.on {
+    background: var(--muted);
+    border-color: var(--muted);
+  }
+  .pip.gold {
+    background: var(--accent);
+    border-color: var(--accent);
+  }
+  .bar {
+    height: 8px;
+    border-radius: var(--radius-pill, 999px);
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    overflow: hidden;
+  }
+  .fill {
+    display: block;
+    height: 100%;
+    background: var(--muted);
+  }
+  .fill.gold {
+    background: var(--accent);
+  }
+  .tobarn {
+    font-size: 0.72rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+
   .teams {
     display: flex;
     gap: 10px;
@@ -185,7 +333,7 @@
     min-height: 46px;
     padding: 12px 10px;
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     background: var(--surface-2);
     color: var(--text);
     cursor: pointer;
@@ -201,6 +349,10 @@
     letter-spacing: 0.06em;
     text-transform: uppercase;
     opacity: 0.75;
+  }
+  .teamtag.makers {
+    opacity: 1;
+    font-weight: 700;
   }
   .avatars {
     display: flex;
@@ -218,7 +370,7 @@
     min-height: 46px;
     padding: 10px 16px;
     border: 1px solid var(--border);
-    border-radius: 999px;
+    border-radius: var(--radius-pill, 999px);
     background: var(--surface-2);
     color: var(--text);
     cursor: pointer;
@@ -241,7 +393,7 @@
     min-height: 46px;
     padding: 8px 14px;
     border: 1px solid var(--border);
-    border-radius: 999px;
+    border-radius: var(--radius-pill, 999px);
     background: var(--surface);
     color: var(--text);
     cursor: pointer;
@@ -266,7 +418,7 @@
     min-height: 46px;
     padding: 10px 6px;
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     background: var(--surface);
     color: var(--text);
     cursor: pointer;
@@ -287,33 +439,87 @@
     font-size: 0.72rem;
     opacity: 0.7;
   }
+
   .preview {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: 12px;
     min-height: 46px;
     padding: 10px 14px;
     border: 1px dashed var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     background: var(--surface-2);
   }
   .preview.ready {
     border-style: solid;
   }
-  .ptext {
-    font-weight: 600;
+  .preview.big {
+    background: var(--surface-3);
+  }
+  .cel-emoji {
+    flex: 0 0 auto;
+    font-size: 1.5rem;
+    line-height: 1;
+  }
+  .cel-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .cel-head {
+    font-weight: 800;
+  }
+  .cel-cheer {
+    font-size: 0.8rem;
+    color: var(--muted);
   }
   .pts {
+    flex: 0 0 auto;
     font-size: 1.2rem;
     font-weight: 800;
     font-variant-numeric: tabular-nums;
   }
+
+  .cel-emoji.animate.sweep {
+    animation: eu-sweep 600ms ease-out both;
+  }
+  .cel-emoji.animate.howl {
+    animation: eu-howl 700ms ease-out both;
+  }
+  .cel-emoji.animate.stamp {
+    animation: eu-stamp 520ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+  @keyframes eu-sweep {
+    0% { transform: translateX(-12px) rotate(-14deg); opacity: 0.2; }
+    60% { transform: translateX(5px) rotate(9deg); opacity: 1; }
+    100% { transform: none; }
+  }
+  @keyframes eu-howl {
+    0% { transform: scale(0.6); opacity: 0.2; }
+    40% { transform: scale(1.25); opacity: 1; }
+    55% { transform: scale(1.1) rotate(-7deg); }
+    70% { transform: scale(1.18) rotate(7deg); }
+    100% { transform: scale(1); }
+  }
+  @keyframes eu-stamp {
+    0% { transform: scale(1.8) rotate(-14deg); opacity: 0; }
+    55% { transform: scale(0.82) rotate(4deg); opacity: 1; }
+    75% { transform: scale(1.07); }
+    100% { transform: scale(1) rotate(0); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .cel-emoji.animate {
+      animation: none !important;
+    }
+  }
+
   .help {
     white-space: pre-wrap;
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 10px;
+    border-radius: var(--radius-chip);
     padding: 12px;
     font-size: 0.85rem;
     margin: 0;

--- a/src/lib/games/euchre/euchre.test.ts
+++ b/src/lib/games/euchre/euchre.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, it } from 'vitest';
-import type { ID, RoundContext, Round } from '../../types';
+import type { ID, RoundContext, Round, Game } from '../../types';
 import { euchre } from './index';
+import { euchreStats } from './stats';
 import {
   DEFAULT_OPTIONS,
+  celebrationFor,
   describeHand,
   handPoints,
+  leadingTeam,
   optionsFromConfig,
   pairingFromConfig,
   resolveTeams,
   scoreEuchre,
   targetFromConfig,
+  teamTotals,
+  toTarget,
   validateEuchre,
   type EuchreInput,
 } from './logic';
@@ -203,6 +208,79 @@ describe('describeHand', () => {
   });
 });
 
+describe('celebrationFor', () => {
+  it('keeps a plain made hand quiet (no flourish)', () => {
+    const c = celebrationFor('made', false);
+    expect(c.big).toBe(false);
+    expect(c.tone).toBe('made');
+    expect(c.emoji).toBe('✋');
+    expect(c.points).toBe(1);
+  });
+
+  it('celebrates a march as a clean sweep worth 2', () => {
+    const c = celebrationFor('march', false);
+    expect(c.big).toBe(true);
+    expect(c.lone).toBe(false);
+    expect(c.emoji).toBe('🧹');
+    expect(c.headline).toMatch(/sweep/i);
+    expect(c.points).toBe(2);
+    expect(c.cheer).toContain('+2');
+  });
+
+  it('lifts a lone sweep to the wolf and 4 points (default bonus)', () => {
+    const c = celebrationFor('march', true);
+    expect(c.big).toBe(true);
+    expect(c.lone).toBe(true);
+    expect(c.emoji).toBe('🐺');
+    expect(c.headline).toMatch(/loner/i);
+    expect(c.points).toBe(4);
+    expect(c.cheer).toContain('+4');
+  });
+
+  it('drops a lone sweep back to 2 when the alone bonus is off', () => {
+    const c = celebrationFor('march', true, { aloneBonus: false, loneEuchreBonus: false });
+    expect(c.points).toBe(2);
+    expect(c.cheer).toContain('+2');
+  });
+
+  it('stamps a euchre and pays the defenders', () => {
+    const c = celebrationFor('euchred', false);
+    expect(c.big).toBe(true);
+    expect(c.emoji).toBe('🚫');
+    expect(c.headline).toMatch(/euchred/i);
+    expect(c.points).toBe(2);
+  });
+
+  it('pays 4 for euchring a loner when that house rule is on', () => {
+    const c = celebrationFor('euchred', true, { aloneBonus: true, loneEuchreBonus: true });
+    expect(c.points).toBe(4);
+    expect(c.cheer).toContain('+4');
+  });
+});
+
+describe('race to the barn', () => {
+  it('reads each team total from the mirrored partner scores', () => {
+    expect(teamTotals(ADJACENT, { a: 7, b: 7, c: 4, d: 4 })).toEqual([7, 4]);
+  });
+
+  it('is robust to a partner missing from the totals map', () => {
+    expect(teamTotals(ADJACENT, { a: 6, c: 3 })).toEqual([6, 3]);
+  });
+
+  it('names the leading team, or null on a tie', () => {
+    expect(leadingTeam([7, 4])).toBe(0);
+    expect(leadingTeam([4, 7])).toBe(1);
+    expect(leadingTeam([5, 5])).toBeNull();
+    expect(leadingTeam([0, 0])).toBeNull();
+  });
+
+  it('counts points still needed, never below zero', () => {
+    expect(toTarget(6, 10)).toBe(4);
+    expect(toTarget(10, 10)).toBe(0);
+    expect(toTarget(12, 10)).toBe(0);
+  });
+});
+
 describe('config coercion', () => {
   it('pairing defaults to adjacent', () => {
     expect(pairingFromConfig({})).toBe('adjacent');
@@ -292,5 +370,51 @@ describe('euchre module', () => {
     );
     // every hand shifted only one team
     expect(sum(euchre.scoreRound(hands[0], ctx()))).toBe(4); // march = 2 to each of two partners
+  });
+});
+
+describe('euchreStats', () => {
+  const games: Game[] = [
+    { id: 'g', type: 'euchre', config: {}, playerIds: ['a', 'b', 'c', 'd'], status: 'finished', createdAt: 0, roundCount: 4 } as Game,
+  ];
+  const mkRound = (index: number, input: EuchreInput): Round =>
+    ({ id: `r${index}`, gameId: 'g', index, input, deltas: {}, createdAt: 0 }) as Round;
+  const rounds: Round[] = [
+    mkRound(0, mk({ maker: 0, result: 'march' })),
+    mkRound(1, mk({ maker: 0, result: 'made' })),
+    mkRound(2, mk({ maker: 0, result: 'euchred' })),
+    mkRound(3, mk({ maker: 0, result: 'march', alone: true, alonePlayer: 'a' })),
+  ];
+  const out = euchreStats({ games, rounds, players: [], canonical: (id: ID) => id });
+
+  const metric = (id: ID, key: string) => out.perPlayer?.[id]?.find((m) => m.key === key);
+  const g = (key: string) => out.global?.find((m) => m.key === key);
+
+  it('counts marches per caller', () => {
+    expect(metric('a', 'eu_march')?.value).toBe('2');
+    expect(metric('b', 'eu_march')?.value).toBe('2');
+  });
+
+  it('tracks how often a team got set', () => {
+    expect(metric('a', 'eu_set')?.value).toBe('1');
+  });
+
+  it('credits landed euchres to the defenders', () => {
+    expect(metric('c', 'eu_euchre')?.value).toBe('1');
+    expect(metric('d', 'eu_euchre')?.value).toBe('1');
+  });
+
+  it('headlines a lone sweep to the individual who braved it', () => {
+    const lone = metric('a', 'eu_lone');
+    expect(lone?.label).toBe('Lone sweeps');
+    expect(lone?.value).toBe('1');
+    // the partner who sat out gets no lone credit
+    expect(metric('b', 'eu_lone')).toBeUndefined();
+  });
+
+  it('reports global make and march rates over all hands', () => {
+    expect(g('eu_make_all')?.value).toBe('75%'); // 3 of 4 made
+    expect(g('eu_march_all')?.value).toBe('50%'); // 2 of 4 swept
+    expect(g('eu_euchre_all')?.value).toBe('1');
   });
 });

--- a/src/lib/games/euchre/logic.ts
+++ b/src/lib/games/euchre/logic.ts
@@ -147,6 +147,108 @@ export function describeHand(
   return `✋ ${makers} made it${lone} ${plus}`;
 }
 
+// --- celebration: the whimsical, earned "big moment" for a recorded hand ---
+
+/**
+ * The card-table drama of a hand, ready for the editor to stage. `big` marks the
+ * three moments worth a flourish (a march, a lone sweep, a euchre); an ordinary made
+ * hand stays deliberately quiet so the loud moments keep their scarcity. `points` is
+ * what the *scoring* side takes this hand (makers on made/march, defenders on a euchre),
+ * derived through {@link handPoints} so the copy always matches the recorded score —
+ * even under house-rule bonuses. Pure (no Svelte) so it's unit-testable.
+ */
+export interface Celebration {
+  tone: HandResult;
+  lone: boolean;
+  /** Deserves an animated flourish (march, lone sweep, or euchre). */
+  big: boolean;
+  emoji: string;
+  headline: string;
+  cheer: string;
+  /** Points to the side that scored this hand. */
+  points: number;
+}
+
+export function celebrationFor(
+  result: HandResult,
+  alone: boolean,
+  opts: EuchreOptions = DEFAULT_OPTIONS,
+): Celebration {
+  const p = handPoints(result, alone, opts);
+  if (result === 'euchred') {
+    const pts = p.defenders;
+    return {
+      tone: 'euchred',
+      lone: alone,
+      big: true,
+      emoji: '🚫',
+      headline: 'Euchred!',
+      cheer: alone
+        ? `Set a loner — defenders take +${pts}!`
+        : `Set them — defenders take +${pts}.`,
+      points: pts,
+    };
+  }
+  if (result === 'march') {
+    const pts = p.maker;
+    return alone
+      ? {
+          tone: 'march',
+          lone: true,
+          big: true,
+          emoji: '🐺',
+          headline: 'Loner sweep!',
+          cheer: `Alone. All five. Legendary — +${pts}.`,
+          points: pts,
+        }
+      : {
+          tone: 'march',
+          lone: false,
+          big: true,
+          emoji: '🧹',
+          headline: 'Clean sweep!',
+          cheer: `All five tricks — march for +${pts}.`,
+          points: pts,
+        };
+  }
+  // made (3–4 tricks): quiet by design.
+  return {
+    tone: 'made',
+    lone: alone,
+    big: false,
+    emoji: '✋',
+    headline: alone ? 'Made it — alone' : 'Made it',
+    cheer: `Three or four tricks — banked for +${p.maker}.`,
+    points: p.maker,
+  };
+}
+
+// --- race to the barn: team totals + who's leading, for the peg track ---
+
+/**
+ * Each team's running score. Both partners mirror the team total (see {@link scoreEuchre}),
+ * so the max across a team's members is the team score and is robust to a missing id.
+ */
+export function teamTotals(
+  teams: [ID[], ID[]],
+  totals: Record<ID, number>,
+): [number, number] {
+  const score = (team: ID[]): number =>
+    team.length ? Math.max(...team.map((id) => totals[id] ?? 0)) : 0;
+  return [score(teams[0] ?? []), score(teams[1] ?? [])];
+}
+
+/** The team in front, or null on a tie (including 0–0). */
+export function leadingTeam(scores: [number, number]): TeamIndex | null {
+  if (scores[0] === scores[1]) return null;
+  return scores[0] > scores[1] ? 0 : 1;
+}
+
+/** Tricks-to-the-barn: points a team still needs to hit the target (never negative). */
+export function toTarget(score: number, target: number): number {
+  return Math.max(0, target - score);
+}
+
 // --- config coercion (config values arrive as `unknown` from stored game config) ---
 
 export function pairingFromConfig(config: Record<string, unknown>): Pairing {

--- a/src/lib/games/euchre/stats.ts
+++ b/src/lib/games/euchre/stats.ts
@@ -12,6 +12,8 @@ interface EuAgg {
   marches: number;
   /** Hands this player's team euchred the makers. */
   euchresLanded: number;
+  /** Hands this player's team called it and got set (euchred). */
+  setAgainst: number;
   /** Hands this player personally played alone. */
   loneCalls: number;
   /** Lone hands that swept all five. */
@@ -30,7 +32,7 @@ export function euchreStats({ games, rounds, canonical }: GameStatsInput): GameS
   const get = (id: ID): EuAgg => {
     let a = per.get(id);
     if (!a) {
-      a = { called: 0, makes: 0, marches: 0, euchresLanded: 0, loneCalls: 0, loneSweeps: 0 };
+      a = { called: 0, makes: 0, marches: 0, euchresLanded: 0, setAgainst: 0, loneCalls: 0, loneSweeps: 0 };
       per.set(id, a);
     }
     return a;
@@ -60,6 +62,7 @@ export function euchreStats({ games, rounds, canonical }: GameStatsInput): GameS
       a.called += 1;
       if (made) a.makes += 1;
       if (input.result === 'march') a.marches += 1;
+      if (input.result === 'euchred') a.setAgainst += 1;
     }
     if (input.result === 'euchred') {
       for (const pid of defTeam) get(canonical(pid)).euchresLanded += 1;
@@ -84,17 +87,32 @@ export function euchreStats({ games, rounds, canonical }: GameStatsInput): GameS
       });
     }
     if (a.marches) {
-      metrics.push({ key: 'eu_march', label: 'Marches', value: fmtInt(a.marches), emoji: '🧹' });
+      metrics.push({
+        key: 'eu_march',
+        label: 'Marches',
+        value: fmtInt(a.marches),
+        sub: a.called ? fmtPct(a.marches / a.called) : undefined,
+        emoji: '🧹',
+      });
     }
     if (a.euchresLanded) {
       metrics.push({ key: 'eu_euchre', label: 'Euchres landed', value: fmtInt(a.euchresLanded), emoji: '🚫' });
     }
+    if (a.setAgainst) {
+      metrics.push({
+        key: 'eu_set',
+        label: 'Got set',
+        value: fmtInt(a.setAgainst),
+        sub: a.called ? fmtPct(a.setAgainst / a.called) : undefined,
+        emoji: '😬',
+      });
+    }
     if (a.loneCalls) {
       metrics.push({
         key: 'eu_lone',
-        label: 'Went alone',
-        value: fmtInt(a.loneCalls),
-        sub: a.loneSweeps ? `${a.loneSweeps} swept` : undefined,
+        label: a.loneSweeps ? 'Lone sweeps' : 'Went alone',
+        value: fmtInt(a.loneSweeps || a.loneCalls),
+        sub: a.loneSweeps ? `${a.loneSweeps}/${a.loneCalls} alone` : `${a.loneCalls} alone`,
         emoji: '🐺',
       });
     }
@@ -104,7 +122,14 @@ export function euchreStats({ games, rounds, canonical }: GameStatsInput): GameS
   const global: Metric[] = [];
   if (hands) {
     global.push({ key: 'eu_make_all', label: 'Make rate', value: fmtPct(makes / hands), emoji: '🎯' });
-    if (marches) global.push({ key: 'eu_march_all', label: 'Marches', value: fmtInt(marches), emoji: '🧹' });
+    if (marches)
+      global.push({
+        key: 'eu_march_all',
+        label: 'March rate',
+        value: fmtPct(marches / hands),
+        sub: `${marches} sweep${marches === 1 ? '' : 's'}`,
+        emoji: '🧹',
+      });
     if (euchres) global.push({ key: 'eu_euchre_all', label: 'Euchres', value: fmtInt(euchres), emoji: '🚫' });
   }
 


### PR DESCRIPTION
## Why

Euchre's scoring was mechanically solid but emotionally flat — a **march**, a **4-point loner sweep**, and getting **euchred** all saved with the same quiet green `+N` as a humble `+1`, and nothing showed the famous **race to 10**. This gives Euchre its card-table costume while keeping the app chrome identical game-to-game (only `src/lib/games/euchre/` changed).

## What's new

**🎉 Big-moment celebrations** (in the round editor)
- 🧹 broom-sweep flourish for a **march**
- 🐺 lone-wolf howl for the **4-point loner sweep** (the game's biggest swing)
- 🚫 cheeky **EUCHRED!** stamp for a set
- A plain **+1** stays deliberately quiet so the loud moments keep their scarcity
- Every flourish has a `prefers-reduced-motion` alternative (emoji + copy, no animation)

**🏁 Race-to-the-barn peg track** (thematic scoreboard costume, on top of the unchanged shared board)
- Two team rows with pips filling toward the target (slim progress-bar fallback for large targets)
- Team scores in `tabular-nums`; **Crown Gold + 👑 reserved for the leading team only**, never signalling by colour alone
- Shows "N to the barn" for each team

**🎭 Role clarity + flow polish**
- Live **MAKERS / DEFENDERS** tags on the team buttons once a caller is picked
- Reordered entry: **caller → result → going alone**
- Light card-table microcopy

**📊 Bragging-rights stats**
- Headline **lone sweeps**, **got-set** rate, and **march rate** per player and globally

## Design notes
Honors the non-negotiables: one Royal Violet primary (unchanged Save button), Crown Gold = leader only, depth via the surface ramp, `tabular-nums` on every changing number, ≥46px targets, never colour-alone, reduced-motion alternatives. Off-scale `12px` radii in the pre-existing editor were migrated to design tokens. All whimsy lives in the per-game editor — the shared shell, scoreboard, nav, and save-toast are untouched.

## Testing (local)
- `npm run check` — svelte-check + tsc: **0 errors, 0 warnings**
- `npm test` — full suite **1087 passing** (52 in euchre, incl. new celebration/peg/stats coverage)
- `npm run build` — production build + PWA succeed

Pure celebration/peg helpers live in the Svelte-free `logic.ts` so they stay unit-testable.