### PR TITLE
Spikeball: rally log, hero score, and courtside tension moments

### DIFF
--- a/src/lib/games/spikeball/SpikeballEditor.svelte
+++ b/src/lib/games/spikeball/SpikeballEditor.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
   import type { Player, RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
+  import { haptic } from '../../haptics';
   import {
     readConfig,
     gameWinner,
     gamePointTeam,
     isMatchPoint,
+    isDeuce,
+    clinchesMatch,
+    currentRun,
+    pushRally,
+    popRally,
+    scoreFromRallies,
     gamesToWin,
     requiredPlayers,
     type SpikeballInput,
@@ -42,19 +49,69 @@
   const winner = $derived(gameWinner(a, b, cfg.target, cfg.winByTwo));
   const gp = $derived(gamePointTeam(a, b, cfg.target, cfg.winByTwo));
   const matchPoint = $derived(isMatchPoint(gp, gamesA, gamesB, cfg.bestOf));
+  const deuce = $derived(isDeuce(a, b, cfg.target, cfg.winByTwo));
   const done = $derived(winner !== null);
+  const clinches = $derived(clinchesMatch(winner, gamesA, gamesB, cfg.bestOf));
+
+  // The rally log powers a true "undo last rally" and the momentum read. It's optional:
+  // rounds recorded before it existed have no log, so we fall back to ± steppers on a/b.
+  const hasLog = $derived(Array.isArray(input.rallies));
+  const rallies = $derived(input.rallies ?? []);
+  const run = $derived(currentRun(rallies));
+  const canUndo = $derived(hasLog && rallies.length > 0);
+  const lastTeam = $derived<0 | 1 | null>(rallies.length ? rallies[rallies.length - 1]! : null);
+  const lastTeamName = $derived(lastTeam === null ? '' : lastTeam === 0 ? nameA : nameB);
 
   const rules = $derived(`First to ${cfg.target}${cfg.winByTwo ? ' · win by 2' : ''}`);
 
+  function setScore(next: (0 | 1)[]): void {
+    input.rallies = next;
+    const s = scoreFromRallies(next);
+    input.a = s.a;
+    input.b = s.b;
+  }
+
   function add(team: 0 | 1) {
     if (done || mismatch) return;
-    if (team === 0) input.a = a + 1;
+    if (hasLog) setScore(pushRally(rallies, team));
+    else if (team === 0) input.a = a + 1;
     else input.b = b + 1;
+    haptic('tick');
   }
+  function undoLast() {
+    if (!canUndo) return;
+    setScore(popRally(rallies));
+    haptic('undo');
+  }
+  // Legacy fallback for rounds with no rally log: a plain per-team decrement.
   function sub(team: 0 | 1) {
     if (team === 0) input.a = Math.max(0, a - 1);
     else input.b = Math.max(0, b - 1);
   }
+
+  // Which team, if any, gets the momentum chip on its card right now.
+  function showRun(team: 0 | 1): boolean {
+    return !done && run.team === team && run.length >= 3;
+  }
+
+  // One sportscaster line for the live status region — whimsy in the copy, never clutter.
+  const call = $derived.by(() => {
+    if (mismatch) return { tone: 'warn', text: `⚠️ ${cfg.format} needs ${needPlayers} players — you have ${ctx.players.length}. Start a new game with ${needPlayers}.` };
+    if (done) {
+      const w = winner === 0 ? nameA : nameB;
+      const hi = Math.max(a, b);
+      const lo = Math.min(a, b);
+      return clinches
+        ? { tone: 'good', text: `🏆 Match! ${w} take it all ${hi}–${lo} — tap “Save round” to seal it.` }
+        : { tone: 'good', text: `🏐 Game! ${w} win ${hi}–${lo} — tap “Save round” to bank it.` };
+    }
+    if (gp !== null && matchPoint) return { tone: 'point', text: `🔵 Match point — ${gp === 0 ? nameA : nameB} serving for the match!` };
+    if (gp !== null) return { tone: 'point', text: `🔵 Game point — ${gp === 0 ? nameA : nameB} one rally away.` };
+    if (deuce) return { tone: 'point', text: `🔥 Deuce at ${a}–${b} — win by 2, nobody blinks.` };
+    if (run.team !== null && run.length >= 4) return { tone: 'muted', text: `🔥 ${run.team === 0 ? nameA : nameB} rolling — ${run.length} straight.` };
+    if (a === 0 && b === 0) return { tone: 'muted', text: `First rally serves it up! ${rules}.` };
+    return { tone: 'muted', text: `Tap ＋1 for the team that won each rally. ${rules}.` };
+  });
 </script>
 
 <div class="stack">
@@ -73,7 +130,13 @@
       {@const isLeader = gamesLeader === team}
       {@const isWinner = done && winner === team}
       {@const atPoint = !done && gp === team}
-      <div class="teamcard" class:won={isWinner}>
+      <div
+        class="teamcard"
+        class:won={isWinner}
+        class:atpoint={atPoint}
+        class:matchpt={atPoint && matchPoint}
+        class:deuce={deuce && !done}
+      >
         <div class="thead row spread">
           <span class="row who">
             {#each mem as m (m.id)}
@@ -81,28 +144,44 @@
             {/each}
             <span class="tname">{teamName}</span>
           </span>
-          <span class="games" class:lead={isLeader}>
-            {#if isLeader}<span aria-hidden="true">👑</span>{/if}
-            <span class="gnum">{games}</span>
-            <span class="glabel">{games === 1 ? 'game' : 'games'}</span>
+          <span class="gamesbox">
+            <span class="games" class:lead={isLeader}>
+              {#if isLeader}<span aria-hidden="true">👑</span>{/if}
+              <span class="gnum">{games}</span>
+              <span class="glabel">{games === 1 ? 'game' : 'games'}</span>
+            </span>
+            {#if cfg.bestOf > 1}
+              <span class="pips" aria-hidden="true">
+                {#each Array(need) as _, i (i)}
+                  <span class="pip" class:on={i < games}></span>
+                {/each}
+              </span>
+            {/if}
           </span>
         </div>
 
-        <div class="scorewrap">
-          <button
-            type="button"
-            class="iconbtn minus"
-            onclick={() => sub(team)}
-            disabled={score <= 0}
-            aria-label={`Remove a point from ${teamName}`}
-          >−</button>
+        <div class="scorewrap" class:solo={hasLog}>
+          {#if !hasLog}
+            <button
+              type="button"
+              class="iconbtn minus"
+              onclick={() => sub(team)}
+              disabled={score <= 0}
+              aria-label={`Remove a point from ${teamName}`}
+            >−</button>
+          {/if}
           {#key score}
             <span class="bigscore">{score}</span>
           {/key}
+        </div>
+
+        <div class="tagline">
           {#if isWinner}
-            <span class="tag win">🏐 Won</span>
+            <span class="tag win">{clinches ? '🏆 Match' : '🏐 Game'}</span>
           {:else if atPoint}
-            <span class="tag point">{matchPoint ? '🔵 Match pt' : '🔵 Game pt'}</span>
+            <span class="tag point" class:match={matchPoint}>{matchPoint ? '🔵 Match pt' : '🔵 Game pt'}</span>
+          {:else if showRun(team)}
+            <span class="tag run">🔥 {run.length} in a row</span>
           {:else}
             <span class="tag ghost" aria-hidden="true">&nbsp;</span>
           {/if}
@@ -122,22 +201,21 @@
     {/each}
   </div>
 
+  {#if hasLog}
+    <button
+      type="button"
+      class="undo"
+      onclick={undoLast}
+      disabled={!canUndo}
+      aria-label={lastTeamName ? `Undo the last rally point for ${lastTeamName}` : 'Undo the last rally'}
+    >
+      <span class="undoicon" aria-hidden="true">↩</span>
+      <span>{canUndo ? `Undo · ${lastTeamName}’s point` : 'Undo last rally'}</span>
+    </button>
+  {/if}
+
   <div class="status" role="status" aria-live="polite">
-    {#if mismatch}
-      <span class="warn">⚠️ {cfg.format} needs {needPlayers} players — you have {ctx.players.length}. Start a new game with {needPlayers}.</span>
-    {:else if done}
-      <span class="score-good"
-        >🏐 {winner === 0 ? nameA : nameB} win {Math.max(a, b)}–{Math.min(a, b)} — tap “Save round” to record it.</span
-      >
-    {:else if gp !== null}
-      <span class="pointmsg"
-        >{matchPoint ? '🔵 Match point' : '🔵 Game point'} — {gp === 0 ? nameA : nameB}{matchPoint
-          ? ', serving to win it all!'
-          : '.'}</span
-      >
-    {:else}
-      <span class="muted">Tap ＋1 for the team that won each rally. {rules}.</span>
-    {/if}
+    <span class={call.tone}>{call.text}</span>
   </div>
 </div>
 
@@ -155,13 +233,39 @@
     padding: 12px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
+    transition: border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
   }
   /* A finished game reads as success (green) — distinct from the match winner's gold. */
   .teamcard.won {
     border-color: color-mix(in srgb, var(--good) 55%, var(--border));
     background: color-mix(in srgb, var(--good) 12%, var(--surface-2));
   }
+  /* Game point: an amber ring backs the tag + copy (never color alone). */
+  .teamcard.atpoint {
+    border-color: color-mix(in srgb, var(--warn) 60%, var(--border));
+    background: color-mix(in srgb, var(--warn) 7%, var(--surface-2));
+  }
+  /* Match point escalates: a stronger ring plus a slow breathing glow. */
+  .teamcard.matchpt {
+    border-color: color-mix(in srgb, var(--warn) 80%, var(--border));
+    animation: sb-breathe 1.5s ease-in-out infinite;
+  }
+  /* Deuce: both cards pulse together — the tension is shared. */
+  .teamcard.deuce {
+    border-color: color-mix(in srgb, var(--warn) 45%, var(--border));
+    animation: sb-breathe 1.7s ease-in-out infinite;
+  }
+  @keyframes sb-breathe {
+    0%,
+    100% {
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--warn) 32%, transparent);
+    }
+    50% {
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--warn) 18%, transparent);
+    }
+  }
+
   .who {
     gap: 6px;
     min-width: 0;
@@ -172,8 +276,14 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .games {
+  .gamesbox {
     flex: none;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+  }
+  .games {
     display: inline-flex;
     align-items: baseline;
     gap: 4px;
@@ -192,21 +302,48 @@
   .games.lead .glabel {
     color: var(--accent-ink);
   }
+  /* Best-of series tracker: filled = games won toward the majority. The leader is already
+     told by 👑 + the gold number, so the pips stay neutral (no second gold signal). */
+  .pips {
+    display: inline-flex;
+    gap: 4px;
+  }
+  .pip {
+    width: 9px;
+    height: 9px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: transparent;
+  }
+  .pip.on {
+    background: var(--text);
+    border-color: var(--text);
+  }
 
   .scorewrap {
     display: flex;
     align-items: center;
     gap: 12px;
   }
+  .scorewrap.solo {
+    justify-content: center;
+  }
+  /* The live courtside score is the hero of the card — big enough to read one-handed,
+     outdoors, at arm's length. Scales with the viewport but stays tabular so it never
+     jitters as it climbs. */
   .bigscore {
     flex: 1;
     text-align: center;
-    font-size: 3.2rem;
+    font-size: clamp(3.4rem, 15vw, 5rem);
     line-height: 1;
-    font-weight: 700;
+    font-weight: 800;
     font-variant-numeric: tabular-nums;
+    letter-spacing: -0.02em;
     min-width: 2ch;
     animation: sb-pop 0.16s ease-out;
+  }
+  .scorewrap.solo .bigscore {
+    flex: none;
   }
   @keyframes sb-pop {
     from {
@@ -218,6 +355,12 @@
   }
   .minus {
     flex: none;
+  }
+
+  .tagline {
+    display: flex;
+    justify-content: center;
+    min-height: 1.5rem;
   }
   .tag {
     flex: none;
@@ -244,6 +387,16 @@
     color: var(--text);
     border-color: color-mix(in srgb, var(--warn) 55%, var(--border));
     background: color-mix(in srgb, var(--warn) 14%, transparent);
+  }
+  .tag.point.match {
+    border-color: color-mix(in srgb, var(--warn) 80%, var(--border));
+    background: color-mix(in srgb, var(--warn) 22%, transparent);
+  }
+  .tag.run {
+    color: var(--text);
+    border-color: color-mix(in srgb, var(--bad) 45%, var(--border));
+    background: color-mix(in srgb, var(--bad) 12%, transparent);
+    font-variant-numeric: tabular-nums;
   }
 
   /* The rally tap: large and thumb-friendly, but a surface control — the one violet
@@ -288,6 +441,38 @@
     color: var(--text);
   }
 
+  /* One honest correction for a live scorer: pop the rally you just tapped. */
+  .undo {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: 100%;
+    min-height: 46px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 600;
+    transition: transform 0.05s ease, background 0.15s ease, border-color 0.15s ease;
+  }
+  .undo:hover:not(:disabled) {
+    background: var(--surface-2);
+    border-color: var(--primary);
+  }
+  .undo:active:not(:disabled) {
+    transform: translateY(1px);
+  }
+  .undo:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+  .undoicon {
+    font-size: 1.1rem;
+  }
+
   .status {
     min-height: 1.4em;
     font-size: 0.95rem;
@@ -296,7 +481,25 @@
   .status .warn {
     color: var(--warn);
   }
-  .status .pointmsg {
+  .status .good {
+    color: var(--good);
+  }
+  .status .point {
     font-weight: 700;
+  }
+  .status .muted {
+    color: var(--muted);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .bigscore {
+      animation: none;
+    }
+    .teamcard.matchpt,
+    .teamcard.deuce {
+      animation: none;
+      /* Keep the static ring so the tension still reads without motion. */
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--warn) 22%, transparent);
+    }
   }
 </style>

--- a/src/lib/games/spikeball/index.ts
+++ b/src/lib/games/spikeball/index.ts
@@ -77,7 +77,7 @@ export const spikeball: GameModule = {
 
   createRoundInput: (ctx: RoundContext): SpikeballInput => {
     const cfg = readConfig(ctx.config);
-    return { teams: splitTeams(playerIds(ctx), cfg.format), a: 0, b: 0 };
+    return { teams: splitTeams(playerIds(ctx), cfg.format), a: 0, b: 0, rallies: [] };
   },
 
   validateRound: (input: SpikeballInput, ctx: RoundContext): string | null =>

--- a/src/lib/games/spikeball/logic.ts
+++ b/src/lib/games/spikeball/logic.ts
@@ -25,6 +25,14 @@ export interface SpikeballInput {
   teams: [ID[], ID[]];
   a: number;
   b: number;
+  /**
+   * Ordered log of which team (0 | 1) won each rally, oldest first. Optional and purely
+   * additive: `a`/`b` remain the scoring source of truth (so validation, scoring, summary
+   * and stats are unchanged), while this log powers live extras — a satisfying single
+   * "undo last rally" and the momentum/run read. New games seed an empty log; rounds
+   * recorded before this existed simply have no log and fall back to the ± steppers.
+   */
+  rallies?: (0 | 1)[];
 }
 
 export const TARGET_OPTIONS = [21, 15, 11] as const;
@@ -66,6 +74,62 @@ export function splitTeams(playerIds: ID[], format: Format): [ID[], ID[]] {
 /** Games one team must win to take a best-of-N match. */
 export function gamesToWin(bestOf: number): number {
   return Math.floor(bestOf / 2) + 1;
+}
+
+/** Rally-log → the two teams' point totals. The log is the ordered list of rally winners. */
+export function scoreFromRallies(rallies: (0 | 1)[]): { a: number; b: number } {
+  let a = 0;
+  let b = 0;
+  for (const t of rallies) t === 0 ? (a += 1) : (b += 1);
+  return { a, b };
+}
+
+/** Append a rally winner, returning a new log (never mutates the input). */
+export function pushRally(rallies: (0 | 1)[], team: 0 | 1): (0 | 1)[] {
+  return [...rallies, team];
+}
+
+/** Drop the most recent rally, returning a new log. No-op on an empty log. */
+export function popRally(rallies: (0 | 1)[]): (0 | 1)[] {
+  return rallies.slice(0, -1);
+}
+
+/**
+ * The current unbroken run — how many rallies in a row the same team just won. Returns the
+ * team on the streak and its length (0 with a null team when there are no rallies yet).
+ */
+export function currentRun(rallies: (0 | 1)[]): { team: 0 | 1 | null; length: number } {
+  if (rallies.length === 0) return { team: null, length: 0 };
+  const team = rallies[rallies.length - 1]!;
+  let length = 0;
+  for (let i = rallies.length - 1; i >= 0 && rallies[i] === team; i--) length += 1;
+  return { team, length };
+}
+
+/**
+ * Deuce — the win-by-2 tension where the score is *tied at or past* one short of the target
+ * (20–20, 21–21, …) and the game isn't decided, so no single rally can end it. Distinct from
+ * game point (an advantage lead one rally from winning). Always false without win-by-2.
+ */
+export function isDeuce(a: number, b: number, target: number, winByTwo: boolean): boolean {
+  if (!winByTwo) return false;
+  if (gameWinner(a, b, target, winByTwo) !== null) return false;
+  return a === b && a >= target - 1;
+}
+
+/**
+ * Would banking this finished game clinch the whole match? True when `winner` is set and that
+ * team, credited this game, reaches the majority needed for the best-of-N.
+ */
+export function clinchesMatch(
+  winner: 0 | 1 | null,
+  gamesA: number,
+  gamesB: number,
+  bestOf: number,
+): boolean {
+  if (winner === null) return false;
+  const held = winner === 0 ? gamesA : gamesB;
+  return held + 1 >= gamesToWin(bestOf);
 }
 
 /**

--- a/src/lib/games/spikeball/spikeball.test.ts
+++ b/src/lib/games/spikeball/spikeball.test.ts
@@ -10,6 +10,12 @@ import {
   gameWinner,
   gamePointTeam,
   isMatchPoint,
+  isDeuce,
+  clinchesMatch,
+  currentRun,
+  pushRally,
+  popRally,
+  scoreFromRallies,
   matchOver,
   scoreDeltas,
   validate,
@@ -143,6 +149,94 @@ describe('match completion', () => {
   });
 });
 
+describe('isDeuce', () => {
+  it('flags a tie at or past one short of the target (20–20, 21–21)', () => {
+    expect(isDeuce(20, 20, 21, true)).toBe(true);
+    expect(isDeuce(22, 22, 21, true)).toBe(true);
+  });
+
+  it('is false before the deuce zone', () => {
+    expect(isDeuce(19, 19, 21, true)).toBe(false);
+    expect(isDeuce(20, 18, 21, true)).toBe(false);
+  });
+
+  it('is false at an advantage lead (that is game point, not deuce)', () => {
+    expect(isDeuce(21, 20, 21, true)).toBe(false);
+  });
+
+  it('is false once the game is decided', () => {
+    expect(isDeuce(23, 21, 21, true)).toBe(false);
+  });
+
+  it('is always false without win-by-2', () => {
+    expect(isDeuce(20, 20, 21, false)).toBe(false);
+  });
+});
+
+describe('clinchesMatch', () => {
+  it('is true when banking the game reaches the majority (best of 3)', () => {
+    expect(clinchesMatch(0, 1, 0, 3)).toBe(true);
+    expect(clinchesMatch(1, 0, 1, 3)).toBe(true);
+  });
+
+  it('is false when the winner still needs more games', () => {
+    expect(clinchesMatch(0, 0, 0, 3)).toBe(false);
+    expect(clinchesMatch(1, 1, 1, 5)).toBe(false);
+  });
+
+  it('is false when there is no winner yet', () => {
+    expect(clinchesMatch(null, 1, 1, 3)).toBe(false);
+  });
+
+  it('clinches a single-game match in one game', () => {
+    expect(clinchesMatch(0, 0, 0, 1)).toBe(true);
+  });
+});
+
+describe('rally log', () => {
+  it('sums a log into the two teams’ scores', () => {
+    expect(scoreFromRallies([])).toEqual({ a: 0, b: 0 });
+    expect(scoreFromRallies([0, 1, 0, 0, 1])).toEqual({ a: 3, b: 2 });
+  });
+
+  it('pushRally and popRally are immutable', () => {
+    const log: (0 | 1)[] = [0, 1];
+    const pushed = pushRally(log, 0);
+    expect(pushed).toEqual([0, 1, 0]);
+    expect(log).toEqual([0, 1]); // original untouched
+    const popped = popRally(pushed);
+    expect(popped).toEqual([0, 1]);
+    expect(pushed).toEqual([0, 1, 0]);
+  });
+
+  it('popRally on an empty log is a no-op', () => {
+    expect(popRally([])).toEqual([]);
+  });
+
+  it('a round-trip of push/score stays consistent', () => {
+    let log: (0 | 1)[] = [];
+    for (const t of [0, 0, 1, 0, 1, 1] as const) log = pushRally(log, t);
+    expect(scoreFromRallies(log)).toEqual({ a: 3, b: 3 });
+    log = popRally(log);
+    expect(scoreFromRallies(log)).toEqual({ a: 3, b: 2 });
+  });
+});
+
+describe('currentRun', () => {
+  it('reports no run for an empty log', () => {
+    expect(currentRun([])).toEqual({ team: null, length: 0 });
+  });
+
+  it('counts the trailing unbroken streak', () => {
+    expect(currentRun([1, 0, 0, 0])).toEqual({ team: 0, length: 3 });
+    expect(currentRun([0, 0, 1])).toEqual({ team: 1, length: 1 });
+  });
+
+  it('resets to length 1 the moment the other team scores', () => {
+    expect(currentRun([0, 0, 0, 1])).toEqual({ team: 1, length: 1 });
+  });
+});
+
 describe('scoreDeltas', () => {
   it('gives every winner +1 game and everyone else 0 (2v2)', () => {
     const input: SpikeballInput = { teams: [['a', 'b'], ['c', 'd']], a: 21, b: 15 };
@@ -222,7 +316,7 @@ describe('spikeball GameModule', () => {
 
   it('seeds a round with teams split from the roster and 0–0', () => {
     const input = spikeball.createRoundInput(ctx(['a', 'b', 'c', 'd'], { format: '2v2' })) as SpikeballInput;
-    expect(input).toEqual({ teams: [['a', 'b'], ['c', 'd']], a: 0, b: 0 });
+    expect(input).toEqual({ teams: [['a', 'b'], ['c', 'd']], a: 0, b: 0, rallies: [] });
   });
 
   it('scores a finished game into per-player game wins', () => {

--- a/src/lib/games/spikeball/stats.ts
+++ b/src/lib/games/spikeball/stats.ts
@@ -34,6 +34,7 @@ export function spikeballStats({ games, rounds, canonical }: GameStatsInput): Ga
   let totalPoints = 0;
   let biggestMargin = -1;
   let biggestLabel = '';
+  let longestRun = 0;
 
   for (const r of rounds) {
     if (!gameIds.has(r.gameId)) continue;
@@ -47,6 +48,17 @@ export function spikeballStats({ games, rounds, canonical }: GameStatsInput): Ga
     const winner = a === b ? null : a > b ? 0 : 1;
     const target = targetByGame.get(r.gameId) ?? 21;
     const deuce = Math.max(a, b) > target;
+
+    // Longest unbroken run of rallies in this game, when the rally log is present.
+    if (Array.isArray(input.rallies)) {
+      let cur = 0;
+      let prev: 0 | 1 | null = null;
+      for (const t of input.rallies) {
+        cur = t === prev ? cur + 1 : 1;
+        prev = t;
+        if (cur > longestRun) longestRun = cur;
+      }
+    }
 
     totalGames += 1;
     totalPoints += a + b;
@@ -102,6 +114,15 @@ export function spikeballStats({ games, rounds, canonical }: GameStatsInput): Ga
         value: biggestLabel,
         sub: `+${biggestMargin}`,
         emoji: '💥',
+      });
+    }
+    if (longestRun >= 3) {
+      global.push({
+        key: 'sb_run',
+        label: 'Longest rally run',
+        value: `${longestRun}`,
+        sub: 'in a row',
+        emoji: '🔥',
       });
     }
   }


### PR DESCRIPTION
## Make Spikeball more fun to score live

Spikeball is a **live rally scorer** — tapped courtside, one-handed, often outdoors in the sun. The module was correct but under-played that identity. This PR keeps the chrome identical and expresses Spikeball's fast rally/net personality through emoji, copy, accents, and animation — never by restyling the shell.

### Critique addressed
- **No haptic on the +1 tap** (nearly every other live editor buzzes) → now buzzes.
- **Score too small/cramped** for glanceable outdoor use → now the card hero.
- **No best-of series tracker at a glance** → ●●○ pips.
- **Silent deuce moment** → called out with shared tension.
- **Game/match point was a tiny tag** → felt moment (accent ring + escalating copy).
- **No rally momentum flavor / no true undo** → rally log powers both.

### What changed
- **Rally log (`rallies?: (0|1)[]`), backward compatible.** `a`/`b` stay the scoring source of truth, so validation, scoring, summary and stats are unchanged. New rounds seed an empty log; rounds recorded before this existed fall back to the − steppers.
- **Satisfying single "↩ Undo last rally"** replacing the twin − buttons (legacy fallback kept).
- **Hero courtside score** — `clamp()`-scaled, tabular-nums, keeps the pop.
- **Haptics** — `tick` on every rally tap, `undo` on undo.
- **Best-of series pips**, a shared **Deuce** moment, escalating **game/match-point** tension, a **momentum run chip** ("🔥 4 in a row"), and 🏆 **Match!** vs 🏐 **Game!** clinch copy.
- **Playful sportscaster microcopy** across states; all motion is reduced-motion safe.
- **Stats payoff** — a global **"Longest rally run"** metric from the log.

### New pure logic (unit-tested)
`scoreFromRallies`, `pushRally`/`popRally`, `currentRun`, `isDeuce`, `clinchesMatch`.

### Design non-negotiables honored
One violet primary (the shell's Save round) · Crown Gold only for leader/winner · surface-ramp depth · `tabular-nums` on all changing numbers · ≥46px targets · never color-alone (icon + word + number) · reduced-motion + haptics gated.

### Verification (local)
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — ✓
- `npm test` — 1170 passed (49 in the Spikeball suite)