### PR TITLE
Two Rooms and a Boom: a tense, delightful spy countdown

### DIFF
--- a/src/lib/games/tworooms/BoomBurst.svelte
+++ b/src/lib/games/tworooms/BoomBurst.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * The full-screen payoff for Two Rooms' final Reveal — the "…and a Boom" moment.
+   *
+   *   kind='boom' → 💥 the Bomber caught the President: a radial debris blast from
+   *                 centre with a hot flash (Red wins).
+   *   kind='dove' → 🕊️ the President escaped: doves lift and feathers drift up
+   *                 (Blue wins).
+   *
+   * Pure delight layered over an outcome already spelled out in words + emoji + the
+   * winner chips, so motion is never the only signal. The overlay is `fixed`,
+   * `pointer-events:none`, `aria-hidden`, replays whenever `token` changes, and
+   * renders nothing at all under reduced motion (the reveal banner is the calm,
+   * instant alternative). Modeled on the app's existing burst components
+   * (KaboomBurst / CoinBurst / PhaseSky).
+   */
+  let { token = 0, kind = 'boom' }: { token?: number; kind?: 'boom' | 'dove' } = $props();
+
+  const reduced = prefersReducedMotion();
+
+  const pieces = $derived.by(() => {
+    const boom = kind === 'boom';
+    const count = boom ? 22 : 16;
+    const glyphs = boom
+      ? ['💥', '💥', '🔥', '💣', '✨', '💨', '⚡']
+      : ['🕊️', '🕊️', '🪶', '✨', '☁️', '🕊️'];
+    return Array.from({ length: count }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      if (boom) {
+        // Radial scatter from screen centre — a real outward blast.
+        const angle = (i / count) * Math.PI * 2 + (rand(0) - 0.5) * 0.6;
+        const dist = 30 + rand(1) * 46; // vw/vh units
+        return {
+          dx: `${Math.cos(angle) * dist}vw`,
+          dy: `${Math.sin(angle) * dist}vh`,
+          startX: 50,
+          startY: 50,
+          delay: rand(2) * 0.1,
+          duration: 0.7 + rand(3) * 0.5,
+          spin: (rand(4) - 0.5) * 420,
+          size: 1.4 + rand(5) * 1.9,
+          glyph: glyphs[Math.floor(rand(6) * glyphs.length)],
+        };
+      }
+      // Doves: lift from a low band and drift up-and-out across the screen.
+      const drift = (rand(0) - 0.5) * 34;
+      return {
+        dx: `${drift}vw`,
+        dy: `${-(58 + rand(1) * 34)}vh`,
+        startX: 12 + rand(2) * 76,
+        startY: 74 + rand(3) * 18,
+        delay: rand(4) * 0.4,
+        duration: 1.5 + rand(5) * 0.9,
+        spin: (rand(6) - 0.5) * 40,
+        size: 1.5 + rand(0) * 1.4,
+        glyph: glyphs[Math.floor(rand(6) * glyphs.length)],
+      };
+    });
+  });
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="boomwrap" class:dove={kind === 'dove'} aria-hidden="true">
+      {#if kind === 'boom'}<div class="flash"></div>{/if}
+      {#each pieces as p, i (i)}
+        <span
+          class="bit"
+          style="
+            left: {p.startX}%;
+            top: {p.startY}%;
+            font-size: {p.size}rem;
+            animation-delay: {p.delay}s;
+            animation-duration: {p.duration}s;
+            --dx: {p.dx};
+            --dy: {p.dy};
+            --spin: {p.spin}deg;
+          ">{p.glyph}</span>
+      {/each}
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .boomwrap {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 60;
+  }
+  /* A hot flash for the boom — semantic loss coral, not Crown Gold. */
+  .flash {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      60% 50% at 50% 50%,
+      color-mix(in srgb, var(--bad) 55%, transparent),
+      transparent 70%
+    );
+    opacity: 0;
+    animation: boom-flash 0.5s ease-out both;
+  }
+  .bit {
+    position: absolute;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    transform: translate(-50%, -50%);
+    animation-name: boom-fly;
+    animation-timing-function: cubic-bezier(0.16, 0.84, 0.44, 1);
+    animation-iteration-count: 1;
+    animation-fill-mode: both;
+    filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.4));
+  }
+  .boomwrap.dove .bit {
+    animation-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1);
+  }
+  @keyframes boom-flash {
+    0% {
+      opacity: 0;
+    }
+    20% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+  @keyframes boom-fly {
+    0% {
+      opacity: 0;
+      transform: translate(-50%, -50%) rotate(0deg) scale(0.3);
+    }
+    16% {
+      opacity: 1;
+      transform: translate(calc(-50% + var(--dx) * 0.4), calc(-50% + var(--dy) * 0.4))
+        rotate(calc(var(--spin) * 0.4)) scale(1.1);
+    }
+    100% {
+      opacity: 0;
+      transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) rotate(var(--spin))
+        scale(0.85);
+    }
+  }
+</style>

--- a/src/lib/games/tworooms/TwoRoomsEditor.svelte
+++ b/src/lib/games/tworooms/TwoRoomsEditor.svelte
@@ -1,10 +1,18 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import type { ID, RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
+  import { haptic } from '../../haptics';
+  import { animateMotion } from '../../motion';
+  import BoomBurst from './BoomBurst.svelte';
   import {
+    formatClock,
     isFinalRound,
     roleBreakdown,
+    roundCount,
+    roundSeconds,
+    soundOn,
     suggestedMinutes,
     type Team,
     type TwoRoomsInput,
@@ -14,10 +22,16 @@
   let { input = $bindable(), ctx }: { input: TwoRoomsInput; ctx: RoundContext } = $props();
 
   const isFinal = $derived(isFinalRound(ctx.roundIndex, ctx.config));
+  const rounds = $derived(roundCount(ctx.config));
   const minutes = $derived(suggestedMinutes(ctx.roundIndex, ctx.config));
   const roles = $derived(roleBreakdown(ctx.players.length));
   const maxHostages = $derived(Math.max(1, ctx.players.length));
   const winner = $derived(input.reveal.winner);
+  const sound = $derived(soundOn(ctx.config));
+
+  // The shrinking-round arc (minutes per round), so the mounting tension is
+  // glanceable: 3 · 2 · 1. Co-signalled by the number itself, never colour alone.
+  const rail = $derived(Array.from({ length: rounds }, (_, r) => suggestedMinutes(r, ctx.config)));
 
   let showRoles = $state(false);
   let showRules = $state(false);
@@ -25,19 +39,40 @@
   const rooms: (1 | 2)[] = [1, 2];
 
   function setLeader(room: 1 | 2, id: ID) {
+    haptic('tick');
     if (room === 1) input.leader1 = input.leader1 === id ? null : id;
     else input.leader2 = input.leader2 === id ? null : id;
   }
 
+  // ── The Reveal payoff ────────────────────────────────────────────────────────
+  let boomToken = $state(0);
+  let boomKind = $state<'boom' | 'dove'>('boom');
+
   function setWinner(team: Team) {
+    const changed = input.reveal.winner !== team;
     input.reveal.winner = team;
+    if (changed) {
+      boomKind = team === 'red' ? 'boom' : 'dove';
+      boomToken += 1; // retriggers the full-screen BoomBurst
+      haptic('win');
+    }
   }
 
   function toggleWinnerMember(id: ID) {
+    haptic('tick');
     const has = input.reveal.winners.includes(id);
     input.reveal.winners = has
       ? input.reveal.winners.filter((x) => x !== id)
       : [...input.reveal.winners, id];
+  }
+
+  function selectAllWinners() {
+    haptic('save');
+    input.reveal.winners = ctx.players.map((p) => p.id);
+  }
+  function clearWinners() {
+    haptic('undo');
+    input.reveal.winners = [];
   }
 
   function setPresident(id: ID) {
@@ -46,12 +81,147 @@
   function setBomber(id: ID) {
     input.reveal.bomber = input.reveal.bomber === id ? null : id;
   }
+
+  // ── The Fuse: a real per-round countdown (transient; never saved) ────────────
+  let remaining = $state(0);
+  let running = $state(false);
+  let started = $state(false); // clock engaged this round (so idle re-arm doesn't fight it)
+  let timesUp = $state(false);
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let clockEl: HTMLDivElement | undefined = $state();
+
+  const full = $derived(roundSeconds(ctx.roundIndex, ctx.config));
+  const barPct = $derived(full > 0 ? Math.max(0, Math.min(100, (remaining / full) * 100)) : 0);
+  const lowAt = $derived(Math.max(10, Math.ceil(full * 0.2)));
+  const low = $derived(running && remaining > 0 && remaining <= lowAt);
+
+  // Reset the Fuse whenever the round changes — each shorter round is a clean,
+  // freshly-armed clock.
+  let lastRound = -1;
+  $effect(() => {
+    if (ctx.roundIndex !== lastRound) {
+      lastRound = ctx.roundIndex;
+      stopInterval();
+      running = false;
+      started = false;
+      timesUp = false;
+      remaining = full;
+    }
+  });
+
+  // Arm the Fuse to a full round while idle (also when the configured length changes).
+  $effect(() => {
+    const f = full;
+    if (!running && !started) remaining = f;
+  });
+
+  onDestroy(stopInterval);
+
+  function stopInterval() {
+    if (timer) {
+      clearInterval(timer);
+      timer = undefined;
+    }
+  }
+
+  // WebAudio "boom" alarm: two descending square blasts. Gated by the sound
+  // toggle; the context is created/resumed on the Start gesture (autoplay policy).
+  // Any failure is swallowed — audio must never break round entry.
+  let audioCtx: AudioContext | undefined;
+  function ensureAudio() {
+    if (!sound) return;
+    try {
+      const AC =
+        window.AudioContext ||
+        (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+      if (!AC) return;
+      if (!audioCtx) audioCtx = new AC();
+      if (audioCtx.state === 'suspended') void audioCtx.resume();
+    } catch {
+      /* no audio — the haptic + visual 💥 still fire */
+    }
+  }
+  function playAlarm() {
+    if (!sound || !audioCtx) return;
+    try {
+      const now = audioCtx.currentTime;
+      for (const [at, freq] of [
+        [0, 320],
+        [0.22, 200],
+      ] as const) {
+        const osc = audioCtx.createOscillator();
+        const gain = audioCtx.createGain();
+        osc.type = 'square';
+        osc.frequency.value = freq;
+        gain.gain.setValueAtTime(0.0001, now + at);
+        gain.gain.exponentialRampToValueAtTime(0.16, now + at + 0.01);
+        gain.gain.exponentialRampToValueAtTime(0.0001, now + at + 0.2);
+        osc.connect(gain).connect(audioCtx.destination);
+        osc.start(now + at);
+        osc.stop(now + at + 0.22);
+      }
+    } catch {
+      /* swallow */
+    }
+  }
+
+  function onTimesUp() {
+    timesUp = true;
+    haptic('buzz');
+    playAlarm();
+    if (clockEl) {
+      animateMotion(clockEl, { x: [0, -6, 6, -4, 4, 0] }, { duration: 0.5, ease: 'easeInOut' });
+    }
+  }
+
+  function tick() {
+    remaining -= 1;
+    if (remaining <= 0) {
+      remaining = 0;
+      stopInterval();
+      running = false;
+      onTimesUp();
+    }
+  }
+
+  function startFuse() {
+    if (running) return;
+    ensureAudio();
+    if (remaining <= 0) remaining = full;
+    started = true;
+    running = true;
+    timesUp = false;
+    stopInterval();
+    timer = setInterval(tick, 1000);
+  }
+  function pauseFuse() {
+    running = false;
+    stopInterval();
+  }
+  function resetFuse() {
+    running = false;
+    started = false;
+    timesUp = false;
+    remaining = full;
+    stopInterval();
+  }
 </script>
 
+<BoomBurst token={boomToken} kind={boomKind} />
+
 <div class="stack">
-  <div class="row spread">
-    <span class="pill">⏱ <span class="tnum">{minutes}</span> min{isFinal ? ' · final round' : ''}</span>
-    <span class="row" style="gap: 8px">
+  <div class="hdr">
+    <div class="rmeta">
+      <strong>Round <span class="tnum">{ctx.roundIndex + 1}</span> of <span class="tnum">{rounds}</span>{isFinal ? ' · final' : ''}</strong>
+      <span class="rail" aria-label="Round lengths, in minutes">
+        {#each rail as m, i (i)}
+          <span class="rung" class:now={i === ctx.roundIndex} class:done={i < ctx.roundIndex}>
+            <span class="tnum">{m}</span>m
+          </span>
+        {/each}
+      </span>
+    </div>
+    <span class="toggles">
       <button type="button" class="btn small ghost" aria-pressed={showRoles} onclick={() => (showRoles = !showRoles)}>
         🎭 Roles
       </button>
@@ -86,35 +256,75 @@
     <pre class="rules">{tworooms.help}</pre>
   {/if}
 
-  {#each rooms as room (room)}
-    <div class="room">
-      <div class="row spread">
-        <strong>Room {room}</strong>
-        <span class="pill">➡️ sends <span class="tnum">{room === 1 ? input.sent1 : input.sent2}</span></span>
-      </div>
-
-      <div class="fieldlabel">Leader <span class="muted">(optional)</span></div>
-      <div class="chips">
-        {#each ctx.players as p (p.id)}
-          {@const on = (room === 1 ? input.leader1 : input.leader2) === p.id}
-          <button type="button" class="chip" class:on aria-pressed={on} onclick={() => setLeader(room, p.id)}>
-            <Avatar name={p.name} color={p.color} size={22} />
-            <span>{p.name}</span>
-            {#if on}<span class="tag">📢 Leader</span>{/if}
-          </button>
-        {/each}
-      </div>
-
-      <div class="row spread hostrow">
-        <span>Hostages sent to Room {room === 1 ? 2 : 1}</span>
-        {#if room === 1}
-          <Stepper bind:value={input.sent1} min={0} max={maxHostages} />
-        {:else}
-          <Stepper bind:value={input.sent2} min={0} max={maxHostages} />
-        {/if}
-      </div>
+  <!-- The Fuse: this round's shrinking countdown -->
+  <div class="fuse" class:low class:up={timesUp} bind:this={clockEl}>
+    <div class="fusehead">
+      <span class="wick" aria-hidden="true">{timesUp ? '💥' : running ? '🧨' : '🕯️'}</span>
+      <span class="time" aria-live="off">{formatClock(remaining)}</span>
+      <span class="flabel">
+        {#if timesUp}Time! Trade hostages{:else if running}counting down…{:else}<span class="tnum">{minutes}</span>-minute round{/if}
+      </span>
     </div>
-  {/each}
+    <div class="track" aria-hidden="true"><div class="burn" style="transform: scaleX({barPct / 100})"></div></div>
+    <div class="fusectl">
+      {#if running}
+        <button type="button" class="btn grow" onclick={pauseFuse}>⏸ Pause</button>
+      {:else}
+        <button type="button" class="btn grow" onclick={startFuse}>{timesUp ? '↻ Re-arm' : '▶ Light the fuse'}</button>
+      {/if}
+      <button type="button" class="btn" onclick={resetFuse} aria-label="Reset the round timer">↺</button>
+    </div>
+  </div>
+
+  <!-- Two rooms, one boom — a corridor of hostage trades between them -->
+  <div class="rooms">
+    {#each rooms as room, ri (room)}
+      {@const leadId = room === 1 ? input.leader1 : input.leader2}
+      {@const leadName = leadId ? (ctx.players.find((p) => p.id === leadId)?.name ?? 'Leader') : null}
+      <div class="room">
+        <div class="roomhead">
+          <span class="door" aria-hidden="true">🚪</span>
+          <strong>Room <span class="tnum">{room}</span></strong>
+          {#if leadName}
+            <span class="ledby">📢 {leadName}</span>
+          {/if}
+        </div>
+
+        <div class="fieldlabel">Leader <span class="muted">(optional)</span></div>
+        <div class="chips">
+          {#each ctx.players as p (p.id)}
+            {@const on = (room === 1 ? input.leader1 : input.leader2) === p.id}
+            <button type="button" class="chip" class:on aria-pressed={on} onclick={() => setLeader(room, p.id)}>
+              <Avatar name={p.name} color={p.color} size={22} />
+              <span>{p.name}</span>
+              {#if on}<span class="tag">📢 Leader</span>{/if}
+            </button>
+          {/each}
+        </div>
+      </div>
+
+      {#if ri === 0}
+        <!-- The corridor: hostages crossing between the two rooms -->
+        <div class="corridor">
+          <div class="chead">🔁 Hostage exchange</div>
+          <div class="lane">
+            <span class="rm">🚪<span class="tnum">1</span></span>
+            <span class="flow send">➡️</span>
+            <Stepper bind:value={input.sent1} min={0} max={maxHostages} label="from Room 1 to Room 2" />
+            <span class="flow send">➡️</span>
+            <span class="rm">🚪<span class="tnum">2</span></span>
+          </div>
+          <div class="lane">
+            <span class="rm">🚪<span class="tnum">1</span></span>
+            <span class="flow recv">⬅️</span>
+            <Stepper bind:value={input.sent2} min={0} max={maxHostages} label="from Room 2 to Room 1" />
+            <span class="flow recv">⬅️</span>
+            <span class="rm">🚪<span class="tnum">2</span></span>
+          </div>
+        </div>
+      {/if}
+    {/each}
+  </div>
 
   {#if isFinal}
     <div class="reveal">
@@ -133,9 +343,15 @@
       </div>
 
       {#if winner}
-        <div class="fieldlabel winlabel">
-          Tap everyone on the winning {winner === 'red' ? '🔴 Red Team' : '🔵 Blue Team'}
-          <span class="muted">· {input.reveal.winners.length} of ~{winner === 'red' ? roles.redTotal : roles.blueTotal}</span>
+        <div class="row spread winlabel">
+          <span class="fieldlabel">
+            Tap everyone on the winning {winner === 'red' ? '🔴 Red Team' : '🔵 Blue Team'}
+            <span class="muted">· <span class="tnum">{input.reveal.winners.length}</span> of ~<span class="tnum">{winner === 'red' ? roles.redTotal : roles.blueTotal}</span></span>
+          </span>
+          <span class="winbtns">
+            <button type="button" class="btn small ghost" onclick={selectAllWinners}>All</button>
+            <button type="button" class="btn small ghost" onclick={clearWinners} disabled={input.reveal.winners.length === 0}>Clear</button>
+          </span>
         </div>
         <div class="chips">
           {#each ctx.players as p (p.id)}
@@ -184,15 +400,190 @@
   }
   .room,
   .ref,
-  .reveal {
+  .reveal,
+  .corridor {
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     padding: 12px;
     display: flex;
     flex-direction: column;
     gap: 10px;
   }
+
+  /* Header + shrinking-round rail */
+  .hdr {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .rmeta {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+  }
+  .toggles {
+    display: flex;
+    gap: 8px;
+    flex: none;
+  }
+  .rail {
+    display: inline-flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .rung {
+    font-size: 0.78rem;
+    color: var(--muted);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 1px 8px;
+    opacity: 0.55;
+  }
+  .rung.done {
+    opacity: 0.8;
+  }
+  .rung.now {
+    opacity: 1;
+    color: var(--text);
+    border-color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 14%, var(--surface));
+  }
+
+  /* The Fuse — a countdown console. Neutral surface: the shell's "Save round"
+     stays the one Royal Violet action; this is a play aid, never a second fill. */
+  .fuse {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px 14px;
+    border-radius: var(--radius);
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+  }
+  .fusehead {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+  }
+  .wick {
+    font-size: 1.4rem;
+    line-height: 1;
+    align-self: center;
+  }
+  .time {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    font-size: 2.4rem;
+    line-height: 1;
+  }
+  .fuse.low .time {
+    color: var(--warn);
+  }
+  .fuse.up .time {
+    color: var(--bad);
+  }
+  .flabel {
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  .fuse.up .flabel {
+    color: var(--bad);
+    font-weight: 600;
+  }
+  .track {
+    width: 100%;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--surface);
+    overflow: hidden;
+  }
+  .burn {
+    height: 100%;
+    width: 100%;
+    transform-origin: left;
+    transform: scaleX(1);
+    background: var(--muted);
+    border-radius: 999px;
+    transition: transform 0.95s linear;
+  }
+  .fuse.low .burn {
+    background: var(--warn);
+  }
+  .fuse.up .burn {
+    background: var(--bad);
+  }
+  .fusectl {
+    display: flex;
+    gap: 8px;
+  }
+  .grow {
+    flex: 1;
+  }
+
+  /* Two rooms + the corridor between them */
+  .rooms {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+  .rooms .room + .corridor,
+  .rooms .corridor + .room {
+    margin-top: -1px;
+  }
+  .roomhead {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .door {
+    font-size: 1.1rem;
+  }
+  .ledby {
+    margin-left: auto;
+    font-size: 0.8rem;
+    color: var(--muted);
+    font-weight: 600;
+  }
+
+  .corridor {
+    position: relative;
+    align-items: stretch;
+    margin: 8px 10px;
+    border-style: dashed;
+    background: var(--surface);
+  }
+  .chead {
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .lane {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+  .rm {
+    display: inline-flex;
+    align-items: center;
+    gap: 1px;
+    font-size: 0.9rem;
+    color: var(--muted);
+    flex: none;
+  }
+  .flow {
+    font-size: 0.95rem;
+    line-height: 1;
+    flex: none;
+  }
+
+  /* Field + chip vocabulary (shared with the shell's other games) */
   .fieldlabel {
     margin: 0;
   }
@@ -205,7 +596,7 @@
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    min-height: 44px;
+    min-height: 46px;
     padding: 6px 12px 6px 8px;
     border-radius: 999px;
     border: 1px solid var(--border);
@@ -222,9 +613,6 @@
     font-size: 0.72rem;
     font-weight: 700;
     color: var(--muted);
-  }
-  .hostrow {
-    gap: 10px;
   }
   .reflist {
     list-style: none;
@@ -250,6 +638,8 @@
     font-family: inherit;
     color: var(--muted);
   }
+
+  /* The Reveal */
   .revhead {
     font-weight: 800;
     font-size: 1.05rem;
@@ -292,6 +682,12 @@
   }
   .winlabel {
     margin-top: 2px;
+    gap: 8px;
+  }
+  .winbtns {
+    display: inline-flex;
+    gap: 6px;
+    flex: none;
   }
   .who {
     margin-top: 2px;

--- a/src/lib/games/tworooms/index.ts
+++ b/src/lib/games/tworooms/index.ts
@@ -57,6 +57,13 @@ export const tworooms: GameModule = {
       default: false,
       help: 'Adds colored roles beyond the President & Bomber. Deal those by hand — the tracker still records leaders, hostages, and the winning team.',
     },
+    {
+      key: 'sound',
+      label: 'Time’s-up buzzer',
+      type: 'boolean',
+      default: true,
+      help: 'Sound the alarm when the round Fuse burns out. The on-screen 💥 and a haptic buzz still fire either way.',
+    },
   ],
 
   maxRounds: (config) => roundCount(config),

--- a/src/lib/games/tworooms/logic.ts
+++ b/src/lib/games/tworooms/logic.ts
@@ -68,6 +68,30 @@ export function suggestedMinutes(roundIndex: number, config: Record<string, unkn
 }
 
 /**
+ * The Fuse length for this round in whole seconds — the shrinking-round rule
+ * ({@link suggestedMinutes}) turned into a real countdown the editor can tick.
+ */
+export function roundSeconds(roundIndex: number, config: Record<string, unknown> | undefined): number {
+  return suggestedMinutes(roundIndex, config) * 60;
+}
+
+/**
+ * Format a whole-second count as "M:SS" for the Fuse clock (e.g. 65 → "1:05").
+ * Negative values clamp to "0:00" so the boom state never shows a minus sign.
+ */
+export function formatClock(seconds: number): string {
+  const s = Math.max(0, Math.floor(Number(seconds) || 0));
+  const m = Math.floor(s / 60);
+  const rest = s % 60;
+  return `${m}:${String(rest).padStart(2, '0')}`;
+}
+
+/** Whether the time's-up buzzer fires when the Fuse burns out (default on). */
+export function soundOn(config: Record<string, unknown> | undefined): boolean {
+  return config?.sound !== false;
+}
+
+/**
  * Suggested hostages a room sends this round, following the official chart:
  *   6–10 players → 1 / 1 / 1,  11–21 → 2 / 1 / 1,  22+ → 3 / 2 / 1.
  * The final round always trades a single hostage; the opening round scales with

--- a/src/lib/games/tworooms/tworooms.test.ts
+++ b/src/lib/games/tworooms/tworooms.test.ts
@@ -5,11 +5,14 @@ import {
   MIN_ROUNDS,
   createInput,
   describe as describeRound,
+  formatClock,
   isFinalRound,
   pickWinners,
   roleBreakdown,
   roundCount,
+  roundSeconds,
   score,
+  soundOn,
   suggestedHostages,
   suggestedMinutes,
   teamLabel,
@@ -67,6 +70,39 @@ describe('suggestedMinutes', () => {
 
   it('never drops below one minute', () => {
     expect(suggestedMinutes(7, cfg(3))).toBe(1);
+  });
+});
+
+describe('roundSeconds', () => {
+  it('turns the shrinking minutes into a real countdown in seconds', () => {
+    expect([0, 1, 2].map((i) => roundSeconds(i, cfg(3)))).toEqual([180, 120, 60]);
+    expect([0, 1, 2, 3, 4].map((i) => roundSeconds(i, cfg(5)))).toEqual([300, 240, 180, 120, 60]);
+  });
+
+  it('never drops below one minute of fuse', () => {
+    expect(roundSeconds(9, cfg(3))).toBe(60);
+  });
+});
+
+describe('formatClock', () => {
+  it('formats seconds as M:SS with a padded remainder', () => {
+    expect(formatClock(180)).toBe('3:00');
+    expect(formatClock(65)).toBe('1:05');
+    expect(formatClock(9)).toBe('0:09');
+  });
+
+  it('clamps negatives and junk to 0:00 so the boom never shows a minus', () => {
+    expect(formatClock(-5)).toBe('0:00');
+    expect(formatClock(Number.NaN)).toBe('0:00');
+  });
+});
+
+describe('soundOn', () => {
+  it('defaults the buzzer on and only silences an explicit false', () => {
+    expect(soundOn(undefined)).toBe(true);
+    expect(soundOn({})).toBe(true);
+    expect(soundOn({ sound: true })).toBe(true);
+    expect(soundOn({ sound: false })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Why
Two Rooms and a Boom is *defined* by its shrinking timer, its two rooms, the hostage trades, and the climactic 💥/🕊️ reveal — but the editor under-delivered on all of it: a **static "timer" pill** (the shrinking minutes were computed but never ticked), two **identical stacked gray room cards**, **disconnected hostage steppers**, no **boom**, tedious winner tagging, and no haptics. Meanwhile the sibling timed game SaladBowl already had a full timer console.

This PR makes the game's personality *real* while keeping the app shell identical (per the "Game-Night LARPer" North Star — costume on top, chrome unchanged).

## What changed
- **🧨 The Fuse** — a real per-round countdown seeded from the shrinking-round rule (3→2→1 min): big `tabular-nums` clock, Start/Pause/Reset, a draining fuse bar, amber→red low-time warning, a WebAudio alarm (gated by a new **`sound`** config), a `buzz` haptic + shake + 💥 **"Time!"** state at zero. Transient play-aid state — **the saved round shape is unchanged**.
- **Shrinking-rounds rail** in the header so the mounting tension is glanceable (co-signalled by the minute number, never colour alone).
- **🚪 Two rooms + a corridor** — Room 1 / Room 2 identity with a dashed "Hostage exchange" corridor between them showing both trade directions with arrows and steppers.
- **💥 BoomBurst** — a bold full-screen 💥 (Red) / 🕊️ (Blue) reveal moment when the winning team is chosen. Reduced-motion safe: renders nothing, the reveal banner is the calm/instant path.
- **Faster winner tagging** — Select all / Clear helpers + haptics + a live "N of ~M" count (big win at 24+ players).
- **Polish** — haptics on leader/winner taps; chips bumped to the ≥46px spec; a stray off-scale radius aligned to the `--radius` token.
- **Pure logic + tests** — new `roundSeconds`, `formatClock`, `soundOn` helpers with 5 new unit tests.

## Design non-negotiables honored
- One Royal Violet primary action = the shell's "Save round"; the Fuse/tally stay neutral surface.
- Crown Gold untouched (leader/winner only); Red/Blue always co-signalled by 🔴/🔵 + text, never colour alone.
- `tabular-nums` on every changing number; depth via the surface ramp; every animation has a `prefers-reduced-motion` alternative.

## Testing (local)
- `npm run check` → 0 errors / 0 warnings
- `npm run build` → success
- `npx vitest run src/lib/games/tworooms` → **47 passed** (42 existing untouched + 5 new)

No data migration: the timer never persists, so History, Stats, and existing rounds are unaffected.