### PR TITLE
Exploding Kittens: explosive whimsy glow-up + optional defuse tracking

### DIFF
--- a/src/lib/games/explodingkittens/ExplodingKittensEditor.svelte
+++ b/src/lib/games/explodingkittens/ExplodingKittensEditor.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
   import type { ID, RoundContext } from '../../types';
+  import { untrack } from 'svelte';
   import Avatar from '../../components/Avatar.svelte';
   import { ordinal } from '../../stats/format';
+  import { animateMotion, popIn } from '../../motion';
+  import { haptic } from '../../haptics';
+  import KittenCountdown from './KittenCountdown.svelte';
+  import KaboomBurst from './KaboomBurst.svelte';
   import type { EKInput } from './logic';
 
   let { input = $bindable(), ctx }: { input: EKInput; ctx: RoundContext } = $props();
 
   const trackOrder = $derived(ctx.config.trackOrder !== false);
+  const trackDefuses = $derived(!!ctx.config.trackDefuses);
   const imploding = $derived(!!ctx.config.imploding);
 
   const outIndex = (id: ID): number => input.order.indexOf(id);
@@ -17,12 +23,55 @@
   // exploded — crowned automatically so entry is a string of single taps.
   const survivorId = $derived(trackOrder ? (alive.length === 1 ? alive[0].id : null) : input.winner);
 
+  // Live ribbing: the first to blow (💥) and — once a match is decided — the runner-up
+  // who was one draw from surviving (😾). Personality that lands at the table, not just
+  // buried in Stats later.
+  const firstOutId = $derived(input.order[0] ?? null);
+  const runnerUpId = $derived(
+    survivorId && input.order.length ? input.order[input.order.length - 1] : null,
+  );
+
+  // Seats for the countdown costume: alive 🐱 / exploded 💥 / survivor 👑.
+  const seats = $derived(
+    ctx.players.map((p) => {
+      const oi = outIndex(p.id);
+      const state: 'alive' | 'out' | 'survivor' =
+        survivorId === p.id ? 'survivor' : oi >= 0 ? 'out' : 'alive';
+      return { id: p.id, name: p.name, color: p.color, state, outRank: oi >= 0 ? oi + 1 : 0 };
+    }),
+  );
+  const aliveCount = $derived(seats.filter((s) => s.state === 'alive').length);
+  const survivorName = $derived(
+    survivorId ? (ctx.players.find((p) => p.id === survivorId)?.name ?? null) : null,
+  );
+
+  // Per-row explosion tokens (bump → the 💥 burst replays on that row) and a single
+  // token for the last-kitten-standing win blast.
+  let boomToken = $state<Record<ID, number>>({});
+  let crownToken = $state(0);
+
+  // Don't fire the win beat for a survivor that was already crowned when this editor
+  // opened (e.g. editing a finished match) — only for a fresh crowning during entry.
+  let prevSurvivor: ID | null = untrack(() => survivorId);
+  $effect(() => {
+    const s = survivorId;
+    if (s && s !== prevSurvivor) {
+      crownToken += 1;
+      haptic('win');
+    }
+    prevSurvivor = s;
+  });
+
   function syncWinner() {
     input.winner = alive.length === 1 ? alive[0].id : null;
   }
 
   function eliminate(id: ID) {
-    if (!input.order.includes(id)) input.order = [...input.order, id];
+    if (!input.order.includes(id)) {
+      input.order = [...input.order, id];
+      boomToken[id] = (boomToken[id] ?? 0) + 1;
+      haptic('save');
+    }
     syncWinner();
   }
   function revive(id: ID) {
@@ -33,101 +82,180 @@
   function crown(id: ID) {
     input.winner = input.winner === id ? null : id;
   }
+
+  function defuseCount(id: ID): number {
+    return input.defuses?.[id] ?? 0;
+  }
+  function defuse(id: ID) {
+    const d = { ...(input.defuses ?? {}) };
+    d[id] = (d[id] ?? 0) + 1;
+    input.defuses = d;
+    haptic('tick');
+  }
+  function undefuse(id: ID) {
+    const d = { ...(input.defuses ?? {}) };
+    const next = (d[id] ?? 0) - 1;
+    if (next > 0) d[id] = next;
+    else delete d[id];
+    input.defuses = d;
+  }
+
+  // Svelte action: a quick shake when a row explodes (token bumps). Motion-only — the
+  // 💥 chip, struck name and rank already carry "out" — so it auto-skips under reduced
+  // motion via animateMotion.
+  function shakeOn(node: HTMLElement, token: number) {
+    let prev = token;
+    return {
+      update(next: number) {
+        if (next !== prev && next > 0) {
+          animateMotion(
+            node,
+            { x: [0, -5, 5, -3, 3, 0], rotate: [0, -1.5, 1.5, -1, 0.6, 0] },
+            { duration: 0.4, ease: 'easeOut' },
+          );
+        }
+        prev = next;
+      },
+    };
+  }
 </script>
 
 <div class="stack">
-  <div class="row spread">
-    <span class="muted">
-      {#if trackOrder}
-        Tap each kitten as they 💥 explode — the survivor is crowned.
-      {:else}
-        Tap the last kitten standing 👑
-      {/if}
-    </span>
-    {#if survivorId}
-      <span class="pill survived">👑 {ctx.players.find((p) => p.id === survivorId)?.name} survives</span>
-    {:else if trackOrder}
-      <span class="pill"><span class="num">{alive.length}</span> still in play</span>
-    {:else}
-      <span class="pill">no survivor yet</span>
-    {/if}
-  </div>
+  <KittenCountdown {seats} {aliveCount} {survivorName} {imploding} />
 
   {#if imploding}
-    <div class="reminder">☠️ <span>Imploding Kitten in play — it can’t be defused.</span></div>
+    <div class="reminder menace">
+      ☠️ <span><strong>Imploding Kitten in play.</strong> No defuse for this one — flip it and you’re gone.</span>
+    </div>
   {/if}
+
+  <span class="prompt muted">
+    {#if survivorId}
+      🎉 Match over — the last kitten reigns. Save it to bank the win.
+    {:else if trackOrder}
+      Tap each kitten the instant it goes 💥 — I’ll crown the survivor.
+    {:else}
+      Tap the last kitten standing 👑
+    {/if}
+  </span>
 
   <div class="stack list">
     {#each ctx.players as p (p.id)}
-      {#if survivorId === p.id}
-        <div class="krow survivor" aria-label="{p.name} is the last kitten standing">
-          <span class="who">
-            <Avatar name={p.name} color={p.color} />
-            <strong>{p.name}</strong>
-          </span>
-          <span class="badge crown">👑 Survivor</span>
-        </div>
-      {:else if trackOrder && isOut(p.id)}
-        <button
-          type="button"
-          class="krow out"
-          onclick={() => revive(p.id)}
-          aria-label="Bring {p.name} back in — they were the {ordinal(outIndex(p.id) + 1)} out"
-        >
-          <span class="who">
-            <Avatar name={p.name} color={p.color} />
-            <span class="name">{p.name}</span>
-          </span>
-          <span class="badge boom">💥 <span class="num">{ordinal(outIndex(p.id) + 1)}</span> out</span>
-        </button>
-      {:else if trackOrder}
-        <button
-          type="button"
-          class="krow"
-          onclick={() => eliminate(p.id)}
-          aria-label="{p.name} exploded"
-        >
-          <span class="who">
-            <Avatar name={p.name} color={p.color} />
-            <strong>{p.name}</strong>
-          </span>
-          <span class="badge action">💥 Out</span>
-        </button>
-      {:else}
-        <button
-          type="button"
-          class="krow pick"
-          class:on={input.winner === p.id}
-          onclick={() => crown(p.id)}
-          aria-pressed={input.winner === p.id}
-        >
-          <span class="who">
-            <Avatar name={p.name} color={p.color} />
-            <strong>{p.name}</strong>
-          </span>
-          <span class="badge">{input.winner === p.id ? '👑 Survivor' : 'Tap to crown'}</span>
-        </button>
-      {/if}
+      {@const dc = defuseCount(p.id)}
+      <div class="krow-wrap" use:shakeOn={boomToken[p.id] ?? 0}>
+        {#if survivorId === p.id}
+          <div class="krow survivor" aria-label="{p.name} is the last kitten standing">
+            <span class="who">
+              <Avatar name={p.name} color={p.color} />
+              <strong>{p.name}</strong>
+            </span>
+            <span class="badge crown" use:popIn>👑 Survivor</span>
+          </div>
+          <KaboomBurst token={crownToken} crown />
+        {:else if trackOrder && isOut(p.id)}
+          <button
+            type="button"
+            class="krow out"
+            onclick={() => revive(p.id)}
+            aria-label="Bring {p.name} back in — they were the {ordinal(outIndex(p.id) + 1)} out"
+          >
+            <span class="who">
+              <Avatar name={p.name} color={p.color} />
+              <span class="name">{p.name}</span>
+              {#if firstOutId === p.id}
+                <span class="rib first">first to blow 🙀</span>
+              {:else if runnerUpId === p.id}
+                <span class="rib close">so close 😾</span>
+              {/if}
+            </span>
+            <span class="badge boom">💥 <span class="num">{ordinal(outIndex(p.id) + 1)}</span> out</span>
+          </button>
+          <KaboomBurst token={boomToken[p.id] ?? 0} />
+        {:else if trackOrder}
+          <button
+            type="button"
+            class="krow"
+            onclick={() => eliminate(p.id)}
+            aria-label="{p.name} exploded"
+          >
+            <span class="who">
+              <Avatar name={p.name} color={p.color} />
+              <strong>{p.name}</strong>
+            </span>
+            <span class="badge action">💥 Out</span>
+          </button>
+        {:else}
+          <button
+            type="button"
+            class="krow pick"
+            class:on={input.winner === p.id}
+            onclick={() => crown(p.id)}
+            aria-pressed={input.winner === p.id}
+          >
+            <span class="who">
+              <Avatar name={p.name} color={p.color} />
+              <strong>{p.name}</strong>
+            </span>
+            <span class="badge">{input.winner === p.id ? '👑 Survivor' : 'Tap to crown'}</span>
+          </button>
+        {/if}
+
+        {#if trackDefuses}
+          <div class="defuse" class:used={dc > 0}>
+            {#if dc > 0}
+              <button
+                type="button"
+                class="dbtn minus"
+                onclick={() => undefuse(p.id)}
+                aria-label="Undo a defuse for {p.name}"
+              >−</button>
+            {/if}
+            <button
+              type="button"
+              class="dbtn add"
+              onclick={() => defuse(p.id)}
+              aria-label="{p.name} defused a kitten — {dc} so far"
+              title="Cheated death — logged a Defuse"
+            >🛡 <span class="num">{dc}</span></button>
+          </div>
+        {/if}
+      </div>
     {/each}
   </div>
+
+  {#if trackDefuses}
+    <span class="hint muted">🛡 Tap when someone Defuses an Exploding Kitten — it feeds the “deaths cheated” stat.</span>
+  {/if}
 </div>
 
 <style>
   .list {
     gap: 8px;
   }
+  .prompt {
+    font-size: 0.88rem;
+  }
+  .krow-wrap {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    gap: 8px;
+    width: 100%;
+    will-change: transform;
+  }
   .krow {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 10px;
-    width: 100%;
+    flex: 1 1 auto;
+    min-width: 0;
     min-height: 56px;
     padding: 10px 12px;
     text-align: left;
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     color: var(--text);
     font: inherit;
     cursor: pointer;
@@ -168,6 +296,20 @@
     font-variant-numeric: tabular-nums;
   }
 
+  /* Live ribbing — a small playful tag next to the name. Text + emoji carry it; kept
+     muted so it's a wink, never a shout, and never colour alone. */
+  .rib {
+    flex: none;
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: var(--muted);
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    white-space: nowrap;
+  }
+
   /* Eliminated: dimmed and struck, carried by the 💥 chip + rank number, never
      colour alone. Not coral — being out isn't an error, just out. */
   .krow.out {
@@ -199,9 +341,52 @@
     color: var(--accent-ink);
   }
 
-  .pill.survived {
-    color: var(--accent-ink);
-    border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  /* Defuse control — a compact secondary stepper, never the primary action (that
+     stays the shell's one violet Save). Surface-ramp only. */
+  .defuse {
+    flex: none;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .dbtn {
+    min-width: 44px;
+    height: 44px;
+    padding: 0 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 3px;
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font: inherit;
+    font-weight: 700;
+    font-size: 0.9rem;
+    cursor: pointer;
+  }
+  .dbtn:hover {
+    background: var(--surface-3);
+  }
+  .dbtn:active {
+    transform: translateY(1px);
+  }
+  .dbtn:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .dbtn.minus {
+    min-width: 40px;
+    color: var(--muted);
+  }
+  .defuse.used .dbtn.add {
+    border-color: color-mix(in srgb, var(--good) 45%, var(--border));
+    color: var(--text);
+  }
+
+  .hint {
+    font-size: 0.78rem;
   }
 
   .reminder {
@@ -214,5 +399,14 @@
     border: 1px solid var(--border);
     color: var(--muted);
     font-size: 0.85rem;
+  }
+  /* Imploding gets a touch of menace — a loss-coral edge, co-signalled by the ☠️ and
+     the words, never colour alone. */
+  .reminder.menace {
+    border-color: color-mix(in srgb, var(--bad) 45%, var(--border));
+    background: color-mix(in srgb, var(--bad) 8%, var(--surface));
+  }
+  .reminder.menace strong {
+    color: var(--text);
   }
 </style>

--- a/src/lib/games/explodingkittens/KaboomBurst.svelte
+++ b/src/lib/games/explodingkittens/KaboomBurst.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * A short 💥 blast when a kitten explodes — the chaotic payoff Exploding Kittens
+   * begs for. Pure delight layered over an outcome already spelled out in words +
+   * chip ("💥 1st out", struck-through name), so motion is never the only signal.
+   * The overlay is `pointer-events: none`, replays whenever `token` changes (a fresh
+   * boom), and renders nothing at all under reduced motion. Modeled on the app's
+   * existing burst components (FeatherBurst / CoinBurst).
+   *
+   * A bigger `crown` blast is used for the last-kitten-standing moment: same engine,
+   * more pieces and a gold-and-sparkle glyph set for the win.
+   */
+  let { token = 0, crown = false }: { token?: number; crown?: boolean } = $props();
+
+  const reduced = prefersReducedMotion();
+
+  const pieces = $derived.by(() => {
+    const count = crown ? 14 : 10;
+    const glyphs = crown ? ['🎉', '✨', '🐱', '👑', '💫', '🎊'] : ['💥', '💥', '🙀', '💨', '✨'];
+    return Array.from({ length: count }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      // Radial scatter from the center of the row so a boom actually bursts outward.
+      const angle = (i / count) * Math.PI * 2 + (rand(0) - 0.5) * 0.7;
+      const dist = (crown ? 46 : 34) + rand(1) * (crown ? 40 : 30);
+      return {
+        dx: Math.cos(angle) * dist,
+        dy: Math.sin(angle) * dist - (crown ? 16 : 8), // bias upward a touch
+        delay: rand(2) * 0.08,
+        duration: (crown ? 0.85 : 0.6) + rand(3) * 0.4,
+        spin: (rand(4) - 0.5) * 320,
+        size: (crown ? 1.0 : 0.85) + rand(5) * 0.6,
+        glyph: glyphs[Math.floor(rand(6) * glyphs.length)],
+      };
+    });
+  });
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="kaboom" class:crown aria-hidden="true">
+      {#each pieces as p, i (i)}
+        <span
+          class="bit"
+          style="
+            font-size: {p.size}rem;
+            animation-delay: {p.delay}s;
+            animation-duration: {p.duration}s;
+            --dx: {p.dx}px;
+            --dy: {p.dy}px;
+            --spin: {p.spin}deg;
+          ">{p.glyph}</span>
+      {/each}
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .kaboom {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    overflow: visible;
+    z-index: 3;
+  }
+  .bit {
+    position: absolute;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: kaboom-fly;
+    animation-timing-function: cubic-bezier(0.16, 0.84, 0.44, 1);
+    animation-iteration-count: 1;
+    animation-fill-mode: both;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
+  }
+  @keyframes kaboom-fly {
+    0% {
+      opacity: 0;
+      transform: translate(0, 0) rotate(0deg) scale(0.3);
+    }
+    18% {
+      opacity: 1;
+      transform: translate(calc(var(--dx) * 0.5), calc(var(--dy) * 0.5)) rotate(calc(var(--spin) * 0.5)) scale(1.15);
+    }
+    100% {
+      opacity: 0;
+      transform: translate(var(--dx), var(--dy)) rotate(var(--spin)) scale(0.9);
+    }
+  }
+</style>

--- a/src/lib/games/explodingkittens/KittenCountdown.svelte
+++ b/src/lib/games/explodingkittens/KittenCountdown.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+  import type { ID } from '../../types';
+
+  /**
+   * Exploding Kittens' per-game costume: a compact strip of kitten faces, one per
+   * player, that visibly go 🐱 → 💥 as the deck thins toward a single survivor. It's
+   * the thematic "stage" the game was missing — the tension of the table shrinking to
+   * one, read at a glance. Lives entirely inside the game editor and never touches the
+   * shared chrome.
+   *
+   * Design guardrails: no Royal Violet (that stays on the shell's one Save action) and
+   * Crown Gold appears only on the lone survivor — the leader/winner rule. Depth comes
+   * from the surface ramp plus muted/semantic tints. Every state is co-signalled by a
+   * glyph + text (💥 / rank number / struck name / 👑), never colour alone, and the
+   * live caption spells out the count, so the strip is decoration that degrades
+   * gracefully and needs no motion to be understood.
+   */
+  type Seat = {
+    id: ID;
+    name: string;
+    color: string;
+    state: 'alive' | 'out' | 'survivor';
+    outRank: number; // 1-based explosion order, 0 for alive/survivor
+  };
+
+  let {
+    seats,
+    aliveCount,
+    survivorName = null,
+    imploding = false,
+  }: {
+    seats: Seat[];
+    aliveCount: number;
+    survivorName?: string | null;
+    imploding?: boolean;
+  } = $props();
+</script>
+
+<div class="stage" class:won={!!survivorName}>
+  <div class="caption">
+    {#if survivorName}
+      <span class="win">🐱👑 {survivorName} — last kitten standing!</span>
+    {:else}
+      <span class="count"><span class="num">{aliveCount}</span> {aliveCount === 1 ? 'kitten' : 'kittens'} still clawing</span>
+      <span class="sub muted">{imploding ? '☠️ one of them can’t be defused…' : 'draw til someone goes 💥'}</span>
+    {/if}
+  </div>
+
+  <div class="strip" aria-hidden="true">
+    {#each seats as s (s.id)}
+      <span
+        class="face"
+        class:out={s.state === 'out'}
+        class:survivor={s.state === 'survivor'}
+        style="--pc: {s.color}"
+        title={s.name}
+      >
+        <span class="glyph">{s.state === 'out' ? '💥' : s.state === 'survivor' ? '👑' : '🐱'}</span>
+        {#if s.state === 'out'}
+          <span class="rank num">{s.outRank}</span>
+        {/if}
+      </span>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .stage {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  /* The win beat borrows the scoreboard's restrained Crown Gold edge — the 👑 and the
+     gold caption carry it, so gold stays a hint, never a block. */
+  .stage.won {
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+    background: color-mix(in srgb, var(--accent) 10%, var(--surface-2));
+  }
+  .caption {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+  }
+  .count {
+    font-weight: 700;
+    font-size: 1rem;
+  }
+  .win {
+    font-weight: 800;
+    font-size: 1.02rem;
+    color: var(--accent-ink);
+  }
+  .sub {
+    font-size: 0.78rem;
+  }
+  .num {
+    font-variant-numeric: tabular-nums;
+  }
+  .strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .face {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 38px;
+    height: 38px;
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    /* A quiet tint of the player's palette colour so seats stay distinguishable,
+       reinforced by the title/name — never colour alone. */
+    border: 1px solid color-mix(in srgb, var(--pc) 45%, var(--border));
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--pc) 14%, transparent);
+    font-size: 1.15rem;
+    line-height: 1;
+  }
+  /* Exploded: dimmed and desaturated, carried by the 💥 glyph + rank number. Not
+     coral — being out isn't an error, just out. */
+  .face.out {
+    opacity: 0.5;
+    border-style: dashed;
+    filter: grayscale(0.4);
+  }
+  .face.survivor {
+    border-color: color-mix(in srgb, var(--accent) 60%, var(--border));
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--accent) 26%, transparent);
+    background: color-mix(in srgb, var(--accent) 12%, var(--surface));
+  }
+  .glyph {
+    display: block;
+  }
+  .rank {
+    position: absolute;
+    right: -3px;
+    bottom: -3px;
+    min-width: 15px;
+    height: 15px;
+    padding: 0 3px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 0.6rem;
+    font-weight: 800;
+  }
+</style>

--- a/src/lib/games/explodingkittens/explodingkittens.test.ts
+++ b/src/lib/games/explodingkittens/explodingkittens.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { Game, ID, Player, Round, RoundContext } from '../../types';
 import {
   emptyInput,
+  defuseTotal,
   finishingPositions,
   matchLimit,
   pickMatchLeaders,
@@ -234,5 +235,81 @@ describe('explodingKittensStats', () => {
     });
     expect(noOrder.perPlayer).toEqual({});
     expect(noOrder.global).toEqual([]);
+  });
+});
+
+describe('defuseTotal — sums the deaths cheated in a match', () => {
+  it('is zero when defuses are untracked', () => {
+    expect(defuseTotal({ winner: 'A', order: ['B'] })).toBe(0);
+  });
+
+  it('sums per-player defuses, flooring and clamping stray values', () => {
+    expect(defuseTotal({ winner: 'A', order: ['B'], defuses: { A: 2, B: 1 } })).toBe(3);
+    expect(defuseTotal({ winner: 'A', order: [], defuses: { A: 1.9, B: -3 } })).toBe(1);
+  });
+});
+
+describe('defuses never change scoring — the survivor still banks exactly +1', () => {
+  it('ignores defuses when scoring the match', () => {
+    expect(scoreMatch({ winner: 'A', order: ['C', 'B'], defuses: { B: 3, A: 1 } }, ['A', 'B', 'C'])).toEqual({
+      A: 1,
+      B: 0,
+      C: 0,
+    });
+  });
+});
+
+describe('validateMatch — defuse guards', () => {
+  it('accepts a match with valid per-player defuses', () => {
+    expect(validateMatch({ winner: 'A', order: ['C', 'B'], defuses: { B: 2, A: 1 } }, ['A', 'B', 'C'], true)).toBeNull();
+  });
+
+  it('rejects a defuse logged for an unknown player', () => {
+    expect(validateMatch({ winner: 'A', order: [], defuses: { Z: 1 } }, ['A', 'B'], false)).toMatch(/isn’t in this game/i);
+  });
+
+  it('rejects a negative defuse count', () => {
+    expect(validateMatch({ winner: 'A', order: [], defuses: { B: -1 } }, ['A', 'B'], false)).toMatch(/can’t be negative/i);
+  });
+});
+
+describe('explodingKittensStats — defuses & win streaks', () => {
+  const games: Game[] = [
+    { id: 'g', type: 'explodingkittens', config: {}, playerIds: ['A', 'B', 'C'], status: 'finished', createdAt: 0, roundCount: 3 } as Game,
+  ];
+
+  it('totals deaths cheated per player and globally', () => {
+    const rounds: Round[] = [
+      mkRound('g', 0, { winner: 'A', order: ['C', 'B'], defuses: { A: 2, B: 1 } }, ['A', 'B', 'C']),
+      mkRound('g', 1, { winner: 'B', order: ['A', 'C'], defuses: { A: 1 } }, ['A', 'B', 'C']),
+    ];
+    const out = explodingKittensStats({ games, rounds, players: [], canonical: (id: ID) => id });
+    expect(out.perPlayer?.['A']?.find((m) => m.key === 'ek_defuse')?.value).toBe('3');
+    expect(out.perPlayer?.['B']?.find((m) => m.key === 'ek_defuse')?.value).toBe('1');
+    expect(out.global?.find((m) => m.key === 'ek_defused')?.value).toBe('4');
+  });
+
+  it('reports the longest run of back-to-back match wins', () => {
+    const rounds: Round[] = [
+      mkRound('g', 0, { winner: 'A', order: ['C', 'B'] }, ['A', 'B', 'C']),
+      mkRound('g', 1, { winner: 'A', order: ['B', 'C'] }, ['A', 'B', 'C']),
+      mkRound('g', 2, { winner: 'B', order: ['C', 'A'] }, ['A', 'B', 'C']),
+    ];
+    const out = explodingKittensStats({ games, rounds, players: [], canonical: (id: ID) => id });
+    expect(out.perPlayer?.['A']?.find((m) => m.key === 'ek_streak')?.value).toBe('2');
+    // A single win isn't a streak, so B (one win) gets no streak metric.
+    expect(out.perPlayer?.['B']?.find((m) => m.key === 'ek_streak')).toBeUndefined();
+  });
+
+  it('resets a streak when another kitten wins, even in reversed round order', () => {
+    // Fed out of order to prove the stat sorts by round index, not array order.
+    const rounds: Round[] = [
+      mkRound('g', 2, { winner: 'A', order: ['B', 'C'] }, ['A', 'B', 'C']),
+      mkRound('g', 0, { winner: 'A', order: ['C', 'B'] }, ['A', 'B', 'C']),
+      mkRound('g', 1, { winner: 'B', order: ['A', 'C'] }, ['A', 'B', 'C']),
+    ];
+    const out = explodingKittensStats({ games, rounds, players: [], canonical: (id: ID) => id });
+    // A wins rounds 0 and 2 but B wins round 1 between them → best streak is 1, no metric.
+    expect(out.perPlayer?.['A']?.find((m) => m.key === 'ek_streak')).toBeUndefined();
   });
 });

--- a/src/lib/games/explodingkittens/index.ts
+++ b/src/lib/games/explodingkittens/index.ts
@@ -3,6 +3,7 @@ import { RoundEditor } from '../editor';
 import { explodingKittensStats } from './stats';
 import {
   emptyInput,
+  defuseTotal,
   matchLimit,
   pickMatchLeaders,
   scoreMatch,
@@ -40,6 +41,13 @@ export const explodingkittens: GameModule = {
       help: 'On: tap each kitten as they explode and the survivor is crowned automatically — unlocks first-to-explode and finish stats. Off: just tap who survived.',
     },
     {
+      key: 'trackDefuses',
+      label: 'Track defuses (who cheated death 🛡)',
+      type: 'boolean',
+      default: false,
+      help: 'On: tap 🛡 whenever someone Defuses an Exploding Kitten — a per-match tally that unlocks the “deaths cheated / most defuses” stat. Off (default): keeps entry to pure single taps.',
+    },
+    {
       key: 'matches',
       label: 'Number of matches (0 = open-ended)',
       type: 'number',
@@ -69,10 +77,13 @@ export const explodingkittens: GameModule = {
     const name = (id: ID | null | undefined) => players.find((p) => p.id === id)?.name ?? '?';
     if (!input?.winner && (!input?.order || input.order.length === 0)) return 'no result';
     const head = input.winner ? `👑 ${name(input.winner)} survived` : 'no survivor';
+    const parts = [head];
     if (input.order && input.order.length) {
-      return `${head} · 💥 ${name(input.order[0])} out first`;
+      parts.push(`💥 ${name(input.order[0])} out first`);
     }
-    return head;
+    const defused = defuseTotal(input);
+    if (defused) parts.push(`🛡 ${defused} defused`);
+    return parts.join(' · ');
   },
 
   help: [
@@ -84,8 +95,9 @@ export const explodingkittens: GameModule = {
     '',
     'Each round here = one match. With “Track elimination order” on, tap each player',
     'as they explode and the survivor is crowned for you; turn it off to just tap the',
-    'winner. Imploding Kittens on? The ☠️ Imploding Kitten can’t be defused — flip it',
-    'and you’re out on the spot.',
+    'winner. Turn on “Track defuses” to tap 🛡 whenever someone cheats death — it feeds',
+    'the deaths-cheated stat. Imploding Kittens on? The ☠️ Imploding Kitten can’t be',
+    'defused — flip it and you’re out on the spot.',
   ].join('\n'),
 
   stats: explodingKittensStats,

--- a/src/lib/games/explodingkittens/logic.ts
+++ b/src/lib/games/explodingkittens/logic.ts
@@ -19,11 +19,26 @@ export interface EKInput {
    * is on; left empty when the group only records who survived.
    */
   order: ID[];
+  /**
+   * Optional per-player Defuse tally for this match — how many Exploding Kittens each
+   * player cheated death on before either surviving or finally blowing up. Present only
+   * when "Track defuses" is on; absent on every match recorded without it, so the field
+   * is fully backward-compatible and never affects scoring (the survivor still banks +1).
+   */
+  defuses?: Record<ID, number>;
 }
 
 /** A fresh, empty match: nobody eliminated, no survivor crowned yet. */
 export function emptyInput(): EKInput {
   return { winner: null, order: [] };
+}
+
+/** Total Exploding Kittens defused across the whole match (0 when untracked). */
+export function defuseTotal(input: EKInput): number {
+  if (!input.defuses) return 0;
+  let sum = 0;
+  for (const v of Object.values(input.defuses)) sum += Math.max(0, Math.floor(v || 0));
+  return sum;
 }
 
 /**
@@ -60,6 +75,13 @@ export function validateMatch(
   }
   if (input.winner && seen.has(input.winner)) {
     return 'The survivor can’t also be in the elimination pile.';
+  }
+
+  if (input.defuses) {
+    for (const [id, n] of Object.entries(input.defuses)) {
+      if (!known.has(id)) return 'A defuse is logged for a player who isn’t in this game.';
+      if (!Number.isFinite(n) || n < 0) return 'Defuse counts can’t be negative.';
+    }
   }
 
   if (trackOrder) {

--- a/src/lib/games/explodingkittens/stats.ts
+++ b/src/lib/games/explodingkittens/stats.ts
@@ -1,4 +1,4 @@
-import type { ID } from '../../types';
+import type { ID, Round } from '../../types';
 import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
 import { fmtAvg } from '../../stats/format';
 import { finishingPositions, type EKInput } from './logic';
@@ -8,6 +8,8 @@ interface EKAgg {
   runnerUp: number;
   finishSum: number;
   finishCount: number;
+  defuses: number;
+  bestStreak: number;
 }
 
 /**
@@ -28,13 +30,14 @@ export function explodingKittensStats({
   const get = (id: ID): EKAgg => {
     let a = per.get(id);
     if (!a) {
-      a = { firstOut: 0, runnerUp: 0, finishSum: 0, finishCount: 0 };
+      a = { firstOut: 0, runnerUp: 0, finishSum: 0, finishCount: 0, defuses: 0, bestStreak: 0 };
       per.set(id, a);
     }
     return a;
   };
 
   let totalExploded = 0;
+  let totalDefused = 0;
 
   for (const r of rounds) {
     if (!gameIds.has(r.gameId)) continue;
@@ -48,6 +51,16 @@ export function explodingKittensStats({
     totalExploded += order.length;
     if (order.length) get(order[0]).firstOut += 1;
 
+    // Defuses: who cheated death, and how often, when the group tracked it.
+    if (raw.defuses) {
+      for (const [id, n] of Object.entries(raw.defuses)) {
+        const count = Math.max(0, Math.floor(n || 0));
+        if (!count) continue;
+        get(canonical(id)).defuses += count;
+        totalDefused += count;
+      }
+    }
+
     // Finishing positions only make sense for a completed match (everyone but the
     // survivor exploded); guard so avg finish isn't skewed by a partial entry.
     const complete = !!winner && order.length === players.length - 1 && order.length > 0;
@@ -58,6 +71,38 @@ export function explodingKittensStats({
         a.finishSum += p;
         a.finishCount += 1;
         if (p === 2) a.runnerUp += 1;
+      }
+    }
+  }
+
+  // Best win streak: the longest run of consecutive match wins within a single game.
+  // Matches are grouped by game and walked in play order; winning bumps a player's
+  // running streak, and any other outcome in a match they were part of resets it.
+  const byGame = new Map<ID, Round[]>();
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    let list = byGame.get(r.gameId);
+    if (!list) {
+      list = [];
+      byGame.set(r.gameId, list);
+    }
+    list.push(r);
+  }
+  for (const gameRounds of byGame.values()) {
+    gameRounds.sort((a, b) => a.index - b.index);
+    const streak = new Map<ID, number>();
+    for (const r of gameRounds) {
+      const raw = r.input as EKInput | undefined;
+      const winner = raw?.winner ? canonical(raw.winner) : null;
+      for (const id of new Set(Object.keys(r.deltas).map(canonical))) {
+        if (id === winner) {
+          const next = (streak.get(id) ?? 0) + 1;
+          streak.set(id, next);
+          const a = get(id);
+          if (next > a.bestStreak) a.bestStreak = next;
+        } else {
+          streak.set(id, 0);
+        }
       }
     }
   }
@@ -79,12 +124,21 @@ export function explodingKittensStats({
         emoji: '🏁',
       });
     }
+    if (a.defuses) {
+      metrics.push({ key: 'ek_defuse', label: 'Deaths cheated', value: `${a.defuses}`, emoji: '🛡' });
+    }
+    if (a.bestStreak >= 2) {
+      metrics.push({ key: 'ek_streak', label: 'Best win streak', value: `${a.bestStreak}`, emoji: '🔥' });
+    }
     if (metrics.length) perPlayer[id] = metrics;
   }
 
   const global: Metric[] = [];
   if (totalExploded) {
     global.push({ key: 'ek_boom', label: 'Kittens exploded', value: `${totalExploded}`, emoji: '💥' });
+  }
+  if (totalDefused) {
+    global.push({ key: 'ek_defused', label: 'Deaths cheated', value: `${totalDefused}`, emoji: '🛡' });
   }
 
   return { perPlayer, global };


### PR DESCRIPTION
## Why
Exploding Kittens is the app's most chaotic, explosive party game — yet its module was the **quietest** of all the playful games. Every other whimsical game has a thematic centerpiece in its editor (chickenfoot's `DominoCountdown`, skullking's `VoyageRibbon`) and burst moments (`FeatherBurst`, `CoinBurst`, `DreadStamp`). Exploding Kittens had a plain tappable list: no stage, no kaboom, no haptic, an anticlimactic survivor crowning, and its personality (first-to-explode ribbing) was buried in Stats instead of landing live at the table.

This PR leans all the way into the chaos — **inside the game editor only**. The shared chrome, shell, Scoreboard and `WinnerCelebration` are untouched, and all unit-testable rules stay in the Svelte-free `logic.ts`.

## What's new
- **`KittenCountdown.svelte`** — the game's missing costume: a compact strip of kitten faces, one per player, that visibly go 🐱 → 💥 as the table thins, with a tension caption shrinking to **"🐱👑 Last kitten standing!"**
- **`KaboomBurst.svelte`** (modeled on the existing `FeatherBurst`) — a 💥🙀💨 blast on every explosion and a bigger gold 🎉👑 blast for the win. Token-driven replay, `pointer-events: none`, renders nothing under reduced motion.
- **Editor upgrades** — row shake + haptic on Out, survivor auto-crown pop + win haptic, **live ribbing** tags ("💥 first to blow!", "😾 so close"), a menacing Imploding reminder, and chaotic-but-clear microcopy.
- **Optional Defuse tracking** — a new `trackDefuses` config toggle (default **off**, so the fast single-tap flow is unchanged). Tap 🛡 to log who cheated death; a backward-compatible optional `EKInput.defuses` field that **never affects scoring**.
- **Stats flourish** — per-player **🛡 Deaths cheated** + **🔥 Best win streak** (longest consecutive match wins within a game), plus a global deaths-cheated total. All pure.

## Design non-negotiables honored
- Crown Gold only on the survivor/leader; no new violet fill (Save stays the one primary action).
- Depth via the surface ramp; no stacked shadows; tokens for radius/spacing.
- Every changing number uses `tabular-nums`; primary targets ≥46px.
- State is co-signalled by glyph + rank + text, never colour alone.
- **Every animation has a reduced-motion no-op** (instant, meaningful state).

## Testing (local only)
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — succeeds
- `npx vitest run` — **1096 passed** (44 in the Exploding Kittens suite, incl. new defuse + win-streak coverage)
- Backward-compatible: existing rounds without `defuses` still validate and score identically.