### PR TITLE
Uno: whimsy + UX overhaul for round entry

### DIFF
--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -8,6 +8,36 @@
         "value": "58px",
         "reason": "Intentional salad-bowl silhouette shape (elliptical bowl motif), not a UI container radius",
         "createdAt": "2026-07-12T17:51:51.610Z"
+      },
+      {
+        "rule": "design-system-color",
+        "value": "#d63d3d",
+        "reason": "Uno red suit color in the game's four-color card-fan motif (user-confirmed)",
+        "createdAt": "2026-07-13T18:07:30.759Z"
+      },
+      {
+        "rule": "design-system-color",
+        "value": "#f0b429",
+        "reason": "Uno yellow suit color in the game's four-color card-fan motif (user-confirmed)",
+        "createdAt": "2026-07-13T18:07:30.873Z"
+      },
+      {
+        "rule": "design-system-color",
+        "value": "#2fa84f",
+        "reason": "Uno green suit color in the game's four-color card-fan motif (user-confirmed)",
+        "createdAt": "2026-07-13T18:07:30.985Z"
+      },
+      {
+        "rule": "design-system-color",
+        "value": "#3b78c4",
+        "reason": "Uno blue suit color in the game's four-color card-fan motif (user-confirmed)",
+        "createdAt": "2026-07-13T18:07:31.096Z"
+      },
+      {
+        "rule": "design-system-radius",
+        "value": "4px",
+        "reason": "Small card-corner radius for the decorative mini Uno cards in the header motif (user-confirmed)",
+        "createdAt": "2026-07-13T18:07:31.219Z"
       }
     ]
   }

--- a/src/lib/games/uno/UnoBurst.svelte
+++ b/src/lib/games/uno/UnoBurst.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * The shout-"Uno!" payoff. A quick scatter of cards + confetti when a player empties
+   * their hand to end a round, layered over an outcome already spelled out in words + chip
+   * ("🎉 Went out", the gold row wash), so motion is never the only signal. The overlay is
+   * `pointer-events: none`, replays whenever `token` changes, and renders nothing at all
+   * under reduced motion. Modeled on the app's existing burst components (KaboomBurst /
+   * CoinBurst).
+   *
+   * `scoop` makes it a bigger, coin-flecked blast for standard mode — the going-out player
+   * literally scoops the pot — while golf uses the plain (no-scoop) confetti pop.
+   */
+  let { token = 0, scoop = false }: { token?: number; scoop?: boolean } = $props();
+
+  const reduced = prefersReducedMotion();
+
+  const pieces = $derived.by(() => {
+    const count = scoop ? 16 : 11;
+    // Uno's four colors carry the theme; glyphs (not hue) are what actually read.
+    const glyphs = scoop
+      ? ['🃏', '💰', '✨', '🔴', '🟡', '🟢', '🔵', '🎉']
+      : ['🎉', '🃏', '✨', '🔴', '🟡', '🟢', '🔵'];
+    return Array.from({ length: count }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      const angle = (i / count) * Math.PI * 2 + (rand(0) - 0.5) * 0.7;
+      const dist = (scoop ? 48 : 34) + rand(1) * (scoop ? 42 : 28);
+      return {
+        dx: Math.cos(angle) * dist,
+        dy: Math.sin(angle) * dist - (scoop ? 18 : 10), // bias upward a touch
+        delay: rand(2) * 0.08,
+        duration: (scoop ? 0.85 : 0.6) + rand(3) * 0.4,
+        spin: (rand(4) - 0.5) * 320,
+        size: (scoop ? 1.0 : 0.85) + rand(5) * 0.55,
+        glyph: glyphs[Math.floor(rand(6) * glyphs.length)],
+      };
+    });
+  });
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="unoburst" class:scoop aria-hidden="true">
+      {#each pieces as p, i (i)}
+        <span
+          class="bit"
+          style="
+            font-size: {p.size}rem;
+            animation-delay: {p.delay}s;
+            animation-duration: {p.duration}s;
+            --dx: {p.dx}px;
+            --dy: {p.dy}px;
+            --spin: {p.spin}deg;
+          ">{p.glyph}</span>
+      {/each}
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .unoburst {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    overflow: visible;
+    z-index: 3;
+  }
+  .bit {
+    position: absolute;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: uno-fly;
+    animation-timing-function: cubic-bezier(0.16, 0.84, 0.44, 1);
+    animation-iteration-count: 1;
+    animation-fill-mode: both;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
+  }
+  @keyframes uno-fly {
+    0% {
+      opacity: 0;
+      transform: translate(0, 0) rotate(0deg) scale(0.3);
+    }
+    18% {
+      opacity: 1;
+      transform: translate(calc(var(--dx) * 0.5), calc(var(--dy) * 0.5)) rotate(calc(var(--spin) * 0.5)) scale(1.15);
+    }
+    100% {
+      opacity: 0;
+      transform: translate(var(--dx), var(--dy)) rotate(var(--spin)) scale(0.9);
+    }
+  }
+</style>

--- a/src/lib/games/uno/UnoEditor.svelte
+++ b/src/lib/games/uno/UnoEditor.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
-  import { opponentsTotal, readConfig, type UnoInput } from './logic';
+  import { bumpOnChange } from '../../motion';
+  import { haptic } from '../../haptics';
+  import UnoBurst from './UnoBurst.svelte';
+  import { handValue, opponentsTotal, readConfig, type UnoInput } from './logic';
 
   let { input = $bindable(), ctx }: { input: UnoInput; ctx: RoundContext } = $props();
 
@@ -11,40 +15,134 @@
   const playerIds = $derived(ctx.players.map((p) => p.id));
   const pot = $derived(opponentsTotal(input, playerIds));
 
+  // Race-to-target header. Totals here are cumulative BEFORE this round. The game ENDS
+  // when any total reaches the target (both modes), so the meter tracks the highest total;
+  // the crown tracks who's actually winning (max in standard, min in golf).
+  const totalsBefore = $derived(ctx.totals ?? {});
+  const maxTotal = $derived(
+    playerIds.reduce((m, id) => Math.max(m, Number(totalsBefore[id]) || 0), 0),
+  );
+  const pct = $derived(
+    cfg.target > 0 ? Math.min(100, Math.round((maxTotal / cfg.target) * 100)) : 0,
+  );
+  const leaderId = $derived.by(() => {
+    const vals = playerIds.map((id) => Number(totalsBefore[id]) || 0);
+    if (!vals.length || vals.every((v) => v === 0)) return null;
+    const best = golf ? Math.min(...vals) : Math.max(...vals);
+    const i = vals.findIndex((v) => v === best);
+    return i >= 0 ? playerIds[i] : null;
+  });
+  const leaderName = $derived(
+    leaderId ? (ctx.players.find((p) => p.id === leaderId)?.name ?? '?') : null,
+  );
+  const leaderTotal = $derived(leaderId ? Number(totalsBefore[leaderId]) || 0 : 0);
+
+  // Older rounds (and freshly loaded edits) may not carry the per-kind `hands` breakdown.
+  // Seed one for every seat so the tally UI always has something to bind to; an old lump
+  // sum lands in `numbers` so its total is preserved and stays editable.
+  $effect(() => {
+    const ids = playerIds;
+    untrack(() => {
+      if (!input.hands) input.hands = {};
+      for (const id of ids) {
+        if (!input.hands[id]) {
+          input.hands[id] = { numbers: Math.max(0, Number(input.left?.[id]) || 0), actions: 0, wilds: 0 };
+        }
+      }
+    });
+  });
+
+  // Keep the authoritative `left` total in lockstep with the per-kind tally, so scoring,
+  // stats and history all read a plain number and never need to know about `hands`.
+  $effect(() => {
+    const c = cfg;
+    const out = input.out;
+    for (const id of playerIds) {
+      input.left[id] = out === id ? 0 : handValue(input.hands?.[id], c);
+    }
+  });
+
+  // Bump a token so the Uno! burst replays on the row that just went out.
+  let outToken = $state(0);
+
+  function handValueOf(id: string): number {
+    return input.out === id ? 0 : handValue(input.hands?.[id], cfg);
+  }
+
   function goOut(id: string) {
     if (input.out === id) {
       input.out = null;
     } else {
       input.out = id;
-      input.left[id] = 0; // whoever went out is holding nothing
+      if (input.hands?.[id]) input.hands[id] = { numbers: 0, actions: 0, wilds: 0 };
+      outToken += 1;
+      haptic('win');
     }
-  }
-
-  function add(id: string, amount: number) {
-    input.left[id] = Math.max(0, (Number(input.left[id]) || 0) + amount);
   }
 </script>
 
 <div class="stack">
-  <div class="row spread">
-    <span class="muted">
-      {input.out ? 'Now tally everyone else’s leftover cards.' : 'Who emptied their hand? Tap 🎉'}
+  <!-- Costume: a little four-colour card fan. Decorative only (aria-hidden); the copy and
+       emoji carry every actual signal, so colour is never doing the talking. -->
+  <div class="uno-head">
+    <span class="fan" aria-hidden="true">
+      <span class="mini c-red"></span>
+      <span class="mini c-yellow"></span>
+      <span class="mini c-green"></span>
+      <span class="mini c-blue"></span>
     </span>
-    {#if golf}
-      <span class="pill">⛳ Low score wins</span>
-    {:else if input.out}
-      <span class="pill take"><span class="tnum">🎉 +{pot}</span></span>
+    <div class="mode">
+      <strong class="modeline">{golf ? '⛳ Everyone banks their own' : '🎉 Winner scoops the table'}</strong>
+      <span class="sub">{golf ? 'Lowest total wins' : 'Highest total wins'}</span>
+    </div>
+  </div>
+
+  {#if cfg.target > 0}
+    <div class="race" role="group" aria-label="Race to {cfg.target} points">
+      <div class="row spread racetop">
+        <span class="racelead">
+          {#if leaderName}
+            👑 <strong class="ellipsis">{leaderName}</strong>
+            <span class="tnum lead" use:bumpOnChange={leaderTotal}>{leaderTotal}</span>
+          {:else}
+            <span class="sub">Nobody's pulled ahead yet</span>
+          {/if}
+        </span>
+        <span class="sub">ends at <span class="tnum">{cfg.target}</span></span>
+      </div>
+      <div class="track"><div class="fill" style="width: {pct}%"></div></div>
+    </div>
+  {/if}
+
+  <div class="row spread">
+    <span class="muted prompt">
+      {input.out ? 'Now tally the cards left in every other hand.' : 'Who shouted “Uno!” and emptied their hand?'}
+    </span>
+    {#if !golf && input.out}
+      <span class="pill take"><span class="tnum" use:bumpOnChange={pot}>🎉 +{pot}</span></span>
     {/if}
   </div>
 
   {#each ctx.players as p (p.id)}
     {@const isOut = input.out === p.id}
-    <div class="prow">
-      <div class="row spread">
-        <span class="row" style="gap: 8px; min-width: 0">
+    <div class="prow" class:out={isOut}>
+      <UnoBurst token={isOut ? outToken : 0} scoop={!golf} />
+
+      <div class="row spread head">
+        <span class="row who">
           <Avatar name={p.name} color={p.color} />
           <strong class="ellipsis">{p.name}</strong>
         </span>
+        {#if isOut}
+          <span class="badge sweep">🎉 Went out</span>
+        {:else}
+          <span class="subtotal tnum" aria-label="{p.name} is holding {handValueOf(p.id)} points">
+            {handValueOf(p.id)}<span class="sub">pts</span>
+          </span>
+        {/if}
+      </div>
+
+      <div class="row outrow">
         <button
           type="button"
           class="wentout"
@@ -52,29 +150,33 @@
           aria-pressed={isOut}
           onclick={() => goOut(p.id)}
         >
-          {isOut ? '🎉 Went out' : 'Went out'}
+          {isOut ? '🎉 Went out' : 'Went out?'}
         </button>
       </div>
 
       {#if isOut}
         <p class="note">
-          {golf
-            ? 'Empty hand — banks 0 this round.'
-            : `Scoops the table · +${pot} point${pot === 1 ? '' : 's'}`}
+          {golf ? 'Empty hand — banks 0 this round.' : `Scoops the table · +${pot} point${pot === 1 ? '' : 's'}`}
         </p>
       {:else}
-        <div class="entry">
-          <div class="chips">
-            <button type="button" class="chip" onclick={() => add(p.id, cfg.actionValue)}>
-              +{cfg.actionValue}<span class="sub">action</span>
-            </button>
-            <button type="button" class="chip" onclick={() => add(p.id, cfg.wildValue)}>
-              +{cfg.wildValue}<span class="sub">wild</span>
-            </button>
-          </div>
-          <label class="left">
-            <span class="sub">leftover</span>
-            <Stepper bind:value={input.left[p.id]} min={0} />
+        <div class="tally">
+          <label class="f">
+            <span class="klabel">🔢 Numbers <span class="hint">face value</span></span>
+            <input
+              type="number"
+              min="0"
+              inputmode="numeric"
+              aria-label="{p.name} number-card face value"
+              bind:value={input.hands![p.id].numbers}
+            />
+          </label>
+          <label class="f">
+            <span class="klabel">⛔ Actions <span class="hint">×{cfg.actionValue}</span></span>
+            <Stepper bind:value={input.hands![p.id].actions} min={0} label="{p.name} action cards" />
+          </label>
+          <label class="f">
+            <span class="klabel">🌈 Wilds <span class="hint">×{cfg.wildValue}</span></span>
+            <Stepper bind:value={input.hands![p.id].wilds} min={0} label="{p.name} wild cards" />
           </label>
         </div>
       {/if}
@@ -83,26 +185,131 @@
 </div>
 
 <style>
-  .prow {
+  .uno-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  /* A tiny fanned deck — pure costume, sits behind the mode copy. */
+  .fan {
+    flex: none;
+    display: inline-flex;
+    width: 40px;
+    height: 34px;
+    position: relative;
+  }
+  .mini {
+    position: absolute;
+    top: 4px;
+    left: 8px;
+    width: 16px;
+    height: 24px;
+    border-radius: 4px;
+    border: 1.5px solid var(--surface);
+    transform-origin: bottom center;
+  }
+  .c-red { background: #d63d3d; transform: rotate(-18deg); }
+  .c-yellow { background: #f0b429; transform: rotate(-6deg); left: 12px; }
+  .c-green { background: #2fa84f; transform: rotate(6deg); left: 12px; }
+  .c-blue { background: #3b78c4; transform: rotate(18deg); }
+  .modeline {
+    display: block;
+    font-size: 1rem;
+  }
+  .mode .sub {
+    font-size: 0.82rem;
+  }
+
+  .race {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
+    padding: 10px 12px;
+  }
+  .racetop {
+    align-items: baseline;
+  }
+  .racelead {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    min-width: 0;
+    font-weight: 700;
+  }
+  .lead {
+    color: var(--accent-ink);
+  }
+  .track {
+    height: 6px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    overflow: hidden;
+  }
+  .fill {
+    height: 100%;
+    border-radius: 999px;
+    background: var(--muted);
+  }
+
+  .prompt {
+    font-size: 0.9rem;
+  }
+
+  .prow {
+    position: relative;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
     padding: 12px;
     display: flex;
     flex-direction: column;
     gap: 10px;
+    transition: background 0.15s ease, border-color 0.15s ease;
+  }
+  /* The player who went out is the round's winner — the restrained Crown-Gold wash the
+     scoreboard uses, co-signalled by the 🎉 badge, never colour alone. */
+  .prow.out {
+    background: color-mix(in srgb, var(--accent) 13%, var(--surface-2));
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  }
+  .head {
+    align-items: center;
+  }
+  .who {
+    gap: 8px;
+    min-width: 0;
   }
   .ellipsis {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .wentout {
+  .subtotal {
     flex: none;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .subtotal .sub {
+    margin-left: 3px;
+    font-weight: 500;
+    font-size: 0.72rem;
+    color: var(--muted);
+  }
+  .badge.sweep {
+    flex: none;
+    font-weight: 700;
+    color: var(--accent-ink);
+  }
+
+  .wentout {
+    flex: 1;
     min-height: 46px;
     padding: 0 14px;
     border: 1px solid var(--border);
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     background: var(--surface);
     color: var(--muted);
     font: inherit;
@@ -112,11 +319,17 @@
   }
   .wentout:hover {
     color: var(--text);
+    background: var(--surface-3);
   }
+  /* Selected = gold-ink + gold border tint (marks the round winner), NOT a violet fill —
+     the one violet action on the screen stays the shell's Save. */
   .wentout.on {
-    background: var(--primary);
-    border-color: var(--primary-strong);
-    color: #fff;
+    background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+    color: var(--accent-ink);
+  }
+  .wentout:active {
+    transform: translateY(1px);
   }
   .wentout:focus-visible {
     outline: 2px solid var(--primary);
@@ -127,55 +340,42 @@
     color: var(--muted);
     font-size: 0.9rem;
   }
-  .entry {
+
+  .tally {
     display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 12px;
+    gap: 14px;
     flex-wrap: wrap;
   }
-  .chips {
+  .f {
     display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-  }
-  .chip {
-    display: inline-flex;
-    align-items: baseline;
+    flex-direction: column;
     gap: 6px;
+  }
+  .klabel {
+    font-size: 0.78rem;
+    color: var(--muted);
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .klabel .hint {
+    font-weight: 500;
+    opacity: 0.85;
+  }
+  .f input {
+    width: 92px;
     min-height: 46px;
-    padding: 0 14px;
+    padding: 11px 12px;
+    border-radius: var(--radius-sm);
     border: 1px solid var(--border);
-    border-radius: 10px;
     background: var(--surface);
     color: var(--text);
     font: inherit;
     font-weight: 700;
     font-variant-numeric: tabular-nums;
-    cursor: pointer;
-    transition: background 0.15s ease, border-color 0.15s ease;
   }
-  .chip:hover {
-    background: var(--surface-3);
-    border-color: var(--primary);
-  }
-  .chip:active {
-    transform: translateY(1px);
-  }
-  .chip:focus-visible {
+  .f input:focus-visible {
     outline: 2px solid var(--primary);
-    outline-offset: 2px;
-  }
-  .left {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    align-items: flex-end;
-  }
-  .sub {
-    color: var(--muted);
-    font-weight: 500;
-    font-size: 0.78rem;
+    outline-offset: 1px;
   }
   .take {
     color: var(--good);
@@ -184,5 +384,13 @@
   }
   .tnum {
     font-variant-numeric: tabular-nums;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .prow,
+    .wentout,
+    .fill {
+      transition: none;
+    }
   }
 </style>

--- a/src/lib/games/uno/index.ts
+++ b/src/lib/games/uno/index.ts
@@ -10,7 +10,7 @@ import {
   type UnoInput,
 } from './logic';
 
-export type { UnoInput, UnoConfig, UnoMode } from './logic';
+export type { UnoInput, UnoConfig, UnoMode, UnoHand } from './logic';
 
 export const uno: GameModule = {
   id: 'uno',
@@ -68,8 +68,11 @@ export const uno: GameModule = {
     const input = round.input as UnoInput;
     if (!input?.out) return 'no result';
     const winner = players.find((p) => p.id === input.out)?.name ?? '?';
-    const pot = opponentsTotal(input, players.map((p) => p.id));
-    return `🎉 ${winner} out · +${pot}`;
+    // Mode isn't available here, so stay mode-neutral: the count of leftover points on the
+    // table reads right whether the winner scooped it (standard) or each player banked their
+    // own (golf) — never the misleading "+pot" that only makes sense in standard.
+    const onTable = opponentsTotal(input, players.map((p) => p.id));
+    return onTable > 0 ? `🎉 ${winner} out · ${onTable} left in hands` : `🎉 ${winner} out · clean sweep`;
   },
 
   help: [

--- a/src/lib/games/uno/logic.ts
+++ b/src/lib/games/uno/logic.ts
@@ -30,11 +30,33 @@ export interface UnoConfig {
   wildValue: number;
 }
 
+/**
+ * A leftover hand tallied by card kind, so the editor can add cards by *type* (the way
+ * you actually read a fanned-out hand) instead of pre-summing points in your head:
+ *  - `numbers`: the summed face value of the number cards (0–9) left in hand
+ *  - `actions`: how many Skip / Reverse / Draw Two cards are left
+ *  - `wilds`:   how many Wild / Wild Draw Four cards are left
+ * Purely an entry convenience — the authoritative points value is always {@link UnoInput.left},
+ * which the editor keeps in sync via {@link handValue}. Absent on rounds saved before the
+ * per-kind tally existed, which still score fine from `left` alone.
+ */
+export interface UnoHand {
+  numbers: number;
+  actions: number;
+  wilds: number;
+}
+
 export interface UnoInput {
   /** The player who emptied their hand to end the round. */
   out: ID | null;
   /** Each player's leftover card points at round end. The player who went out holds 0. */
   left: Record<ID, number>;
+  /**
+   * Optional per-kind breakdown behind each player's {@link left} total, so re-opening a
+   * round restores the exact card counts. `left` stays authoritative for scoring; this is
+   * a display/editing aid only and may be absent (older rounds, or a hand typed as a lump).
+   */
+  hands?: Record<ID, UnoHand>;
 }
 
 export const UNO_DEFAULTS: UnoConfig = {
@@ -65,7 +87,25 @@ export function createUnoInput(playerIds: ID[]): UnoInput {
   return {
     out: null,
     left: Object.fromEntries(playerIds.map((id) => [id, 0])),
+    hands: Object.fromEntries(playerIds.map((id) => [id, emptyHand()])),
   };
+}
+
+/** A fresh, empty per-kind hand (no cards counted yet). */
+export function emptyHand(): UnoHand {
+  return { numbers: 0, actions: 0, wilds: 0 };
+}
+
+/** Points a per-kind hand is worth given the card values in play. Clamps to ≥ 0. */
+export function handValue(
+  hand: UnoHand | undefined,
+  cfg: Pick<UnoConfig, 'actionValue' | 'wildValue'>,
+): number {
+  if (!hand) return 0;
+  const n = Math.max(0, Number(hand.numbers) || 0);
+  const a = Math.max(0, Number(hand.actions) || 0);
+  const w = Math.max(0, Number(hand.wilds) || 0);
+  return n + a * cfg.actionValue + w * cfg.wildValue;
 }
 
 /** A player's leftover points, clamped to a non-negative number. */

--- a/src/lib/games/uno/uno.test.ts
+++ b/src/lib/games/uno/uno.test.ts
@@ -5,6 +5,8 @@ import { uno } from './index';
 import { unoStats } from './stats';
 import {
   createUnoInput,
+  emptyHand,
+  handValue,
   isUnoFinished,
   opponentsTotal,
   readConfig,
@@ -61,8 +63,44 @@ describe('readConfig', () => {
 // ---- round input -----------------------------------------------------------
 
 describe('createUnoInput', () => {
-  it('starts with nobody out and everyone on zero', () => {
-    expect(createUnoInput(ids)).toEqual({ out: null, left: { A: 0, B: 0, C: 0 } });
+  it('starts with nobody out, everyone on zero, and a fresh per-kind hand each', () => {
+    expect(createUnoInput(ids)).toEqual({
+      out: null,
+      left: { A: 0, B: 0, C: 0 },
+      hands: {
+        A: { numbers: 0, actions: 0, wilds: 0 },
+        B: { numbers: 0, actions: 0, wilds: 0 },
+        C: { numbers: 0, actions: 0, wilds: 0 },
+      },
+    });
+  });
+});
+
+// ---- per-kind hand tally ---------------------------------------------------
+
+describe('emptyHand', () => {
+  it('is a zeroed per-kind hand', () => {
+    expect(emptyHand()).toEqual({ numbers: 0, actions: 0, wilds: 0 });
+  });
+});
+
+describe('handValue', () => {
+  const cfg = { actionValue: 20, wildValue: 50 };
+
+  it('sums number face value plus action and wild counts × their values', () => {
+    expect(handValue({ numbers: 12, actions: 2, wilds: 1 }, cfg)).toBe(12 + 40 + 50);
+  });
+
+  it('treats a missing hand as zero', () => {
+    expect(handValue(undefined, cfg)).toBe(0);
+  });
+
+  it('clamps negative counts to zero', () => {
+    expect(handValue({ numbers: -5, actions: -1, wilds: 3 }, cfg)).toBe(150);
+  });
+
+  it('honours custom card values', () => {
+    expect(handValue({ numbers: 0, actions: 1, wilds: 1 }, { actionValue: 15, wildValue: 40 })).toBe(55);
   });
 });
 
@@ -170,12 +208,35 @@ describe('uno module', () => {
 
   it('builds a fresh input and validates/scores through the context', () => {
     const fresh = uno.createRoundInput(ctx({})) as UnoInput;
-    expect(fresh).toEqual({ out: null, left: { A: 0, B: 0, C: 0 } });
+    expect(fresh).toEqual({
+      out: null,
+      left: { A: 0, B: 0, C: 0 },
+      hands: {
+        A: { numbers: 0, actions: 0, wilds: 0 },
+        B: { numbers: 0, actions: 0, wilds: 0 },
+        C: { numbers: 0, actions: 0, wilds: 0 },
+      },
+    });
 
     const hand = input('A', { A: 0, B: 25, C: 40 });
     expect(uno.validateRound(hand, ctx({ mode: 'winner' }))).toBeNull();
     expect(uno.scoreRound(hand, ctx({ mode: 'winner' }))).toEqual({ A: 65, B: 0, C: 0 });
     expect(uno.scoreRound(hand, ctx({ mode: 'golf' }))).toEqual({ A: 0, B: 25, C: 40 });
+  });
+
+  it('scores from the authoritative left total even when a hands breakdown is present', () => {
+    // The editor keeps `left` in sync with `hands`; scoring only ever reads `left`, so a
+    // stale/absent breakdown can never change the points.
+    const hand: UnoInput = {
+      out: 'A',
+      left: { A: 0, B: 25, C: 40 },
+      hands: {
+        A: { numbers: 0, actions: 0, wilds: 0 },
+        B: { numbers: 5, actions: 1, wilds: 0 },
+        C: { numbers: 0, actions: 2, wilds: 0 },
+      },
+    };
+    expect(uno.scoreRound(hand, ctx({ mode: 'winner' }))).toEqual({ A: 65, B: 0, C: 0 });
   });
 
   it('ends the game via isFinished at the target', () => {
@@ -190,9 +251,14 @@ describe('uno module', () => {
     expect(defaultWinners(uno, totals, { mode: 'golf' })).toEqual(['C']);
   });
 
-  it('summarises a recorded round for the history table', () => {
+  it('summarises a recorded round for the history table (mode-neutral)', () => {
     const round = { input: input('A', { A: 0, B: 25, C: 40 }) } as Round;
-    expect(uno.describeRound?.(round, players)).toBe('🎉 Alice out · +65');
+    expect(uno.describeRound?.(round, players)).toBe('🎉 Alice out · 65 left in hands');
+  });
+
+  it('describes a hand where everyone else was empty as a clean sweep', () => {
+    const round = { input: input('B', { A: 0, B: 0, C: 0 }) } as Round;
+    expect(uno.describeRound?.(round, players)).toBe('🎉 Bob out · clean sweep');
   });
 });
 


### PR DESCRIPTION
## What & why

Makes the **Uno** round editor faster to use and more fun, while keeping the app chrome identical game-to-game and honoring every design non-negotiable. Uno's fast, colorful, shout-"Uno!" personality now comes through in copy, emoji, accent moments, and motion — not by restyling the shell.

## Highlights

- **Per-kind card tally** — enter the cards left in each hand *by type* (🔢 Numbers face value · ⛔ Actions ×value · 🌈 Wilds ×value) with a **live per-hand subtotal**, instead of pre-summing points in your head. Mirrors the clarity of the sibling Uno Golf entry.
- **"Uno!" / scoop burst** (`UnoBurst.svelte`) — a card + confetti pop when a player empties their hand, upgraded to a coin-flecked **scoop** in winner mode. `pointer-events: none`, replays on a token bump, and **renders nothing under reduced motion**.
- **Thematic header** — a decorative four-color card-fan motif (`aria-hidden`) + a **mode banner** that spells out *winner-scoops / high wins* vs *golf banks-own / low wins*, plus a **race-to-target meter** with the leader crown in Crown-Gold ink.
- **Playful microcopy** throughout the prompts, badges, and notes.

## Design-system fixes

- **One-Voice fix:** the "Went out" toggle no longer fills **Royal Violet** (it was competing with the shell's single Save action). It now uses a restrained **Crown-Gold** wash + 🎉 badge to mark the round winner — Crown-Gold stays reserved for the leader/winner.
- **Never color-alone:** every card-kind chip carries an icon **and** a text label; the four Uno suit colors are decoration only.
- All changing numbers use `tabular-nums`; touch targets ≥46px; animations honor `prefers-reduced-motion`.
- Registered the four Uno suit colors + the 4px mini-card radius as intentional, reasoned design-detector exceptions (`.impeccable/config.json`).

## Data model / correctness

- Scoring stays pure and history stays re-scorable: the summed **`left[id]`** total remains the authoritative value read by `scoreUno` / stats / `isFinished`. The new optional `hands` breakdown (`{ numbers, actions, wilds }`) is an **editor convenience only** — the editor keeps `left` in lockstep via `handValue`.
- **Backward compatible:** rounds saved before the tally existed have no `hands` and still score correctly; the editor back-fills an old lump sum into `numbers` so it stays editable.
- `describeRound` is now **mode-neutral** ("N left in hands" / "clean sweep") so golf-mode summaries no longer imply a scoop.

## Tests

Extended `uno.test.ts`: `handValue` / `emptyHand`, `left` stays authoritative when `hands` is present, backward-compat with hand-less rounds, and the new `describeRound` copy.

## Local verification

- `npm run check` → **0 errors / 0 warnings**
- `npx vitest run` → **1182 tests pass** (46 files)
- `npm run build` → **succeeds**

Scope: **Uno only** — no shared chrome or sibling games touched.