### PR TITLE
Mario Kart: dress the Grand Prix in racing delight

### DIFF
--- a/src/lib/games/mariokart/MarioKartEditor.svelte
+++ b/src/lib/games/mariokart/MarioKartEditor.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
+  import { flip } from 'svelte/animate';
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
   import { ordinal } from '../../stats/format';
+  import { prefersReducedMotion } from '../../motion';
   import {
-    pointsForPosition,
+    announcerLine,
+    cupProgress,
+    cupStandings,
     normalizeRacers,
     normalizeTable,
+    pointsForPosition,
+    raceComplete,
     tableMeta,
     type MarioKartInput,
   } from './logic';
@@ -17,7 +23,17 @@
   const racers = $derived(normalizeRacers(ctx.config.racers));
   const meta = $derived(tableMeta(table));
 
+  // The Grand Prix context: which race this is, and the announcer's voice for it.
+  const cup = $derived(cupProgress(ctx.roundIndex, ctx.config.racesPerCup));
+  const announcer = $derived(announcerLine(ctx.roundIndex, ctx.config.racesPerCup));
+
+  // Motion preference is read once (matches the rest of the app) so the row
+  // reorder and the checkered flag get a calm, instant alternative.
+  const reduced = prefersReducedMotion();
+  const flipDur = $derived(reduced ? 0 : 220);
+
   let showPoints = $state(false);
+  let showStandings = $state(true);
 
   function pos(id: string): number {
     return Math.floor(Number(input.positions[id]) || 0);
@@ -25,6 +41,40 @@
   function pts(id: string): number {
     return pointsForPosition(table, pos(id), racers);
   }
+
+  // This race's points per racer, recomputed as spots are assigned — feeds both
+  // the per-row payout and the live cup projection.
+  const raceDeltas = $derived.by(() => {
+    const out: Record<string, number> = {};
+    for (const p of ctx.players) out[p.id] = pts(p.id);
+    return out;
+  });
+
+  // Entry rows always read top→bottom as the current finishing order: 1st on top,
+  // unentered racers sink to the back. Steps are ±1 so a change is a gentle
+  // neighbour swap, animated via flip (snap under reduced motion).
+  const sortedPlayers = $derived.by(() => {
+    const order = new Map(ctx.players.map((p, i) => [p.id, i]));
+    return [...ctx.players].sort((a, b) => {
+      const pa = pos(a.id) || Number.POSITIVE_INFINITY;
+      const pb = pos(b.id) || Number.POSITIVE_INFINITY;
+      return pa - pb || (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0);
+    });
+  });
+
+  // The podium for THIS race — the single racer holding 1st / 2nd / 3rd (blank on
+  // a clash or an unfilled spot), so the rostrum reads at a glance.
+  const podium = $derived.by(() => {
+    return [1, 2, 3].map((spot) => {
+      const holders = ctx.players.filter((p) => pos(p.id) === spot);
+      return { spot, player: holders.length === 1 ? holders[0] : null };
+    });
+  });
+
+  // Cumulative cup standings with this race projected in, and the current leader.
+  const standings = $derived(cupStandings(ctx.players, ctx.totals, raceDeltas));
+  const hasBanked = $derived(Object.values(ctx.totals ?? {}).some((v) => Number(v) > 0));
+  const complete = $derived(raceComplete(input, ctx.players, ctx.config));
 
   // Two racers can't share a spot — flag any clash so it's fixable at a glance.
   const clashes = $derived.by(() => {
@@ -61,9 +111,45 @@
 </script>
 
 <div class="stack">
-  <div class="row spread">
-    <span class="pill">{meta.emoji} {meta.label}</span>
-    <button type="button" class="btn small ghost" onclick={() => (showPoints = !showPoints)}>
+  <!-- Cup progress: which race, how far through the cup, and the announcer's call. -->
+  <div class="gp" role="group" aria-label={`Race ${cup.race}${cup.endless ? '' : ` of ${cup.total}`}`}>
+    <div class="row spread gp-head">
+      <span class="race-label tnum">
+        🏁 Race <strong>{cup.race}</strong>{cup.endless ? ' ♾️' : ` of ${cup.total}`}
+      </span>
+      <span class="pill">{meta.emoji} {meta.label}</span>
+    </div>
+    {#if !cup.endless}
+      <div class="pips" aria-hidden="true">
+        {#each cup.pips as p, i (i)}
+          <span class="pip {p}" class:final={cup.isFinal && p === 'current'}></span>
+        {/each}
+      </div>
+    {/if}
+    <p class="announcer">{announcer}</p>
+  </div>
+
+  <!-- This race's podium — the signature rostrum, updating as spots are assigned. -->
+  <div class="podium" role="group" aria-label="This race's podium">
+    {#each podium as slot (slot.spot)}
+      <div class="stand s{slot.spot}">
+        <span class="pmedal" aria-hidden="true">{medal(slot.spot)}</span>
+        <span class="pname" class:empty={!slot.player}>
+          {slot.player ? slot.player.name : '—'}
+        </span>
+        <span class="ppos tnum">{ordinal(slot.spot)}</span>
+      </div>
+    {/each}
+  </div>
+
+  <!-- Toolbar: reveal the payout table and (from race 2) the running cup board. -->
+  <div class="row toolbar">
+    {#if hasBanked}
+      <button type="button" class="btn small ghost" aria-pressed={showStandings} onclick={() => (showStandings = !showStandings)}>
+        {showStandings ? 'Hide cup' : '🏆 Cup standings'}
+      </button>
+    {/if}
+    <button type="button" class="btn small ghost" aria-pressed={showPoints} onclick={() => (showPoints = !showPoints)}>
       {showPoints ? 'Hide points' : 'Points'}
     </button>
   </div>
@@ -82,10 +168,35 @@
     </div>
   {/if}
 
-  {#each ctx.players as p (p.id)}
+  {#if hasBanked && showStandings}
+    <div class="board" role="table" aria-label="Cup standings, projected after this race">
+      <div class="brow bhead" role="row">
+        <span role="columnheader">Cup standings</span>
+        <span class="bproj" role="columnheader">After race {cup.race}</span>
+      </div>
+      {#each standings as s, i (s.id)}
+        {@const p = ctx.players.find((pl) => pl.id === s.id)}
+        <div class="brow" class:leader={s.isLeader} role="row" animate:flip={{ duration: flipDur }}>
+          <span class="bwho" role="cell">
+            <span class="brank tnum">{i + 1}</span>
+            {#if p}<Avatar name={p.name} color={p.color} size={22} />{/if}
+            <span class="bname">{p?.name ?? '—'}</span>
+            {#if s.isLeader}<span class="crown" aria-label="Cup leader">👑</span>{/if}
+          </span>
+          <span class="bproj tnum" role="cell">
+            <span class="proj" class:lead={s.isLeader}>{s.projected}</span>
+            {#if s.delta > 0}<span class="bdelta">+{s.delta}</span>{/if}
+          </span>
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  <!-- Finishing-order entry: the field sorts itself as you assign each spot. -->
+  {#each sortedPlayers as p (p.id)}
     {@const finish = pos(p.id)}
     {@const clash = isClash(p.id)}
-    <div class="prow" class:clash>
+    <div class="prow" class:clash animate:flip={{ duration: flipDur }}>
       <div class="row spread head">
         <span class="who">
           <Avatar name={p.name} color={p.color} />
@@ -100,20 +211,208 @@
           {#if medal(finish)}<span class="badge" aria-hidden="true">{medal(finish)}</span>{/if}
           {rankLabel(finish)}
         </span>
-        <Stepper bind:value={input.positions[p.id]} min={1} max={racers} />
+        <Stepper bind:value={input.positions[p.id]} min={1} max={racers} label={p.name} />
         {#if clash}
           <span class="clash-tag" role="status">⚠ ties {ordinal(finish)}</span>
         {/if}
       </div>
     </div>
   {/each}
+
+  <!-- Checkered flag: the race is a wrap once every spot is distinct and seated. -->
+  {#if complete}
+    <div class="flag" class:animate={!reduced} role="status">
+      <span class="checker" aria-hidden="true"></span>
+      <span class="flag-text">🏁 Race ready — take the flag!</span>
+      <span class="checker" aria-hidden="true"></span>
+    </div>
+  {/if}
 </div>
 
 <style>
+  /* ── Cup progress ─────────────────────────────────────────────────────────── */
+  .gp {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-chip);
+    padding: 12px;
+  }
+  .gp-head {
+    align-items: center;
+  }
+  .race-label {
+    font-size: 0.95rem;
+    font-weight: 600;
+  }
+  .race-label strong {
+    font-weight: 800;
+  }
+  .pips {
+    display: flex;
+    gap: 6px;
+    margin: 10px 0 8px;
+  }
+  .pip {
+    flex: 1 1 0;
+    height: 6px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+  }
+  .pip.done {
+    background: var(--muted);
+    border-color: var(--muted);
+  }
+  .pip.current {
+    background: var(--primary);
+    border-color: var(--primary);
+  }
+  /* The final race gets a gold pip — the cup is on the line (leader/winner gold). */
+  .pip.current.final {
+    background: var(--accent);
+    border-color: var(--accent);
+  }
+  .announcer {
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--muted);
+  }
+
+  /* ── Podium (this race) ───────────────────────────────────────────────────── */
+  .podium {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    align-items: end;
+    gap: 8px;
+  }
+  .stand {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-chip);
+    padding: 8px 6px;
+    text-align: center;
+    min-width: 0;
+  }
+  /* A real rostrum: the winner stands tallest, bronze lowest — order via padding. */
+  .stand.s1 {
+    padding-top: 12px;
+    padding-bottom: 14px;
+  }
+  .stand.s2 {
+    padding-top: 8px;
+  }
+  .stand.s3 {
+    padding-top: 4px;
+  }
+  .pmedal {
+    font-size: 1.35rem;
+    line-height: 1;
+  }
+  .pname {
+    font-weight: 700;
+    font-size: 0.85rem;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .pname.empty {
+    color: var(--muted);
+    font-weight: 600;
+  }
+  .ppos {
+    font-size: 0.72rem;
+    color: var(--muted);
+    font-weight: 700;
+  }
+
+  /* ── Toolbar ──────────────────────────────────────────────────────────────── */
+  .toolbar {
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  /* ── Cup standings board ──────────────────────────────────────────────────── */
+  .board {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .brow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 5px 6px;
+    border-radius: var(--radius-sm);
+  }
+  .bhead {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+    padding-bottom: 2px;
+  }
+  /* Restrained crown-gold wash on the projected leader — matches the scoreboard's
+     leader treatment; the 👑 and gold number carry it, so the wash stays a hint. */
+  .brow.leader {
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+  }
+  .bwho {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .brank {
+    min-width: 1.2em;
+    font-weight: 800;
+    color: var(--muted);
+    text-align: right;
+  }
+  .bname {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .crown {
+    font-size: 0.95rem;
+  }
+  .bproj {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    white-space: nowrap;
+  }
+  .proj {
+    font-weight: 800;
+    font-size: 1.05rem;
+  }
+  .proj.lead {
+    color: var(--accent-ink);
+  }
+  .bdelta {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--good);
+  }
+
+  /* ── Entry rows ───────────────────────────────────────────────────────────── */
   .prow {
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius-chip);
     padding: 12px;
   }
   .prow.clash {
@@ -165,6 +464,8 @@
     font-weight: 700;
     color: var(--bad);
   }
+
+  /* ── Points reference ─────────────────────────────────────────────────────── */
   .points {
     background: var(--surface);
     border: 1px solid var(--border);
@@ -195,6 +496,63 @@
   .chip .v {
     font-weight: 800;
   }
+
+  /* ── Checkered-flag finish ────────────────────────────────────────────────── */
+  .flag {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    border-radius: 10px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+  }
+  .flag-text {
+    font-weight: 700;
+    font-size: 0.9rem;
+    white-space: nowrap;
+  }
+  .checker {
+    flex: 1 1 0;
+    height: 12px;
+    background-image:
+      conic-gradient(var(--text) 90deg, transparent 0 180deg, var(--text) 0 270deg, transparent 0);
+    background-size: 12px 12px;
+    opacity: 0.7;
+  }
+  /* Wave the flag in once — the race is a wrap. Instant under reduced motion. */
+  .flag.animate {
+    animation: flag-in 0.4s var(--ease-out) both;
+  }
+  .flag.animate .checker {
+    animation: flag-wave 1.1s ease-in-out infinite;
+  }
+  @keyframes flag-in {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  @keyframes flag-wave {
+    0%,
+    100% {
+      background-position: 0 0;
+    }
+    50% {
+      background-position: 12px 0;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .flag.animate,
+    .flag.animate .checker {
+      animation: none;
+    }
+  }
+
   .tnum {
     font-variant-numeric: tabular-nums;
   }

--- a/src/lib/games/mariokart/logic.ts
+++ b/src/lib/games/mariokart/logic.ts
@@ -172,3 +172,119 @@ export function freshPositions(
     positions: Object.fromEntries(players.map((p, i) => [p.id, Math.min(i + 1, racers)])),
   };
 }
+
+// ── Grand Prix presentation helpers ─────────────────────────────────────────────
+// Pure, Svelte-free derivations that let the round editor dress up the cup — race
+// progress, the announcer's voice, the running cup standings and a "race in the
+// books" check — without duplicating any logic the tests can't reach.
+
+/** Where a cup stands right now: which race this is and how the field of pips reads. */
+export interface CupProgress {
+  /** 1-based number of the race being entered. */
+  race: number;
+  /** Total races in the cup, or 0 for an endless cup. */
+  total: number;
+  /** True when the cup has no fixed length. */
+  endless: boolean;
+  /** True when this is the last race of a fixed-length cup (the trophy is on the line). */
+  isFinal: boolean;
+  /**
+   * One pip per race in a fixed cup: 'done' (already raced), 'current' (this race),
+   * or 'todo' (still to come). Empty for an endless cup, which shows a count instead.
+   */
+  pips: ('done' | 'current' | 'todo')[];
+}
+
+/**
+ * Read the cup's shape from the 0-based round index being entered and the configured
+ * races-per-cup. Endless cups (0) carry no pips — the UI shows a plain race count.
+ */
+export function cupProgress(roundIndex: number, racesPerCup: unknown): CupProgress {
+  const total = normalizeRaces(racesPerCup);
+  const idx = Math.max(0, Math.floor(Number(roundIndex) || 0));
+  const race = idx + 1;
+  const endless = total === 0;
+  const isFinal = !endless && race >= total;
+  const pips: CupProgress['pips'] = [];
+  if (!endless) {
+    for (let i = 0; i < total; i++) {
+      pips.push(i < idx ? 'done' : i === idx ? 'current' : 'todo');
+    }
+  }
+  return { race, total, endless, isFinal, pips };
+}
+
+/**
+ * The race announcer's one-liner for the race being entered — start-line hype on race
+ * one, plain lap copy in the middle, and trophy stakes on the final race. Endless cups
+ * get their own open-road flavor. Copy only; kept here so it's snapshot-testable.
+ */
+export function announcerLine(roundIndex: number, racesPerCup: unknown): string {
+  const { race, endless, isFinal } = cupProgress(roundIndex, racesPerCup);
+  if (endless) return '♾️ Endless cup — keep the engines running!';
+  if (race === 1) return '🚦 Start your engines — the cup begins!';
+  if (isFinal) return '🏆 Final race — the cup is on the line!';
+  return '🏁 Back on the grid — every point counts.';
+}
+
+/** A racer's standing in the cup, blending the banked total with this race's preview. */
+export interface CupStanding {
+  id: ID;
+  /** Points banked in the cup BEFORE this race. */
+  total: number;
+  /** This race's points for the racer (0 until they're given a spot). */
+  delta: number;
+  /** total + delta — where they'd sit once this race is saved. */
+  projected: number;
+  /** True for the racer(s) leading on projected total (ties share the crown). */
+  isLeader: boolean;
+}
+
+/**
+ * Build the live cup standings for the editor: each racer's banked total, this race's
+ * projected points, and the resulting order. Sorted by projected total (desc), then by
+ * banked total, then name, so the board is stable as spots are assigned. The projected
+ * leader(s) are flagged for the 👑 — but only once someone is actually ahead, so a
+ * still-scoreless grid crowns no one.
+ */
+export function cupStandings(
+  players: Pick<Player, 'id' | 'name'>[],
+  totals: Record<ID, number>,
+  raceDeltas: Record<ID, number>,
+): CupStanding[] {
+  const rows = players.map((p) => {
+    const total = Math.round(Number(totals?.[p.id]) || 0);
+    const delta = Math.round(Number(raceDeltas?.[p.id]) || 0);
+    return { id: p.id, name: p.name, total, delta, projected: total + delta };
+  });
+  const best = rows.reduce((m, r) => Math.max(m, r.projected), 0);
+  rows.sort(
+    (a, b) => b.projected - a.projected || b.total - a.total || a.name.localeCompare(b.name),
+  );
+  return rows.map(({ name: _name, ...r }) => ({
+    ...r,
+    isLeader: best > 0 && r.projected === best,
+  }));
+}
+
+/**
+ * Is this race a wrap? True when every racer holds a distinct, in-field finishing spot
+ * — i.e. the entry is complete and valid, ready for the checkered flag. Mirrors
+ * {@link validateRace}'s success case as a boolean the UI can react to.
+ */
+export function raceComplete(
+  input: MarioKartInput,
+  players: Pick<Player, 'id'>[],
+  config: Partial<MarioKartConfig> | Record<string, unknown> = {},
+): boolean {
+  const racers = normalizeRacers((config as Record<string, unknown>).racers);
+  if (players.length === 0 || players.length > racers) return false;
+  const positions = input?.positions ?? {};
+  const seen = new Set<number>();
+  for (const p of players) {
+    const pos = Math.floor(Number(positions[p.id]) || 0);
+    if (pos < 1 || pos > racers || seen.has(pos)) return false;
+    seen.add(pos);
+  }
+  return true;
+}

--- a/src/lib/games/mariokart/mariokart.test.ts
+++ b/src/lib/games/mariokart/mariokart.test.ts
@@ -5,11 +5,15 @@ import { mariokart } from './index';
 import { mariokartStats } from './stats';
 import {
   POINTS_TABLES,
+  announcerLine,
+  cupProgress,
+  cupStandings,
   freshPositions,
   normalizeRaces,
   normalizeRacers,
   normalizeTable,
   pointsForPosition,
+  raceComplete,
   scoreRace,
   validateRace,
   type MarioKartInput,
@@ -161,6 +165,93 @@ describe('freshPositions', () => {
     const input = freshPositions(P, { racers: 12 });
     expect(input.positions).toEqual({ a: 1, b: 2, c: 3, d: 4 });
     expect(validateRace(input, P, { racers: 12 })).toBeNull();
+  });
+});
+
+describe('cupProgress', () => {
+  it('reads a fixed 4-race cup with pips that walk across the grid', () => {
+    expect(cupProgress(0, 4)).toEqual({
+      race: 1,
+      total: 4,
+      endless: false,
+      isFinal: false,
+      pips: ['current', 'todo', 'todo', 'todo'],
+    });
+    expect(cupProgress(3, 4)).toEqual({
+      race: 4,
+      total: 4,
+      endless: false,
+      isFinal: true,
+      pips: ['done', 'done', 'done', 'current'],
+    });
+  });
+
+  it('marks an endless cup with no pips and a plain race count', () => {
+    const p = cupProgress(2, 0);
+    expect(p.endless).toBe(true);
+    expect(p.isFinal).toBe(false);
+    expect(p.race).toBe(3);
+    expect(p.pips).toEqual([]);
+  });
+
+  it('coerces junk round indices to the first race', () => {
+    expect(cupProgress(-5, 4).race).toBe(1);
+    expect(cupProgress(Number.NaN, 4).race).toBe(1);
+  });
+});
+
+describe('announcerLine', () => {
+  it('hypes the start, the middle, and the final race distinctly', () => {
+    expect(announcerLine(0, 4)).toMatch(/engines/i);
+    expect(announcerLine(1, 4)).toMatch(/grid|count/i);
+    expect(announcerLine(3, 4)).toMatch(/final/i);
+  });
+
+  it('gives an endless cup its own open-road voice', () => {
+    expect(announcerLine(5, 0)).toMatch(/endless/i);
+  });
+});
+
+describe('cupStandings', () => {
+  it('blends banked totals with this race projection and orders by projected', () => {
+    const totals = { a: 30, b: 30, c: 10 };
+    const deltas = { a: 10, b: 1, c: 15 };
+    const rows = cupStandings(P.slice(0, 3), totals, deltas);
+    // projected: a 40, b 31, c 25 → descending a, b, c
+    expect(rows.map((r) => r.id)).toEqual(['a', 'b', 'c']);
+    expect(rows.map((r) => r.projected)).toEqual([40, 31, 25]);
+  });
+
+  it('projects correctly and flags the leader (only once someone is ahead)', () => {
+    const rows = cupStandings(P.slice(0, 2), { a: 12, b: 0 }, { a: 0, b: 15 });
+    const a = rows.find((r) => r.id === 'a')!;
+    const b = rows.find((r) => r.id === 'b')!;
+    expect(a.projected).toBe(12);
+    expect(b.projected).toBe(15);
+    expect(b.isLeader).toBe(true);
+    expect(a.isLeader).toBe(false);
+  });
+
+  it('crowns no one on a still-scoreless grid', () => {
+    const rows = cupStandings(P.slice(0, 2), { a: 0, b: 0 }, { a: 0, b: 0 });
+    expect(rows.every((r) => !r.isLeader)).toBe(true);
+  });
+
+  it('shares the crown on a projected tie', () => {
+    const rows = cupStandings(P.slice(0, 2), { a: 10, b: 5 }, { a: 0, b: 5 });
+    expect(rows.every((r) => r.isLeader)).toBe(true);
+  });
+});
+
+describe('raceComplete', () => {
+  const cfg = { racers: 12 };
+  it('is true only when every racer holds a distinct in-field spot', () => {
+    expect(raceComplete({ positions: { a: 1, b: 2, c: 3, d: 4 } }, P, cfg)).toBe(true);
+  });
+  it('is false when a spot is missing, clashing, or out of the field', () => {
+    expect(raceComplete({ positions: { a: 1, b: 0, c: 3, d: 4 } }, P, cfg)).toBe(false);
+    expect(raceComplete({ positions: { a: 1, b: 1, c: 3, d: 4 } }, P, cfg)).toBe(false);
+    expect(raceComplete({ positions: { a: 1, b: 2, c: 3, d: 4 } }, P, { racers: 3 })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## 🏎️ Mario Kart — Grand Prix delight

Layers a full Grand-Prix costume onto the **Mario Kart** round editor without touching the shared shell. The crux — fast, unambiguous finishing-position entry — now reads as a live race, and the cup finally accumulates *in view* during entry (all from `ctx.totals`/`roundIndex`, previously unused).

### Critique that drove this
- Entry showed only *this race's* points — cup totals, the leader 👑, and "Race N of M" progress were invisible at the moment you enter finishes.
- Position entry was a bare −/+ stepper (8th = seven taps) and the card never read as an actual finishing order.
- The beloved racing energy (podium, checkered flag, announcer, the cup) was muted.

### What changed
- **Live-sorting finishing order** — entry rows auto-reorder (`animate:flip`, snap under reduced motion) so the card always reads top→bottom as the current race order. The signature Stepper is kept as the canonical control.
- **🥇🥈🥉 podium rostrum** for this race's top 3, updating live.
- **Cup-progress strip** — "Race N of M" with race pips (a gold pip on the final race); endless cups show a plain race count.
- **Live cup standings** — cumulative totals with a *projected after-this-race* preview; the projected leader gets the sanctioned Crown Gold + 👑 (ties share it). Appears from race 2 so race 1 stays clean.
- **Race-announcer microcopy** that reacts to cup state (start-line → final-race stakes → endless).
- **Checkered-flag "race ready"** flourish once every spot is distinct and seated.

### Where it lives
- `logic.ts` — new pure, Svelte-free, unit-tested helpers: `cupProgress`, `announcerLine`, `cupStandings`, `raceComplete`.
- `MarioKartEditor.svelte` — the costume (Stepper/Avatar reused, radii on the documented token scale).
- `mariokart.test.ts` — coverage for the new helpers.

### Design non-negotiables honored
One Royal Violet primary (the shell's Save) — editor adds no second violet fill · Crown Gold only on the projected cup leader/winner · depth via the surface ramp, no shell restyle · `tabular-nums` on every changing number · ≥46px targets · never color-alone (👑 + rank + name + medals co-signal) · full `prefers-reduced-motion` paths for the flip reorder and the flag. Design hook clean.

### Verification (local)
- `npm run check` → 0 errors / 0 warnings
- `npm test` → 46 files, **1135 tests pass** (42 in the Mario Kart suite)
- `npm run build` → succeeds
- Runtime render smoke-checked (throwaway) to confirm the editor mounts and shows the progress strip, podium, crowned standings, and checkered flag.