### PR TITLE
Uno Golf: sink celebration, links/target progress & sibling polish

### DIFF
--- a/src/lib/games/unogolf/SinkBurst.svelte
+++ b/src/lib/games/unogolf/SinkBurst.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * The "sank it" payoff — Uno Golf's marquee beat. When a player empties their hand
+   * and drops the ball in the cup, a golf ball rolls home over a quick scatter of Uno
+   * confetti. It's layered over an outcome already spelled out in words + chip ("⛳
+   * Sank it", the green row wash, the 0), so motion is never the only signal. The
+   * overlay is `pointer-events: none`, replays whenever `token` changes, and renders
+   * nothing at all under reduced motion — matching the app's UnoBurst / BirdieBurst.
+   */
+  let { token = 0 }: { token?: number } = $props();
+
+  const reduced = prefersReducedMotion();
+
+  const pieces = $derived.by(() => {
+    const count = 12;
+    // Uno's four colours + a golf flag carry the theme; the glyph (not hue) reads.
+    const glyphs = ['🎉', '⛳', '✨', '🔴', '🟡', '🟢', '🔵', '🏌️'];
+    return Array.from({ length: count }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      const angle = (i / count) * Math.PI * 2 + (rand(0) - 0.5) * 0.7;
+      const dist = 40 + rand(1) * 34;
+      return {
+        dx: Math.cos(angle) * dist,
+        dy: Math.sin(angle) * dist - 14, // bias upward a touch
+        delay: 0.12 + rand(2) * 0.1, // let the ball drop first
+        duration: 0.7 + rand(3) * 0.4,
+        spin: (rand(4) - 0.5) * 320,
+        size: 0.85 + rand(5) * 0.5,
+        glyph: glyphs[Math.floor(rand(6) * glyphs.length)],
+      };
+    });
+  });
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="sinkburst" aria-hidden="true">
+      <!-- The ball rolls in and drops into the cup, then the confetti pops. -->
+      <span class="ball">⛳</span>
+      {#each pieces as p, i (i)}
+        <span
+          class="bit"
+          style="
+            font-size: {p.size}rem;
+            animation-delay: {p.delay}s;
+            animation-duration: {p.duration}s;
+            --dx: {p.dx}px;
+            --dy: {p.dy}px;
+            --spin: {p.spin}deg;
+          ">{p.glyph}</span>
+      {/each}
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .sinkburst {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    overflow: visible;
+    z-index: 3;
+  }
+  .ball {
+    position: absolute;
+    line-height: 1;
+    font-size: 1.5rem;
+    opacity: 0;
+    will-change: transform, opacity;
+    animation: ball-sink 0.5s cubic-bezier(0.4, 0, 0.6, 1) both;
+    filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.4));
+  }
+  @keyframes ball-sink {
+    0% {
+      opacity: 0;
+      transform: translate(-64px, -8px) rotate(-90deg) scale(0.9);
+    }
+    35% {
+      opacity: 1;
+      transform: translate(-10px, -2px) rotate(-20deg) scale(1);
+    }
+    70% {
+      opacity: 1;
+      transform: translate(0, 0) rotate(0deg) scale(1);
+    }
+    100% {
+      opacity: 0;
+      transform: translate(0, 8px) rotate(0deg) scale(0.5);
+    }
+  }
+  .bit {
+    position: absolute;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: sink-fly;
+    animation-timing-function: cubic-bezier(0.16, 0.84, 0.44, 1);
+    animation-iteration-count: 1;
+    animation-fill-mode: both;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
+  }
+  @keyframes sink-fly {
+    0% {
+      opacity: 0;
+      transform: translate(0, 0) rotate(0deg) scale(0.3);
+    }
+    20% {
+      opacity: 1;
+      transform: translate(calc(var(--dx) * 0.5), calc(var(--dy) * 0.5)) rotate(calc(var(--spin) * 0.5)) scale(1.15);
+    }
+    100% {
+      opacity: 0;
+      transform: translate(var(--dx), var(--dy)) rotate(var(--spin)) scale(0.9);
+    }
+  }
+</style>

--- a/src/lib/games/unogolf/UnoGolfEditor.svelte
+++ b/src/lib/games/unogolf/UnoGolfEditor.svelte
@@ -2,19 +2,51 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
-  import { handStrokes, resolveConfig, type UnoGolfInput } from './logic';
+  import { bumpOnChange } from '../../motion';
+  import { haptic } from '../../haptics';
+  import SinkBurst from './SinkBurst.svelte';
+  import UnoGolfProgress from './UnoGolfProgress.svelte';
+  import { closestToPin, handStrokes, resolveConfig, type UnoGolfInput } from './logic';
 
   let { input = $bindable(), ctx }: { input: UnoGolfInput; ctx: RoundContext } = $props();
 
   const cfg = $derived(resolveConfig(ctx.config));
   const hole = $derived(ctx.roundIndex + 1);
-  const totalHoles = $derived(cfg.format === 'holes' ? cfg.holes : null);
+  const playerIds = $derived(ctx.players.map((p) => p.id));
   const parked = $derived(ctx.players.length - (input.out ? 1 : 0));
 
+  // Race header (Target format): totals here are cumulative BEFORE this hole. The game
+  // ends when any total reaches the cap, so the fill tracks the highest total; the 👑
+  // tracks who's actually winning — the LOWEST total, since low wins in golf.
+  const totalsBefore = $derived(ctx.totals ?? {});
+  const maxTotal = $derived(
+    playerIds.reduce((m, id) => Math.max(m, Number(totalsBefore[id]) || 0), 0),
+  );
+  const leaderId = $derived.by(() => {
+    const vals = playerIds.map((id) => Number(totalsBefore[id]) || 0);
+    if (!vals.length || vals.every((v) => v === 0)) return null;
+    const best = Math.min(...vals);
+    const i = vals.findIndex((v) => v === best);
+    return i >= 0 ? playerIds[i] : null;
+  });
+  const leaderName = $derived(
+    leaderId ? (ctx.players.find((p) => p.id === leaderId)?.name ?? '?') : null,
+  );
+  const leaderTotal = $derived(leaderId ? Number(totalsBefore[leaderId]) || 0 : 0);
+
+  // Whoever parked closest to the pin this hole (fewest leftover strokes among the
+  // players still counting). Null until it's a clear, non-tied call.
+  const closestId = $derived(closestToPin(input, playerIds, cfg));
+
   let showKey = $state(false);
+  // Per-player token that replays the "sank it" burst each time they drop the ball.
+  let sinkToken = $state<Record<string, number>>({});
 
   function strokes(id: string): number {
     return input.out === id ? 0 : handStrokes(input.hands[id], cfg);
+  }
+  function projected(id: string): number {
+    return (Number(totalsBefore[id]) || 0) + strokes(id);
   }
 
   function sink(id: string) {
@@ -23,14 +55,30 @@
     } else {
       input.out = id;
       input.hands[id] = { numbers: 0, actions: 0, wilds: 0 };
+      sinkToken[id] = (sinkToken[id] ?? 0) + 1;
+      haptic('win');
     }
   }
 </script>
 
 <div class="stack">
+  <UnoGolfProgress
+    format={cfg.format}
+    {hole}
+    holes={cfg.holes}
+    target={cfg.target}
+    {leaderName}
+    {leaderTotal}
+    {maxTotal}
+  />
+
   <div class="row spread">
-    <span class="pill">
-      {#if totalHoles}⛳ Hole {hole} of {totalHoles}{:else}⛳ Hole {hole}{/if}
+    <span class="muted hint">
+      {#if input.out}
+        Tally the cards left in every other hand — lowest total wins.
+      {:else}
+        Someone sinks the hole for 0; everyone else counts what's left in hand.
+      {/if}
     </span>
     <button
       type="button"
@@ -44,41 +92,52 @@
 
   {#if showKey}
     <div class="key" role="note">
-      <span class="chip">0–9 = face</span>
-      <span class="chip">Action = {cfg.actionValue}</span>
-      <span class="chip">Wild = {cfg.wildValue}</span>
+      <span class="chip">🔢 0–9 = face</span>
+      <span class="chip">⛔ Action = {cfg.actionValue}</span>
+      <span class="chip">🌈 Wild = {cfg.wildValue}</span>
     </div>
   {/if}
 
-  <p class="muted hint">
-    {#if input.out}
-      Tally the cards left in each other hand — number faces, then action &amp; wild counts.
-    {:else}
-      Tap ⛳ to mark who went out, then tally the cards left in every other hand.
-    {/if}
-  </p>
-
   {#each ctx.players as p (p.id)}
     {@const isOut = input.out === p.id}
+    {@const isClosest = !isOut && closestId === p.id}
     <div class="prow" class:out={isOut}>
+      <SinkBurst token={isOut ? (sinkToken[p.id] ?? 0) : 0} />
+
       <div class="row spread head">
         <span class="row who">
           <Avatar name={p.name} color={p.color} />
-          <strong>{p.name}</strong>
+          <strong class="ellipsis">{p.name}</strong>
         </span>
-        <span class="preview" class:score-good={isOut}>
+        {#if isOut}
+          <span class="badge">⛳ Sank it</span>
+        {:else}
+          <span class="subtotal tnum" aria-label="{p.name} carries {strokes(p.id)} strokes this hole">
+            +{strokes(p.id)}<span class="sub">strokes</span>
+          </span>
+        {/if}
+      </div>
+
+      <div class="row spread foot">
+        <span class="tag" class:pin={isClosest}>
           {#if isOut}
-            <span class="sank">⛳ 0</span>
+            Cleared the hole — 0 strokes.
+          {:else if isClosest}
+            ⛳🎯 Closest to the pin
           {:else}
-            +{strokes(p.id)}
+            &nbsp;
           {/if}
+        </span>
+        <span class="running">
+          <span class="lbl">total</span>
+          <span class="num tnum" use:bumpOnChange={projected(p.id)}>{projected(p.id)}</span>
         </span>
       </div>
 
       <div class="row sinkrow">
         <button
           type="button"
-          class="toggle"
+          class="sink"
           class:on={isOut}
           onclick={() => sink(p.id)}
           aria-pressed={isOut}
@@ -87,88 +146,155 @@
         </button>
       </div>
 
-      {#if isOut}
-        <p class="cleared muted">Cleared the hole — 0 strokes.</p>
-      {:else}
-        <div class="fields">
+      {#if !isOut}
+        <div class="tally">
           <label class="f">
-            <span>Number cards</span>
+            <span class="klabel">🔢 Numbers <span class="khint">face value</span></span>
             <input
               type="number"
               min="0"
               inputmode="numeric"
+              aria-label="{p.name} number-card face value"
               bind:value={input.hands[p.id].numbers}
             />
           </label>
           <label class="f">
-            <span>Actions ×{cfg.actionValue}</span>
-            <Stepper bind:value={input.hands[p.id].actions} min={0} />
+            <span class="klabel">⛔ Actions <span class="khint">×{cfg.actionValue}</span></span>
+            <Stepper bind:value={input.hands[p.id].actions} min={0} label="{p.name} action cards" />
           </label>
           <label class="f">
-            <span>Wilds ×{cfg.wildValue}</span>
-            <Stepper bind:value={input.hands[p.id].wilds} min={0} />
+            <span class="klabel">🌈 Wilds <span class="khint">×{cfg.wildValue}</span></span>
+            <Stepper bind:value={input.hands[p.id].wilds} min={0} label="{p.name} wild cards" />
           </label>
         </div>
       {/if}
     </div>
   {/each}
 
-  <p class="muted foot">
+  <p class="muted foot-note">
     {#if input.out}
       {parked}
       {parked === 1 ? 'player counts' : 'players count'} their leftover strokes this hole.
     {:else}
-      Someone always goes out to end a hole — mark them with ⛳.
+      Someone always goes out to end a hole — tap ⛳ to sink it.
     {/if}
   </p>
 </div>
 
 <style>
   .prow {
+    position: relative;
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
     transition: border-color 0.15s ease, background 0.15s ease;
   }
+  /* The player who sank the hole took the best possible line — 0 strokes. That reads as
+     a semantic-good win (green + ⛳ + words), never a second Royal Violet fill and never
+     Crown Gold (reserved for the game leader/winner). */
   .prow.out {
-    background: var(--surface-3);
-    border-color: color-mix(in srgb, var(--primary) 45%, var(--border));
+    background: color-mix(in srgb, var(--good) 12%, var(--surface-2));
+    border-color: color-mix(in srgb, var(--good) 45%, var(--border));
   }
   .head {
-    margin-bottom: 10px;
+    align-items: center;
   }
   .who {
     gap: 8px;
+    min-width: 0;
   }
-  .sinkrow {
-    margin-bottom: 10px;
-  }
-  .toggle {
-    flex: 1;
-    min-height: 46px;
-    padding: 10px;
-    border: 1px solid var(--border);
-    border-radius: 10px;
-    background: var(--surface);
-    color: var(--text);
-    cursor: pointer;
-    font-weight: 700;
-    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
-  }
-  .toggle.on {
-    background: var(--primary);
-    border-color: var(--primary-strong);
-    color: #fff;
-  }
-  .preview {
-    font-weight: 800;
-    font-variant-numeric: tabular-nums;
-  }
-  .sank {
+  .ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .fields {
+  .badge {
+    flex: none;
+    font-weight: 700;
+    color: var(--good);
+  }
+  .subtotal {
+    flex: none;
+    font-weight: 800;
+  }
+  .subtotal .sub {
+    margin-left: 3px;
+    font-weight: 500;
+    font-size: 0.72rem;
+    color: var(--muted);
+  }
+
+  .foot {
+    align-items: baseline;
+  }
+  .tag {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .tag.pin {
+    color: var(--good);
+    font-weight: 700;
+  }
+  .running {
+    flex: none;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+  .lbl {
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .num {
+    font-weight: 800;
+  }
+
+  .sinkrow {
+    margin: 0;
+  }
+  .sink {
+    flex: 1;
+    min-height: 46px;
+    padding: 0 14px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--muted);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  }
+  .sink:hover {
+    color: var(--text);
+    background: var(--surface-3);
+  }
+  /* Selected = green-good tint (marks the hole cleared), NOT a violet fill — the one
+     Royal Violet action on the screen stays the shell's Save. */
+  .sink.on {
+    background: color-mix(in srgb, var(--good) 14%, var(--surface));
+    border-color: color-mix(in srgb, var(--good) 55%, var(--border));
+    color: var(--good);
+  }
+  .sink:active {
+    transform: translateY(1px);
+  }
+  .sink:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+
+  .tally {
     display: flex;
     gap: 14px;
     flex-wrap: wrap;
@@ -177,12 +303,34 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
+  }
+  .klabel {
     font-size: 0.78rem;
     color: var(--muted);
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .klabel .khint {
+    font-weight: 500;
+    opacity: 0.85;
   }
   .f input {
-    width: 84px;
+    width: 92px;
+    min-height: 46px;
+    padding: 11px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
   }
+  .f input:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+
   .key {
     display: flex;
     gap: 8px;
@@ -198,21 +346,19 @@
     font-variant-numeric: tabular-nums;
   }
   .hint {
-    margin: 0;
     font-size: 0.85rem;
   }
-  .cleared {
-    margin: 2px 0 0;
-    font-size: 0.85rem;
+  .tnum {
+    font-variant-numeric: tabular-nums;
   }
-  .foot {
+  .foot-note {
     margin: 2px 0 0;
     font-size: 0.82rem;
   }
 
   @media (prefers-reduced-motion: reduce) {
     .prow,
-    .toggle {
+    .sink {
       transition: none;
     }
   }

--- a/src/lib/games/unogolf/UnoGolfProgress.svelte
+++ b/src/lib/games/unogolf/UnoGolfProgress.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import { bumpOnChange } from '../../motion';
+
+  /**
+   * Uno Golf's per-game "costume" header, format-aware:
+   *  - Fixed holes → a slim links ribbon of flags, one per hole, that fills as the
+   *    course is played and highlights the hole being entered (front/back-nine aware,
+   *    modelled on Golf's LinksProgress).
+   *  - Play-to-target → a race-to-the-cap meter: the fill tracks the highest total
+   *    creeping toward the cap that ends the game, and the 👑 marks whoever's actually
+   *    winning (the LOWEST total, since low wins). Modelled on Uno's race meter.
+   *
+   * Pure flavour — it lives inside the editor and never touches the shared chrome. The
+   * "Hole N of M" / leader text carries the meaning, so the fill is reinforcement only
+   * and there's nothing essential to animate under reduced motion.
+   */
+  let {
+    format,
+    hole,
+    holes,
+    target,
+    leaderName = null,
+    leaderTotal = 0,
+    maxTotal = 0,
+  }: {
+    format: 'holes' | 'target';
+    hole: number;
+    holes: number;
+    target: number;
+    leaderName?: string | null;
+    leaderTotal?: number;
+    maxTotal?: number;
+  } = $props();
+
+  const flags = $derived(Array.from({ length: holes }, (_, i) => i + 1));
+  const nine = $derived(holes > 9 ? (hole <= 9 ? 'Front nine' : 'Back nine') : '');
+  const done = $derived(hole - 1);
+  const pct = $derived(target > 0 ? Math.min(100, Math.round((maxTotal / target) * 100)) : 0);
+</script>
+
+<div class="links">
+  <div class="cap">
+    <span class="where">⛳ Hole {hole}{#if format === 'holes'} <span class="of">of {holes}</span>{/if}</span>
+    {#if format === 'holes' && nine}
+      <span class="nine">{nine}</span>
+    {:else if format === 'target'}
+      <span class="nine">to {target}</span>
+    {/if}
+  </div>
+
+  {#if format === 'holes'}
+    <div class="fairway" aria-hidden="true">
+      {#each flags as f (f)}
+        <span class="flag" class:played={f < hole} class:current={f === hole}
+          >{f === hole ? '⛳' : f < hole ? '🚩' : '·'}</span>
+      {/each}
+    </div>
+    <span class="sr-only">Hole {hole} of {holes}{nine ? `, ${nine}` : ''}, {done} played.</span>
+  {:else}
+    <div class="racetop">
+      {#if leaderName}
+        <span class="lead">👑 <strong class="ellipsis">{leaderName}</strong>
+          <span class="tnum leadnum" use:bumpOnChange={leaderTotal}>{leaderTotal}</span>
+          <span class="sub">out front</span>
+        </span>
+      {:else}
+        <span class="sub">Nobody's pulled ahead yet</span>
+      {/if}
+    </div>
+    <div class="track"><div class="fill" style="width: {pct}%"></div></div>
+    <span class="sr-only">
+      Racing to {target}. {leaderName ? `${leaderName} leads with ${leaderTotal}.` : 'No leader yet.'}
+    </span>
+  {/if}
+</div>
+
+<style>
+  .links {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+  }
+  .cap {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .where {
+    font-weight: 700;
+    font-size: 0.9rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .of {
+    color: var(--muted);
+    font-weight: 600;
+  }
+  .nine {
+    font-size: 0.72rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .fairway {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 6px;
+    align-items: center;
+  }
+  .flag {
+    font-size: 0.92rem;
+    line-height: 1;
+    opacity: 0.5;
+    filter: grayscale(0.6);
+  }
+  .flag.played {
+    opacity: 1;
+    filter: none;
+  }
+  .flag.current {
+    opacity: 1;
+    filter: none;
+    transform: scale(1.25);
+  }
+
+  .racetop {
+    display: flex;
+    align-items: baseline;
+    min-width: 0;
+  }
+  .lead {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    min-width: 0;
+    font-weight: 700;
+  }
+  .ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  /* The leader's number is the one sanctioned Crown-Gold moment here. */
+  .leadnum {
+    color: var(--accent-ink);
+  }
+  .sub {
+    font-weight: 500;
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .tnum {
+    font-variant-numeric: tabular-nums;
+  }
+  .track {
+    height: 6px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    overflow: hidden;
+  }
+  .fill {
+    height: 100%;
+    border-radius: 999px;
+    background: var(--muted);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .flag.current {
+      transform: none;
+    }
+  }
+</style>

--- a/src/lib/games/unogolf/logic.ts
+++ b/src/lib/games/unogolf/logic.ts
@@ -94,6 +94,37 @@ export function scoreHole(
   return out;
 }
 
+/**
+ * "Closest to the pin": among the players who did NOT sink the hole, the one who
+ * carried the fewest leftover strokes — a fun, golf-flavoured relative nod. Returns
+ * that player's id, or `null` when there's no clear winner: nobody is out yet, fewer
+ * than two players are counting strokes, or the lowest count is tied. Pure so the
+ * editor and tests share one definition of who parked it closest.
+ */
+export function closestToPin(
+  input: UnoGolfInput,
+  playerIds: ID[],
+  cfg: CardValues,
+): ID | null {
+  if (!input.out) return null;
+  const counters = playerIds.filter((id) => id !== input.out);
+  if (counters.length < 2) return null;
+  let bestId: ID | null = null;
+  let best = Infinity;
+  let tied = false;
+  for (const id of counters) {
+    const s = handStrokes(input.hands?.[id], cfg);
+    if (s < best) {
+      best = s;
+      bestId = id;
+      tied = false;
+    } else if (s === best) {
+      tied = true;
+    }
+  }
+  return tied ? null : bestId;
+}
+
 /** Validate a hole entry. Returns null when valid, else a friendly message. */
 export function validateHole(
   input: UnoGolfInput,

--- a/src/lib/games/unogolf/stats.ts
+++ b/src/lib/games/unogolf/stats.ts
@@ -10,6 +10,8 @@ interface UGAgg {
   sunk: number;
   /** Total strokes accumulated across holes. */
   strokes: number;
+  /** Fewest strokes carried on a single hole — their best hole. */
+  best: number;
   /** Wild cards (Wild / Wild Draw Four) left in hand across holes — the pricey ones. */
   wilds: number;
 }
@@ -26,7 +28,7 @@ export function unogolfStats({ games, rounds, canonical }: GameStatsInput): Game
   const get = (id: ID): UGAgg => {
     let a = per.get(id);
     if (!a) {
-      a = { holes: 0, sunk: 0, strokes: 0, wilds: 0 };
+      a = { holes: 0, sunk: 0, strokes: 0, best: Infinity, wilds: 0 };
       per.set(id, a);
     }
     return a;
@@ -39,7 +41,9 @@ export function unogolfStats({ games, rounds, canonical }: GameStatsInput): Game
     for (const [pid, hand] of Object.entries(input.hands)) {
       const a = get(canonical(pid));
       a.holes += 1;
-      a.strokes += Number(r.deltas?.[pid]) || 0;
+      const strokes = Number(r.deltas?.[pid]) || 0;
+      a.strokes += strokes;
+      if (strokes < a.best) a.best = strokes;
       a.wilds += Math.max(0, Number(hand?.wilds) || 0);
     }
     if (input.out) get(canonical(input.out)).sunk += 1;
@@ -47,8 +51,10 @@ export function unogolfStats({ games, rounds, canonical }: GameStatsInput): Game
 
   const perPlayer: Record<ID, Metric[]> = {};
   let totSunk = 0;
+  let courseRecord = Infinity;
   for (const [id, a] of per) {
     totSunk += a.sunk;
+    if (a.holes && a.best < courseRecord) courseRecord = a.best;
     const metrics: Metric[] = [];
     if (a.holes) {
       metrics.push({
@@ -57,6 +63,13 @@ export function unogolfStats({ games, rounds, canonical }: GameStatsInput): Game
         value: fmtAvg(a.strokes / a.holes),
         sub: 'strokes per hole',
         emoji: '📊',
+      });
+      metrics.push({
+        key: 'ug_best',
+        label: 'Best hole',
+        value: fmtInt(a.best),
+        sub: 'fewest strokes',
+        emoji: '🏌️',
       });
     }
     if (a.sunk) {
@@ -71,6 +84,9 @@ export function unogolfStats({ games, rounds, canonical }: GameStatsInput): Game
   const global: Metric[] = [];
   if (totSunk) {
     global.push({ key: 'ug_sunk_all', label: 'Holes sunk', value: fmtInt(totSunk), emoji: '⛳' });
+  }
+  if (Number.isFinite(courseRecord)) {
+    global.push({ key: 'ug_record', label: 'Best hole', value: fmtInt(courseRecord), emoji: '🏌️' });
   }
   return { perPlayer, global };
 }

--- a/src/lib/games/unogolf/unogolf.test.ts
+++ b/src/lib/games/unogolf/unogolf.test.ts
@@ -3,6 +3,7 @@ import type { Game, Player, Round, RoundContext } from '../../types';
 import { defaultWinners } from '../../types';
 import {
   DEFAULTS,
+  closestToPin,
   emptyHand,
   handStrokes,
   resolveConfig,
@@ -128,6 +129,50 @@ describe('scoreHole', () => {
   it('emits a zero for a player with no recorded hand', () => {
     const out = scoreHole({ hands: {}, out: null }, ['a', 'b'], DEFAULTS);
     expect(out).toEqual({ a: 0, b: 0 });
+  });
+});
+
+describe('closestToPin', () => {
+  const vals = { actionValue: 20, wildValue: 50 };
+
+  it('picks the non-sinker holding the fewest strokes', () => {
+    const input: UnoGolfInput = {
+      hands: {
+        a: { numbers: 3, actions: 0, wilds: 0 },
+        b: emptyHand(),
+        c: { numbers: 9, actions: 0, wilds: 0 },
+      },
+      out: 'b',
+    };
+    expect(closestToPin(input, ['a', 'b', 'c'], vals)).toBe('a');
+  });
+
+  it('returns null when nobody has sunk the hole yet', () => {
+    const input: UnoGolfInput = {
+      hands: { a: { numbers: 3, actions: 0, wilds: 0 }, b: emptyHand(), c: emptyHand() },
+      out: null,
+    };
+    expect(closestToPin(input, ['a', 'b', 'c'], vals)).toBeNull();
+  });
+
+  it('returns null on a tie for the fewest strokes', () => {
+    const input: UnoGolfInput = {
+      hands: {
+        a: { numbers: 5, actions: 0, wilds: 0 },
+        b: emptyHand(),
+        c: { numbers: 5, actions: 0, wilds: 0 },
+      },
+      out: 'b',
+    };
+    expect(closestToPin(input, ['a', 'b', 'c'], vals)).toBeNull();
+  });
+
+  it('returns null when only one player is left counting', () => {
+    const input: UnoGolfInput = {
+      hands: { a: { numbers: 3, actions: 0, wilds: 0 }, b: emptyHand() },
+      out: 'b',
+    };
+    expect(closestToPin(input, ['a', 'b'], vals)).toBeNull();
   });
 });
 
@@ -279,7 +324,15 @@ describe('unogolfStats', () => {
     expect(perPlayer['c']?.find((m) => m.key === 'ug_wilds')?.value).toBe('2');
   });
 
-  it('aggregates total holes sunk globally', () => {
+  it('reports each player’s best (fewest-stroke) hole', () => {
+    // A: holes of 25 then 0 → best 0. B: 0 then 3 → best 0. C: 50 then 50 → best 50.
+    expect(perPlayer['a']?.find((m) => m.key === 'ug_best')?.value).toBe('0');
+    expect(perPlayer['b']?.find((m) => m.key === 'ug_best')?.value).toBe('0');
+    expect(perPlayer['c']?.find((m) => m.key === 'ug_best')?.value).toBe('50');
+  });
+
+  it('aggregates total holes sunk and the course record globally', () => {
     expect(global.find((m) => m.key === 'ug_sunk_all')?.value).toBe('2');
+    expect(global.find((m) => m.key === 'ug_record')?.value).toBe('0');
   });
 });


### PR DESCRIPTION
## What & why

A critique-driven pass over the **Uno Golf** module (`src/lib/games/unogolf/`), aligning it with the freshly-improved **Uno** and **Golf** siblings while leaning into its own links-meets-Uno identity. Uno Golf is a hybrid — golf HOLES played with Uno cards, **lowest total wins**; each hole one player "sinks it" (⛳, 0 strokes) and everyone else tallies leftover cards.

## Critique (what was weak)

- 🚩 **Design non-negotiable violated** — the "Sank it" toggle turned **Royal Violet** when on, a second violet fill competing with the shell's single primary (Save). Both siblings deliberately avoid this.
- **No signature celebration** — Uno has `UnoBurst`, Golf has `BirdieBurst`; Uno Golf's marquee *sink* beat had **no animation and no haptic** at all.
- **Weak progress** — just a text pill; no flag ribbon, and the **target format shipped with zero progress UI** despite Uno having a race meter.
- **No running standings**, a **less-polished/inconsistent tally** vs Uno, and **no "best hole" stat** vs Golf.

## Changes

- **A. Fix the violet violation** — sinking (0 strokes) now reads as **semantic-good green** (⛳ + words), keeping Royal Violet and Crown Gold sacred.
- **B. `SinkBurst.svelte`** — the "sank it" moment: a golf ball drops into the cup over a scatter of Uno confetti. Modelled on the siblings' bursts — `pointer-events: none`, token-replay, renders nothing under reduced motion — plus `haptic('win')` on sink.
- **C. `UnoGolfProgress.svelte`** — a format-aware header: a links **flag ribbon** for fixed holes (front/back-nine aware) and a **race-to-cap meter** with the 👑 leader (lowest total) for the target format.
- **D.** Per-player **projected running total** (`bumpOnChange`) + a clear per-hole `+N strokes` readout.
- **E. "Closest to the pin"** ⛳🎯 — highlights the non-sinker holding the fewest leftover strokes (unit-tested `closestToPin`).
- **F.** Polished tally to match Uno (🔢/⛔/🌈 labels, aria-labels, 46px inputs) and snapped radii to DESIGN tokens.
- **G. Stats** — a per-player **Best hole** (fewest strokes) and a global course record.

Pure scoring/validation stays Svelte-free in `logic.ts`; the new helper + stats are unit-tested.

## Design compliance

One Royal Violet action/screen · Crown Gold only for the leader/winner · depth via the surface ramp · `tabular-nums` on every number · ≥46px targets · never color-alone · `prefers-reduced-motion` alternatives · identical chrome, personality only via emoji/copy/accent/motion. Design hooks pass clean.

## Local verification

- `npm run check` — 0 errors, 0 warnings
- `npm test` — **1187 passed** (added `closestToPin` + best-hole/course-record coverage)
- `npm run build` — succeeds