### PR TITLE
Rummikub: tile-rack costume, swinging pot, and fast keypad entry

### DIFF
--- a/src/lib/games/rummikub/JokerSting.svelte
+++ b/src/lib/games/rummikub/JokerSting.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * Joker dread: when a joker is stranded on a non-winner's rack, a 🃏 penalty stamp slams
+   * over their row — because a caught joker is the single most painful tile in Rummikub (30
+   * points by default, straight into the winner's pot). Pure delight over a sting that's
+   * already spelled out in words + number (the joker count and the row's leftover total both
+   * jump), so motion is never the only signal. `pointer-events: none`, replays whenever
+   * `token` changes, and renders nothing under reduced motion (mirrors DreadStamp).
+   */
+  let { token = 0, value = 0 }: { token?: number; value?: number } = $props();
+
+  const reduced = prefersReducedMotion();
+</script>
+
+{#if !reduced && token > 0 && value > 0}
+  {#key token}
+    <div class="dread" aria-hidden="true">
+      <span class="stamp">🃏 −{value}</span>
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .dread {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    overflow: hidden;
+    z-index: 3;
+  }
+  .stamp {
+    font-weight: 800;
+    font-size: 1.5rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--bad);
+    padding: 4px 14px;
+    border: 2px solid var(--bad);
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--bad) 14%, var(--surface));
+    white-space: nowrap;
+    opacity: 0;
+    will-change: transform, opacity;
+    transform: rotate(-9deg);
+    animation: stamp-slam 1s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  @keyframes stamp-slam {
+    0% {
+      opacity: 0;
+      transform: rotate(-9deg) scale(2.1);
+    }
+    22% {
+      opacity: 1;
+      transform: rotate(-9deg) scale(0.92);
+    }
+    34% {
+      transform: rotate(-9deg) scale(1.04);
+    }
+    46% {
+      transform: rotate(-9deg) scale(1);
+    }
+    80% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+      transform: rotate(-9deg) scale(1);
+    }
+  }
+</style>

--- a/src/lib/games/rummikub/Pot.svelte
+++ b/src/lib/games/rummikub/Pot.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+  /**
+   * Rummikub's zero-sum heart made visible: the round **pot** — the total value of everyone's
+   * leftover tiles — which the player who goes out scoops whole while the rest of the table
+   * loses it. The number is the truth (tabular, always shown); the fill bar is decorative
+   * reinforcement of "how big the pot is getting," and once someone is marked out the pot
+   * visibly **swings to them** (→ name) in the semantic good accent. Pure per-game costume:
+   * no Royal Violet (Save) and no Crown Gold (leader) — the swing is the calm "good" green,
+   * co-signalled by 🎁/🏆, the arrow, and the winner's name so colour is never alone.
+   *
+   * Motion is a flourish: the fill glides, but drops to an instant set under reduced motion —
+   * the pot value and destination read the same either way.
+   */
+  import { prefersReducedMotion } from '../../motion';
+
+  let {
+    total = 0,
+    winnerName = null,
+  }: { total?: number; winnerName?: string | null } = $props();
+
+  const reduced = prefersReducedMotion();
+  // A soft, capped scale so the bar reads as "small / building / fat pot" without pretending
+  // to be a precise metric — the number carries the exact stakes.
+  const fill = $derived(Math.max(0, Math.min(1, total / 90)));
+  const claimed = $derived(!!winnerName && total > 0);
+</script>
+
+<div class="pot" class:claimed role="img"
+  aria-label={winnerName
+    ? `Pot of ${total}, going to ${winnerName}`
+    : `Pot of ${total}, up for grabs`}>
+  <div class="bar" class:reduced aria-hidden="true">
+    <div class="fillbar" style="--fill: {fill}"></div>
+  </div>
+  <div class="face">
+    <span class="left">
+      <span class="gift">🎁</span>
+      <strong class="amt">{total}</strong>
+      <span class="lbl">in the pot</span>
+    </span>
+    {#if claimed}
+      <span class="dest" aria-hidden="true">🏆 → {winnerName}</span>
+    {:else}
+      <span class="grab" aria-hidden="true">up for grabs</span>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .pot {
+    position: relative;
+    overflow: hidden;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 10px 12px;
+  }
+  .bar {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+  }
+  /* Decorative "how fat is the pot" fill, contained behind the text. Neutral while up for
+     grabs; the parent .claimed swaps it to the good accent when the pot swings to a winner. */
+  .fillbar {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+    transform: scaleX(var(--fill, 0));
+    transform-origin: left center;
+    background: color-mix(in srgb, var(--muted) 22%, transparent);
+    transition: transform 0.4s var(--ease-out), background var(--dur-base) var(--ease-standard);
+  }
+  .claimed .fillbar {
+    background: color-mix(in srgb, var(--good) 26%, transparent);
+  }
+  .bar.reduced .fillbar {
+    transition: none;
+  }
+  .face {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .left {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    min-width: 0;
+  }
+  .gift {
+    font-size: 1rem;
+  }
+  .amt {
+    font-size: 1.25rem;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .lbl {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .grab {
+    font-size: 0.8rem;
+    color: var(--muted);
+    white-space: nowrap;
+  }
+  .dest {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--good);
+    white-space: nowrap;
+    max-width: 55%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+</style>

--- a/src/lib/games/rummikub/RummikubEditor.svelte
+++ b/src/lib/games/rummikub/RummikubEditor.svelte
@@ -2,8 +2,14 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
-  import { handPenalty, type RummikubInput } from './logic';
+  import { haptic } from '../../haptics';
+  import { handPenalty, potTotal, type RummikubInput } from './logic';
   import { rummikub } from './index';
+  import TileRack from './TileRack.svelte';
+  import Pot from './Pot.svelte';
+  import TileBurst from './TileBurst.svelte';
+  import JokerSting from './JokerSting.svelte';
+  import TileKeypad from './TileKeypad.svelte';
 
   let { input = $bindable(), ctx }: { input: RummikubInput; ctx: RoundContext } = $props();
 
@@ -11,25 +17,46 @@
   const fixedRounds = $derived(
     ctx.config.endMode === 'target' ? null : Number(ctx.config.rounds) || 4,
   );
+  const target = $derived(ctx.config.endMode === 'target' ? Number(ctx.config.target) || 100 : null);
 
-  /** The winner's derived score: the sum of every opponent's leftover tiles. */
-  const pot = $derived(
-    ctx.players.reduce(
-      (sum, p) => (p.id === input.winner ? sum : sum + handPenalty(input.hands[p.id], jokerValue)),
-      0,
-    ),
-  );
+  /** The pot: the sum of every non-winner's leftovers — what the player who goes out scoops. */
+  const pot = $derived(potTotal(input, ctx.players.map((p) => p.id), jokerValue));
+  const winnerName = $derived(ctx.players.find((p) => p.id === input.winner)?.name ?? null);
 
   let showHelp = $state(false);
 
+  // Delight tokens, bumped only by a real user tap (never on mount / edit-open), so a fresh
+  // go-out flings tiles and a fresh stranded joker slams the dread stamp.
+  let burstTokens = $state<Record<string, number>>({});
+  let stingTokens = $state<Record<string, number>>({});
+
   function setWinner(id: string) {
-    input.winner = input.winner === id ? null : id;
+    const turningOn = input.winner !== id;
+    input.winner = turningOn ? id : null;
+    if (turningOn) {
+      // A fresh winner starts with an empty rack; clear any leftovers they'd entered.
+      input.hands[id] = { tiles: 0, jokers: 0 };
+      burstTokens = { ...burstTokens, [id]: (burstTokens[id] ?? 0) + 1 };
+      haptic('save');
+    }
+  }
+
+  function stingJoker(id: string) {
+    if (jokerValue > 0) stingTokens = { ...stingTokens, [id]: (stingTokens[id] ?? 0) + 1 };
   }
 </script>
 
 <div class="stack">
+  <TileRack round={ctx.roundIndex + 1} total={fixedRounds} {target} />
+
+  <Pot total={pot} {winnerName} />
+
   <div class="row spread">
-    <span class="pill">Round {ctx.roundIndex + 1}{fixedRounds ? ` of ${fixedRounds}` : ''}</span>
+    <p class="muted hint">
+      {input.winner
+        ? '🎁 Now tap everyone else’s leftover tiles into the pot.'
+        : '🏁 Tap whoever shouted “Rummikub!” — emptied their rack.'}
+    </p>
     <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
       How to score
     </button>
@@ -39,16 +66,13 @@
     <pre class="help">{rummikub.help}</pre>
   {/if}
 
-  <p class="muted hint">
-    {input.winner
-      ? 'Now enter everyone else’s leftover tiles.'
-      : 'Tap whoever went out — emptied their rack.'}
-  </p>
-
   {#each ctx.players as p (p.id)}
     {@const isWinner = input.winner === p.id}
     {@const penalty = handPenalty(input.hands[p.id], jokerValue)}
     <div class="prow" class:winner={isWinner}>
+      <TileBurst token={burstTokens[p.id] ?? 0} />
+      <JokerSting token={stingTokens[p.id] ?? 0} value={jokerValue} />
+
       <div class="row spread">
         <span class="row" style="gap: 8px">
           <Avatar name={p.name} color={p.color} />
@@ -69,18 +93,27 @@
           aria-pressed={isWinner}
           onclick={() => setWinner(p.id)}
         >
-          {isWinner ? '🏆 Rummikub!' : 'Went out'}
+          {isWinner ? '🏆 Rummikub!' : '🏁 Went out'}
         </button>
 
-        {#if !isWinner}
+        {#if isWinner}
+          <div class="emptyrack">🎉 Rack emptied — scoops the whole {pot}-point pot!</div>
+        {:else}
+          <TileKeypad
+            bind:tiles={input.hands[p.id].tiles}
+            bind:jokers={input.hands[p.id].jokers}
+            {jokerValue}
+            label={p.name}
+            onjoker={() => stingJoker(p.id)}
+          />
           <div class="fields">
             <label class="f">
               Tiles
-              <Stepper bind:value={input.hands[p.id].tiles} min={0} />
+              <Stepper bind:value={input.hands[p.id].tiles} min={0} label={`${p.name} tiles`} />
             </label>
             <label class="f">
               Jokers
-              <Stepper bind:value={input.hands[p.id].jokers} min={0} max={2} />
+              <Stepper bind:value={input.hands[p.id].jokers} min={0} max={2} label={`${p.name} jokers`} />
             </label>
           </div>
         {/if}
@@ -91,16 +124,19 @@
 
 <style>
   .prow {
+    position: relative;
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     padding: 12px;
     display: flex;
     flex-direction: column;
     gap: 12px;
   }
+  /* Going out is the winning outcome — co-signal it with a calm good edge, never colour alone:
+     the 🏆, the "Rummikub!" label, the "rack emptied" line and the +pot all say it too. */
   .prow.winner {
-    border-color: var(--primary);
+    border-color: color-mix(in srgb, var(--good) 50%, var(--border));
   }
   .controls {
     display: flex;
@@ -116,11 +152,20 @@
     color: var(--text);
     cursor: pointer;
     font-weight: 700;
+    transition: background var(--dur-base) var(--ease-standard), border-color var(--dur-base) var(--ease-standard);
   }
+  /* The winner toggle uses the semantic good accent — NOT Royal Violet, which the shell
+     reserves for the single Save action, nor Crown Gold, reserved for the leader/winner. */
   .toggle.on {
-    background: var(--primary);
-    border-color: var(--primary-strong);
-    color: #fff;
+    background: color-mix(in srgb, var(--good) 20%, var(--surface));
+    border-color: var(--good);
+    color: var(--text);
+  }
+  .emptyrack {
+    color: var(--good);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    padding: 2px 0;
   }
   .fields {
     display: flex;
@@ -152,5 +197,10 @@
     margin: 0;
     font-family: inherit;
     color: var(--muted);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .toggle {
+      transition: none;
+    }
   }
 </style>

--- a/src/lib/games/rummikub/TileBurst.svelte
+++ b/src/lib/games/rummikub/TileBurst.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+  import { tileInk, TILE_FACE } from './tiles';
+
+  /**
+   * The triumphant "Rummikub!" moment — a short flurry of colourful numbered tiles flung up
+   * off a player's row the instant they're marked out (their rack emptied onto the table).
+   * Pure delight layered over an outcome already spelled out in words + number ("🏆 Rummikub!"
+   * and the +pot), so motion is never the only signal. The overlay is `pointer-events: none`,
+   * replays whenever `token` changes (a fresh go-out), and renders nothing under reduced motion
+   * (mirrors CoinBurst / FeatherBurst).
+   */
+  let { token = 0 }: { token?: number } = $props();
+
+  const reduced = prefersReducedMotion();
+  const COUNT = 10;
+
+  // Deterministic pseudo-random, seeded by token so each burst looks a little different but is
+  // stable across a single render (mirrors CoinBurst/MoonRise/FeatherBurst).
+  const bits = $derived(
+    Array.from({ length: COUNT }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      const isSparkle = rand(9) > 0.72;
+      const num = 1 + Math.floor(rand(0) * 13);
+      return {
+        sparkle: isSparkle,
+        num,
+        left: 50 + (rand(1) - 0.5) * 96,
+        delay: rand(2) * 0.12,
+        duration: 0.72 + rand(3) * 0.5,
+        rise: 26 + rand(4) * 40,
+        drift: (rand(5) - 0.5) * 44,
+        spin: (rand(6) - 0.5) * 300,
+        size: 0.85 + rand(7) * 0.5,
+      };
+    }),
+  );
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="burst" aria-hidden="true">
+      {#each bits as b, i (i)}
+        {#if b.sparkle}
+          <span
+            class="fly spark"
+            style="
+              left: {b.left}%;
+              font-size: {b.size}rem;
+              animation-delay: {b.delay}s;
+              animation-duration: {b.duration}s;
+              --rise: {b.rise}px;
+              --drift: {b.drift}px;
+              --spin: {b.spin}deg;
+            ">✨</span>
+        {:else}
+          <span
+            class="fly tile"
+            style="
+              left: {b.left}%;
+              transform-origin: center;
+              font-size: {b.size}rem;
+              animation-delay: {b.delay}s;
+              animation-duration: {b.duration}s;
+              --ink: {tileInk(b.num)};
+              --face: {TILE_FACE};
+              --rise: {b.rise}px;
+              --drift: {b.drift}px;
+              --spin: {b.spin}deg;
+            ">{b.num}</span>
+        {/if}
+      {/each}
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .burst {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    height: 0;
+    pointer-events: none;
+    overflow: visible;
+    z-index: 3;
+  }
+  .fly {
+    position: absolute;
+    top: 0;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: tile-fly;
+    animation-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1);
+    animation-iteration-count: 1;
+    animation-fill-mode: both;
+  }
+  /* A mini ivory tile with a coloured numeral — the same physical tile as the rack. */
+  .fly.tile {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5em;
+    height: 2em;
+    border-radius: var(--radius-sm);
+    background: var(--face);
+    color: var(--ink);
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+    border: 1px solid color-mix(in srgb, var(--ink) 30%, transparent);
+  }
+  @keyframes tile-fly {
+    0% {
+      opacity: 0;
+      transform: translate(0, 8px) rotate(0deg) scale(0.5);
+    }
+    18% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+      transform: translate(var(--drift), calc(var(--rise) * -1)) rotate(var(--spin)) scale(1);
+    }
+  }
+</style>

--- a/src/lib/games/rummikub/TileKeypad.svelte
+++ b/src/lib/games/rummikub/TileKeypad.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+  import { haptic } from '../../haptics';
+  import { animateMotion } from '../../motion';
+  import { tileInk, TILE_FACE } from './tiles';
+
+  /**
+   * Fast, thematic leftover entry: tap the numbered tiles a player was caught holding and each
+   * tap adds that tile's face value to their rack total — far quicker than nudging a step-by-one
+   * stepper up to 40+. A 🃏 key adds a stranded joker (the big penalty), and Clear wipes the
+   * rack. The colourful ivory tiles are Rummikub's costume; every key shows its number, so
+   * colour never carries meaning alone. Keys are ≥46px for one-handed, dim-light use and fire a
+   * light haptic tick per tap. The precise steppers remain alongside for fine corrections.
+   */
+  let {
+    tiles = $bindable(0),
+    jokers = $bindable(0),
+    jokerValue = 30,
+    maxJokers = 2,
+    onjoker,
+    label = '',
+  }: {
+    tiles?: number;
+    jokers?: number;
+    jokerValue?: number;
+    maxJokers?: number;
+    onjoker?: () => void;
+    label?: string;
+  } = $props();
+
+  const values = Array.from({ length: 13 }, (_, i) => i + 1);
+  let readoutEl: HTMLSpanElement | undefined = $state();
+
+  function bump() {
+    if (readoutEl) animateMotion(readoutEl, { scale: [1, 1.14, 1] }, { duration: 0.16, ease: 'easeOut' });
+  }
+
+  function addTile(n: number) {
+    tiles = Math.max(0, (Number(tiles) || 0) + n);
+    haptic('tick');
+    bump();
+  }
+
+  function addJoker() {
+    if ((Number(jokers) || 0) >= maxJokers) return;
+    jokers = (Number(jokers) || 0) + 1;
+    haptic('tick');
+    bump();
+    onjoker?.();
+  }
+
+  function clear() {
+    if (!(Number(tiles) > 0) && !(Number(jokers) > 0)) return;
+    tiles = 0;
+    jokers = 0;
+    haptic('tick');
+    bump();
+  }
+</script>
+
+<div class="keypad">
+  <div class="pad" role="group" aria-label={label ? `Add leftover tiles for ${label}` : 'Add leftover tiles'}>
+    {#each values as n (n)}
+      <button
+        type="button"
+        class="key tile"
+        style="--ink: {tileInk(n)}; --face: {TILE_FACE}"
+        onclick={() => addTile(n)}
+        aria-label={`Add a ${n} tile`}
+      >{n}</button>
+    {/each}
+    <button
+      type="button"
+      class="key joker"
+      onclick={addJoker}
+      disabled={(Number(jokers) || 0) >= maxJokers}
+      aria-label={`Add a stranded joker, worth ${jokerValue}`}
+    >🃏</button>
+  </div>
+
+  <div class="foot">
+    <span class="readout" aria-hidden="true">
+      🧮 <strong bind:this={readoutEl} class="sum">{tiles}</strong>{#if jokers > 0}<span class="jk"> + 🃏×{jokers}</span>{/if}
+    </span>
+    <button
+      type="button"
+      class="clear"
+      onclick={clear}
+      disabled={!(Number(tiles) > 0) && !(Number(jokers) > 0)}
+    >Clear rack</button>
+  </div>
+</div>
+
+<style>
+  .keypad {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .pad {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 6px;
+  }
+  .key {
+    min-height: 46px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-weight: 800;
+    font-size: 0.95rem;
+    font-variant-numeric: tabular-nums;
+    cursor: pointer;
+    transition: transform var(--dur-press) var(--ease-standard), filter var(--dur-base) var(--ease-standard);
+  }
+  /* Ivory tile face with a coloured numeral — the physical Rummikub tile as a key. */
+  .key.tile {
+    background: var(--face);
+    color: var(--ink);
+    border-color: color-mix(in srgb, var(--ink) 30%, transparent);
+  }
+  .key.joker {
+    background: var(--surface-3);
+    color: var(--text);
+    font-size: 1.15rem;
+  }
+  .key:active {
+    transform: scale(0.92);
+  }
+  .key:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .key:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .readout {
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  .sum {
+    display: inline-block;
+    color: var(--text);
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .jk {
+    color: var(--muted);
+  }
+  .clear {
+    min-height: 46px;
+    padding: 6px 14px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--muted);
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform var(--dur-press) var(--ease-standard), background var(--dur-base) var(--ease-standard);
+  }
+  .clear:active {
+    transform: scale(0.94);
+  }
+  .clear:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .key,
+    .clear {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/games/rummikub/TileRack.svelte
+++ b/src/lib/games/rummikub/TileRack.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  /**
+   * Rummikub's costume header: a rack ledge with the round's progress seated on it as tiles —
+   * played rounds face-up (ivory, coloured numeral), the current round raised on the rack, and
+   * upcoming rounds still face-down. In target mode (no fixed round count) it shows the target
+   * readout with the current round's tile. Pure per-game flavour: it lives entirely inside the
+   * editor, never touches the shared chrome, and uses neither Royal Violet nor Crown Gold. The
+   * "Round N" text and the raised current tile carry the meaning, so there is nothing essential
+   * to animate — it renders identically under reduced motion.
+   */
+  import { tileInk, TILE_FACE } from './tiles';
+
+  let {
+    round,
+    total = null,
+    target = null,
+  }: { round: number; total?: number | null; target?: number | null } = $props();
+
+  // Show a real tile per round only when the count is small enough to read as a rack;
+  // otherwise fall back to a single current tile + text so it never overflows.
+  const asTiles = $derived(total != null && total > 0 && total <= 14);
+  const tiles = $derived(
+    asTiles ? Array.from({ length: total as number }, (_, i) => i + 1) : [],
+  );
+  const label = $derived(
+    total != null ? `Round ${round} of ${total}` : `Round ${round}`,
+  );
+</script>
+
+<div class="rack" role="img" aria-label={`${label}${target != null ? `, playing to ${target}` : ''}`}>
+  <div class="shelf">
+    {#if asTiles}
+      <div class="tiles" aria-hidden="true">
+        {#each tiles as n (n)}
+          <span
+            class="tile"
+            class:played={n < round}
+            class:current={n === round}
+            class:upcoming={n > round}
+            style={n <= round ? `--ink: ${tileInk(n)}; --face: ${TILE_FACE}` : ''}
+          >{n <= round ? n : ''}</span>
+        {/each}
+      </div>
+    {:else}
+      <span class="tile current solo" aria-hidden="true" style={`--ink: ${tileInk(round)}; --face: ${TILE_FACE}`}>{round}</span>
+    {/if}
+  </div>
+  <div class="ledge" aria-hidden="true"></div>
+  <div class="cap">
+    <span class="where">🔢 {label}</span>
+    {#if target != null}<span class="goal">🎯 to {target}</span>{/if}
+  </div>
+</div>
+
+<style>
+  .rack {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px 12px 10px;
+  }
+  .shelf {
+    min-height: 40px;
+    display: flex;
+    align-items: flex-end;
+  }
+  .tiles {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: flex-end;
+  }
+  /* A physical ivory tile with a coloured numeral — the classic Rummikub look. The number is
+     always present on a face-up tile, so colour never carries meaning alone. */
+  .tile {
+    width: 22px;
+    height: 30px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 800;
+    font-size: 0.82rem;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+  .tile.played,
+  .tile.current {
+    background: var(--face);
+    color: var(--ink);
+    border-color: color-mix(in srgb, var(--ink) 30%, transparent);
+  }
+  .tile.current {
+    transform: translateY(-6px);
+    box-shadow: var(--shadow);
+    outline: 2px solid color-mix(in srgb, var(--ink) 55%, transparent);
+    outline-offset: 1px;
+  }
+  .tile.solo {
+    width: 26px;
+    height: 34px;
+    font-size: 0.95rem;
+    transform: none;
+  }
+  /* Face-down (upcoming) tiles: the back of a tile, quiet on the rack. */
+  .tile.upcoming {
+    background: var(--surface-3);
+    color: transparent;
+  }
+  /* The rack ledge the tiles sit on — a quiet shelf edge built from the surface ramp. */
+  .ledge {
+    height: 6px;
+    margin-top: 2px;
+    border-radius: var(--radius-sm);
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+  }
+  .cap {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+    margin-top: 8px;
+  }
+  .where {
+    font-weight: 700;
+    font-size: 0.9rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .goal {
+    font-size: 0.75rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+</style>

--- a/src/lib/games/rummikub/index.ts
+++ b/src/lib/games/rummikub/index.ts
@@ -2,6 +2,7 @@ import type { GameModule, ID, Round, RoundContext } from '../../types';
 import { RoundEditor } from '../editor';
 import {
   DEFAULT_JOKER_VALUE,
+  potTotal,
   scoreRummikub,
   validateRummikub,
   type RummikubInput,
@@ -9,7 +10,7 @@ import {
 import { rummikubStats } from './stats';
 
 export type { RummikubHand, RummikubInput } from './logic';
-export { handPenalty } from './logic';
+export { handPenalty, potTotal } from './logic';
 
 const jokerValueOf = (config: Record<string, unknown>): number =>
   Math.max(0, Number(config.jokerValue) || DEFAULT_JOKER_VALUE);

--- a/src/lib/games/rummikub/logic.ts
+++ b/src/lib/games/rummikub/logic.ts
@@ -80,6 +80,26 @@ export function scoreRummikub(
   return out;
 }
 
+/**
+ * The round's **pot**: the sum of every non-winner's leftover hand — exactly what the
+ * player who goes out will scoop, and exactly what the rest of the table loses. Pure and
+ * winner-agnostic when no winner is marked yet (it simply totals every hand), so the editor
+ * can show the stakes building *before* anyone is tapped out. Shared by the Pot gauge and
+ * the editor so there's one tested source of truth for the zero-sum swing.
+ */
+export function potTotal(
+  input: RummikubInput,
+  playerIds: ID[],
+  jokerValue: number = DEFAULT_JOKER_VALUE,
+): number {
+  let pot = 0;
+  for (const id of playerIds) {
+    if (id === input.winner) continue;
+    pot += handPenalty(input.hands?.[id], jokerValue);
+  }
+  return pot;
+}
+
 /** Return `null` when the round is valid, otherwise a human-readable reason. */
 export function validateRummikub(input: RummikubInput, playerIds: ID[]): string | null {
   if (!input.winner) return 'Tap the player who went out (emptied their rack).';

--- a/src/lib/games/rummikub/rummikub.test.ts
+++ b/src/lib/games/rummikub/rummikub.test.ts
@@ -3,6 +3,7 @@ import type { Player, Round } from '../../types';
 import {
   DEFAULT_JOKER_VALUE,
   handPenalty,
+  potTotal,
   scoreRummikub,
   validateRummikub,
   type RummikubInput,
@@ -48,6 +49,29 @@ describe('handPenalty', () => {
   it('defaults the joker to the official 30', () => {
     expect(DEFAULT_JOKER_VALUE).toBe(30);
     expect(handPenalty(hand(0, 1))).toBe(30);
+  });
+});
+
+describe('potTotal', () => {
+  it('sums every non-winner leftover — the pot the winner scoops', () => {
+    expect(potTotal(input('a', { a: hand(0), b: hand(15), c: hand(8) }), ['a', 'b', 'c'])).toBe(23);
+  });
+
+  it('folds stranded jokers into the pot at the house joker value', () => {
+    expect(potTotal(input('b', { a: hand(12, 1), b: hand(0), c: hand(3) }), ['a', 'b', 'c'])).toBe(45);
+    expect(potTotal(input('a', { a: hand(0), b: hand(4, 1) }), ['a', 'b'], 15)).toBe(19);
+  });
+
+  it('totals every hand while no winner is marked yet (stakes building)', () => {
+    expect(potTotal(input(null, { a: hand(5), b: hand(9), c: hand(0) }), ['a', 'b', 'c'])).toBe(14);
+  });
+
+  it('equals the winner’s recorded delta for any winner', () => {
+    const hands = { a: hand(13, 2), b: hand(9), c: hand(40), d: hand(1, 1) };
+    for (const winner of P) {
+      const deltas = scoreRummikub(input(winner, hands), P, 30);
+      expect(potTotal(input(winner, hands), P, 30)).toBe(deltas[winner]);
+    }
   });
 });
 

--- a/src/lib/games/rummikub/tiles.ts
+++ b/src/lib/games/rummikub/tiles.ts
@@ -1,0 +1,24 @@
+/**
+ * Presentational-only tile palette for Rummikub's per-game costume. These are the classic
+ * four Rummikub numeral colours printed on an ivory tile face — decorative accents contained
+ * entirely to the rack / keypad / burst, never used to signal score, standing, or state (the
+ * number on every tile always co-signals, so colour is never alone). Deliberately distinct
+ * from the app's Royal Violet (Save) and Crown Gold (leader/winner), and kept off the exact
+ * semantic good/bad tokens so a cream tile never reads as a win or a loss.
+ */
+
+/** The four numeral inks, in Rummikub's canonical order (black · red · blue · orange). */
+export const TILE_INKS = ['#2c2e4d', '#c8384e', '#1f6feb', '#e07a1f'] as const;
+
+/** The ivory tile face — a physical tile, readable in both themes. */
+export const TILE_FACE = '#f4efe1';
+
+/**
+ * A stable ink for a numbered tile. Rummikub has a copy of every number in each colour, so
+ * for display we simply cycle the four inks by value — enough variety to read as a colourful
+ * rack while staying deterministic (same number, same colour, every render).
+ */
+export function tileInk(n: number): string {
+  const i = ((Math.round(n) - 1) % TILE_INKS.length + TILE_INKS.length) % TILE_INKS.length;
+  return TILE_INKS[i];
+}


### PR DESCRIPTION
## Rummikub, but fun 🔢🎁

Rummikub had a rock-solid, well-tested scoring engine but was the plainest module in the catalog — a bare "Round X of Y" pill, a generic 🔢, no thematic costume, no delight moments, an invisible zero-sum pot, slow step-by-1 leftover entry, and a real design-system violation. This gives it a numbered-tile personality and dramatizes its zero-sum swing, all as *contained per-game costume* that never touches the shared chrome.

### What changed
- **`logic.ts`** — new pure, tested `potTotal()` helper: one source of truth for the pot the winner scoops.
- **`TileRack`** — costume header: round progress rendered as colourful numbered tiles seated on a rack (target-mode readout when playing to a score).
- **`Pot`** — the zero-sum heart made visible: a live gauge that fills as leftovers are tallied and **swings to the winner** (→ name) the moment someone goes out.
- **`TileBurst`** — a "Rummikub!" flurry of colourful tiles + sparkles when a player is marked out.
- **`JokerSting`** — a 🃏 `−30` dread stamp when a joker strands on a non-winner's rack (a caught joker is Rummikub's most painful tile).
- **`TileKeypad`** — tap 1–13 tiles + a joker key to enter leftovers fast, replacing the slow step-by-1 stepper (kept alongside for fine corrections).
- **`RummikubEditor`** — restructured around all of the above; rack-themed microcopy and going-out haptics.

### Design-system fix
The winner toggle previously filled with **Royal Violet** — which the shell reserves for the single Save action (the One Voice Rule). It now uses the semantic **good** accent, co-signalled by 🏆 + "Rummikub!" + the +pot, matching how ChickenFoot handles its toggles.

### Non-negotiables honored
Tile colours are decorative accents only (every tile shows its number, so colour is never alone); no Royal Violet except Save; no Crown Gold except leader/winner; `tabular-nums` on every changing number; ≥46px touch targets; `prefers-reduced-motion` fallbacks throughout. Chrome untouched — the costume lives entirely in the editor.

### Verified locally
- `npm test` (vitest) — 44 passed, including new `potTotal` cases
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — success
- impeccable design hooks — clean on all touched files