### PR TITLE
Spades: card-table costume — bag meter, contract reveal, nil gambit, target rail

### DIFF
--- a/src/lib/games/spades/BagMeter.svelte
+++ b/src/lib/games/spades/BagMeter.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import { animateMotion, prefersReducedMotion } from '../../motion';
+  import { bagDanger, bagsToPenalty, type BagDanger } from './logic';
+
+  /**
+   * Spades' signature costume: a meter of the sticky "bags" a unit is carrying,
+   * filling toward the flat −100 sandbag hit. The bag count and the words
+   * ("N to the −100 hit" / the danger caption) always carry the meaning, so the
+   * colour escalation and the burst are decoration only — fully skipped under
+   * reduced motion. Colour uses the semantic caution/loss tokens, never Crown
+   * Gold (which belongs to the leader/winner alone). Lives entirely inside the
+   * Spades editor and never touches the shared chrome.
+   */
+  let {
+    /** Bags the unit carries after this hand — the 0..threshold-1 remainder. */
+    bags,
+    /** Bags that trip the flat −100 (the config's bag threshold). */
+    threshold,
+    /** How many −100 penalties this hand tripped (drives the burst + tag). */
+    penalties = 0,
+  }: { bags: number; threshold: number; penalties?: number } = $props();
+
+  const level = $derived<BagDanger>(bagDanger(bags, threshold, penalties));
+  const toHit = $derived(bagsToPenalty(bags, threshold));
+  // Pips shown: a compact row capped so a huge house-rule threshold never sprawls.
+  const pipCount = $derived(Math.min(Math.max(threshold, 1), 12));
+  const filled = $derived(
+    threshold > 0 ? Math.round((bags / threshold) * pipCount) : 0,
+  );
+
+  const caption = $derived(
+    penalties > 0
+      ? `💥 bags burst · −${100 * penalties}`
+      : level === 'critical'
+        ? 'one more and it pops!'
+        : level === 'heavy'
+          ? 'getting heavy'
+          : 'traveling light',
+  );
+
+  // A one-shot shudder when a hand tips the pile over the threshold. The −100 is
+  // already shown in the caption + the score, so this is pure delight.
+  let meterEl: HTMLDivElement | undefined = $state();
+  let prevPenalties = 0;
+  let firstRun = true;
+  $effect(() => {
+    const p = penalties;
+    if (firstRun) {
+      firstRun = false;
+      prevPenalties = p;
+      return;
+    }
+    if (p > prevPenalties && meterEl && !prefersReducedMotion()) {
+      animateMotion(
+        meterEl,
+        { x: [0, -3, 3, -2, 2, 0], scale: [1, 1.03, 1] },
+        { duration: 0.4, ease: 'easeOut' },
+      );
+    }
+    prevPenalties = p;
+  });
+</script>
+
+<div class="meter" data-level={level} bind:this={meterEl}>
+  <div class="track" aria-hidden="true">
+    {#each Array(pipCount) as _, i (i)}
+      <span class="pip" class:on={i < filled}></span>
+    {/each}
+  </div>
+  <div class="read">
+    <span class="tally">🛍️ {bags} {bags === 1 ? 'bag' : 'bags'}</span>
+    <span class="dot" aria-hidden="true">·</span>
+    <span class="hint">
+      {#if penalties > 0}
+        {caption}
+      {:else}
+        {toHit} to the −100 hit · {caption}
+      {/if}
+    </span>
+  </div>
+</div>
+
+<style>
+  .meter {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    /* Level tints stay on the semantic caution/loss tokens — never gold. */
+    --meter: var(--muted);
+  }
+  .meter[data-level='heavy'] {
+    --meter: var(--warn);
+  }
+  .meter[data-level='critical'] {
+    --meter: var(--bad);
+  }
+  .track {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+  }
+  .pip {
+    flex: 1;
+    height: 7px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    transition: background var(--dur-base, 0.2s) var(--ease-standard, ease);
+  }
+  .pip.on {
+    background: var(--meter);
+    border-color: var(--meter);
+  }
+  .read {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    font-size: 0.78rem;
+    flex-wrap: wrap;
+  }
+  .tally {
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--meter);
+  }
+  .dot {
+    color: var(--muted);
+  }
+  .hint {
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .meter[data-level='critical'] .hint {
+    color: var(--bad);
+    font-weight: 600;
+  }
+</style>

--- a/src/lib/games/spades/SpadesEditor.svelte
+++ b/src/lib/games/spades/SpadesEditor.svelte
@@ -2,9 +2,14 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
+  import { bumpOnChange, prefersReducedMotion, animateMotion } from '../../motion';
+  import { haptic } from '../../haptics';
   import { spades } from './index';
+  import BagMeter from './BagMeter.svelte';
+  import TargetRail from './TargetRail.svelte';
   import {
     bagCountsAfter,
+    contractView,
     emptyRow,
     readConfig,
     resolveMode,
@@ -13,6 +18,8 @@
     unitsFor,
     type NilKind,
     type SpadesInput,
+    type Unit,
+    type UnitHandResult,
   } from './logic';
 
   let { input = $bindable(), ctx }: { input: SpadesInput; ctx: RoundContext } = $props();
@@ -47,6 +54,35 @@
   const totalTricks = $derived(
     ctx.players.reduce((a, p) => a + (Number(input.rows[p.id]?.tricks) || 0), 0),
   );
+  const handComplete = $derived(totalTricks === table);
+  const left = $derived(table - totalTricks);
+
+  // Standing before this hand, per unit — feeds the race rail and the leader 👑.
+  const unitBefore = (u: Unit) => ctx.totals[u.memberIds[0]] ?? 0;
+  const leaderKeys = $derived(computeLeaders(units, ctx.totals));
+  function computeLeaders(us: Unit[], totals: Record<string, number>): Set<string> {
+    const vals = us.map((u) => totals[u.memberIds[0]] ?? 0);
+    const max = Math.max(...vals);
+    const min = Math.min(...vals);
+    if (us.length < 2 || max === min) return new Set(); // all tied → nobody leads yet
+    return new Set(us.filter((u) => (totals[u.memberIds[0]] ?? 0) === max).map((u) => u.key));
+  }
+
+  // The made/set stamp for a unit — a neutral countdown mid-hand, a green "made"
+  // the moment the contract lands, and the schadenfreude "SET!" only once the
+  // table's tricks are fully dealt out (so a half-entered hand isn't prematurely
+  // damned). The label carries the state; colour and the pop only reinforce it.
+  function contractTag(res: UnitHandResult): { kind: 'needs' | 'made' | 'set'; label: string } {
+    const cv = contractView(res.contract, res.tricks);
+    if (cv.status === 'made') {
+      return {
+        kind: 'made',
+        label: cv.over > 0 ? `✓ made · +${cv.over} bag${cv.over === 1 ? '' : 's'}` : '✓ made',
+      };
+    }
+    if (handComplete) return { kind: 'set', label: `SET! ${res.base}` };
+    return { kind: 'needs', label: `needs ${cv.short} more` };
+  }
 
   let showHelp = $state(false);
 
@@ -56,12 +92,34 @@
     row.nil = row.nil === kind ? 'none' : kind;
   }
 
+  // A tiny buzz + shudder the instant a live nil gets broken (a trick sneaks in),
+  // so the gamble turning sour is felt, not just read. The ✓/✗ text still carries
+  // the state; motion is skipped wholesale under reduced motion.
+  const brokenSeen: Record<string, boolean> = {};
+  function nilPulse(node: HTMLElement, broken: boolean) {
+    const pid = node.dataset.pid ?? '';
+    brokenSeen[pid] = broken;
+    return {
+      update(next: boolean) {
+        if (next && !brokenSeen[pid]) {
+          haptic('tick');
+          if (!prefersReducedMotion()) {
+            animateMotion(node, { x: [0, -4, 4, -2, 2, 0] }, { duration: 0.36, ease: 'easeOut' });
+          }
+        }
+        brokenSeen[pid] = next;
+      },
+    };
+  }
+
   const signed = (n: number) => (n >= 0 ? `+${n}` : `${n}`);
 </script>
 
 <div class="stack">
   <div class="row spread wrap">
-    <span class="pill" class:score-bad={totalTricks !== table}>♠ {totalTricks}/{table} tricks</span>
+    <span class="pill" class:score-bad={totalTricks > table}>
+      ♠ {totalTricks} of {table} laid{#if left > 0} · {left} to go{:else if left === 0} · full table ✓{:else} · {-left} over!{/if}
+    </span>
     <span class="row wrap" style="gap: 8px">
       <span class="pill">{partners ? '👥 Partners' : '🙋 Solo'}{soloFallback ? ' · need 4 for teams' : ''}</span>
       <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
@@ -76,26 +134,43 @@
 
   {#each units as u (u.key)}
     {@const res = results.get(u.key)}
+    {@const tag = res ? contractTag(res) : { kind: 'needs' as const, label: '' }}
     <div class="unit">
       <div class="uhead row spread">
         <span class="uleft row wrap">
           {#if partners}<span class="team">Team {u.index + 1}</span>{/if}
-          <span class="sub">bid {res?.contract ?? 0} · won {res?.tricks ?? 0}</span>
-          {#if cfg.sandbagging}
-            <span class="bags" class:score-bad={(res?.penalties ?? 0) > 0}>
-              🛍️ {res?.bagsAfter ?? 0}{(res?.penalties ?? 0) > 0 ? ` · −${100 * (res?.penalties ?? 0)}` : ''}
-            </span>
-          {/if}
+          <span class="contract">🤝 <strong>{res?.contract ?? 0}</strong> · won <strong>{res?.tricks ?? 0}</strong></span>
+          <span
+            class="stamp"
+            class:score-good={tag.kind === 'made'}
+            class:score-bad={tag.kind === 'set'}
+            class:muted={tag.kind === 'needs'}
+            use:bumpOnChange={tag.kind}
+          >{tag.label}</span>
         </span>
         <span class="proj" class:score-good={(res?.score ?? 0) >= 0} class:score-bad={(res?.score ?? 0) < 0}>
           {signed(res?.score ?? 0)}
         </span>
       </div>
 
+      {#if cfg.sandbagging && res}
+        <BagMeter bags={res.bagsAfter} threshold={cfg.bagThreshold} penalties={res.penalties} />
+      {/if}
+
+      {#if res}
+        <TargetRail
+          before={unitBefore(u)}
+          delta={res.score}
+          target={cfg.target}
+          leading={leaderKeys.has(u.key)}
+        />
+      {/if}
+
       {#each u.memberIds as id (id)}
         {@const p = byId.get(id)}
         {@const row = input.rows[id]}
         {#if p && row}
+          {@const broken = row.nil !== 'none' && (Number(row.tricks) || 0) > 0}
           <div class="mrow">
             <div class="row spread who-row">
               <span class="who row" style="gap: 8px">
@@ -103,8 +178,18 @@
                 <strong>{p.name}</strong>
               </span>
               {#if row.nil !== 'none'}
-                <span class="nilhint" class:score-good={(Number(row.tricks) || 0) === 0} class:score-bad={(Number(row.tricks) || 0) > 0}>
-                  {(Number(row.tricks) || 0) === 0 ? 'on track ✓' : 'broken ✗'}
+                <span
+                  class="nilhint"
+                  class:score-good={!broken}
+                  class:score-bad={broken}
+                  data-pid={id}
+                  use:nilPulse={broken}
+                >
+                  {#if row.nil === 'blind'}
+                    {broken ? '🙈 blind faith broken ✗' : '🙈 eyes shut, holding ✓'}
+                  {:else}
+                    {broken ? '💔 nil broken ✗' : '🚫 clean so far ✓'}
+                  {/if}
                 </span>
               {/if}
             </div>
@@ -113,14 +198,14 @@
               <label class="f">
                 <span>Bid</span>
                 {#if row.nil === 'none'}
-                  <Stepper bind:value={row.bid} min={0} max={table} />
+                  <Stepper bind:value={row.bid} min={0} max={table} label={`${p.name} bid`} />
                 {:else}
                   <span class="nilbid">{row.nil === 'blind' ? '🙈 Blind nil' : '🚫 Nil'}</span>
                 {/if}
               </label>
               <label class="f">
                 <span>Tricks</span>
-                <Stepper bind:value={row.tricks} min={0} max={table} />
+                <Stepper bind:value={row.tricks} min={0} max={table} label={`${p.name} tricks`} />
               </label>
             </div>
 
@@ -164,11 +249,12 @@
     gap: 12px;
   }
   .uhead {
-    align-items: center;
+    align-items: flex-start;
   }
   .uleft {
     gap: 8px;
     row-gap: 4px;
+    align-items: baseline;
   }
   .team {
     font-weight: 700;
@@ -178,20 +264,31 @@
     border: 1px solid var(--border);
     font-size: 0.82rem;
   }
-  .sub {
+  .contract {
     color: var(--muted);
     font-size: 0.85rem;
     font-variant-numeric: tabular-nums;
   }
-  .bags {
-    font-size: 0.82rem;
-    color: var(--muted);
+  .contract strong {
+    color: var(--text);
+    font-weight: 700;
+  }
+  .stamp {
+    font-size: 0.78rem;
+    font-weight: 700;
     font-variant-numeric: tabular-nums;
+    display: inline-block;
+  }
+  .stamp.muted {
+    color: var(--muted);
+    font-weight: 600;
   }
   .proj {
     font-weight: 800;
     font-size: 1.05rem;
     font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    padding-left: 8px;
   }
   .mrow {
     background: var(--surface);
@@ -208,6 +305,7 @@
   .nilhint {
     font-size: 0.78rem;
     font-weight: 700;
+    text-align: right;
   }
   .fields {
     gap: 16px;

--- a/src/lib/games/spades/TargetRail.svelte
+++ b/src/lib/games/spades/TargetRail.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+  import { targetView } from './logic';
+
+  /**
+   * A slim "race to the target" rail for one scoring unit: where it stands now,
+   * where this hand's projected delta lands it, and how that measures against the
+   * winning score. Complements (never duplicates) the shared Scoreboard by showing
+   * finish-line proximity and *this hand's* swing. The number + words always carry
+   * the meaning; the fill uses neutral/primary only. Crown Gold is reserved for the
+   * leader/winner — so a 👑 shows solely when this unit already leads the table.
+   */
+  let {
+    /** The unit's cumulative total before this hand. */
+    before,
+    /** This hand's projected delta for the unit. */
+    delta,
+    /** Winning score; 0/absent means open-ended (rail hides). */
+    target,
+    /** True when this unit currently leads the table (drives the 👑, from ctx.totals). */
+    leading = false,
+  }: { before: number; delta: number; target: number; leading?: boolean } = $props();
+
+  const v = $derived(targetView(before, delta, target));
+  // Clamp the fill to the rail; a projected total can exceed the target (a win).
+  const pct = $derived(
+    v.target > 0 ? Math.max(0, Math.min(100, (v.projected / v.target) * 100)) : 0,
+  );
+  const nowPct = $derived(
+    v.target > 0 ? Math.max(0, Math.min(100, (v.before / v.target) * 100)) : 0,
+  );
+  const signedDelta = $derived(delta >= 0 ? `+${delta}` : `${delta}`);
+</script>
+
+{#if target > 0}
+  <div class="rail" class:reach={v.reaches}>
+    <div class="bar" aria-hidden="true">
+      <span class="fill proj" style="transform: scaleX({pct / 100})"></span>
+      <span class="fill now" style="transform: scaleX({nowPct / 100})"></span>
+    </div>
+    <div class="cap">
+      <span class="race">
+        🏁 <span class="n">{before}</span>
+        <span class="arrow" aria-hidden="true">→</span>
+        <span class="n proj-n">{v.projected}</span>
+        <span class="of">/ {target}</span>
+      </span>
+      <span class="tag">
+        {#if v.reaches}
+          👑 reign! <span class="swing">({signedDelta})</span>
+        {:else}
+          {v.remaining} to go <span class="swing">({signedDelta})</span>
+        {/if}
+        {#if leading && !v.reaches}<span class="lead" title="Leading">👑</span>{/if}
+      </span>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .rail {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .bar {
+    position: relative;
+    height: 6px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    overflow: hidden;
+  }
+  .fill {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    transform-origin: left center;
+    border-radius: 999px;
+    transition: transform var(--dur-base, 0.2s) var(--ease-standard, ease);
+  }
+  /* Two layers: the settled total, and a lighter projected reach ahead of it. */
+  .fill.proj {
+    background: color-mix(in srgb, var(--primary) 40%, transparent);
+  }
+  .fill.now {
+    background: var(--primary);
+  }
+  .rail.reach .fill.proj {
+    background: color-mix(in srgb, var(--primary) 70%, transparent);
+  }
+  .cap {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 0.76rem;
+    color: var(--muted);
+  }
+  .race {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    font-variant-numeric: tabular-nums;
+  }
+  .n {
+    font-weight: 700;
+    color: var(--text);
+  }
+  .proj-n {
+    color: var(--primary);
+  }
+  .of {
+    color: var(--muted);
+  }
+  .arrow {
+    color: var(--muted);
+  }
+  .tag {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 5px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+  .rail.reach .tag {
+    color: var(--text);
+  }
+  .swing {
+    color: var(--muted);
+    font-weight: 500;
+  }
+</style>

--- a/src/lib/games/spades/logic.ts
+++ b/src/lib/games/spades/logic.ts
@@ -269,3 +269,81 @@ export function validateHand(
   }
   return null;
 }
+
+// ── UI-facing view helpers ───────────────────────────────────────────────────
+// Small, pure derivations the Spades editor renders from. They add no scoring
+// behaviour — they only shape numbers the components already have into the cues
+// (danger levels, made/set status, target proximity) the costume needs, so those
+// decisions stay unit-testable and out of the Svelte layer.
+
+/** How hot a unit's bag pile is running toward the next −100 sandbag hit. */
+export type BagDanger = 'calm' | 'heavy' | 'critical';
+
+/**
+ * Bags a unit must still collect before the next flat −100 penalty. `bagsAfter`
+ * is the post-hand remainder (always 0..threshold-1 while sandbagging is on), so
+ * this is simply the pips left in the current row. Returns Infinity when there is
+ * no threshold to cross.
+ */
+export function bagsToPenalty(bagsAfter: number, threshold: number): number {
+  if (threshold <= 0) return Infinity;
+  const filled = ((bagsAfter % threshold) + threshold) % threshold;
+  return threshold - filled;
+}
+
+/**
+ * A three-step danger cue for the bag meter, co-signalled in the UI by words and
+ * colour (never colour alone). `critical` the moment a penalty just fired or the
+ * pile sits one bag from the hit; `heavy` from ~70% of the way there; else `calm`.
+ */
+export function bagDanger(bagsAfter: number, threshold: number, penaltiesThisHand = 0): BagDanger {
+  if (penaltiesThisHand > 0) return 'critical';
+  if (threshold <= 0) return 'calm';
+  const filled = ((bagsAfter % threshold) + threshold) % threshold;
+  if (threshold - filled <= 1) return 'critical';
+  if (filled / threshold >= 0.7) return 'heavy';
+  return 'calm';
+}
+
+/** Whether a unit made its contract this hand, and by how much. */
+export interface ContractView {
+  status: 'made' | 'set';
+  /** Tricks still needed to make the contract (0 once made). */
+  short: number;
+  /** Overtricks beyond the contract this hand (0 when set). */
+  over: number;
+}
+
+/** Live made/set view for a unit from its combined contract and tricks taken. */
+export function contractView(contract: number, tricks: number): ContractView {
+  const made = tricks >= contract;
+  return {
+    status: made ? 'made' : 'set',
+    short: made ? 0 : contract - tricks,
+    over: made ? tricks - contract : 0,
+  };
+}
+
+/** A unit's standing relative to the winning target after this hand's projected delta. */
+export interface TargetView {
+  before: number;
+  projected: number;
+  target: number;
+  /** True when the projected total reaches a positive target (this hand could win). */
+  reaches: boolean;
+  /** Points still needed after this hand to reach the target (0 once reached). */
+  remaining: number;
+}
+
+/** Project a unit's total by `delta` and measure it against the winning `target`. */
+export function targetView(before: number, delta: number, target: number): TargetView {
+  const projected = before + delta;
+  const reaches = target > 0 && projected >= target;
+  return {
+    before,
+    projected,
+    target,
+    reaches,
+    remaining: target > 0 ? Math.max(0, target - projected) : 0,
+  };
+}

--- a/src/lib/games/spades/spades.test.ts
+++ b/src/lib/games/spades/spades.test.ts
@@ -3,11 +3,15 @@ import type { Player, Round, RoundContext } from '../../types';
 import { spades } from './index';
 import {
   bagCountsAfter,
+  bagDanger,
+  bagsToPenalty,
+  contractView,
   readConfig,
   resolveMode,
   scoreGame,
   scoreLatest,
   scoreUnitHand,
+  targetView,
   tricksAvailable,
   unitsFor,
   validateHand,
@@ -247,6 +251,66 @@ describe('validateHand', () => {
   it('blocks blind nil when blind is disabled', () => {
     const h = hand({ a: row(0, 0, 'blind'), b: row(3, 3), c: row(2, 2), d: row(5, 5) });
     expect(validateHand(h, P4, { blindNil: false })).toMatch(/Blind nil is turned off/);
+  });
+});
+
+// ── UI view helpers ─────────────────────────────────────────────────────────
+describe('bagsToPenalty', () => {
+  it('counts pips left to the next −100 hit', () => {
+    expect(bagsToPenalty(0, 10)).toBe(10);
+    expect(bagsToPenalty(7, 10)).toBe(3);
+    expect(bagsToPenalty(9, 10)).toBe(1);
+  });
+  it('is Infinity with no threshold', () => {
+    expect(bagsToPenalty(3, 0)).toBe(Infinity);
+  });
+});
+
+describe('bagDanger', () => {
+  it('is calm well below the threshold', () => {
+    expect(bagDanger(0, 10)).toBe('calm');
+    expect(bagDanger(6, 10)).toBe('calm');
+  });
+  it('turns heavy from ~70% of the way', () => {
+    expect(bagDanger(7, 10)).toBe('heavy');
+    expect(bagDanger(8, 10)).toBe('heavy');
+  });
+  it('is critical on the last pip or when a penalty just fired', () => {
+    expect(bagDanger(9, 10)).toBe('critical');
+    expect(bagDanger(2, 10, 1)).toBe('critical');
+  });
+});
+
+describe('contractView', () => {
+  it('reports made with overtricks', () => {
+    expect(contractView(7, 9)).toEqual({ status: 'made', short: 0, over: 2 });
+  });
+  it('reports set with the shortfall', () => {
+    expect(contractView(7, 5)).toEqual({ status: 'set', short: 2, over: 0 });
+  });
+  it('treats an exact make as made with no overtricks', () => {
+    expect(contractView(4, 4)).toEqual({ status: 'made', short: 0, over: 0 });
+  });
+  it('treats a zero contract as always made', () => {
+    expect(contractView(0, 0)).toEqual({ status: 'made', short: 0, over: 0 });
+  });
+});
+
+describe('targetView', () => {
+  it('projects the total and flags crossing the target', () => {
+    expect(targetView(430, 71, 500)).toEqual({
+      before: 430,
+      projected: 501,
+      target: 500,
+      reaches: true,
+      remaining: 0,
+    });
+  });
+  it('reports how far short a projected total falls', () => {
+    expect(targetView(300, 50, 500)).toMatchObject({ projected: 350, reaches: false, remaining: 150 });
+  });
+  it('never reaches a non-positive target', () => {
+    expect(targetView(999, 10, 0)).toMatchObject({ reaches: false, remaining: 0 });
   });
 });
 


### PR DESCRIPTION
## What & why

Spades scored correctly but wore the plainest editor of all the trick-taking games — muted grey subtext where siblings like Skull King have a whole costume (a sailing voyage ribbon, treasure pops, outcome labels, playful microcopy). Its three signature tensions were all buried: the **team contract**, the **sticky bags creeping toward the flat −100 sandbag hit**, and the **nil gamble**.

This PR gives Spades its own card-table personality — entirely inside the Spades module. The shared chrome (top bar, tab bar, Stepper, Scoreboard, buttons) is untouched.

## What's new

- **🛍️ BagMeter (the hero):** a row of pips that fills as your team's bags climb toward the −100 penalty, escalating calm → amber *"getting heavy"* → coral *"one more and it pops!"*, with a little shudder + `−100` tag when a hand tips it over. Replaces today's mute `🛍️ 4`.
- **🤝 Contract clarity + Made/SET! reveal:** a legible team-contract line with a live stamp — `needs N more` (neutral) → `✓ made · +2 bags` (good) → `SET! −70` schadenfreude (bad, only once the table's tricks are fully dealt).
- **🚫 Nil gambit polish:** armed rows show tension microcopy (`clean so far ✓` / `nil broken ✗`, `eyes shut, holding` for blind) and a buzz + shudder the instant a nil breaks.
- **♠ Trick-tally aid:** the top pill becomes a fast-entry helper — `8 of 13 laid · 5 to go`.
- **🏁 TargetRail:** a slim per-team race to the winning score that projects this hand across the line — `430 → 501 · reign!`.
- **Pure, tested helpers** in `logic.ts` (`bagDanger`, `bagsToPenalty`, `contractView`, `targetView`). **No scoring behaviour changed.**

## Design non-negotiables honored

- Crown Gold stays **leader/winner only** — bag danger uses the semantic caution/loss tokens, never gold.
- One violet primary action per screen (the editor adds none).
- `tabular-nums` on every changing number; ≥46px touch targets.
- Never colour-alone — every state co-signalled by text + emoji.
- All motion routed through `animateMotion` / `prefers-reduced-motion`.

## Verification (local)

- `npm run check` — 0 errors, 0 warnings
- `npx vitest run` — **1154 passed** (incl. 12 new helper tests)
- `npm run build` — succeeds

## Files

- `src/lib/games/spades/logic.ts` — new pure view helpers + types
- `src/lib/games/spades/BagMeter.svelte` — new
- `src/lib/games/spades/TargetRail.svelte` — new
- `src/lib/games/spades/SpadesEditor.svelte` — wired the costume together
- `src/lib/games/spades/spades.test.ts` — helper tests