### PR TITLE
Golf: tap-the-grid helper, links costume & red-numbers delight

### DIFF
--- a/src/lib/games/golf/BirdieBurst.svelte
+++ b/src/lib/games/golf/BirdieBurst.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * The red-numbers moment: when a player's hole dips under par, a brief flourish
+   * of feathers lifts off the row. Pure delight layered over a swing that's already
+   * spelled out by the 🐦/🦅 verdict chip and the negative number, so motion is
+   * never the only signal. The overlay is `pointer-events: none`, replays whenever
+   * `token` changes (a fresh birdie), and renders nothing at all under reduced
+   * motion — the verdict chip is the calm, instant alternative shown either way.
+   * `eagle` deepens the burst a touch for the rarer, deeper-red hole.
+   */
+  let { token = 0, eagle = false }: { token?: number; eagle?: boolean } = $props();
+
+  const reduced = prefersReducedMotion();
+  const COUNT = $derived(eagle ? 12 : 8);
+
+  // Deterministic pseudo-random, seeded by token so each birdie looks a little
+  // different but is stable across a single render (mirrors MoonRise / CoinBurst).
+  const feathers = $derived(
+    Array.from({ length: COUNT }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      const glyphs = eagle ? ['🪶', '🦅', '✦', '🪶'] : ['🪶', '🐦', '✦', '🪶'];
+      return {
+        left: 8 + rand(1) * 84,
+        delay: rand(2) * 0.18,
+        duration: 0.85 + rand(3) * 0.6,
+        drift: (rand(4) - 0.5) * 70,
+        rise: 26 + rand(5) * 46,
+        size: 0.6 + rand(6) * 0.6,
+        glyph: glyphs[Math.floor(rand(7) * glyphs.length)],
+      };
+    }),
+  );
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="burst" aria-hidden="true">
+      {#each feathers as f, i (i)}
+        <span
+          class="feather"
+          style="
+            left: {f.left}%;
+            font-size: {f.size}rem;
+            animation-delay: {f.delay}s;
+            animation-duration: {f.duration}s;
+            --drift: {f.drift}px;
+            --rise: {f.rise}px;
+          ">{f.glyph}</span>
+      {/each}
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .burst {
+    position: absolute;
+    inset: 0;
+    overflow: visible;
+    pointer-events: none;
+    z-index: 2;
+  }
+  .feather {
+    position: absolute;
+    bottom: 30%;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: feather-rise;
+    animation-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1);
+    animation-fill-mode: both;
+  }
+  @keyframes feather-rise {
+    0% {
+      opacity: 0;
+      transform: translate(0, 8px) rotate(-8deg) scale(0.6);
+    }
+    25% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+      transform: translate(var(--drift), calc(var(--rise) * -1)) rotate(10deg) scale(1);
+    }
+  }
+</style>

--- a/src/lib/games/golf/GolfEditor.svelte
+++ b/src/lib/games/golf/GolfEditor.svelte
@@ -2,7 +2,21 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
-  import { holeCeiling, holeFloor, holeTag, readConfig, rulesetLines, type GolfInput } from './logic';
+  import { haptic } from '../../haptics';
+  import GolfGrid from './GolfGrid.svelte';
+  import LinksProgress from './LinksProgress.svelte';
+  import BirdieBurst from './BirdieBurst.svelte';
+  import {
+    computeGrid,
+    gridShape,
+    holeCeiling,
+    holeFloor,
+    holeVerdict,
+    readConfig,
+    rulesetLines,
+    type CardCode,
+    type GolfInput,
+  } from './logic';
 
   let { input = $bindable(), ctx }: { input: GolfInput; ctx: RoundContext } = $props();
 
@@ -10,16 +24,82 @@
   const n = $derived(ctx.roundIndex + 1);
   const floor = $derived(holeFloor(cfg));
   const ceil = $derived(holeCeiling(cfg));
+  const gridSize = $derived(gridShape(cfg.grid).cols * gridShape(cfg.grid).rows);
   let showRules = $state(false);
 
+  // Per-player: is the tap-the-grid helper open, and a token that fires the birdie
+  // burst each time that player crosses (down) into the red on this hole.
+  let openGrid = $state<Record<string, boolean>>({});
+  let birdieToken = $state<Record<string, number>>({});
+  let eagleFlag = $state<Record<string, boolean>>({});
+  const wasUnder: Record<string, boolean> = {};
+  let ready = false;
+
+  function scoreOf(id: string): number {
+    return Math.trunc(Number(input.scores[id]) || 0);
+  }
   function projected(id: string): number {
-    return (ctx.totals[id] ?? 0) + (Math.trunc(Number(input.scores[id]) || 0));
+    return (ctx.totals[id] ?? 0) + scoreOf(id);
+  }
+
+  // Watch each player's hole score; when it drops under par (0 → negative) fire a
+  // birdie burst. Primed on first run so re-opening a red hole to edit doesn't
+  // celebrate on mount — only a fresh dip into the red does.
+  $effect(() => {
+    for (const p of ctx.players) {
+      const under = scoreOf(p.id) < 0;
+      if (ready && under && !wasUnder[p.id]) {
+        birdieToken[p.id] = (birdieToken[p.id] ?? 0) + 1;
+        eagleFlag[p.id] = holeVerdict(scoreOf(p.id), cfg).kind === 'eagle';
+        haptic('win');
+      }
+      wasUnder[p.id] = under;
+    }
+    ready = true;
+  });
+
+  // Data hygiene: a *closed* grid that no longer sums to its player's score was
+  // overtaken by a manual stepper edit, so drop it — the two entry modes never
+  // save a grid that misrepresents the hole. An open grid owns its score and is
+  // left alone (it writes the score as cards are tapped).
+  $effect(() => {
+    const grids = input.grids;
+    if (!grids) return;
+    for (const id of Object.keys(grids)) {
+      if (openGrid[id]) continue;
+      const cells = grids[id];
+      if (cells && computeGrid(cells, cfg).total !== scoreOf(id)) delete grids[id];
+    }
+  });
+
+  function ensureGrid(id: string) {
+    if (!input.grids) input.grids = {};
+    if (!input.grids[id] || input.grids[id].length !== gridSize) {
+      input.grids[id] = new Array(gridSize).fill(null) as (CardCode | null)[];
+    }
+  }
+  function toggleGrid(id: string) {
+    const next = !openGrid[id];
+    openGrid[id] = next;
+    if (next) {
+      ensureGrid(id);
+      // Resume the laid-out grid only if it still matches the score; otherwise the
+      // score was hand-edited since, so start the felt fresh.
+      if (computeGrid(input.grids![id], cfg).total !== scoreOf(id)) {
+        input.grids![id] = new Array(gridSize).fill(null) as (CardCode | null)[];
+      }
+    }
+  }
+  function applyGridScore(id: string, total: number) {
+    input.scores[id] = total;
   }
 </script>
 
 <div class="stack">
+  <LinksProgress hole={n} holes={cfg.holes} />
+
   <div class="row spread">
-    <span class="pill">⛳ Hole {n} / {cfg.holes}</span>
+    <span class="muted hint">Fewest points wins — cancel columns, chase the red numbers.</span>
     <button type="button" class="btn small ghost" onclick={() => (showRules = !showRules)}>
       Card values
     </button>
@@ -32,34 +112,70 @@
   {/if}
 
   {#each ctx.players as p (p.id)}
-    {@const tag = holeTag(Math.trunc(Number(input.scores[p.id]) || 0))}
+    {@const v = holeVerdict(scoreOf(p.id), cfg)}
     <div class="prow">
+      <BirdieBurst token={birdieToken[p.id] ?? 0} eagle={eagleFlag[p.id] ?? false} />
       <div class="row spread">
-        <span class="row" style="gap: 8px">
+        <span class="row" style="gap: 8px; min-width: 0">
           <Avatar name={p.name} color={p.color} />
-          <strong>{p.name}</strong>
+          <strong class="pname">{p.name}</strong>
         </span>
         <Stepper bind:value={input.scores[p.id]} min={floor} max={ceil} label={p.name} />
       </div>
+
       <div class="row spread foot">
-        <span class="tag" class:under={tag === 'under'}>
-          {#if tag === 'under'}🐦 under par{:else if tag === 'clean'}⛳ clean sheet{:else}&nbsp;{/if}
+        <span
+          class="tag"
+          class:good={v.kind === 'birdie' || v.kind === 'eagle' || v.kind === 'clean'}
+          class:rough={v.kind === 'rough'}
+        >
+          {#if v.label}{v.emoji} {v.label}{:else}&nbsp;{/if}
         </span>
         <span class="running">
           <span class="lbl">total</span>
           <span class="num">{projected(p.id)}</span>
         </span>
       </div>
+
+      <button
+        type="button"
+        class="btn small ghost grid-toggle"
+        aria-expanded={!!openGrid[p.id]}
+        onclick={() => toggleGrid(p.id)}
+      >
+        {openGrid[p.id] ? '▾ Hide grid' : '⛳ Tap the grid'}
+      </button>
+
+      {#if openGrid[p.id]}
+        {#key cfg.grid}
+          <GolfGrid
+            {cfg}
+            bind:cells={input.grids![p.id]}
+            onscore={(t) => applyGridScore(p.id, t)}
+            label={p.name}
+          />
+        {/key}
+      {/if}
     </div>
   {/each}
 </div>
 
 <style>
+  .hint {
+    font-size: 0.85rem;
+  }
   .prow {
+    position: relative;
+    z-index: 0;
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: 14px;
     padding: 12px;
+  }
+  .pname {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .foot {
     margin-top: 8px;
@@ -69,8 +185,13 @@
     font-weight: 700;
     color: var(--muted);
   }
-  .tag.under {
+  /* Under-par (birdie/eagle) and a clean sheet read in semantic green; a blown-up
+     hole reads in caution amber. Colour is always paired with the emoji + word. */
+  .tag.good {
     color: var(--good);
+  }
+  .tag.rough {
+    color: var(--warn);
   }
   .running {
     display: inline-flex;
@@ -86,6 +207,9 @@
   .num {
     font-weight: 800;
     font-variant-numeric: tabular-nums;
+  }
+  .grid-toggle {
+    margin-top: 10px;
   }
   .help {
     display: flex;

--- a/src/lib/games/golf/GolfGrid.svelte
+++ b/src/lib/games/golf/GolfGrid.svelte
@@ -1,0 +1,272 @@
+<script lang="ts">
+  import { haptic } from '../../haptics';
+  import {
+    cardCodes,
+    cardLabel,
+    cardValue,
+    computeGrid,
+    gridShape,
+    type CardCode,
+    type GolfConfig,
+  } from './logic';
+
+  /**
+   * Golf's flagship "tap the grid" helper — an optional card layout that mirrors
+   * the physical grid on the table (3×2 / 2×2 / 3×3). Tap a cell to set its card;
+   * two-or-more matching cards in the same column strike through (they cancel to 0,
+   * the heart of Golf), and the hole total is computed live and handed back to the
+   * editor via {@link onscore}. Pure convenience layered over the manual stepper —
+   * every cell is ≥46px, the total is tabular, and the strike + "cancels" wording
+   * co-signal the cancel so it never rests on colour alone.
+   */
+  let {
+    cfg,
+    cells = $bindable(),
+    onscore,
+    label = '',
+  }: {
+    cfg: GolfConfig;
+    cells: (CardCode | null)[];
+    onscore: (total: number) => void;
+    label?: string;
+  } = $props();
+
+  const shape = $derived(gridShape(cfg.grid));
+  const size = $derived(shape.cols * shape.rows);
+  const codes = $derived(cardCodes(cfg));
+
+  // Keep the cell array sized to the current ruleset (grid size can differ per game).
+  $effect(() => {
+    if (cells.length !== size) {
+      const next = cells.slice(0, size);
+      while (next.length < size) next.push(null);
+      cells = next;
+    }
+  });
+
+  const breakdown = $derived(computeGrid(cells, cfg));
+  const filled = $derived(cells.some((c) => c != null));
+  const canceledCount = $derived(breakdown.canceled.filter(Boolean).length);
+
+  // Push the computed total up whenever the laid-out grid changes, but only once
+  // a card is actually placed — an untouched helper never overwrites a typed score.
+  let prev = -Infinity;
+  $effect(() => {
+    const t = breakdown.total;
+    if (filled && t !== prev) {
+      prev = t;
+      onscore(t);
+    }
+  });
+
+  let picking = $state<number | null>(null);
+
+  function openCell(i: number) {
+    picking = picking === i ? null : i;
+  }
+  function setCard(i: number, code: CardCode | null) {
+    cells[i] = code;
+    picking = null;
+    haptic('tick');
+  }
+  function clearAll() {
+    for (let i = 0; i < cells.length; i++) cells[i] = null;
+    prev = -Infinity;
+    picking = null;
+    haptic('tick');
+    onscore(0);
+  }
+</script>
+
+<div class="grid-helper">
+  <div
+    class="grid"
+    style="grid-template-columns: repeat({shape.cols}, 1fr)"
+    role="group"
+    aria-label={label ? `${label} card grid` : 'Card grid'}
+  >
+    {#each cells as code, i (i)}
+      {@const canceled = breakdown.canceled[i]}
+      <button
+        type="button"
+        class="cell"
+        class:set={code != null}
+        class:canceled
+        aria-pressed={picking === i}
+        aria-label={code ? `Card ${cardLabel(code)}${canceled ? ', cancelled' : ''} — change` : `Empty cell — add a card`}
+        onclick={() => openCell(i)}
+      >
+        {#if code}
+          <span class="face">{cardLabel(code)}</span>
+          {#if canceled}<span class="strike" aria-hidden="true">⊘</span>{/if}
+        {:else}
+          <span class="plus" aria-hidden="true">＋</span>
+        {/if}
+      </button>
+    {/each}
+  </div>
+
+  {#if picking !== null}
+    <div class="picker" role="group" aria-label="Pick a card">
+      {#each codes as code (code)}
+        <button type="button" class="pick" onclick={() => setCard(picking!, code)}>
+          <span class="pface">{cardLabel(code)}</span>
+          <span class="pval">{cardValue(code, cfg)}</span>
+        </button>
+      {/each}
+      <button type="button" class="pick clear" onclick={() => setCard(picking!, null)}>
+        <span class="pface">⌫</span>
+        <span class="pval">clear</span>
+      </button>
+    </div>
+  {/if}
+
+  <div class="foot row spread">
+    <span class="hint">
+      {#if canceledCount > 0}
+        ⊘ {canceledCount} card{canceledCount === 1 ? '' : 's'} cancel in-column
+      {:else if filled}
+        Tap a card to change it
+      {:else}
+        Tap a cell to lay out your grid
+      {/if}
+    </span>
+    <span class="tot">
+      <span class="tlbl">hole</span>
+      <span class="tnum">{breakdown.total}</span>
+      {#if filled}
+        <button type="button" class="clr" onclick={clearAll} aria-label="Clear the grid">clear</button>
+      {/if}
+    </span>
+  </div>
+</div>
+
+<style>
+  .grid-helper {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 10px;
+    padding: 12px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+  }
+  .grid {
+    display: grid;
+    gap: 8px;
+    /* Keep the felt compact so the whole hand fits a thumb's reach. */
+    max-width: 260px;
+  }
+  .cell {
+    position: relative;
+    aspect-ratio: 3 / 4;
+    min-height: 54px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 800;
+    font-size: 1.15rem;
+    font-variant-numeric: tabular-nums;
+    transition: transform var(--dur-press, 90ms) var(--ease-standard, ease),
+      border-color var(--dur-base, 180ms) var(--ease-standard, ease);
+  }
+  .cell:active {
+    transform: scale(0.95);
+  }
+  .cell.set {
+    background: var(--surface-3);
+    border-color: color-mix(in srgb, var(--primary) 40%, var(--border));
+  }
+  .cell.canceled .face {
+    opacity: 0.4;
+    text-decoration: line-through;
+  }
+  .cell.canceled {
+    border-style: dashed;
+    border-color: color-mix(in srgb, var(--good) 55%, var(--border));
+  }
+  .strike {
+    position: absolute;
+    top: 2px;
+    right: 4px;
+    font-size: 0.7rem;
+    color: var(--good);
+  }
+  .plus {
+    color: var(--muted);
+    font-weight: 700;
+    font-size: 1.1rem;
+  }
+  .picker {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(46px, 1fr));
+    gap: 6px;
+  }
+  .pick {
+    min-height: 46px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1px;
+    border: 1px solid var(--border);
+    border-radius: 9px;
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+  }
+  .pick:active {
+    transform: translateY(1px);
+  }
+  .pick.clear {
+    color: var(--muted);
+  }
+  .pface {
+    font-size: 0.98rem;
+    line-height: 1.1;
+  }
+  .pval {
+    font-size: 0.66rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .foot {
+    align-items: center;
+  }
+  .hint {
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+  .tot {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .tlbl {
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .tnum {
+    font-weight: 800;
+    font-size: 1.1rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .clr {
+    border: none;
+    background: transparent;
+    color: var(--muted);
+    font-size: 0.72rem;
+    cursor: pointer;
+    padding: 2px 4px;
+    text-decoration: underline;
+  }
+</style>

--- a/src/lib/games/golf/LinksProgress.svelte
+++ b/src/lib/games/golf/LinksProgress.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  /**
+   * Golf's per-game "costume": a slim links ribbon of flags, one per hole, that
+   * fills as the course is played and highlights the hole being entered. Front /
+   * back-nine aware so a full 18 reads like a real card. Pure flavor — it lives
+   * entirely inside the editor and never touches the shared chrome. The "Hole N of
+   * M" text and the current-flag marker carry the meaning, so the fill is only
+   * reinforcement and there's nothing essential to animate under reduced motion.
+   */
+  let { hole, holes }: { hole: number; holes: number } = $props();
+
+  const flags = $derived(Array.from({ length: holes }, (_, i) => i + 1));
+  // Only split into nines when there's a back nine to speak of.
+  const nine = $derived(
+    holes > 9 ? (hole <= 9 ? 'Front nine' : 'Back nine') : '',
+  );
+  const done = $derived(hole - 1);
+</script>
+
+<div class="links">
+  <div class="cap">
+    <span class="where">⛳ Hole {hole} <span class="of">of {holes}</span></span>
+    {#if nine}<span class="nine">{nine}</span>{/if}
+  </div>
+  <div class="fairway" aria-hidden="true">
+    {#each flags as f (f)}
+      <span
+        class="flag"
+        class:played={f < hole}
+        class:current={f === hole}
+      >{f === hole ? '⛳' : f < hole ? '🚩' : '·'}</span>
+    {/each}
+  </div>
+  <span class="sr-only">Hole {hole} of {holes}{nine ? `, ${nine}` : ''}, {done} played.</span>
+</div>
+
+<style>
+  .links {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+  }
+  .cap {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .where {
+    font-weight: 700;
+    font-size: 0.9rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .of {
+    color: var(--muted);
+    font-weight: 600;
+  }
+  .nine {
+    font-size: 0.72rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .fairway {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 6px;
+    align-items: center;
+  }
+  .flag {
+    font-size: 0.92rem;
+    line-height: 1;
+    opacity: 0.5;
+    filter: grayscale(0.6);
+  }
+  .flag.played {
+    opacity: 1;
+    filter: none;
+  }
+  .flag.current {
+    opacity: 1;
+    filter: none;
+    transform: scale(1.25);
+  }
+</style>

--- a/src/lib/games/golf/golf.test.ts
+++ b/src/lib/games/golf/golf.test.ts
@@ -5,16 +5,23 @@ import type { GameStatsInput, Metric } from '../../stats/types';
 import { golf } from './index';
 import { golfStats } from './stats';
 import {
+  cardCodes,
+  cardValue,
+  computeGrid,
   createGolfInput,
   gridCount,
+  gridScore,
+  gridShape,
   holeCeiling,
   holeFloor,
   holeTag,
+  holeVerdict,
   minCardValue,
   readConfig,
   rulesetLines,
   scoreGolf,
   validateGolf,
+  type CardCode,
   type GolfConfig,
   type GolfInput,
 } from './logic';
@@ -104,6 +111,97 @@ describe('golf ruleset helpers', () => {
     expect(spicy[0]).toContain('K -2');
     expect(spicy[0]).toContain('Joker −2');
     expect(spicy[2]).toContain('1 hole wins');
+  });
+});
+
+describe('golf grid helper', () => {
+  it('maps grid size to a physical column/row layout', () => {
+    expect(gridShape('6')).toEqual({ cols: 3, rows: 2 });
+    expect(gridShape('4')).toEqual({ cols: 2, rows: 2 });
+    expect(gridShape('9')).toEqual({ cols: 3, rows: 3 });
+    expect(gridShape('nonsense')).toEqual({ cols: 3, rows: 2 });
+  });
+
+  it('values each card by the common ruleset, honouring the king variant', () => {
+    const base = cfg();
+    expect(cardValue('A', base)).toBe(1);
+    expect(cardValue('7', base)).toBe(7);
+    expect(cardValue('10', base)).toBe(10);
+    expect(cardValue('J', base)).toBe(10);
+    expect(cardValue('Q', base)).toBe(10);
+    expect(cardValue('K', base)).toBe(0);
+    expect(cardValue('JK', base)).toBe(-2);
+    expect(cardValue(null, base)).toBe(0);
+    expect(cardValue('K', cfg({ kingValue: -2 }))).toBe(-2);
+  });
+
+  it('offers the joker in the picker only when the ruleset enables it', () => {
+    expect(cardCodes(cfg())).not.toContain('JK');
+    expect(cardCodes(cfg({ jokers: true }))).toContain('JK');
+  });
+
+  it('sums a grid with no column matches', () => {
+    // 3×2: cols are [0,3] [1,4] [2,5]
+    const cells: (CardCode | null)[] = ['A', '5', 'K', '3', 'Q', '2'];
+    expect(gridScore(cells, cfg())).toBe(1 + 5 + 0 + 3 + 10 + 2);
+  });
+
+  it('cancels a matched pair in one column to zero', () => {
+    const cells: (CardCode | null)[] = ['7', '5', 'K', '7', 'Q', '2'];
+    const { total, canceled } = computeGrid(cells, cfg());
+    expect(total).toBe(5 + 0 + 10 + 2);
+    expect(canceled[0]).toBe(true);
+    expect(canceled[3]).toBe(true);
+    expect(canceled[1]).toBe(false);
+  });
+
+  it('cancels matches in two columns independently', () => {
+    const cells: (CardCode | null)[] = ['7', '5', '3', '7', '5', '9'];
+    expect(gridScore(cells, cfg())).toBe(3 + 9);
+  });
+
+  it('lets negative cards drive a hole into the red', () => {
+    // Two aces cancel in a column, leaving a lone joker at −2.
+    const cells: (CardCode | null)[] = ['JK', 'A', 'A', 'K', 'A', 'A'];
+    expect(gridScore(cells, cfg({ jokers: true }))).toBe(-2);
+  });
+
+  it('cancels a full column of a kind (triple) to zero on a 3×3 grid', () => {
+    const cells: (CardCode | null)[] = ['4', 'A', null, '4', null, null, '4', null, null];
+    const { total, canceled } = computeGrid(cells, cfg({ grid: '9' }));
+    expect(total).toBe(1);
+    expect(canceled[0] && canceled[3] && canceled[6]).toBe(true);
+  });
+
+  it('scores a 2×2 grid with a cancelled column', () => {
+    // 2×2: cols are [0,2] [1,3]
+    const cells: (CardCode | null)[] = ['8', '8', '8', '5'];
+    expect(gridScore(cells, cfg({ grid: '4' }))).toBe(8 + 5);
+  });
+
+  it('treats an empty grid as zero with nothing cancelled', () => {
+    const { total, canceled } = computeGrid([null, null, null, null, null, null], cfg());
+    expect(total).toBe(0);
+    expect(canceled.some(Boolean)).toBe(false);
+  });
+});
+
+describe('golf caddie verdict', () => {
+  it('reads par, birdie and the rough on a plain ruleset', () => {
+    const base = cfg();
+    expect(holeVerdict(0, base).kind).toBe('clean');
+    expect(holeVerdict(-1, base).kind).toBe('birdie');
+    expect(holeVerdict(5, base).kind).toBe('ok');
+    expect(holeVerdict(5, base).label).toBe('');
+    expect(holeVerdict(50, base).kind).toBe('rough');
+  });
+
+  it('promotes a deep-red hole to an eagle only when negatives are in play', () => {
+    const spicy = cfg({ jokers: true }); // floor −12
+    expect(holeVerdict(-2, spicy).kind).toBe('birdie');
+    expect(holeVerdict(-8, spicy).kind).toBe('eagle');
+    // With no negative cards a hole can never dip far enough for an eagle.
+    expect(holeVerdict(-4, cfg()).kind).toBe('birdie');
   });
 });
 
@@ -233,5 +331,26 @@ describe('golf stats', () => {
     });
     expect(metric(merged.perPlayer!['A'], 'golf_best')?.value).toBe('-6');
     expect(merged.perPlayer!['A2']).toBeUndefined();
+  });
+
+  it('counts eagles for deep-red holes under a ruleset with negatives', () => {
+    const jokerGame: Game = { id: 'gj', type: 'golf', config: { jokers: true }, playerIds: [], status: 'finished', createdAt: 0, roundCount: 0 };
+    const res2 = golfStats({
+      games: [jokerGame],
+      rounds: [
+        mkRound('gj', 0, { A: -7 }), // ≤ −6 → eagle
+        mkRound('gj', 1, { A: -2 }), // under par but not deep → birdie only
+      ],
+      players: [player('A')],
+      canonical: identity,
+    });
+    const a = res2.perPlayer!['A'];
+    expect(metric(a, 'golf_birdie')?.value).toBe('2');
+    expect(metric(a, 'golf_eagle')?.value).toBe('1');
+  });
+
+  it('awards no eagles when the plain ruleset has no negative cards', () => {
+    // The base game (config {}) has a floor of 0, so an eagle is impossible.
+    expect(metric(res.perPlayer!['A'], 'golf_eagle')).toBeUndefined();
   });
 });

--- a/src/lib/games/golf/logic.ts
+++ b/src/lib/games/golf/logic.ts
@@ -30,6 +30,149 @@ export interface GolfConfig {
 /** One hole's raw entry: each player's called-out grid total. */
 export interface GolfInput {
   scores: Record<ID, number>;
+  /**
+   * Optional, additive: the actual cards each player tapped into the "grid helper",
+   * in row-major order (null = an empty cell). Persisted so re-opening a hole to edit
+   * restores the laid-out grid. `scores` stays the single source of truth for scoring,
+   * validation, and stats — a hand-typed hole never needs a grid.
+   */
+  grids?: Record<ID, (CardCode | null)[]>;
+}
+
+/**
+ * Every card a Golf grid can hold. `JK` (Joker) only appears when the ruleset
+ * enables it. Equality is by code, so two Kings — or two Jokers — in the same
+ * column cancel just like two 7s do.
+ */
+export type CardCode = 'A' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | 'J' | 'Q' | 'K' | 'JK';
+
+/** The base deck order shown in the card picker (Jokers appended per-ruleset). */
+export const BASE_CARD_CODES: CardCode[] = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+
+/** The card codes a player can pick for this ruleset (adds the Joker when enabled). */
+export function cardCodes(cfg: GolfConfig): CardCode[] {
+  return cfg.jokers ? [...BASE_CARD_CODES, 'JK'] : BASE_CARD_CODES;
+}
+
+/** Points a single card contributes before column cancels (null = empty = 0). */
+export function cardValue(code: CardCode | null, cfg: GolfConfig): number {
+  switch (code) {
+    case null:
+    case undefined:
+      return 0;
+    case 'A':
+      return 1;
+    case 'J':
+    case 'Q':
+      return 10;
+    case 'K':
+      return cfg.kingValue;
+    case 'JK':
+      return -2;
+    default: {
+      const n = Number(code);
+      return Number.isFinite(n) ? n : 0;
+    }
+  }
+}
+
+/** A short, friendly face for a card code (for the picker + laid-out cells). */
+export function cardLabel(code: CardCode | null): string {
+  if (!code) return '';
+  if (code === 'JK') return '🃏';
+  return code;
+}
+
+/** Column/row layout of the laid-out grid for a ruleset. */
+export interface GridShape {
+  cols: number;
+  rows: number;
+}
+
+/** Map a grid size to its physical layout: 6→3×2, 4→2×2, 9→3×3. */
+export function gridShape(grid: string): GridShape {
+  switch (grid) {
+    case '4':
+      return { cols: 2, rows: 2 };
+    case '9':
+      return { cols: 3, rows: 3 };
+    default:
+      return { cols: 3, rows: 2 };
+  }
+}
+
+/**
+ * Score a laid-out grid, applying the heart of Golf: within each column, any set
+ * of two-or-more matching cards cancels to 0 (a pair, or a full column of a kind).
+ * Cards outside a matched set keep their value. Returns the hole total *and* a
+ * per-cell `canceled` mask so the editor can strike the cards that zeroed out —
+ * a single source of truth for the math and its visual explanation.
+ */
+export function computeGrid(cells: (CardCode | null)[], cfg: GolfConfig): { total: number; canceled: boolean[] } {
+  const { cols, rows } = gridShape(cfg.grid);
+  const size = cols * rows;
+  const canceled = new Array(size).fill(false);
+  for (let c = 0; c < cols; c++) {
+    // Group this column's filled cells by card code; any code with 2+ members cancels.
+    const byCode = new Map<CardCode, number[]>();
+    for (let r = 0; r < rows; r++) {
+      const idx = r * cols + c;
+      const code = cells[idx];
+      if (!code) continue;
+      const list = byCode.get(code) ?? [];
+      list.push(idx);
+      byCode.set(code, list);
+    }
+    for (const idxs of byCode.values()) {
+      if (idxs.length >= 2) for (const i of idxs) canceled[i] = true;
+    }
+  }
+  let total = 0;
+  for (let i = 0; i < size; i++) {
+    if (canceled[i]) continue;
+    total += cardValue(cells[i] ?? null, cfg);
+  }
+  return { total, canceled };
+}
+
+/** Just the hole total for a laid-out grid (see {@link computeGrid}). */
+export function gridScore(cells: (CardCode | null)[], cfg: GolfConfig): number {
+  return computeGrid(cells, cfg).total;
+}
+
+/** True once at least one cell is filled — used to decide whether the grid drives the score. */
+export function gridHasCards(cells: (CardCode | null)[] | undefined): boolean {
+  return !!cells && cells.some((c) => c != null);
+}
+
+/** A caddie's read on a hole score. */
+export type HoleVerdictKind = 'eagle' | 'birdie' | 'clean' | 'ok' | 'rough';
+export interface HoleVerdict {
+  kind: HoleVerdictKind;
+  emoji: string;
+  label: string;
+}
+
+/**
+ * The caddie's read on a called hole, scaled to the ruleset. Par is a cleanly
+ * cancelled grid (0); dipping into the red is a birdie, and a deep red hole (only
+ * reachable with −2 kings / jokers) earns an eagle. A blown-up, near-max hole
+ * lands "in the rough". Every verdict pairs an emoji with words, so the meaning is
+ * never carried by colour alone.
+ */
+export function holeVerdict(score: number, cfg: GolfConfig): HoleVerdict {
+  if (score === 0) return { kind: 'clean', emoji: '⛳', label: 'clean sheet' };
+  if (score < 0) {
+    const floor = holeFloor(cfg);
+    const eagle = floor < 0 && score <= Math.round(floor / 2);
+    return eagle
+      ? { kind: 'eagle', emoji: '🦅', label: 'eagle' }
+      : { kind: 'birdie', emoji: '🐦', label: 'birdie' };
+  }
+  if (score >= Math.round(holeCeiling(cfg) * 0.6)) {
+    return { kind: 'rough', emoji: '🌳', label: 'in the rough' };
+  }
+  return { kind: 'ok', emoji: '', label: '' };
 }
 
 export const DEFAULT_HOLES = 9;

--- a/src/lib/games/golf/stats.ts
+++ b/src/lib/games/golf/stats.ts
@@ -1,5 +1,5 @@
 import type { ID } from '../../types';
-import type { GolfInput } from './logic';
+import { holeVerdict, readConfig, type GolfConfig, type GolfInput } from './logic';
 import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
 import { fmtAvg, fmtInt } from '../../stats/format';
 
@@ -8,21 +8,24 @@ interface GolfAgg {
   sum: number;
   best: number;
   birdies: number;
+  eagles: number;
 }
 
 /**
- * Golf stats, derived purely from each recorded hole. A "birdie" here is a hole
- * scored below zero (all pairs cancelled with red cards to spare); "best hole" is
- * a player's single lowest hole. Pure — no Svelte — so it is unit-testable and
- * safe for the stats engine to import.
+ * Golf stats, derived purely from each recorded hole. A "birdie" is a hole scored
+ * under par (below zero); an "eagle" is a deep-red hole (only reachable with −2
+ * kings / jokers), judged by the same ruleset-scaled {@link holeVerdict} the editor
+ * shows. "Best hole" is a player's single lowest hole. Pure — no Svelte — so it is
+ * unit-testable and safe for the stats engine to import.
  */
 export function golfStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
   const gameIds = new Set(games.map((g) => g.id));
+  const cfgOf = new Map<ID, GolfConfig>(games.map((g) => [g.id, readConfig(g.config)]));
   const per = new Map<ID, GolfAgg>();
   const get = (id: ID): GolfAgg => {
     let a = per.get(id);
     if (!a) {
-      a = { holes: 0, sum: 0, best: Infinity, birdies: 0 };
+      a = { holes: 0, sum: 0, best: Infinity, birdies: 0, eagles: 0 };
       per.set(id, a);
     }
     return a;
@@ -32,6 +35,7 @@ export function golfStats({ games, rounds, canonical }: GameStatsInput): GameSpe
     if (!gameIds.has(r.gameId)) continue;
     const input = r.input as GolfInput | undefined;
     if (!input?.scores) continue;
+    const cfg = cfgOf.get(r.gameId);
     for (const [pid, raw] of Object.entries(input.scores)) {
       const v = Math.trunc(Number(raw) || 0);
       const a = get(canonical(pid));
@@ -39,6 +43,7 @@ export function golfStats({ games, rounds, canonical }: GameStatsInput): GameSpe
       a.sum += v;
       if (v < a.best) a.best = v;
       if (v < 0) a.birdies += 1;
+      if (cfg && holeVerdict(v, cfg).kind === 'eagle') a.eagles += 1;
     }
   }
 
@@ -56,8 +61,17 @@ export function golfStats({ games, rounds, canonical }: GameStatsInput): GameSpe
         key: 'golf_birdie',
         label: 'Birdies',
         value: fmtInt(a.birdies),
-        sub: 'holes under par (0)',
+        sub: 'holes under par',
         emoji: '🐦',
+      });
+    }
+    if (a.eagles) {
+      metrics.push({
+        key: 'golf_eagle',
+        label: 'Eagles',
+        value: fmtInt(a.eagles),
+        sub: 'deep-red holes',
+        emoji: '🦅',
       });
     }
     perPlayer[id] = metrics;


### PR DESCRIPTION
## What & why

Golf's scoring was solid but its round editor was the blandest of the built-in games — just a stepper per player and a tiny tag, while Hearts wears a moon meter and Skull King sails a voyage ribbon. This gives Golf a proper **links personality** and makes per-hole entry fast and accurate, **without touching the shared chrome**.

## Highlights

- **⛳ Tap-the-grid helper (`GolfGrid.svelte`)** — an optional card grid mirroring the physical layout (3×2 / 2×2 / 3×3). Tap a cell to pick a card; two-or-more matching cards in the same column **strike through and cancel to 0** (the heart of Golf), and the hole score is computed live into the entry. The manual stepper stays the default fast path.
- **🚩 Links progress ribbon (`LinksProgress.svelte`)** — a flag-per-hole course strip, front/back-nine aware.
- **🐦 Red-numbers celebration (`BirdieBurst.svelte`)** — a tasteful feather flourish when a hole dips under par; deepens for an eagle.
- **Caddie verdict chips** — hole scores read as 🦅 eagle / 🐦 birdie / ⛳ clean sheet / 🌳 in the rough, scaled to the ruleset.
- **Stats** — counts eagles alongside birdies.

## Under the hood (pure, tested)

- `logic.ts`: `cardValue` / `cardCodes`, `gridShape`, `gridScore` / `computeGrid` (same-column pair-cancel engine), `holeVerdict`. `GolfInput` gains an optional, additive `grids` field so a laid-out hole persists for editing. All Svelte-free.
- **+14 unit tests** (38 golf tests total) covering grid scoring, column cancels (pairs & triples), joker/−2-king negatives, 4/6/9 grids, verdict thresholds, and eagle stats.

## Design guardrails honored

No new Crown Gold (leader/winner only, shell-owned); one Royal Violet primary action untouched; ≥46px touch targets; `tabular-nums` on changing numbers; **state never carried by colour alone** (emoji + word + sign co-signal); every animation is **reduced-motion safe** with a calm/instant alternative; depth via the surface ramp; radii aligned to the documented token scale.

## Local verification

- `npm run check` → 0 errors, 0 warnings
- `npm run build` → success
- `npx vitest run` → **1124/1124 pass** (46 files)
- impeccable design hooks → clean