### PR TITLE
Werewords: cinematic reveal, spell field, night briefing & standings

### DIFF
--- a/src/lib/games/werewords/HowlReveal.svelte
+++ b/src/lib/games/werewords/HowlReveal.svelte
@@ -1,0 +1,228 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * Werewords' signature payoff. When a round lands, this overlay dramatizes which side
+   * took it — mirroring Avalon's `AssassinReveal` and BotC's `TownVerdict`, but tuned to
+   * the village-vs-pack story:
+   *
+   *   • Village win → 🌅 dawn breaks over the town under a Win-Green glow and the cracked
+   *     secret word rises in letter-spaced caps — the table's "we got it!" beat.
+   *   • Werewolf win → 🌕 a full moon climbs, 🐺 the pack howls, and a cold violet/coral
+   *     night washes in — the wolves ran out the clock.
+   *   • A twist stamps an extra 🔀 "STOLEN!" ribbon, because a steal is the game's soul.
+   *
+   * Pure delight layered over a result already spelled out by the pressed toggle + the
+   * banner text + the winning-side tally, so motion is never the only signal — and never
+   * Crown Gold, which belongs to the leader/winner alone. `pointer-events: none`, replays
+   * whenever `token` changes, and renders nothing at all under reduced motion (the banner
+   * is the calm, instant alternative).
+   */
+  let {
+    token = 0,
+    team = 'village',
+    twist = false,
+    word = '',
+  }: { token?: number; team?: 'village' | 'werewolf'; twist?: boolean; word?: string } =
+    $props();
+
+  const reduced = prefersReducedMotion();
+  const SPARK_COUNT = 12;
+
+  const cracked = $derived(word.trim().toUpperCase());
+
+  // Deterministic pseudo-random seeded by token (mirrors AssassinReveal / PhaseSky).
+  const sparks = $derived(
+    Array.from({ length: SPARK_COUNT }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      const day = ['✦', '✧', '⋆', '·', '✨'];
+      const night = ['🌾', '✦', '·', '⋆', '🐾'];
+      const glyphs = team === 'werewolf' ? night : day;
+      return {
+        left: 20 + rand(1) * 60,
+        bottom: 24 + rand(2) * 40,
+        delay: 0.3 + rand(3) * 0.22,
+        duration: 0.7 + rand(4) * 0.6,
+        spread: (rand(5) - 0.5) * 150,
+        rise: 22 + rand(6) * 54,
+        size: 0.5 + rand(7) * 0.7,
+        glyph: glyphs[Math.floor(rand(8) * glyphs.length)],
+      };
+    }),
+  );
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="howl" class:wolves={team === 'werewolf'} aria-hidden="true">
+      <div class="wash"></div>
+      <div class="stage">
+        <span class="orb">{team === 'werewolf' ? '🌕' : '🌅'}</span>
+        {#if team === 'werewolf'}
+          <span class="wolf">🐺</span>
+        {:else if cracked}
+          <span class="word">{cracked}</span>
+        {/if}
+        {#if twist}
+          <span class="stolen">🔀 STOLEN!</span>
+        {/if}
+      </div>
+      <div class="sparks">
+        {#each sparks as s, i (i)}
+          <span
+            class="spark"
+            style="
+              left: {s.left}%;
+              bottom: {s.bottom}%;
+              font-size: {s.size}rem;
+              animation-delay: {s.delay}s;
+              animation-duration: {s.duration}s;
+              --spread: {s.spread}px;
+              --rise: {s.rise}px;
+            ">{s.glyph}</span>
+        {/each}
+      </div>
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .howl {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    border-radius: 14px;
+    z-index: 3;
+  }
+  .wash {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    /* Village → a warm dawn/green break of day. Never Crown Gold. */
+    background:
+      radial-gradient(120% 90% at 50% 62%, color-mix(in srgb, var(--good) 32%, transparent), transparent 70%),
+      linear-gradient(to top, color-mix(in srgb, var(--good) 14%, transparent), transparent 55%);
+    animation: howl-wash 1.6s ease-out both;
+  }
+  .howl.wolves .wash {
+    /* Wolves → a cold violet night with a coral bite of danger. */
+    background:
+      radial-gradient(120% 90% at 50% 26%, color-mix(in srgb, var(--bad) 30%, transparent), transparent 68%),
+      linear-gradient(to bottom, color-mix(in srgb, var(--primary) 24%, transparent), transparent 62%);
+    animation-duration: 1.8s;
+  }
+  .stage {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+  }
+  .orb {
+    font-size: 2.4rem;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    filter: drop-shadow(0 0 12px color-mix(in srgb, var(--good) 55%, transparent));
+    animation: orb-rise 1.6s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  .howl.wolves .orb {
+    filter: drop-shadow(0 0 14px color-mix(in srgb, var(--primary) 60%, transparent));
+    animation: moon-climb 1.8s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  }
+  .wolf {
+    font-size: 1.7rem;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    animation: wolf-howl 1.7s ease-out both;
+    animation-delay: 0.24s;
+  }
+  .word {
+    font-weight: 800;
+    font-size: 1.35rem;
+    letter-spacing: 0.22em;
+    padding-left: 0.22em;
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+    text-shadow: 0 2px 10px color-mix(in srgb, var(--good) 40%, transparent);
+    opacity: 0;
+    white-space: nowrap;
+    will-change: transform, opacity;
+    animation: word-flash 1.6s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+    animation-delay: 0.18s;
+  }
+  .stolen {
+    font-weight: 800;
+    font-size: 0.95rem;
+    letter-spacing: 0.06em;
+    padding: 4px 12px;
+    border-radius: 999px;
+    color: #fff;
+    background: var(--bad);
+    box-shadow: 0 6px 18px color-mix(in srgb, var(--bad) 45%, transparent);
+    opacity: 0;
+    will-change: transform, opacity;
+    animation: stolen-stamp 1.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation-delay: 0.5s;
+  }
+  .sparks {
+    position: absolute;
+    inset: 0;
+  }
+  .spark {
+    position: absolute;
+    line-height: 1;
+    color: var(--text);
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: spark-fly;
+    animation-timing-function: ease-out;
+    animation-fill-mode: both;
+  }
+
+  @keyframes howl-wash {
+    0% { opacity: 0; }
+    30% { opacity: 1; }
+    100% { opacity: 0; }
+  }
+  @keyframes orb-rise {
+    0% { opacity: 0; transform: translateY(30px) scale(0.7); }
+    35% { opacity: 1; transform: translateY(-8px) scale(1.06); }
+    72% { opacity: 0.95; transform: translateY(-12px) scale(1); }
+    100% { opacity: 0; transform: translateY(-16px) scale(1); }
+  }
+  @keyframes moon-climb {
+    0% { opacity: 0; transform: translateY(34px) scale(0.6); }
+    38% { opacity: 1; transform: translateY(-10px) scale(1.08); }
+    75% { opacity: 0.9; transform: translateY(-16px) scale(1); }
+    100% { opacity: 0; transform: translateY(-22px) scale(1); }
+  }
+  @keyframes wolf-howl {
+    0% { opacity: 0; transform: translateY(8px) rotate(-6deg) scale(0.8); }
+    30% { opacity: 1; transform: translateY(0) rotate(-14deg) scale(1.1); }
+    60% { opacity: 1; transform: translateY(-2px) rotate(-14deg) scale(1.05); }
+    100% { opacity: 0; transform: translateY(-4px) rotate(-8deg) scale(1); }
+  }
+  @keyframes word-flash {
+    0% { opacity: 0; transform: translateY(14px) scale(0.9); letter-spacing: 0.02em; }
+    36% { opacity: 1; transform: translateY(0) scale(1.05); letter-spacing: 0.22em; }
+    72% { opacity: 1; transform: translateY(0) scale(1); }
+    100% { opacity: 0; transform: translateY(-6px) scale(1); }
+  }
+  @keyframes stolen-stamp {
+    0% { opacity: 0; transform: rotate(-8deg) scale(1.8); }
+    26% { opacity: 1; transform: rotate(-8deg) scale(1); }
+    78% { opacity: 1; transform: rotate(-8deg) scale(1); }
+    100% { opacity: 0; transform: rotate(-8deg) scale(1.05); }
+  }
+  @keyframes spark-fly {
+    0% { opacity: 0; transform: translate(0, 0) scale(0.5); }
+    30% { opacity: 1; }
+    100% { opacity: 0; transform: translate(var(--spread), calc(var(--rise) * -1)) scale(1); }
+  }
+</style>

--- a/src/lib/games/werewords/WerewordsEditor.svelte
+++ b/src/lib/games/werewords/WerewordsEditor.svelte
@@ -1,14 +1,36 @@
 <script lang="ts">
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
+  import { haptic } from '../../haptics';
+  import HowlReveal from './HowlReveal.svelte';
   import { resolveOutcome, type WerewordsInput } from './logic';
+  import { suggestWord } from './words';
 
   let { input = $bindable(), ctx }: { input: WerewordsInput; ctx: RoundContext } = $props();
 
   const seerOn = $derived(!!ctx.config.seer);
   const expectedWolves = $derived(Math.max(1, Number(ctx.config.werewolves) || 1));
+  const timerMins = $derived(Math.max(1, Number(ctx.config.timer) || 4));
   const wolfCount = $derived(input.werewolves.length);
   const outcome = $derived(resolveOutcome(input));
+
+  let showBriefing = $state(false);
+  let showStandings = $state(false);
+
+  // The running "rounds won" race, from the cumulative totals before this round. Purely
+  // glanceable ladder energy inside the editor — 👑 marks whoever is reigning right now.
+  const standings = $derived.by(() => {
+    const rows = ctx.players.map((p) => ({
+      id: p.id,
+      name: p.name,
+      color: p.color,
+      wins: Number(ctx.totals[p.id] ?? 0),
+    }));
+    rows.sort((a, b) => b.wins - a.wins || a.name.localeCompare(b.name));
+    return rows;
+  });
+  const topWins = $derived(standings.length ? standings[0].wins : 0);
+  const anyScored = $derived(topWins > 0);
 
   function isWolf(id: string): boolean {
     return input.werewolves.includes(id);
@@ -33,6 +55,7 @@
       if (input.mayor === id) input.mayor = null;
       if (input.seer === id) clearSeer();
     }
+    haptic('tick');
   }
   function toggleMayor(id: string) {
     input.mayor = input.mayor === id ? null : id;
@@ -40,16 +63,19 @@
       input.werewolves = input.werewolves.filter((w) => w !== id);
       if (input.seer === id) clearSeer();
     }
+    haptic('tick');
   }
   function toggleSeer(id: string) {
     if (input.seer === id) {
       clearSeer();
+      haptic('tick');
       return;
     }
     input.seer = id;
     input.werewolfFoundSeer = false;
     input.werewolves = input.werewolves.filter((w) => w !== id);
     if (input.mayor === id) input.mayor = null;
+    haptic('tick');
   }
 
   function setGuessed(g: boolean) {
@@ -59,15 +85,48 @@
     else input.werewolfFoundSeer = false;
   }
 
+  function rollWord() {
+    input.word = suggestWord(Math.floor(Math.random() * 1_000_000_000), input.word);
+    haptic('tick');
+  }
+
   const showSeerTwist = $derived(input.guessed && seerOn && input.seer != null);
   const showMayorTwist = $derived(!input.guessed);
   const mayorName = $derived(ctx.players.find((p) => p.id === input.mayor)?.name ?? '');
+  const preview = $derived(input.word.trim().toUpperCase());
+
+  // ── The reveal payoff ────────────────────────────────────────────────────────
+  // Fire HowlReveal whenever the round's *resolved side* flips — i.e. the table taps
+  // guessed/missed or engages a twist — never on mount and never on a mere word edit.
+  let revealToken = $state(0);
+  let revealPrimed = false;
+  let lastSignature = '';
+  $effect(() => {
+    const sig = `${outcome.team}|${outcome.twist}`;
+    if (!revealPrimed) {
+      revealPrimed = true;
+      lastSignature = sig;
+      return;
+    }
+    if (sig !== lastSignature) {
+      lastSignature = sig;
+      revealToken += 1;
+      haptic('win');
+    }
+  });
 </script>
 
 <div class="stack">
-  <label class="field">
-    <span class="fieldlabel">🔮 Secret word</span>
+  <!-- The secret word: Werewords' centerpiece, dressed as a little spellbook field. -->
+  <div class="spell">
+    <div class="spell-top">
+      <span class="fieldlabel spell-label">🔮 The secret word</span>
+      <button type="button" class="dice" onclick={rollWord} title="Suggest a word">
+        🎲 Need a word?
+      </button>
+    </div>
     <input
+      class="spell-input"
       type="text"
       autocapitalize="characters"
       autocomplete="off"
@@ -75,15 +134,46 @@
       placeholder="e.g. PYRAMID"
       bind:value={input.word}
     />
-  </label>
+    <span class="spell-preview tnum" class:empty={!preview} aria-hidden="true">
+      {preview || 'the Mayor’s magic word'}
+    </span>
+  </div>
 
-  <div class="row spread">
-    <span class="muted">Tap each player’s role — untapped are Villagers.</span>
-    <span class="pill" class:score-bad={wolfCount !== expectedWolves}>🐺 {wolfCount}/{expectedWolves}</span>
+  <!-- Optional table briefing: who wakes, and the yes/no/maybe ritual. Closed by default. -->
+  <div class="brief">
+    <button
+      type="button"
+      class="brief-toggle"
+      aria-expanded={showBriefing}
+      onclick={() => (showBriefing = !showBriefing)}
+    >
+      <span class="row" style="gap: 8px">
+        <span aria-hidden="true">🌙</span>
+        <span><strong>Lower the lights</strong> · {expectedWolves} 🐺 · {seerOn ? '🔮 Seer in play' : 'no Seer'}</span>
+      </span>
+      <span class="muted small">{showBriefing ? 'Hide' : 'How to play'}</span>
+    </button>
+    {#if showBriefing}
+      <div class="brief-body">
+        <p class="brief-lead small muted">Douse the lights — here’s the night ritual.</p>
+        <ul class="brief-list">
+          <li>👑 The <strong>Mayor</strong> knows the word and answers only 👍&nbsp;yes · 👎&nbsp;no · 🤷&nbsp;maybe.</li>
+          <li>🏘️ The <strong>Villagers</strong> race the clock to crack it — about {timerMins} min at the table (you run the clock).</li>
+          {#if seerOn}<li>🔮 The <strong>Seer</strong> secretly knows the word too, and quietly nudges the town.</li>{/if}
+          <li>🐺 The <strong>{expectedWolves === 1 ? 'werewolf' : `${expectedWolves} werewolves`}</strong> {expectedWolves === 1 ? 'also knows' : 'also know'} the word — they blend in and stall.</li>
+          <li>🔀 Guessed in time? A wolf can <strong>steal it</strong> by naming the Seer. Out of time? The Mayor can <strong>steal it back</strong> by naming a wolf.</li>
+        </ul>
+      </div>
+    {/if}
+  </div>
+
+  <div class="row spread rolehead">
+    <span class="muted small">Tap each player’s role — untapped are Villagers.</span>
+    <span class="pill tnum" class:score-bad={wolfCount !== expectedWolves}>🐺 pack {wolfCount}/{expectedWolves}</span>
   </div>
 
   {#each ctx.players as p (p.id)}
-    <div class="prow">
+    <div class="prow" class:wolfrow={isWolf(p.id)}>
       <span class="who">
         <Avatar name={p.name} color={p.color} />
         <span class="name">
@@ -114,7 +204,7 @@
         {/if}
         <button
           type="button"
-          class="rbtn"
+          class="rbtn wolf"
           class:on={isWolf(p.id)}
           aria-pressed={isWolf(p.id)}
           aria-label={`${p.name}: Werewolf`}
@@ -146,6 +236,8 @@
       >⏳ Ran out of time</button>
     </div>
 
+    <!-- The steal: the game's soul. A dramatic, clearly-labelled flip, co-signalled by
+         emoji + label + pressed state (never colour alone). -->
     {#if showSeerTwist}
       <button
         type="button"
@@ -154,7 +246,12 @@
         aria-pressed={input.werewolfFoundSeer}
         onclick={() => (input.werewolfFoundSeer = !input.werewolfFoundSeer)}
       >
-        🐺 A werewolf then named the Seer
+        <span class="twist-emoji" aria-hidden="true">🐺</span>
+        <span class="twist-copy">
+          <strong>A werewolf sniffed out the Seer</strong>
+          <span class="twist-sub muted">…and steals the win from the village</span>
+        </span>
+        <span class="twist-mark" aria-hidden="true">{input.werewolfFoundSeer ? '✓' : ''}</span>
       </button>
     {:else if showMayorTwist}
       <button
@@ -164,24 +261,173 @@
         aria-pressed={input.mayorFoundWerewolf}
         onclick={() => (input.mayorFoundWerewolf = !input.mayorFoundWerewolf)}
       >
-        🕵️ {mayorName ? `${mayorName} (Mayor)` : 'The Mayor'} then named a werewolf
+        <span class="twist-emoji" aria-hidden="true">🕵️</span>
+        <span class="twist-copy">
+          <strong>{mayorName ? `${mayorName} (Mayor)` : 'The Mayor'} pointed at a werewolf</strong>
+          <span class="twist-sub muted">…and steals the win back for the village</span>
+        </span>
+        <span class="twist-mark" aria-hidden="true">{input.mayorFoundWerewolf ? '✓' : ''}</span>
       </button>
     {/if}
 
-    <div class="banner" class:wolves={outcome.team === 'werewolf'}>
-      <div class="verdict">
-        <span>{outcome.team === 'werewolf' ? '🐺 Werewolves win' : '🏘️ Villagers win'}</span>
-        {#if outcome.twist}<span class="pill twistpill">🔀 Twist!</span>{/if}
+    <!-- The stage: the outcome banner, with the cinematic reveal layered over it. -->
+    <div class="stage">
+      <HowlReveal token={revealToken} team={outcome.team} twist={outcome.twist} word={input.word} />
+      <div class="banner" class:wolves={outcome.team === 'werewolf'}>
+        <div class="verdict">
+          <span>{outcome.team === 'werewolf' ? '🐺 Werewolves win' : '🏘️ Villagers win'}</span>
+          {#if outcome.twist}<span class="pill twistpill">🔀 Twist!</span>{/if}
+        </div>
+        <div class="reason muted">{outcome.reason}</div>
       </div>
-      <div class="reason muted">{outcome.reason}</div>
     </div>
+  </div>
+
+  <!-- Optional running ladder: who's reigning in the rounds-won race. Closed by default. -->
+  <div class="brief">
+    <button
+      type="button"
+      class="brief-toggle"
+      aria-expanded={showStandings}
+      onclick={() => (showStandings = !showStandings)}
+    >
+      <span class="row" style="gap: 8px">
+        <span aria-hidden="true">🏆</span>
+        <span><strong>Standings</strong> <span class="muted small">· rounds won so far</span></span>
+      </span>
+      <span class="muted small">{showStandings ? 'Hide' : 'Show'}</span>
+    </button>
+    {#if showStandings}
+      <div class="ladder">
+        {#if !anyScored}
+          <p class="small muted ladder-empty">No rounds banked yet — the first to crack it takes the lead.</p>
+        {/if}
+        {#each standings as s, i (s.id)}
+          <div class="lrow" class:leader={anyScored && s.wins === topWins}>
+            <span class="lrank tnum muted">{i + 1}</span>
+            <Avatar name={s.name} color={s.color} size={24} />
+            <span class="lname">{s.name}</span>
+            {#if anyScored && s.wins === topWins}<span class="lcrown" aria-hidden="true">👑</span>{/if}
+            <span class="lwins tnum" class:lead={anyScored && s.wins === topWins}>{s.wins}</span>
+          </div>
+        {/each}
+      </div>
+    {/if}
   </div>
 </div>
 
 <style>
-  .field {
+  /* Secret-word spell field ------------------------------------------------- */
+  .spell {
     display: flex;
     flex-direction: column;
+    gap: 8px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+  }
+  .spell-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .spell-label {
+    margin-bottom: 0;
+  }
+  .dice {
+    flex: none;
+    min-height: 36px;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: border-color 0.12s ease, background 0.12s ease;
+  }
+  .dice:hover {
+    border-color: var(--primary);
+  }
+  .dice:active {
+    transform: translateY(1px);
+  }
+  .dice:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .spell-input {
+    width: 100%;
+    text-align: center;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 700;
+  }
+  .spell-preview {
+    text-align: center;
+    font-size: 0.8rem;
+    letter-spacing: 0.16em;
+    color: var(--muted);
+  }
+  .spell-preview.empty {
+    text-transform: none;
+    letter-spacing: normal;
+    font-style: italic;
+    opacity: 0.75;
+  }
+
+  /* Collapsible panels (briefing + standings) ------------------------------- */
+  .brief {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+  }
+  .brief-toggle {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 46px;
+    padding: 10px 12px;
+    border: 0;
+    background: transparent;
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+    text-align: left;
+  }
+  .brief-toggle:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: -2px;
+  }
+  .brief-body {
+    padding: 0 12px 12px;
+  }
+  .brief-lead {
+    margin: 2px 0 8px;
+  }
+  .brief-list {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.9rem;
+    line-height: 1.4;
+  }
+
+  /* Role rows --------------------------------------------------------------- */
+  .rolehead {
+    margin-top: 2px;
+  }
+  .small {
+    font-size: 0.85rem;
   }
   .prow {
     display: flex;
@@ -190,8 +436,15 @@
     gap: 10px;
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     padding: 10px 12px;
+    transition: background 0.15s ease, border-color 0.15s ease;
+  }
+  /* Wolf rows take on a subtle night tint — always paired with the 🐺 label + pressed
+     wolf button, so the hidden side is never signalled by colour alone. */
+  .wolfrow {
+    background: color-mix(in srgb, var(--primary) 12%, var(--surface-2));
+    border-color: color-mix(in srgb, var(--primary) 40%, var(--border));
   }
   .who {
     display: inline-flex;
@@ -241,11 +494,15 @@
     filter: none;
     opacity: 1;
   }
+  .rbtn:active {
+    transform: translateY(1px);
+  }
   .rbtn:focus-visible {
     outline: 2px solid var(--primary);
     outline-offset: 2px;
   }
 
+  /* Result + twist ---------------------------------------------------------- */
   .result {
     display: flex;
     flex-direction: column;
@@ -280,41 +537,86 @@
     background: var(--primary);
     color: #fff;
   }
+  .ch:active {
+    transform: translateY(1px);
+  }
   .ch:focus-visible {
     outline: 2px solid var(--primary);
     outline-offset: 2px;
   }
 
   .twist {
+    display: flex;
+    align-items: center;
+    gap: 12px;
     min-height: 46px;
-    padding: 10px 12px;
-    border: 1px solid var(--border);
-    border-radius: 10px;
+    padding: 10px 14px;
+    border: 1px dashed var(--border);
+    border-radius: var(--radius);
     background: var(--surface);
     color: var(--text);
-    font-weight: 700;
     cursor: pointer;
     text-align: left;
-    transition: background 0.12s ease, border-color 0.12s ease;
+    transition: background 0.15s ease, border-color 0.15s ease;
   }
   .twist:hover {
     border-color: var(--primary);
   }
   .twist.on {
     background: var(--primary);
+    border-style: solid;
     border-color: var(--primary-strong);
     color: #fff;
+  }
+  .twist:active {
+    transform: translateY(1px);
   }
   .twist:focus-visible {
     outline: 2px solid var(--primary);
     outline-offset: 2px;
   }
+  .twist-emoji {
+    font-size: 1.4rem;
+    line-height: 1;
+    flex: none;
+  }
+  .twist-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+  .twist-sub {
+    font-size: 0.8rem;
+  }
+  .twist.on .twist-sub {
+    color: color-mix(in srgb, #fff 82%, transparent);
+  }
+  .twist-mark {
+    flex: none;
+    width: 1.2rem;
+    text-align: center;
+    font-weight: 800;
+  }
 
+  /* Outcome stage + banner -------------------------------------------------- */
+  .stage {
+    position: relative;
+    overflow: hidden;
+    border-radius: var(--radius);
+  }
   .banner {
+    position: relative;
+    z-index: 2;
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     padding: 12px 14px;
+  }
+  .banner.wolves {
+    background: color-mix(in srgb, var(--primary) 10%, var(--surface-2));
+    border-color: color-mix(in srgb, var(--primary) 36%, var(--border));
   }
   .verdict {
     display: flex;
@@ -330,5 +632,61 @@
   .reason {
     font-size: 0.85rem;
     margin-top: 2px;
+  }
+
+  /* Standings ladder -------------------------------------------------------- */
+  .ladder {
+    padding: 0 8px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .ladder-empty {
+    padding: 2px 4px 6px;
+  }
+  .lrow {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 8px;
+    border-radius: 10px;
+  }
+  .lrow.leader {
+    background: color-mix(in srgb, var(--accent) 13%, transparent);
+  }
+  .lrank {
+    width: 1.2rem;
+    text-align: center;
+    font-size: 0.85rem;
+  }
+  .lname {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .lcrown {
+    flex: none;
+    font-size: 0.9rem;
+  }
+  .lwins {
+    flex: none;
+    font-weight: 700;
+    min-width: 1.5rem;
+    text-align: right;
+  }
+
+  .tnum {
+    font-variant-numeric: tabular-nums;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .dice:active,
+    .rbtn:active,
+    .ch:active,
+    .twist:active {
+      transform: none;
+    }
   }
 </style>

--- a/src/lib/games/werewords/stats.test.ts
+++ b/src/lib/games/werewords/stats.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Round } from '../../types';
+import type { GameStatsInput } from '../../stats/types';
+import { werewordsStats } from './stats';
+import type { WerewordsInput } from './logic';
+
+/** Build the minimal GameStatsInput the werewords stats hook actually reads. */
+function statsFor(playerIds: ID[], inputs: WerewordsInput[]): GameStatsInput {
+  const game = { id: 'g1', type: 'werewords', config: {}, playerIds } as unknown as Game;
+  const rounds = inputs.map(
+    (input, i) => ({ id: `r${i}`, gameId: 'g1', index: i, input, deltas: {} }) as unknown as Round,
+  );
+  return {
+    games: [game],
+    rounds,
+    players: [],
+    canonical: (id: ID) => id,
+  };
+}
+
+function round(overrides: Partial<WerewordsInput> = {}): WerewordsInput {
+  return {
+    word: 'PYRAMID',
+    mayor: 'A',
+    seer: 'B',
+    werewolves: ['C'],
+    guessed: true,
+    werewolfFoundSeer: false,
+    mayorFoundWerewolf: false,
+    ...overrides,
+  };
+}
+
+describe('werewordsStats — the per-role flavour metrics', () => {
+  it('emits a Seer-rounds metric (previously computed but never surfaced)', () => {
+    const perPlayer = werewordsStats(statsFor(['A', 'B', 'C'], [round(), round()])).perPlayer ?? {};
+    const seer = perPlayer['B']?.find((m) => m.key === 'ww_seer');
+    expect(seer).toBeDefined();
+    expect(seer?.value).toBe('2');
+  });
+
+  it('tracks how often the Mayor’s table cracked the word', () => {
+    const inputs = [round({ guessed: true }), round({ guessed: false }), round({ guessed: true })];
+    const perPlayer = werewordsStats(statsFor(['A', 'B', 'C'], inputs)).perPlayer ?? {};
+    const cracked = perPlayer['A']?.find((m) => m.key === 'ww_mayor_cracked');
+    expect(cracked?.value).toBe('2/3');
+  });
+
+  it('still reports round win rate and werewolf record', () => {
+    const inputs = [round({ guessed: false }), round({ guessed: false })];
+    const res = werewordsStats(statsFor(['A', 'B', 'C'], inputs));
+    const perPlayer = res.perPlayer ?? {};
+    const global = res.global ?? [];
+    // C was the lone wolf both rounds, and wolves won both (time ran out).
+    expect(perPlayer['C']?.find((m) => m.key === 'ww_wolf')?.value).toBe('2/2');
+    expect(global.find((m) => m.key === 'ww_wolves')).toBeDefined();
+  });
+});

--- a/src/lib/games/werewords/stats.ts
+++ b/src/lib/games/werewords/stats.ts
@@ -9,6 +9,7 @@ interface WWAgg {
   wolfGames: number;
   wolfWins: number;
   mayor: number;
+  mayorCracked: number;
   seer: number;
 }
 
@@ -26,7 +27,7 @@ export function werewordsStats({ games, rounds, canonical }: GameStatsInput): Ga
   const get = (id: ID): WWAgg => {
     let a = per.get(id);
     if (!a) {
-      a = { played: 0, won: 0, wolfGames: 0, wolfWins: 0, mayor: 0, seer: 0 };
+      a = { played: 0, won: 0, wolfGames: 0, wolfWins: 0, mayor: 0, mayorCracked: 0, seer: 0 };
       per.set(id, a);
     }
     return a;
@@ -57,7 +58,11 @@ export function werewordsStats({ games, rounds, canonical }: GameStatsInput): Ga
         if (winner === 'werewolf') a.wolfWins += 1;
       }
     }
-    if (input.mayor) get(canonical(input.mayor)).mayor += 1;
+    if (input.mayor) {
+      const m = get(canonical(input.mayor));
+      m.mayor += 1;
+      if (input.guessed) m.mayorCracked += 1;
+    }
     if (input.seer) get(canonical(input.seer)).seer += 1;
   }
 
@@ -72,6 +77,15 @@ export function werewordsStats({ games, rounds, canonical }: GameStatsInput): Ga
     }
     if (a.mayor) {
       metrics.push({ key: 'ww_mayor', label: 'Mayor rounds', value: `${a.mayor}`, emoji: '👑' });
+      metrics.push({
+        key: 'ww_mayor_cracked',
+        label: 'Cracked as Mayor',
+        value: `${a.mayorCracked}/${a.mayor}`,
+        emoji: '🧩',
+      });
+    }
+    if (a.seer) {
+      metrics.push({ key: 'ww_seer', label: 'Seer rounds', value: `${a.seer}`, emoji: '🔮' });
     }
     if (metrics.length) perPlayer[id] = metrics;
   }

--- a/src/lib/games/werewords/words.test.ts
+++ b/src/lib/games/werewords/words.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { WEREWORDS_WORDS, suggestWord } from './words';
+
+describe('suggestWord — the offline "Need a word?" helper', () => {
+  it('always returns a word from the bank', () => {
+    for (let seed = 0; seed < 200; seed++) {
+      expect(WEREWORDS_WORDS).toContain(suggestWord(seed));
+    }
+  });
+
+  it('is deterministic for a given seed', () => {
+    expect(suggestWord(42)).toBe(suggestWord(42));
+  });
+
+  it('maps the seed across the whole bank (indexes by modulo)', () => {
+    expect(suggestWord(0)).toBe(WEREWORDS_WORDS[0]);
+    expect(suggestWord(WEREWORDS_WORDS.length)).toBe(WEREWORDS_WORDS[0]);
+    expect(suggestWord(1)).toBe(WEREWORDS_WORDS[1]);
+  });
+
+  it('never repeats the word currently in the field (steps to the next)', () => {
+    // Seed 0 naturally lands on entry 0; avoiding it must pick something different.
+    const natural = WEREWORDS_WORDS[0];
+    const picked = suggestWord(0, natural);
+    expect(picked).not.toBe(natural);
+    expect(WEREWORDS_WORDS).toContain(picked);
+  });
+
+  it('is case- and whitespace-insensitive when avoiding', () => {
+    const natural = WEREWORDS_WORDS[0];
+    expect(suggestWord(0, `  ${natural.toLowerCase()}  `)).not.toBe(natural);
+  });
+
+  it('tolerates junk seeds without throwing', () => {
+    expect(WEREWORDS_WORDS).toContain(suggestWord(Number.NaN));
+    expect(WEREWORDS_WORDS).toContain(suggestWord(-7));
+    expect(WEREWORDS_WORDS).toContain(suggestWord(3.9));
+  });
+
+  it('ships a clean bank — non-empty, unique, upper-case, trimmed', () => {
+    expect(WEREWORDS_WORDS.length).toBeGreaterThan(20);
+    const seen = new Set<string>();
+    for (const w of WEREWORDS_WORDS) {
+      expect(w).toBe(w.trim());
+      expect(w).toBe(w.toUpperCase());
+      expect(w.length).toBeGreaterThan(0);
+      expect(seen.has(w)).toBe(false);
+      seen.add(w);
+    }
+  });
+});

--- a/src/lib/games/werewords/words.ts
+++ b/src/lib/games/werewords/words.ts
@@ -1,0 +1,52 @@
+/**
+ * A tiny, offline word bank for Werewords — the "🎲 Need a word?" helper the Mayor can
+ * tap when nobody at the table has a secret word ready. Pure and Svelte-free so it can be
+ * unit-tested and can't drag any network dependency into the round editor.
+ *
+ * The list is deliberately curated for the game: everyday, guessable, family-friendly
+ * nouns (a few verbs/adjectives for spice) that give the table a fair yes/no chase — no
+ * proper nouns, no obscure trivia, nothing that needs spelling out. It is not meant to be
+ * exhaustive; it just breaks the "who has a word?" stall so play keeps moving.
+ */
+export const WEREWORDS_WORDS: readonly string[] = [
+  // Around the house
+  'PILLOW', 'CANDLE', 'MIRROR', 'KETTLE', 'BLANKET', 'LADDER', 'UMBRELLA', 'DRAWER',
+  'TEAPOT', 'CURTAIN', 'DOORBELL', 'MATTRESS',
+  // Outdoors & nature
+  'VOLCANO', 'GLACIER', 'THUNDER', 'RAINBOW', 'CANYON', 'MEADOW', 'WHIRLPOOL', 'ICEBERG',
+  'AVALANCHE', 'MOONLIGHT', 'FOREST', 'DESERT',
+  // Creatures
+  'OCTOPUS', 'PENGUIN', 'HEDGEHOG', 'DOLPHIN', 'FIREFLY', 'JELLYFISH', 'SCARECROW',
+  'BUTTERFLY', 'SQUIRREL', 'FLAMINGO', 'WEREWOLF', 'DRAGON',
+  // Food & drink
+  'PANCAKE', 'PRETZEL', 'POPCORN', 'CUPCAKE', 'MEATBALL', 'PICKLE', 'WAFFLE', 'NOODLE',
+  'MARMALADE', 'GUMBO',
+  // Places & things
+  'CASTLE', 'PYRAMID', 'LIGHTHOUSE', 'HARBOR', 'MARKET', 'STADIUM', 'BRIDGE', 'WINDMILL',
+  'TREASURE', 'COMPASS', 'ANCHOR', 'CATAPULT',
+  // Play & wonder
+  'BALLOON', 'PUPPET', 'CAROUSEL', 'FIREWORK', 'MARBLE', 'KAZOO', 'YO-YO', 'ORIGAMI',
+  'JIGSAW', 'TRAMPOLINE',
+  // Verbs & adjectives for variety
+  'WHISPER', 'SHIVER', 'TANGLE', 'WOBBLE', 'GLOW', 'SPARKLE', 'SLIPPERY', 'FLUFFY',
+  'CRUNCHY', 'GIGANTIC',
+];
+
+/**
+ * Pick a suggested word deterministically from {@link WEREWORDS_WORDS}.
+ *
+ * Deterministic for a given `seed` so it is trivially testable; the editor feeds it a
+ * fresh random seed each tap to feel spontaneous. When `avoid` matches the natural pick
+ * (e.g. the word already sitting in the field), we step to the next entry so a tap always
+ * visibly changes the word rather than appearing to do nothing.
+ */
+export function suggestWord(seed: number, avoid?: string | null): string {
+  const list = WEREWORDS_WORDS;
+  const n = list.length;
+  // A non-negative integer index from any finite seed (floats, negatives, NaN → 0).
+  const base = Number.isFinite(seed) ? Math.abs(Math.floor(seed)) % n : 0;
+  const wanted = avoid?.trim().toUpperCase() ?? '';
+  let idx = base;
+  if (wanted && list[idx] === wanted) idx = (idx + 1) % n;
+  return list[idx];
+}


### PR DESCRIPTION
## 🐺 Werewords — make it more fun

Werewords was the plain sibling of Score King's other hidden-role games. Avalon, Blood on the Clocktower, and Two Rooms each get a cinematic thematic reveal, haptics, a briefing, and day/night atmosphere — Werewords had none. This PR gives it that personality **without touching the app chrome** (identical shell, thematic costume on top).

### What's new
- **`HowlReveal.svelte` — the cinematic outcome overlay.** Replays on every genuine round landing/flip:
  - 🌅 Village win → dawn breaks, the cracked word flashes up in letter-spaced caps.
  - 🌕 Werewolf win → the moon rises with a 🐺 howl and a cool night wash.
  - 🔀 Twist → an extra **STOLEN!** beat.
  - Seeded particles, `pointer-events:none`, fires `haptic('win')`, and renders nothing under `prefers-reduced-motion` (the banner is the calm alternative).
- **Secret word "spell field"** — reframed 🔮 field with a letter-spaced uppercase preview and a **🎲 Need a word?** button backed by a pure, offline word bank (field stays freely editable).
- **Night briefing (collapsible, closed by default)** — 🌙 who-wakes reference and the yes/no/maybe ritual with playful moderator copy.
- **The twist as a dramatic steal card** — the game's soul is now a clearly-labelled flip with narrator microcopy, co-signalled by emoji + label + pressed state.
- **Role rows** — wolf rows get a subtle night tint and a glanceable **🐺 pack N/N** counter that warns (colour + count) when the tapped pack doesn't match the config.
- **Standings ladder (collapsible)** — running "rounds won" from the live totals, 👑 Crown Gold on the leader only.
- **Haptics** on role taps and the outcome landing.
- **Stats** — emit the previously-dead Seer metric and add a Mayor "cracked" flavour metric.

### Design fidelity
- One Royal Violet primary action (Save); selected role chips use the established sibling selected-state convention.
- Crown Gold reserved for the standings leader only.
- Depth via the surface ramp; radii aligned to the DESIGN.md token scale; `tabular-nums` on changing numbers; ≥46px targets; state never signalled by colour alone; reduced-motion honoured.

### Testing (local)
- `npx vitest run src/lib/games/werewords` → **34 passed**
- `npm run check` → **0 errors, 0 warnings**
- `npm run build` → clean
- Walked the full round-entry flow in a headless browser (add players → start → spell field + 🎲 → briefing → role tapping + pack counter + wolf tint → guessed/twist branching firing HowlReveal → standings). No console/page errors.

All scoring logic stays Svelte-free and unit-tested in `logic.ts` / `words.ts`.