### PR TITLE
Volleyball: courtside live-scoring overhaul

### DIFF
--- a/src/lib/games/volleyball/VolleyballEditor.svelte
+++ b/src/lib/games/volleyball/VolleyballEditor.svelte
@@ -2,13 +2,23 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import { PALETTE } from '../../util';
-  import type { VolleyballInput } from './logic';
+  import { haptic } from '../../haptics';
+  import type { Side, VolleyballInput } from './logic';
   import {
     cloneTeams,
+    currentRun,
+    dropRally,
     foldStandings,
+    isDeuceSet,
     makeTeam,
+    popRally,
+    pushRally,
     readConfig,
+    scoreFromRallies,
+    serving,
+    setPointSide,
     setWinner,
+    shuffleTeams,
     type Team,
     unassigned,
   } from './logic';
@@ -33,54 +43,92 @@
 
   const home = $derived(input.teams?.find((t) => t.id === input.home));
   const away = $derived(input.teams?.find((t) => t.id === input.away));
+
+  // The rally log powers a true single "undo", the serve indicator and the momentum read.
+  // It's optional and additive — `points` stays the scoring truth, and legacy sets with no
+  // log fall back to plain ± on the point totals.
+  const hasLog = $derived(Array.isArray(input.rallies));
+  const rallies = $derived(input.rallies ?? []);
   const ptsHome = $derived(Number(input.points?.home) || 0);
   const ptsAway = $derived(Number(input.points?.away) || 0);
   const target = $derived(cfg.pointsPerSet);
   const result = $derived(setWinner(ptsHome, ptsAway, target, cfg.winBy2, cfg.hardCap));
+  const done = $derived(result !== null);
+
+  const spSide = $derived(done ? null : setPointSide(ptsHome, ptsAway, target, cfg.winBy2, cfg.hardCap));
+  const spHome = $derived(spSide === 'a');
+  const spAway = $derived(spSide === 'b');
+  const deuce = $derived(isDeuceSet(ptsHome, ptsAway, target, cfg.winBy2, cfg.hardCap));
+  const serveSide = $derived(serving(rallies));
+  const run = $derived(currentRun(rallies));
+
+  const canUndo = $derived(hasLog && rallies.length > 0);
+  const lastSide = $derived<Side | null>(rallies.length ? rallies[rallies.length - 1]! : null);
+  const lastName = $derived(lastSide === null ? '' : lastSide === 'a' ? (home?.name ?? 'Home') : (away?.name ?? 'Away'));
 
   const benchIds = $derived(unassigned(input.teams ?? [], pool.map((p) => p.id)));
 
+  // Beach vs indoor costume — flavour through emoji + copy, never a restyled shell.
+  const formatEmoji = $derived(cfg.format === 'beach' ? '🏖️' : cfg.format === 'indoor' ? '🏟️' : '🏐');
+  const formatLabel = $derived(
+    cfg.format === 'beach' ? 'Beach' : cfg.format === 'indoor' ? 'Indoor' : cfg.format === 'fours' ? 'Fours' : 'Custom',
+  );
+
   // ── Score entry ──────────────────────────────────────────────────────────
-  function bump(slot: 'home' | 'away', delta: number) {
-    const next = Math.max(0, (Number(input.points?.[slot]) || 0) + delta);
-    input.points = { ...input.points, [slot]: next };
+  /** Sync `points` from a rally log so the log and the score stay the one truth. */
+  function setScore(next: Side[]) {
+    input.rallies = next;
+    const s = scoreFromRallies(next);
+    input.points = { home: s.home, away: s.away };
   }
-  function onType(slot: 'home' | 'away', value: string) {
-    const n = Math.floor(Number(value));
-    input.points = { ...input.points, [slot]: Number.isFinite(n) && n > 0 ? n : 0 };
+  /** Would giving `side` the next rally clinch the set right now? */
+  function clinches(side: Side): boolean {
+    const na = side === 'a' ? ptsHome + 1 : ptsHome;
+    const nb = side === 'b' ? ptsAway + 1 : ptsAway;
+    return setWinner(na, nb, target, cfg.winBy2, cfg.hardCap) === side;
+  }
+  function add(slot: 'home' | 'away') {
+    if (done) return;
+    const side: Side = slot === 'home' ? 'a' : 'b';
+    const win = clinches(side);
+    if (hasLog) setScore(pushRally(rallies, side));
+    else input.points = { ...input.points, [slot]: (Number(input.points?.[slot]) || 0) + 1 };
+    haptic(win ? 'win' : 'tick');
+  }
+  function sub(slot: 'home' | 'away') {
+    const side: Side = slot === 'home' ? 'a' : 'b';
+    if (hasLog) setScore(dropRally(rallies, side));
+    else input.points = { ...input.points, [slot]: Math.max(0, (Number(input.points?.[slot]) || 0) - 1) };
+  }
+  function undoLast() {
+    if (!canUndo) return;
+    setScore(popRally(rallies));
+    haptic('undo');
   }
   function swapSides() {
     const h = input.home;
     input.home = input.away;
     input.away = h;
-    input.points = { home: ptsAway, away: ptsHome };
+    if (hasLog) setScore(rallies.map((s) => (s === 'a' ? 'b' : 'a')));
+    else input.points = { home: ptsAway, away: ptsHome };
   }
 
-  /** Would one more point here win the set? */
-  function isSetPoint(slot: 'home' | 'away'): boolean {
-    if (result) return false;
-    const na = slot === 'home' ? ptsHome + 1 : ptsHome;
-    const nb = slot === 'away' ? ptsAway + 1 : ptsAway;
-    const side = slot === 'home' ? 'a' : 'b';
-    return setWinner(na, nb, target, cfg.winBy2, cfg.hardCap) === side;
-  }
-  const spHome = $derived(isSetPoint('home'));
-  const spAway = $derived(isSetPoint('away'));
-  const deuce = $derived(!result && cfg.winBy2 && ptsHome >= target - 1 && ptsAway >= target - 1);
-
-  const status = $derived.by(() => {
-    if (result) {
-      const w = result === 'a' ? home : away;
+  // One sportscaster line for the live status region — whimsy in the copy, never clutter.
+  const call = $derived.by(() => {
+    if (!home || !away) return { tone: 'muted', text: '🏐 Pick the two teams playing this set.' };
+    const hn = home.name;
+    const an = away.name;
+    if (done) {
+      const w = result === 'a' ? hn : an;
       const hi = Math.max(ptsHome, ptsAway);
       const lo = Math.min(ptsHome, ptsAway);
-      return { emoji: '✅', text: `${w?.name ?? 'Winner'} take the set ${hi}–${lo}`, tone: 'good' };
+      return { tone: 'good', text: `✅ ${w} take the set ${hi}–${lo} — tap “Save round” to bank it.` };
     }
-    if (spHome || spAway) {
-      const t = spHome ? home : away;
-      return { emoji: '🎯', text: `Set point — ${t?.name ?? ''}`, tone: 'warn' };
-    }
-    if (deuce) return { emoji: '🔁', text: 'Deuce — must win by two', tone: 'muted' };
-    return { emoji: '🏐', text: `Rally to ${target}${cfg.winBy2 ? ', win by two' : ''}`, tone: 'muted' };
+    if (spHome || spAway) return { tone: 'warn', text: `🎯 Set point — ${spHome ? hn : an} one rally away!` };
+    if (deuce) return { tone: 'warn', text: `🔁 Deuce at ${ptsHome}–${ptsAway} — win by two, nobody blinks.` };
+    if (run.side !== null && run.length >= 4) return { tone: 'muted', text: `🔥 ${run.side === 'a' ? hn : an} rolling — ${run.length} straight.` };
+    if (ptsHome === 0 && ptsAway === 0) return { tone: 'muted', text: `${formatEmoji} ${formatLabel} • first serve! Rally to ${target}${cfg.winBy2 ? ', win by two' : ''}.` };
+    return { tone: 'muted', text: `Tap ＋1 for the side that won each rally. Rally to ${target}${cfg.winBy2 ? ', win by two' : ''}.` };
   });
 
   // ── Team management ──────────────────────────────────────────────────────
@@ -104,6 +152,12 @@
     const teams = cloneTeams(input.teams ?? []);
     teams.push(makeTeam(teams.length));
     commit(teams);
+  }
+  /** Whimsical one-tap re-deal: reshuffle the whole pool across the current teams. */
+  function doShuffle() {
+    commit(shuffleTeams(input.teams ?? [], pool.map((p) => p.id), cfg));
+    selectedMember = null;
+    haptic('tick');
   }
   function removeTeam(id: string) {
     if ((input.teams?.length ?? 0) <= 2) return;
@@ -171,78 +225,110 @@
 
   <!-- ── This set ── -->
   <div class="row spread meta">
-    <span class="pill">🏐 Set {setNumber} · to {target}</span>
+    <span class="pill">{formatEmoji} Set {setNumber} · to {target}</span>
     <button type="button" class="linklike" onclick={() => (managing = !managing)} aria-expanded={managing}>
       {managing ? '✕ Done editing' : '⚙ Manage teams'}
     </button>
   </div>
 
-  <p class="status" class:good={status.tone === 'good'} class:warn={status.tone === 'warn'} aria-live="polite">
-    <span aria-hidden="true">{status.emoji}</span>
-    <span>{status.text}</span>
-  </p>
+  {#snippet sideCard(slot: 'home' | 'away', team: Team | undefined, pts: number, sp: boolean, side: Side)}
+    {@const won = side === 'a' ? result === 'a' : result === 'b'}
+    {@const serves = hasLog && !done && serveSide === side}
+    {@const rolling = !done && run.side === side && run.length >= 3}
+    <div
+      class="side"
+      class:won
+      class:atpoint={sp}
+      class:deuce={deuce && !done}
+      data-drop={team?.id ?? undefined}
+      style={`--tc:${team?.color ?? 'var(--primary)'}`}
+    >
+      <button
+        type="button"
+        class="sidehead"
+        onclick={() => (picking = picking === slot ? null : slot)}
+        aria-label={`Choose the ${slot} team (currently ${team?.name ?? 'none'})`}
+      >
+        <span class="temoji sm" style={`--tc:${team?.color ?? 'var(--primary)'}`}>{team?.emoji ?? '🏐'}</span>
+        <span class="pickname">{team?.name ?? 'Pick team'}</span>
+        {#if serves}<span class="serve" title="Serving next">🏐</span>{/if}
+        {#if (input.teams?.length ?? 0) > 2}<span class="caret" aria-hidden="true">▾</span>{/if}
+      </button>
+
+      {#if picking === slot && (input.teams?.length ?? 0) > 2}
+        <div class="picklist" role="listbox">
+          {#each input.teams as t (t.id)}
+            {@const taken = t.id === (slot === 'home' ? input.away : input.home)}
+            <button
+              type="button"
+              class="pickopt"
+              class:on={t.id === team?.id}
+              disabled={taken}
+              onclick={() => {
+                if (slot === 'home') input.home = t.id; else input.away = t.id;
+                picking = null;
+              }}
+            >
+              <span class="temoji xs" style={`--tc:${t.color}`}>{t.emoji}</span>
+              <span>{t.name}</span>
+              {#if taken}<span class="muted xs">playing</span>{/if}
+            </button>
+          {/each}
+        </div>
+      {/if}
+
+      <div class="scorebox">
+        <span class="sr-only">{team?.name ?? slot} points this set</span>
+        {#key pts}
+          <span class="bigscore tnum" class:goodnum={won}>{pts}</span>
+        {/key}
+      </div>
+
+      <div class="tagline" aria-hidden="true">
+        {#if won}
+          <span class="tag win">✅ Set!</span>
+        {:else if sp}
+          <span class="tag point">🎯 Set pt</span>
+        {:else if rolling}
+          <span class="tag run">🔥 {run.length} in a row</span>
+        {:else}
+          <span class="tag ghost">&nbsp;</span>
+        {/if}
+      </div>
+
+      <div class="ctrls">
+        <button type="button" class="minus" onclick={() => sub(slot)} disabled={pts <= 0} aria-label={`Take a point back from ${team?.name ?? slot}`}>−1</button>
+        <button type="button" class="plus" class:pt={sp} disabled={done} onclick={() => add(slot)} aria-label={`${sp ? 'Set point — ' : ''}Add a rally point for ${team?.name ?? slot}`}>
+          <span class="plussign">＋1</span>
+          <span class="pluslabel">{sp ? 'set point' : 'rally'}</span>
+        </button>
+      </div>
+    </div>
+  {/snippet}
 
   <div class="match">
-    {#each [{ slot: 'home' as const, team: home, pts: ptsHome, sp: spHome }, { slot: 'away' as const, team: away, pts: ptsAway, sp: spAway }] as s (s.slot)}
-      <div class="side" class:won={(s.slot === 'home' ? result === 'a' : result === 'b')} data-drop={s.team?.id ?? undefined} style={`--tc:${s.team?.color ?? 'var(--primary)'}`}>
-        <button
-          type="button"
-          class="sidehead"
-          onclick={() => (picking = picking === s.slot ? null : s.slot)}
-          aria-label={`Choose the ${s.slot} team (currently ${s.team?.name ?? 'none'})`}
-        >
-          <span class="temoji sm" style={`--tc:${s.team?.color ?? '#7c5cff'}`}>{s.team?.emoji ?? '🏐'}</span>
-          <span class="pickname">{s.team?.name ?? 'Pick team'}</span>
-          {#if (input.teams?.length ?? 0) > 2}<span class="caret" aria-hidden="true">▾</span>{/if}
-        </button>
-
-        {#if picking === s.slot && (input.teams?.length ?? 0) > 2}
-          <div class="picklist" role="listbox">
-            {#each input.teams as t (t.id)}
-              {@const taken = t.id === (s.slot === 'home' ? input.away : input.home)}
-              <button
-                type="button"
-                class="pickopt"
-                class:on={t.id === s.team?.id}
-                disabled={taken}
-                onclick={() => {
-                  if (s.slot === 'home') input.home = t.id; else input.away = t.id;
-                  picking = null;
-                }}
-              >
-                <span class="temoji xs" style={`--tc:${t.color}`}>{t.emoji}</span>
-                <span>{t.name}</span>
-                {#if taken}<span class="muted xs">playing</span>{/if}
-              </button>
-            {/each}
-          </div>
-        {/if}
-
-        <label class="scorewrap">
-          <span class="sr-only">{s.team?.name} points this set</span>
-          <input
-            class="score"
-            class:score-good={s.slot === 'home' ? result === 'a' : result === 'b'}
-            type="number"
-            inputmode="numeric"
-            min="0"
-            value={s.pts}
-            oninput={(e) => onType(s.slot, e.currentTarget.value)}
-          />
-        </label>
-
-        <div class="ctrls">
-          <button type="button" class="minus" onclick={() => bump(s.slot, -1)} disabled={s.pts <= 0} aria-label={`Take a point back from ${s.team?.name}`}>−1</button>
-          <button type="button" class="plus" class:pt={s.sp} onclick={() => bump(s.slot, 1)} aria-label={`Add a point for ${s.team?.name}`}>
-            <span class="big">+1</span>
-            {#if s.sp}<span class="ptlabel">set pt</span>{/if}
-          </button>
-        </div>
-      </div>
-    {/each}
+    {@render sideCard('home', home, ptsHome, spHome, 'a')}
+    <div class="net" aria-hidden="true"><span class="netbadge">🥅</span></div>
+    {@render sideCard('away', away, ptsAway, spAway, 'b')}
   </div>
 
-  <button type="button" class="swap" onclick={swapSides} aria-label="Swap which side is home and away">⇄ Swap sides</button>
+  <p class="status" class:good={call.tone === 'good'} class:warn={call.tone === 'warn'} role="status" aria-live="polite">
+    {call.text}
+  </p>
+
+  <div class="livebar">
+    <button
+      type="button"
+      class="undo"
+      onclick={undoLast}
+      disabled={!canUndo}
+      aria-label={canUndo ? `Undo the last point for ${lastName}` : 'Undo last point'}
+    >
+      <span class="undoicon" aria-hidden="true">↩</span>
+      <span>{canUndo ? `Undo · ${lastName}` : 'Undo last point'}</span>
+    </button>
+    <button type="button" class="swap" onclick={swapSides} aria-label="Swap which side is home and away">⇄ Swap sides</button>
+  </div>
 
   <!-- ── Manage teams ── -->
   {#if managing}
@@ -309,7 +395,10 @@
         </div>
       {/each}
 
-      <button type="button" class="addteam" onclick={addTeam} disabled={(input.teams?.length ?? 0) >= 8}>＋ Add team</button>
+      <div class="manage-actions">
+        <button type="button" class="addteam" onclick={addTeam} disabled={(input.teams?.length ?? 0) >= 8}>＋ Add team</button>
+        <button type="button" class="shuffle" onclick={doShuffle} disabled={pool.length === 0} title="Randomly redeal every player across the teams">🎲 Shuffle teams</button>
+      </div>
 
       <div class="bench-area" data-drop="bench">
         <div class="section-lbl">🪑 Bench</div>
@@ -477,11 +566,33 @@
     background: color-mix(in srgb, var(--warn) 12%, var(--surface-2));
   }
 
-  /* ── Match (two contesting sides) ── */
+  /* ── Match (two contesting sides, split by the net) ── */
   .match {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 10px;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 8px;
+    align-items: stretch;
+  }
+  /* The net between the two courts — a dashed centre line with a 🥅 badge. Pure flavour,
+     aria-hidden, and never the only signal for anything. */
+  .net {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    width: 26px;
+  }
+  .net::before,
+  .net::after {
+    content: '';
+    flex: 1;
+    width: 0;
+    border-left: 2px dashed color-mix(in srgb, var(--border) 80%, var(--muted));
+  }
+  .netbadge {
+    font-size: 1.1rem;
+    line-height: 1;
   }
   .side {
     display: flex;
@@ -492,9 +603,47 @@
     border: 1px solid var(--border);
     border-radius: var(--radius);
     position: relative;
+    transition:
+      border-color 0.18s ease,
+      background 0.18s ease,
+      box-shadow 0.18s ease;
   }
+  /* A won set reads as success — green, distinct from the standings leader's Crown Gold. */
   .side.won {
     border-color: color-mix(in srgb, var(--good) 55%, var(--border));
+    background: color-mix(in srgb, var(--good) 12%, var(--surface-2));
+    animation: vb-setpop 0.4s var(--ease-out, cubic-bezier(0.22, 0.61, 0.36, 1)) both;
+  }
+  /* Set point: an amber ring backs the 🎯 tag + copy (never colour alone). */
+  .side.atpoint {
+    border-color: color-mix(in srgb, var(--warn) 65%, var(--border));
+    background: color-mix(in srgb, var(--warn) 7%, var(--surface-2));
+    animation: vb-breathe 1.5s ease-in-out infinite;
+  }
+  /* Deuce: both cards breathe together — the tension is shared. */
+  .side.deuce {
+    border-color: color-mix(in srgb, var(--warn) 45%, var(--border));
+    animation: vb-breathe 1.7s ease-in-out infinite;
+  }
+  @keyframes vb-breathe {
+    0%,
+    100% {
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--warn) 30%, transparent);
+    }
+    50% {
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--warn) 16%, transparent);
+    }
+  }
+  @keyframes vb-setpop {
+    0% {
+      transform: scale(0.97);
+    }
+    55% {
+      transform: scale(1.02);
+    }
+    100% {
+      transform: scale(1);
+    }
   }
   .sidehead {
     display: flex;
@@ -520,6 +669,23 @@
     white-space: nowrap;
     flex: 1;
     min-width: 0;
+  }
+  /* Serve indicator: the side that won the last rally serves next. A gentle bob draws the
+     eye; the 🏐 + title carry the meaning, so motion is never the only cue. */
+  .serve {
+    flex: none;
+    font-size: 0.95rem;
+    line-height: 1;
+    animation: vb-serve 1.4s ease-in-out infinite;
+  }
+  @keyframes vb-serve {
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(-2px);
+    }
   }
   .caret {
     color: var(--muted);
@@ -565,30 +731,69 @@
     cursor: not-allowed;
   }
 
-  .scorewrap {
-    display: block;
-    margin: 0;
+  /* The live courtside score is the hero of each card — big enough to read one-handed,
+     outdoors, at arm's length. Tabular so it never jitters as it climbs; pops on change. */
+  .scorebox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 84px;
   }
-  .score {
-    width: 100%;
-    height: 84px;
-    padding: 0 8px;
-    text-align: center;
-    font-size: 3rem;
-    font-weight: 800;
-    font-variant-numeric: tabular-nums;
+  .bigscore {
+    font-size: clamp(3.2rem, 14vw, 4.6rem);
     line-height: 1;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    appearance: textfield;
-    -moz-appearance: textfield;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    min-width: 2ch;
+    text-align: center;
+    animation: vb-pop 0.16s ease-out;
   }
-  .score::-webkit-outer-spin-button,
-  .score::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    appearance: none;
-    margin: 0;
+  .goodnum {
+    color: var(--good);
+  }
+  @keyframes vb-pop {
+    from {
+      transform: scale(1.14);
+    }
+    to {
+      transform: scale(1);
+    }
+  }
+
+  /* Reserved tag row so the card never reflows as tags come and go. */
+  .tagline {
+    display: flex;
+    justify-content: center;
+    min-height: 1.6rem;
+  }
+  .tag {
+    flex: none;
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 3px 9px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    white-space: nowrap;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+  .tag.ghost {
+    visibility: hidden;
+  }
+  .tag.win {
+    color: var(--good);
+    border-color: color-mix(in srgb, var(--good) 45%, var(--border));
+    background: color-mix(in srgb, var(--good) 12%, transparent);
+  }
+  .tag.point {
+    color: var(--warn);
+    border-color: color-mix(in srgb, var(--warn) 55%, var(--border));
+    background: color-mix(in srgb, var(--warn) 14%, transparent);
+  }
+  .tag.run {
+    color: var(--text);
+    border-color: color-mix(in srgb, var(--bad) 45%, var(--border));
+    background: color-mix(in srgb, var(--bad) 12%, transparent);
   }
 
   .ctrls {
@@ -612,7 +817,7 @@
   }
   .minus {
     flex: none;
-    width: 56px;
+    width: 52px;
     min-height: 56px;
     font-size: 1.2rem;
   }
@@ -623,6 +828,8 @@
     opacity: 0.4;
     cursor: not-allowed;
   }
+  /* The rally tap: large and thumb-friendly, but a surface control — the one Royal Violet
+     primary on this screen stays the shell's "Save round" button below the editor. */
   .plus {
     flex: 1;
     min-height: 56px;
@@ -633,40 +840,90 @@
     gap: 1px;
     background: var(--surface-3);
   }
-  .plus:hover {
+  .plus:hover:not(:disabled) {
     border-color: var(--primary);
+    background: color-mix(in srgb, var(--text) 6%, var(--surface-3));
   }
-  .plus:active {
+  .plus:active:not(:disabled) {
     transform: translateY(1px);
   }
-  .plus .big {
+  .plus:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .plussign {
     font-size: 1.35rem;
+    font-variant-numeric: tabular-nums;
   }
-  .plus.pt {
-    border-color: color-mix(in srgb, var(--warn) 55%, var(--border));
-  }
-  .ptlabel {
+  .pluslabel {
     font-size: 0.62rem;
     font-weight: 700;
     letter-spacing: 0.04em;
     text-transform: uppercase;
+    color: var(--muted);
+  }
+  .plus.pt {
+    border-color: color-mix(in srgb, var(--warn) 55%, var(--border));
+  }
+  .plus.pt .pluslabel {
     color: var(--warn);
   }
 
+  /* Undo + swap sit together under the courts, as low-emphasis surface controls. */
+  .livebar {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+  }
+  .undo {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    min-height: 46px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 600;
+    transition:
+      transform 0.05s ease,
+      background 0.15s ease,
+      border-color 0.15s ease;
+  }
+  .undo:hover:not(:disabled) {
+    background: var(--surface-2);
+    border-color: var(--primary);
+  }
+  .undo:active:not(:disabled) {
+    transform: translateY(1px);
+  }
+  .undo:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+  .undoicon {
+    font-size: 1.1rem;
+  }
   .swap {
-    align-self: center;
-    background: none;
-    border: none;
+    flex: none;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
     color: var(--muted);
     font: inherit;
     font-weight: 600;
     font-size: 0.85rem;
     cursor: pointer;
     padding: 8px 12px;
-    min-height: 40px;
+    min-height: 46px;
   }
   .swap:hover {
     color: var(--text);
+    border-color: var(--primary);
   }
 
   /* ── Manage teams ── */
@@ -911,10 +1168,26 @@
     :global(.vb-drag-ghost) {
       transition: none;
     }
+    .bigscore,
+    .serve,
+    .side.won {
+      animation: none;
+    }
+    /* Keep a static ring so set-point / deuce tension still reads without motion. */
+    .side.atpoint,
+    .side.deuce {
+      animation: none;
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--warn) 22%, transparent);
+    }
   }
 
-  .addteam {
-    align-self: flex-start;
+  .manage-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .addteam,
+  .shuffle {
     min-height: 40px;
     padding: 8px 14px;
     border: 1px dashed var(--border);
@@ -925,10 +1198,12 @@
     font-weight: 600;
     cursor: pointer;
   }
-  .addteam:hover:not(:disabled) {
+  .addteam:hover:not(:disabled),
+  .shuffle:hover:not(:disabled) {
     border-color: var(--primary);
   }
-  .addteam:disabled {
+  .addteam:disabled,
+  .shuffle:disabled {
     opacity: 0.5;
     cursor: not-allowed;
   }
@@ -955,7 +1230,9 @@
 
   .minus:focus-visible,
   .plus:focus-visible,
-  .score:focus-visible,
+  .undo:focus-visible,
+  .swap:focus-visible,
+  .shuffle:focus-visible,
   .sidehead:focus-visible,
   .chip:focus-visible,
   .mvbtn:focus-visible,
@@ -967,8 +1244,8 @@
   }
 
   @media (max-width: 360px) {
-    .score {
-      font-size: 2.5rem;
+    .bigscore {
+      font-size: 2.6rem;
     }
   }
 </style>

--- a/src/lib/games/volleyball/index.ts
+++ b/src/lib/games/volleyball/index.ts
@@ -77,7 +77,7 @@ export const volleyball: GameModule = {
       last?.away && ids.includes(last.away) && last.away !== home
         ? last.away
         : ids.find((id) => id !== home) ?? '';
-    return { teams, home, away, points: { home: 0, away: 0 } };
+    return { teams, home, away, points: { home: 0, away: 0 }, rallies: [] };
   },
 
   validateRound: (input: VolleyballInput, ctx: RoundContext): string | null => {

--- a/src/lib/games/volleyball/logic.ts
+++ b/src/lib/games/volleyball/logic.ts
@@ -37,6 +37,15 @@ export interface VolleyballInput {
   away: string;
   /** Final points for the two contesting sides. */
   points: { home: number; away: number };
+  /**
+   * Ordered log of which side (`'a'` = home, `'b'` = away) won each rally, oldest first.
+   * Optional and purely additive: `points` stays the scoring/validation/stats source of
+   * truth, while this log powers the courtside live extras — a single satisfying
+   * "undo last point", the serve indicator, and the momentum/run read. New sets seed an
+   * empty log; sets recorded before it existed simply have no log and fall back to the
+   * ± controls on `points`.
+   */
+  rallies?: Side[];
 }
 
 export type Format = 'beach' | 'fours' | 'indoor' | 'custom';
@@ -243,4 +252,121 @@ export function winningTeamId(input: VolleyballInput, cfg: VolleyConfig): string
   const w = setWinner(input.points.home, input.points.away, cfg.pointsPerSet, cfg.winBy2, cfg.hardCap);
   if (!w) return null;
   return w === 'a' ? input.home : input.away;
+}
+
+// ── Live rally scoring ───────────────────────────────────────────────────────
+// A small, pure toolkit powering the courtside feel. The rally log is the ordered
+// list of who won each rally; `points` is always derivable from it, so the log is a
+// superset the editor can seed while `points` stays the durable scoring truth.
+
+/** Rally log → the two sides' point totals (home = 'a', away = 'b'). */
+export function scoreFromRallies(rallies: Side[]): { home: number; away: number } {
+  let home = 0;
+  let away = 0;
+  for (const s of rallies) s === 'a' ? (home += 1) : (away += 1);
+  return { home, away };
+}
+
+/** Append a rally winner, returning a new log (never mutates the input). */
+export function pushRally(rallies: Side[], side: Side): Side[] {
+  return [...rallies, side];
+}
+
+/** Drop the most recent rally, returning a new log. No-op on an empty log. */
+export function popRally(rallies: Side[]): Side[] {
+  return rallies.slice(0, -1);
+}
+
+/**
+ * Remove the most recent rally won by `side`, returning a new log (never mutates). Used by
+ * the per-side "take a point back" control so the log stays consistent with `points`. No-op
+ * when that side has no rally to drop.
+ */
+export function dropRally(rallies: Side[], side: Side): Side[] {
+  for (let i = rallies.length - 1; i >= 0; i--) {
+    if (rallies[i] === side) return [...rallies.slice(0, i), ...rallies.slice(i + 1)];
+  }
+  return rallies;
+}
+
+/**
+ * The current unbroken run — how many rallies in a row the same side just won. Returns
+ * the side on the streak and its length (0 with a null side when there are no rallies yet).
+ */
+export function currentRun(rallies: Side[]): { side: Side | null; length: number } {
+  if (rallies.length === 0) return { side: null, length: 0 };
+  const side = rallies[rallies.length - 1]!;
+  let length = 0;
+  for (let i = rallies.length - 1; i >= 0 && rallies[i] === side; i--) length += 1;
+  return { side, length };
+}
+
+/**
+ * Who serves the next rally: in rally scoring the side that won the last rally serves,
+ * so this is simply the most recent rally winner. Null before the first rally.
+ */
+export function serving(rallies: Side[]): Side | null {
+  return rallies.length ? rallies[rallies.length - 1]! : null;
+}
+
+/**
+ * Which side is at *set point* — one rally from taking the set — or null. A side is at set
+ * point when winning the next rally would end the set and it hasn't ended already. Honours
+ * win-by-two and the hard cap via {@link setWinner}.
+ */
+export function setPointSide(a: number, b: number, target: number, winBy2: boolean, hardCap = 0): Side | null {
+  if (setWinner(a, b, target, winBy2, hardCap) !== null) return null;
+  if (setWinner(a + 1, b, target, winBy2, hardCap) === 'a') return 'a';
+  if (setWinner(a, b + 1, target, winBy2, hardCap) === 'b') return 'b';
+  return null;
+}
+
+/**
+ * Deuce — the win-by-two tension where the score is *level at or past* one short of the
+ * target (24–24, 25–25 for indoor) and the set isn't decided, so no single rally can end
+ * it. Distinct from set point (an advantage lead one rally from winning). Always false
+ * without win-by-two. A hard cap dissolves the deuce the instant it's in reach, since then
+ * a single rally to the cap can win.
+ */
+export function isDeuceSet(a: number, b: number, target: number, winBy2: boolean, hardCap = 0): boolean {
+  if (!winBy2) return false;
+  if (setWinner(a, b, target, winBy2, hardCap) !== null) return false;
+  if (setPointSide(a, b, target, winBy2, hardCap) !== null) return false;
+  return a === b && a >= target - 1;
+}
+
+/**
+ * Whimsically redistribute the whole player pool across the current teams, keeping each
+ * team's branding but reshuffling its roster. Deals players round-robin into a random team
+ * order, honouring the format's roster cap (Custom = no limit); any overflow lands on the
+ * bench. Pure: takes an injectable `rng` (default `Math.random`) so tests are deterministic.
+ */
+export function shuffleTeams(teams: Team[], pool: string[], cfg: VolleyConfig, rng: () => number = Math.random): Team[] {
+  const next = teams.map((t) => ({ ...t, memberIds: [] as string[] }));
+  if (next.length === 0) return next;
+
+  // Fisher–Yates shuffle of the pool so the deal itself is random.
+  const order = [...pool];
+  for (let i = order.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [order[i], order[j]] = [order[j]!, order[i]!];
+  }
+
+  const cap = cfg.teamSize > 0 ? cfg.teamSize : Infinity;
+  const n = next.length;
+  let start = Math.floor(rng() * n); // random starting team so team 0 isn't always favoured
+  for (const id of order) {
+    let placed = false;
+    for (let k = 0; k < n; k++) {
+      const t = next[(start + k) % n]!;
+      if (t.memberIds.length < cap) {
+        t.memberIds.push(id);
+        start = (start + k + 1) % n;
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) break; // every team full — the rest sit on the bench
+  }
+  return next;
 }

--- a/src/lib/games/volleyball/volleyball.test.ts
+++ b/src/lib/games/volleyball/volleyball.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from 'vitest';
 import {
+  currentRun,
   DEFAULTS,
   defaultTeams,
+  dropRally,
   foldStandings,
+  isDeuceSet,
   makeTeam,
+  popRally,
+  pushRally,
   readConfig,
+  scoreFromRallies,
+  serving,
+  setPointSide,
   setWinner,
+  shuffleTeams,
+  type Side,
   type Team,
   unassigned,
   validateSetScore,
@@ -195,3 +205,126 @@ describe('foldStandings — sets won per team across a session', () => {
     expect(table[0].team.id).toBe(a.id);
   });
 });
+
+describe('rally log — score, push, pop & drop', () => {
+  it('sums a rally log into home/away points', () => {
+    expect(scoreFromRallies([])).toEqual({ home: 0, away: 0 });
+    expect(scoreFromRallies(['a', 'a', 'b', 'a'])).toEqual({ home: 3, away: 1 });
+  });
+
+  it('pushes and pops rallies without mutating the input', () => {
+    const log: Side[] = ['a', 'b'];
+    const pushed = pushRally(log, 'a');
+    expect(pushed).toEqual(['a', 'b', 'a']);
+    expect(log).toEqual(['a', 'b']); // unchanged
+    expect(popRally(pushed)).toEqual(['a', 'b']);
+    expect(popRally([])).toEqual([]);
+  });
+
+  it('drops a side’s most recent rally, leaving the rest in order', () => {
+    expect(dropRally(['a', 'b', 'a', 'b'], 'a')).toEqual(['a', 'b', 'b']);
+    expect(dropRally(['a', 'b', 'a', 'b'], 'b')).toEqual(['a', 'b', 'a']);
+    expect(dropRally(['a', 'a'], 'b')).toEqual(['a', 'a']); // no-op when side absent
+  });
+});
+
+describe('currentRun & serving — momentum from the log', () => {
+  it('reports the unbroken run of the last winner', () => {
+    expect(currentRun([])).toEqual({ side: null, length: 0 });
+    expect(currentRun(['a'])).toEqual({ side: 'a', length: 1 });
+    expect(currentRun(['b', 'a', 'a', 'a'])).toEqual({ side: 'a', length: 3 });
+    expect(currentRun(['a', 'a', 'b'])).toEqual({ side: 'b', length: 1 });
+  });
+
+  it('serves the side that won the last rally', () => {
+    expect(serving([])).toBeNull();
+    expect(serving(['a', 'b'])).toBe('b');
+    expect(serving(['b', 'a', 'a'])).toBe('a');
+  });
+});
+
+describe('setPointSide — one rally from the set', () => {
+  it('flags the side a single rally from winning', () => {
+    expect(setPointSide(24, 20, 25, true)).toBe('a');
+    expect(setPointSide(20, 24, 25, true)).toBe('b');
+  });
+
+  it('is null when neither side can win next rally', () => {
+    expect(setPointSide(24, 24, 25, true)).toBeNull(); // deuce, +1 only reaches 25-24
+    expect(setPointSide(0, 0, 25, true)).toBeNull();
+  });
+
+  it('is null once the set is already decided', () => {
+    expect(setPointSide(25, 20, 25, true)).toBeNull();
+  });
+
+  it('honours win-by-two off (target reached is set point)', () => {
+    expect(setPointSide(24, 10, 25, false)).toBe('a');
+  });
+
+  it('reads a hard cap as set point at the ceiling', () => {
+    // 26-26 with cap 27: both sides could win the next rally; home is checked first.
+    expect(setPointSide(26, 26, 25, true, 27)).toBe('a');
+    expect(setPointSide(26, 25, 25, true, 27)).toBe('a');
+  });
+});
+
+describe('isDeuceSet — shared win-by-two tension', () => {
+  it('is true level at or past one short of target', () => {
+    expect(isDeuceSet(24, 24, 25, true)).toBe(true);
+    expect(isDeuceSet(26, 26, 25, true)).toBe(true);
+  });
+
+  it('is false at set point (an advantage lead)', () => {
+    expect(isDeuceSet(25, 24, 25, true)).toBe(false);
+  });
+
+  it('is false without win-by-two and once decided', () => {
+    expect(isDeuceSet(24, 24, 25, false)).toBe(false);
+    expect(isDeuceSet(26, 24, 25, true)).toBe(false);
+  });
+
+  it('dissolves when a hard cap puts a rally-to-win in reach', () => {
+    // 26-26 cap 27: next rally to 27 wins by one, so it's not a stalemate deuce.
+    expect(isDeuceSet(26, 26, 25, true, 27)).toBe(false);
+  });
+});
+
+describe('shuffleTeams — random re-deal across teams', () => {
+  const teams = [makeTeam(0), makeTeam(1)];
+
+  it('places every pooled player and loses none', () => {
+    const out = shuffleTeams(teams, ['p1', 'p2', 'p3', 'p4'], { ...cfg, teamSize: 6 });
+    const placed = out.flatMap((t) => t.memberIds).sort();
+    expect(placed).toEqual(['p1', 'p2', 'p3', 'p4']);
+  });
+
+  it('keeps team branding, only reshuffling rosters', () => {
+    const out = shuffleTeams(teams, ['p1', 'p2'], { ...cfg, teamSize: 6 });
+    expect(out.map((t) => t.id)).toEqual(teams.map((t) => t.id));
+    expect(out.map((t) => t.name)).toEqual(teams.map((t) => t.name));
+  });
+
+  it('honours the roster cap, benching the overflow', () => {
+    // Deterministic RNG so the deal is reproducible; cap 1 means only 2 of 4 fit.
+    const rng = seq([0, 0, 0, 0, 0]);
+    const out = shuffleTeams(teams, ['p1', 'p2', 'p3', 'p4'], { ...cfg, teamSize: 1 }, rng);
+    const placed = out.flatMap((t) => t.memberIds);
+    expect(placed).toHaveLength(2);
+    expect(out.every((t) => t.memberIds.length <= 1)).toBe(true);
+    expect(unassigned(out, ['p1', 'p2', 'p3', 'p4'])).toHaveLength(2);
+  });
+
+  it('does not mutate the input teams', () => {
+    const seeded = [makeTeam(0, ['p1']), makeTeam(1, ['p2'])];
+    shuffleTeams(seeded, ['p1', 'p2'], { ...cfg, teamSize: 6 });
+    expect(seeded[0].memberIds).toEqual(['p1']);
+    expect(seeded[1].memberIds).toEqual(['p2']);
+  });
+});
+
+/** A deterministic RNG that walks a fixed list of values (looping) — for stable shuffles. */
+function seq(values: number[]): () => number {
+  let i = 0;
+  return () => values[i++ % values.length]!;
+}


### PR DESCRIPTION
## What & why

Volleyball's team builder and sets-won standings were strong, but its **live set scoring** was weak for the courtside, one-handed, glanceable mission it's built for: a small editable number input for the score (which invited the keyboard), no haptics, no true undo, no momentum read, and a flat status line. A set win — the core payoff — had no punctuation, and set-point/deuce tension was just a static border.

This PR rebuilds the live-scoring area around fast one-tap rally scoring, aligning the feel to the sibling **Spikeball** module while keeping Volleyball's own team builder and open-ended standings.

## Changes

**`logic.ts` (pure, Svelte-free, unit-tested)**
- Add an additive rally log: `rallies?: Side[]` on `VolleyballInput`. `points` stays the scoring/validation/stats source of truth — the log is a superset that powers the courtside extras.
- New pure helpers: `scoreFromRallies`, `pushRally`, `popRally`, `dropRally`, `currentRun` (momentum), `serving` (next server = last rally winner), `setPointSide`, `isDeuceSet`.
- `shuffleTeams(teams, pool, cfg, rng)` — round-robin deal that honors the roster cap, with an injectable RNG for deterministic tests.

**`index.ts`**
- Seed an empty rally log on new rounds. No scoring/validation change.

**`VolleyballEditor.svelte` (the rebuild)**
- Big tabular score that pops on change; full-width **＋1 rally point** surface tap (≥60px) with a compact **−1**.
- **Serve indicator** (🏐), **set-point** (🎯 amber ring) / **deuce** (breathing glow) tension, **green set-won celebration** (✅ Set!), and a **🔥 N in a row** momentum tag — every state pairs emoji + copy, never color alone.
- **Net divider** (🥅) between the two courts; **beach 🏖️ / indoor 🏟️** flavor; sportscaster status line.
- True **Undo last point** (rally-log powered) + **Swap sides**; a whimsical **🎲 Shuffle teams** in Manage teams.
- Haptics: `tick` on +1, `undo` on undo, `win` on the clinching tap. All animations honor `prefers-reduced-motion`. Rounds without a log fall back to ± on `points`.

**Tests**
- Extend `volleyball.test.ts`: rally log math, run/serving, set point, deuce, and shuffle (deterministic RNG, cap honored, no player lost).

## Design non-negotiables respected
- The one Royal Violet primary stays the shell's **Save round** — all +1/−1/undo/shuffle are surface controls.
- **Crown Gold** stays on the standings leader/winner only; the set-won card celebrates in **green** (`--good`), never gold.
- `tabular-nums` on the big score; touch targets ≥46px (rally tap ≥60px); chrome unchanged — personality via emoji, copy, accent moments, and animation.

## Verification (local)
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — success
- `npm test` — 1205 passed (46 files), incl. 45 volleyball tests