### PR TITLE
Finspan: ocean-depths costume for the end-game scoresheet

### DIFF
--- a/src/lib/games/finspan/FinspanEditor.svelte
+++ b/src/lib/games/finspan/FinspanEditor.svelte
@@ -2,12 +2,16 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
+  import OceanGauge from './OceanGauge.svelte';
+  import { leaders } from '../../scoring';
+  import { bumpOnChange, popIn, animateMotion } from '../../motion';
   import {
     FINSPAN_CATEGORIES,
     FINSPAN_HELP,
     categoryPoints,
     emptyRow,
     scoreRow,
+    weeklyTotal,
     type FinspanInput,
   } from './logic';
 
@@ -22,15 +26,57 @@
 
   let showHelp = $state(false);
 
+  // The three weekly achievements collapse into one trio; the rest are cards in your ocean.
+  const weekly = FINSPAN_CATEGORIES.filter((c) => c.group === 'weekly');
+  const ocean = FINSPAN_CATEGORIES.filter((c) => c.group === 'ocean');
+
   function total(id: string): number {
     return scoreRow(input.values[id]);
+  }
+
+  // Live totals + the app's shared "who's pulled ahead" rule, so the biggest catch wears the
+  // crown (and only the crown's Gold) — and nobody is crowned at an all-tied-at-zero table.
+  const totals = $derived(Object.fromEntries(ctx.players.map((p) => [p.id, total(p.id)])));
+  const leaderSet = $derived(leaders(totals, ctx.players.map((p) => p.id)));
+
+  /**
+   * A one-shot "＋6 🐠 school forms!" bubble that floats up when a schools count ticks up — the
+   * game's most satisfying tally (three young shoal into a school worth six). Motion-only
+   * decoration, so under reduced motion {@link animateMotion} resolves instantly and the bubble
+   * is removed with no movement.
+   */
+  function schoolBurst(node: HTMLElement, value: number | undefined) {
+    let prev = Number(value) || 0;
+    return {
+      update(next: number | undefined) {
+        const v = Number(next) || 0;
+        if (v > prev) {
+          const b = document.createElement('span');
+          b.className = 'burst';
+          b.textContent = '＋6 🐠';
+          b.setAttribute('aria-hidden', 'true');
+          node.appendChild(b);
+          animateMotion(
+            b,
+            { opacity: [0, 1, 0], transform: ['translateY(2px)', 'translateY(-14px)', 'translateY(-28px)'] },
+            { duration: 0.7, ease: 'easeOut' },
+          ).finished.finally(() => b.remove());
+        }
+        prev = v;
+      },
+    };
   }
 </script>
 
 <div class="stack">
   <div class="row spread">
-    <span class="pill">🐟 Final scoresheet · week 4</span>
-    <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+    <span class="pill">🌊 Your ocean · after week 4</span>
+    <button
+      type="button"
+      class="btn small ghost"
+      onclick={() => (showHelp = !showHelp)}
+      aria-expanded={showHelp}
+    >
       Scoring
     </button>
   </div>
@@ -42,23 +88,60 @@
   {#each ctx.players as p (p.id)}
     {@const row = input.values[p.id]}
     {#if row}
-      <div class="prow">
+      {@const isLeader = leaderSet.has(p.id)}
+      <div class="prow" class:leader={isLeader}>
         <div class="row spread phead">
-          <span class="row" style="gap: 8px">
+          <span class="who">
             <Avatar name={p.name} color={p.color} />
             <strong>{p.name}</strong>
+            {#if isLeader}
+              <span class="crown" title="Biggest catch" aria-hidden="true" use:popIn>👑</span>
+              <span class="sr-only">Biggest catch</span>
+            {/if}
           </span>
-          <span class="total">{total(p.id)}<span class="unit">pts</span></span>
+          <span class="total" class:lead={isLeader}>
+            <span class="totnum" use:bumpOnChange={total(p.id)}>{total(p.id)}</span><span class="unit"
+              >pts</span
+            >
+          </span>
         </div>
+
+        <OceanGauge total={total(p.id)} />
+
+        <div class="weekly">
+          <span class="wlabel"><span aria-hidden="true">🏅</span> Weekly achievements</span>
+          <div class="weeks">
+            {#each weekly as c (c.key)}
+              <label class="wk">
+                <span class="wkcap">{c.label.replace('Week ', 'Wk ')}</span>
+                <input
+                  class="pts sm"
+                  type="number"
+                  min="0"
+                  step="1"
+                  inputmode="numeric"
+                  aria-label={`${p.name} ${c.label}`}
+                  bind:value={row[c.key]}
+                />
+              </label>
+            {/each}
+            <span class="wsub">= {weeklyTotal(row)}</span>
+          </div>
+        </div>
+
         <div class="grid">
-          {#each FINSPAN_CATEGORIES as c (c.key)}
-            <div class="f">
+          {#each ocean as c (c.key)}
+            <div
+              class="f"
+              class:pcell={c.entry === 'points'}
+              use:schoolBurst={c.key === 'schools' ? row.schools : undefined}
+            >
               <span class="flabel">
                 <span aria-hidden="true">{c.emoji}</span>
                 {c.label}{#if c.per !== 1}<span class="mult">×{c.per}</span>{/if}
               </span>
               {#if c.entry === 'count'}
-                <Stepper bind:value={row[c.key]} min={0} />
+                <Stepper bind:value={row[c.key]} min={0} label={`${p.name} ${c.label}`} />
               {:else}
                 <input
                   class="pts"
@@ -85,31 +168,108 @@
   .prow {
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: 12px;
+    border-radius: var(--radius);
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  /* The biggest catch: a restrained Crown-Gold ring around the leader's card — the crown and
+     gold total already carry the meaning, so the ring stays a whisper, never a gold block. */
+  .prow.leader {
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+    background: color-mix(in srgb, var(--accent) 6%, var(--surface-2));
   }
   .phead {
-    margin-bottom: 10px;
+    margin: 0;
+  }
+  .who {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .who strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .crown {
+    flex: none;
+    font-size: 1rem;
+    line-height: 1;
   }
   .total {
     display: inline-flex;
     align-items: baseline;
     gap: 4px;
+    flex: none;
     font-weight: 800;
-    font-size: 1.1rem;
+    font-size: 1.5rem;
     font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+  /* Gold reserved for the leader/winner number, per the Crown-Gold rule. */
+  .total.lead {
+    color: var(--accent-ink);
   }
   .unit {
     font-size: 0.72rem;
     font-weight: 600;
     color: var(--muted);
   }
+
+  /* Weekly achievements — the three banked weeks, collapsed into one quiet trio with a subtotal
+     so they read as a single idea instead of three near-identical columns. */
+  .weekly {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    border: 1px solid var(--border);
+  }
+  .wlabel {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--muted);
+  }
+  .weeks {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+  .wk {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+  .wkcap {
+    white-space: nowrap;
+  }
+  .wsub {
+    margin-left: auto;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+  }
+
   .grid {
     display: flex;
     flex-wrap: wrap;
     gap: 12px 16px;
   }
   .f {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: 6px;
@@ -128,23 +288,43 @@
   }
   .pts {
     width: 88px;
+    height: 46px;
     text-align: center;
+    font-weight: 700;
     font-variant-numeric: tabular-nums;
+  }
+  .pts.sm {
+    width: 58px;
+    height: 40px;
   }
   .contrib {
     font-size: 0.72rem;
     color: var(--muted);
     font-variant-numeric: tabular-nums;
   }
+  /* The floating "＋6 🐠" school-forms beat. Positioned over its cell; pointer-inert so it never
+     blocks the next tap. Motion-only — animateMotion drops it instantly under reduced motion. */
+  .f :global(.burst) {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--good);
+    pointer-events: none;
+    white-space: nowrap;
+  }
   .help {
     white-space: pre-wrap;
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     padding: 12px;
     font-size: 0.85rem;
     margin: 0;
     font-family: inherit;
     color: var(--muted);
+    line-height: 1.5;
   }
 </style>

--- a/src/lib/games/finspan/OceanGauge.svelte
+++ b/src/lib/games/finspan/OceanGauge.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  /**
+   * Finspan's signature "fill your ocean" gauge — a horizontal tank that fills left→right with
+   * a researcher's running total and sinks through the three depth zones (Sunlight → Twilight →
+   * Midnight) as it grows. Pure per-game costume: it never touches the app chrome, never uses
+   * Royal Violet (the one primary action lives in the play screen) or Crown Gold (reserved for
+   * the leader), and always co-signals depth with an emoji + zone word, never colour alone.
+   *
+   * Motion is a flourish, not a gate: the fill glides and a faint waterline drifts, but both are
+   * dropped under reduced motion — the tank still shows its final fill and zone instantly.
+   */
+  import { depthZone, tankFill } from './logic';
+  import { prefersReducedMotion } from '../../motion';
+
+  let { total = 0 }: { total?: number } = $props();
+
+  const zone = $derived(depthZone(total));
+  const fill = $derived(tankFill(total));
+  const reduced = prefersReducedMotion();
+</script>
+
+<div class="gauge" class:reduced>
+  <div class="tank zone-{zone.key}" role="img" aria-label={`Ocean depth: ${zone.label} zone, ${total} points`}>
+    <div class="water" style="--fill: {fill}">
+      <span class="waterline" aria-hidden="true"></span>
+    </div>
+  </div>
+  <span class="zone" aria-hidden="true">
+    <span class="zemoji">{zone.emoji}</span>{zone.label}
+  </span>
+</div>
+
+<style>
+  .gauge {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .tank {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    height: 14px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    overflow: hidden;
+    /* The ocean tint is a contained decorative accent — clearly teal/blue, never the brand
+       violet or the leader's gold. Each zone deepens the water. */
+    --w1: #7dd3fc;
+    --w2: #38bdf8;
+  }
+  .tank.zone-twilight {
+    --w1: #22d3ee;
+    --w2: #3b82f6;
+  }
+  .tank.zone-midnight {
+    --w1: #3b82f6;
+    --w2: #1e40af;
+  }
+  .water {
+    position: relative;
+    height: 100%;
+    width: 100%;
+    border-radius: 999px;
+    background: linear-gradient(90deg, var(--w1), var(--w2));
+    transform: scaleX(var(--fill, 0));
+    transform-origin: left center;
+    transition: transform 0.45s cubic-bezier(0.22, 0.61, 0.36, 1);
+  }
+  /* A drifting highlight so the water reads as water, not a progress bar. */
+  .waterline {
+    position: absolute;
+    inset: 0;
+    border-radius: 999px;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      color-mix(in srgb, #ffffff 34%, transparent) 45%,
+      transparent 70%
+    );
+    background-size: 220% 100%;
+    animation: drift 2.6s linear infinite;
+  }
+  .zone {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex: none;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--muted);
+    white-space: nowrap;
+  }
+  .zemoji {
+    font-size: 0.85rem;
+  }
+  .reduced .water {
+    transition: none;
+  }
+  .reduced .waterline {
+    animation: none;
+    background-position: 0 0;
+  }
+  @keyframes drift {
+    from {
+      background-position: 120% 0;
+    }
+    to {
+      background-position: -120% 0;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .water {
+      transition: none;
+    }
+    .waterline {
+      animation: none;
+    }
+  }
+</style>

--- a/src/lib/games/finspan/finspan.test.ts
+++ b/src/lib/games/finspan/finspan.test.ts
@@ -2,15 +2,20 @@ import { describe, expect, it } from 'vitest';
 import type { Game, Player, Round, RoundContext } from '../../types';
 import { defaultWinners } from '../../types';
 import {
+  DEPTH_ZONES,
   FINSPAN_CATEGORIES,
   FINSPAN_HELP,
+  FULL_TANK,
   categoryPoints,
+  depthZone,
   describeFinspan,
   emptyInput,
   emptyRow,
   scoreFinspan,
   scoreRow,
+  tankFill,
   validateFinspan,
+  weeklyTotal,
   type FinspanRow,
 } from './logic';
 import { finspan } from './index';
@@ -76,6 +81,63 @@ describe('Finspan categories', () => {
       expect(c.emoji.length).toBeGreaterThan(0);
       expect(c.hint.length).toBeGreaterThan(0);
     }
+  });
+
+  it('groups exactly the three weeks as weekly and the rest as ocean', () => {
+    const weekly = FINSPAN_CATEGORIES.filter((c) => c.group === 'weekly').map((c) => c.key);
+    const ocean = FINSPAN_CATEGORIES.filter((c) => c.group === 'ocean').map((c) => c.key);
+    expect(weekly).toEqual(['week1', 'week2', 'week3']);
+    expect(ocean).toEqual(['gameEnd', 'fish', 'consumed', 'eggsYoung', 'schools']);
+    for (const c of FINSPAN_CATEGORIES) expect(['weekly', 'ocean']).toContain(c.group);
+  });
+});
+
+describe('weeklyTotal', () => {
+  it('sums only the three banked weeks, ignoring the rest of the ocean', () => {
+    expect(weeklyTotal(row({ week1: 5, week2: 6, week3: 8, fish: 40, schools: 3 }))).toBe(19);
+  });
+
+  it('is 0 for an empty or missing row', () => {
+    expect(weeklyTotal(emptyRow())).toBe(0);
+    expect(weeklyTotal(undefined)).toBe(0);
+  });
+});
+
+describe('depthZone', () => {
+  it('lists Sunlight, Twilight and Midnight, shallowest first', () => {
+    expect(DEPTH_ZONES.map((z) => z.key)).toEqual(['sunlight', 'twilight', 'midnight']);
+    for (const z of DEPTH_ZONES) {
+      expect(z.label.length).toBeGreaterThan(0);
+      expect(z.emoji.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('sinks through the zones as the total grows', () => {
+    expect(depthZone(0).key).toBe('sunlight');
+    expect(depthZone(39).key).toBe('sunlight');
+    expect(depthZone(40).key).toBe('twilight');
+    expect(depthZone(79).key).toBe('twilight');
+    expect(depthZone(80).key).toBe('midnight');
+    expect(depthZone(999).key).toBe('midnight');
+  });
+
+  it('clamps a negative or non-finite total to Sunlight', () => {
+    expect(depthZone(-10).key).toBe('sunlight');
+    expect(depthZone(Number.NaN).key).toBe('sunlight');
+  });
+});
+
+describe('tankFill', () => {
+  it('rises from empty toward a brim-full deep ocean', () => {
+    expect(tankFill(0)).toBe(0);
+    expect(tankFill(FULL_TANK / 2)).toBeCloseTo(0.5);
+    expect(tankFill(FULL_TANK)).toBe(1);
+  });
+
+  it('never overflows past full or drops below empty', () => {
+    expect(tankFill(FULL_TANK * 3)).toBe(1);
+    expect(tankFill(-50)).toBe(0);
+    expect(tankFill(Number.NaN)).toBe(0);
   });
 });
 

--- a/src/lib/games/finspan/logic.ts
+++ b/src/lib/games/finspan/logic.ts
@@ -22,6 +22,13 @@ import type { ID, Player, Round } from '../../types';
 /** How a category value is entered on the sheet. */
 export type FinspanEntry = 'points' | 'count';
 
+/**
+ * Which part of the scoresheet a category belongs to. The three identical weekly
+ * achievements collapse into one "Weekly achievements" trio in the editor; everything
+ * else is a card in your ocean. Purely a presentation grouping — scoring is unchanged.
+ */
+export type FinspanGroup = 'weekly' | 'ocean';
+
 export interface FinspanCategory {
   /** Stable key stored on the round input. */
   key: string;
@@ -35,6 +42,8 @@ export interface FinspanCategory {
    * `count`  — the value is a token/card count the sheet multiplies by {@link per}.
    */
   entry: FinspanEntry;
+  /** Editor grouping: the weekly achievements trio vs the rest of your ocean. */
+  group: FinspanGroup;
   /** One-line scoring reference, shown in the editor and the help popover. */
   hint: string;
 }
@@ -47,6 +56,7 @@ export const FINSPAN_CATEGORIES: readonly FinspanCategory[] = [
     emoji: '🏅',
     per: 1,
     entry: 'points',
+    group: 'weekly',
     hint: 'Achievement points you banked at the end of week 1.',
   },
   {
@@ -55,6 +65,7 @@ export const FINSPAN_CATEGORIES: readonly FinspanCategory[] = [
     emoji: '🏅',
     per: 1,
     entry: 'points',
+    group: 'weekly',
     hint: 'Achievement points you banked at the end of week 2.',
   },
   {
@@ -63,6 +74,7 @@ export const FINSPAN_CATEGORIES: readonly FinspanCategory[] = [
     emoji: '🏅',
     per: 1,
     entry: 'points',
+    group: 'weekly',
     hint: 'Achievement points you banked at the end of week 3.',
   },
   {
@@ -71,6 +83,7 @@ export const FINSPAN_CATEGORIES: readonly FinspanCategory[] = [
     emoji: '🟡',
     per: 1,
     entry: 'points',
+    group: 'ocean',
     hint: 'Points from yellow "GAME END" fish abilities (visible fish only).',
   },
   {
@@ -79,6 +92,7 @@ export const FINSPAN_CATEGORIES: readonly FinspanCategory[] = [
     emoji: '🐟',
     per: 1,
     entry: 'points',
+    group: 'ocean',
     hint: 'Points printed on your visible (uncovered) fish.',
   },
   {
@@ -87,6 +101,7 @@ export const FINSPAN_CATEGORIES: readonly FinspanCategory[] = [
     emoji: '🍽️',
     per: 1,
     entry: 'count',
+    group: 'ocean',
     hint: '1 point for each consumed fish — cards and forage.',
   },
   {
@@ -95,6 +110,7 @@ export const FINSPAN_CATEGORIES: readonly FinspanCategory[] = [
     emoji: '🥚',
     per: 1,
     entry: 'count',
+    group: 'ocean',
     hint: '1 point for each egg and each young in your ocean.',
   },
   {
@@ -103,6 +119,7 @@ export const FINSPAN_CATEGORIES: readonly FinspanCategory[] = [
     emoji: '🐠',
     per: 6,
     entry: 'count',
+    group: 'ocean',
     hint: '6 points for each school — three young shoal into one school.',
   },
 ] as const;
@@ -143,6 +160,56 @@ export function scoreRow(row: FinspanRow | undefined): number {
   let sum = 0;
   for (const c of FINSPAN_CATEGORIES) sum += categoryPoints(c, row?.[c.key]);
   return sum;
+}
+
+/** Just the banked weekly-achievement points (weeks 1–3), for the grouped subtotal. */
+export function weeklyTotal(row: FinspanRow | undefined): number {
+  let sum = 0;
+  for (const c of FINSPAN_CATEGORIES) {
+    if (c.group === 'weekly') sum += categoryPoints(c, row?.[c.key]);
+  }
+  return sum;
+}
+
+/**
+ * The ocean's three depth zones, shallow → deep. A running total sinks through them as it
+ * grows, giving the tally a sense of place ("you've reached the Twilight zone") without ever
+ * relying on colour alone — every zone carries an emoji and a label. `min` is the inclusive
+ * floor; zones are listed deepest-last so {@link depthZone} can scan from the bottom up.
+ */
+export interface DepthZone {
+  key: 'sunlight' | 'twilight' | 'midnight';
+  label: string;
+  emoji: string;
+  /** Inclusive lower bound, in points. */
+  min: number;
+}
+
+export const DEPTH_ZONES: readonly DepthZone[] = [
+  { key: 'sunlight', label: 'Sunlight', emoji: '☀️', min: 0 },
+  { key: 'twilight', label: 'Twilight', emoji: '🌆', min: 40 },
+  { key: 'midnight', label: 'Midnight', emoji: '🌑', min: 80 },
+] as const;
+
+/** A full "deep ocean" tank — the point total at which the gauge reads brim-full. */
+export const FULL_TANK = 120;
+
+/** Which depth zone a running total currently sits in (negatives clamp to Sunlight). */
+export function depthZone(total: number): DepthZone {
+  const n = Number(total);
+  let zone = DEPTH_ZONES[0];
+  if (!Number.isFinite(n)) return zone;
+  for (const z of DEPTH_ZONES) {
+    if (n >= z.min) zone = z;
+  }
+  return zone;
+}
+
+/** How full the ocean tank reads, 0–1, for a running total (clamped to {@link FULL_TANK}). */
+export function tankFill(total: number): number {
+  const n = Number(total);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return Math.min(1, n / FULL_TANK);
 }
 
 /** Per-player point totals for the whole scoresheet. */


### PR DESCRIPTION
## What & why

Finspan's scoring is faithful and well-tested, but the end-game scoresheet was flat and a little tedious: mixed entry controls, three repetitive 🏅 week columns, a small total with no running-leader feedback, and almost no thematic personality. This PR gives Finspan an **ocean-depths costume** — while keeping the app chrome identical and all changes scoped to `src/lib/games/finspan/`.

## Changes

- **`logic.ts`** — new pure, unit-tested helpers: depth zones (Sunlight ☀️ / Twilight 🌆 / Midnight 🌑), `depthZone`, `tankFill`, `FULL_TANK`, `weeklyTotal`, and a `group` tag on each category. Scoring math is untouched.
- **`OceanGauge.svelte`** (new) — a horizontal **"fill your ocean" tank** that fills with each researcher's running total and tints through the depth zones. `transform: scaleX` fill (no layout thrash), reduced-motion safe, and always co-signals depth with an emoji + zone word (never colour alone).
- **`FinspanEditor.svelte`** — reworked layout:
  - Weeks 1–3 collapse into one **"Weekly achievements"** trio with a live subtotal.
  - Unified "reef" cells — numeric inputs for the point categories (Fish can be 40+), Steppers for the count categories, one visual language.
  - The **ocean gauge** per player + a **biggest-catch 👑 crown** and Crown-Gold total via the shared `leaders()` scarcity rule.
  - Delight: total bump on change and a floating **"＋6 🐠 school forms"** beat, plus playful sea microcopy.

## Design non-negotiables honoured

No violet fill in the editor (the one primary — Save round — lives in the play screen); Crown Gold only for the biggest catch; depth built on the surface ramp, not stacked shadows; `tabular-nums` on every changing number; ≥46px touch targets; never colour alone; every animation drops to an instant state under reduced motion.

## Verification (local)

- `npm run check` — 0 errors / 0 warnings
- `npm run build` — succeeds
- `npx vitest run` — **1104 passed** (36 in the Finspan suite, including the new depth-zone / tank-fill / weekly-total / grouping tests)