### PR TITLE
Give Wingspan a Finspan-sibling glow-up

### DIFF
--- a/src/lib/games/wingspan/FlockGauge.svelte
+++ b/src/lib/games/wingspan/FlockGauge.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  /**
+   * Wingspan's signature "grow your flock" gauge — a horizontal bar that fills left→right with a
+   * player's running total and climbs through the four habitats (Forest → Grassland → Wetland →
+   * Oceania) as it grows. Pure per-game costume: it never touches the app chrome, never uses
+   * Royal Violet (the one primary action lives on the play screen) or Crown Gold (reserved for
+   * the leader), and always co-signals the habitat with an emoji + label, never colour alone.
+   *
+   * Motion is a flourish, not a gate: the fill glides and a faint breeze drifts across it, but
+   * both are dropped under reduced motion — the bar still shows its final fill and habitat
+   * instantly. Mirrors Finspan's OceanGauge so the two siblings feel of a piece.
+   */
+  import { habitatTier, flockFill } from './logic';
+  import { prefersReducedMotion } from '../../motion';
+
+  let { total = 0 }: { total?: number } = $props();
+
+  const tier = $derived(habitatTier(total));
+  const fill = $derived(flockFill(total));
+  const reduced = prefersReducedMotion();
+</script>
+
+<div class="gauge" class:reduced>
+  <div
+    class="meter tier-{tier.key}"
+    role="img"
+    aria-label={`Flock habitat: ${tier.label}, ${total} points`}
+  >
+    <div class="fill" style="--fill: {fill}">
+      <span class="breeze" aria-hidden="true"></span>
+    </div>
+  </div>
+  <span class="tier" aria-hidden="true">
+    <span class="temoji">{tier.emoji}</span>{tier.label}
+  </span>
+</div>
+
+<style>
+  .gauge {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .meter {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    height: 14px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    overflow: hidden;
+    /* The habitat tint is a contained decorative accent — clearly green/earth/teal, never the
+       brand violet or the leader's gold. Each tier shifts the fill toward its habitat. */
+    --h1: #4ade80;
+    --h2: #22c55e;
+  }
+  .meter.tier-grassland {
+    --h1: #a3e635;
+    --h2: #ca8a04;
+  }
+  .meter.tier-wetland {
+    --h1: #34d399;
+    --h2: #0891b2;
+  }
+  .meter.tier-oceania {
+    --h1: #22d3ee;
+    --h2: #2563eb;
+  }
+  .fill {
+    position: relative;
+    height: 100%;
+    width: 100%;
+    border-radius: 999px;
+    background: linear-gradient(90deg, var(--h1), var(--h2));
+    transform: scaleX(var(--fill, 0));
+    transform-origin: left center;
+    transition: transform 0.45s cubic-bezier(0.22, 0.61, 0.36, 1);
+  }
+  /* A drifting highlight so the bar reads as a living habitat, not a bare progress bar. */
+  .breeze {
+    position: absolute;
+    inset: 0;
+    border-radius: 999px;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      color-mix(in srgb, #ffffff 34%, transparent) 45%,
+      transparent 70%
+    );
+    background-size: 220% 100%;
+    animation: drift 2.6s linear infinite;
+  }
+  .tier {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex: none;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--muted);
+    white-space: nowrap;
+  }
+  .temoji {
+    font-size: 0.85rem;
+  }
+  .reduced .fill {
+    transition: none;
+  }
+  .reduced .breeze {
+    animation: none;
+    background-position: 0 0;
+  }
+  @keyframes drift {
+    from {
+      background-position: 120% 0;
+    }
+    to {
+      background-position: -120% 0;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .fill {
+      transition: none;
+    }
+    .breeze {
+      animation: none;
+    }
+  }
+</style>

--- a/src/lib/games/wingspan/WingspanEditor.svelte
+++ b/src/lib/games/wingspan/WingspanEditor.svelte
@@ -2,6 +2,9 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
+  import FlockGauge from './FlockGauge.svelte';
+  import { leaders } from '../../scoring';
+  import { bumpOnChange, popIn, animateMotion } from '../../motion';
   import {
     LEFTOVER_CATEGORY,
     emptyRow,
@@ -16,10 +19,13 @@
   let { input = $bindable(), ctx }: { input: WingspanInput; ctx: RoundContext } = $props();
 
   const cats = $derived(scoringCategories(ctx.config));
+  // The big point totals get a fast numeric field; the +1 token tallies keep the Stepper nudge.
+  const pointCats = $derived(cats.filter((c) => c.entry === 'points'));
+  const countCats = $derived(cats.filter((c) => c.entry === 'count'));
   const showFood = $derived(tracksFood(ctx.config));
   let showHelp = $state(false);
 
-  // Keep the draft's shape in sync with the current players and config, so every stepper always
+  // Keep the draft's shape in sync with the current players and config, so every field always
   // has a real number to bind to — even if a player joined, or Nectar toggled on, after this
   // scoresheet draft was first created. Mirrors the custom-game editor's self-healing draft.
   $effect(() => {
@@ -40,11 +46,45 @@
   function total(id: string): number {
     return scoreRow(input.rows?.[id]);
   }
+
+  // Live totals + the app's shared "who's pulled ahead" rule, so the biggest flock wears the
+  // crown (and only the crown's Gold) — and nobody is crowned at an all-tied-at-zero table.
+  const totals = $derived(Object.fromEntries(ctx.players.map((p) => [p.id, total(p.id)])));
+  const leaderSet = $derived(leaders(totals, ctx.players.map((p) => p.id)));
+  // A genuine dead heat: two or more players share the lead. Time to settle it with food.
+  const deadHeat = $derived(leaderSet.size > 1);
+
+  /**
+   * A one-shot "🥚→🐣 hatch!" bubble that floats up when a player's egg count ticks up — the
+   * flock's most satisfying tally. Motion-only decoration, so under reduced motion
+   * {@link animateMotion} resolves instantly and the bubble is removed with no movement.
+   */
+  function eggHatch(node: HTMLElement, value: number | undefined) {
+    let prev = Number(value) || 0;
+    return {
+      update(next: number | undefined) {
+        const v = Number(next) || 0;
+        if (v > prev) {
+          const b = document.createElement('span');
+          b.className = 'burst';
+          b.textContent = '🥚→🐣';
+          b.setAttribute('aria-hidden', 'true');
+          node.appendChild(b);
+          animateMotion(
+            b,
+            { opacity: [0, 1, 0], transform: ['translateY(2px)', 'translateY(-14px)', 'translateY(-28px)'] },
+            { duration: 0.7, ease: 'easeOut' },
+          ).finished.finally(() => b.remove());
+        }
+        prev = v;
+      },
+    };
+  }
 </script>
 
 <div class="stack">
   <div class="row spread">
-    <span class="pill">Final scoresheet 🪶</span>
+    <span class="pill">Tally the flock · game end 🪶</span>
     <button
       type="button"
       class="btn small ghost"
@@ -60,41 +100,73 @@
   {/if}
 
   {#each ctx.players as p (p.id)}
-    <div class="prow">
-      <div class="phead">
-        <span class="who">
-          <Avatar name={p.name} color={p.color} />
-          <strong>{p.name}</strong>
-        </span>
-        <span class="total">
-          <span class="totnum">{total(p.id)}</span>
-          <span class="totlbl">pts</span>
-        </span>
-      </div>
+    {@const row = input.rows?.[p.id]}
+    {#if row}
+      {@const isLeader = leaderSet.has(p.id)}
+      <div class="prow" class:leader={isLeader}>
+        <div class="row spread phead">
+          <span class="who">
+            <Avatar name={p.name} color={p.color} />
+            <strong>{p.name}</strong>
+            {#if isLeader}
+              <span class="crown" title="In the lead" aria-hidden="true" use:popIn>👑</span>
+              <span class="sr-only">In the lead</span>
+            {/if}
+          </span>
+          <span class="total" class:lead={isLeader}>
+            <span class="totnum" use:bumpOnChange={total(p.id)}>{total(p.id)}</span><span class="totlbl"
+              >pts</span
+            >
+          </span>
+        </div>
 
-      {#if input.rows?.[p.id]}
+        <FlockGauge total={total(p.id)} />
+
         <div class="grid">
-          {#each cats as c (c.key)}
+          {#each pointCats as c (c.key)}
             <label class="cell">
               <span class="clabel"><span class="cemoji" aria-hidden="true">{c.emoji}</span>{c.short}</span>
-              <Stepper bind:value={input.rows[p.id][c.key]} min={0} max={999} />
+              <input
+                class="pts"
+                type="number"
+                min="0"
+                step="1"
+                inputmode="numeric"
+                aria-label={`${p.name} ${c.label}`}
+                bind:value={row[c.key]}
+              />
             </label>
           {/each}
         </div>
 
+        <div class="grid tokens">
+          {#each countCats as c (c.key)}
+            <div class="cell" use:eggHatch={c.key === 'eggs' ? row.eggs : undefined}>
+              <span class="clabel"><span class="cemoji" aria-hidden="true">{c.emoji}</span>{c.short}</span>
+              <Stepper bind:value={row[c.key]} min={0} max={999} label={`${p.name} ${c.label}`} />
+            </div>
+          {/each}
+        </div>
+
         {#if showFood}
-          <div class="tiebreak">
-            <label class="cell">
+          <div class="tiebreak" class:heat={deadHeat && isLeader}>
+            <div class="cell">
               <span class="clabel">
                 <span class="cemoji" aria-hidden="true">{LEFTOVER_CATEGORY.emoji}</span>{LEFTOVER_CATEGORY.label}
               </span>
-              <Stepper bind:value={input.rows[p.id].leftover} min={0} max={999} />
-            </label>
-            <span class="tienote">Breaks ties · not scored</span>
+              <Stepper bind:value={row.leftover} min={0} max={999} label={`${p.name} ${LEFTOVER_CATEGORY.label}`} />
+            </div>
+            <span class="tienote">
+              {#if deadHeat && isLeader}
+                🍽️ Dead heat — most unused food wins
+              {:else}
+                Breaks ties · not scored
+              {/if}
+            </span>
           </div>
         {/if}
-      {/if}
-    </div>
+      </div>
+    {/if}
   {/each}
 </div>
 
@@ -102,15 +174,20 @@
   .prow {
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  /* The leading flock: a restrained Crown-Gold ring around the leader's card — the crown and
+     gold total already carry the meaning, so the ring stays a whisper, never a gold block. */
+  .prow.leader {
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+    background: color-mix(in srgb, var(--accent) 6%, var(--surface-2));
   }
   .phead {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    margin-bottom: 12px;
+    margin: 0;
   }
   .who {
     display: flex;
@@ -123,17 +200,27 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+  .crown {
+    flex: none;
+    font-size: 1rem;
+    line-height: 1;
+  }
   .total {
     display: inline-flex;
     align-items: baseline;
     gap: 4px;
     flex: none;
-  }
-  .totnum {
-    font-size: 1.5rem;
     font-weight: 800;
+    font-size: 1.5rem;
     font-variant-numeric: tabular-nums;
     line-height: 1;
+  }
+  .totnum {
+    font-variant-numeric: tabular-nums;
+  }
+  /* Gold reserved for the leader/winner number, per the Crown-Gold rule. */
+  .total.lead {
+    color: var(--accent-ink);
   }
   .totlbl {
     font-size: 0.75rem;
@@ -145,7 +232,15 @@
     flex-wrap: wrap;
     gap: 14px 18px;
   }
+  /* The +1 token tallies sit a touch quieter than the big point fields above them. */
+  .grid.tokens {
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    border: 1px solid var(--border);
+  }
   .cell {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: 6px;
@@ -161,11 +256,30 @@
   .cemoji {
     font-size: 0.95rem;
   }
+  .pts {
+    width: 88px;
+    height: 46px;
+    text-align: center;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+  /* The floating "🥚→🐣 hatch" beat. Positioned over its cell; pointer-inert so it never blocks
+     the next tap. Motion-only — animateMotion drops it instantly under reduced motion. */
+  .cell :global(.burst) {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--good);
+    pointer-events: none;
+    white-space: nowrap;
+  }
   .tiebreak {
     display: flex;
     align-items: flex-end;
     gap: 14px;
-    margin-top: 14px;
     padding-top: 12px;
     border-top: 1px dashed var(--border);
   }
@@ -174,11 +288,17 @@
     color: var(--muted);
     padding-bottom: 12px;
   }
+  /* When the leaders are actually tied, the food column becomes the decider — call it out in
+     words + emoji (never colour alone) on the tied leaders' cards. */
+  .tiebreak.heat .tienote {
+    color: var(--text);
+    font-weight: 700;
+  }
   .help {
     white-space: pre-wrap;
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     padding: 12px;
     font-size: 0.85rem;
     margin: 0;

--- a/src/lib/games/wingspan/logic.ts
+++ b/src/lib/games/wingspan/logic.ts
@@ -43,23 +43,35 @@ export interface WingspanInput {
   rows: Record<ID, WingspanRow>;
 }
 
+/**
+ * How a category value is entered on the sheet — mirrors Finspan so the two siblings share one
+ * interaction model:
+ *   `points` — a big, typeable total (birds, bonus, goals, nectar majorities). Tapping a stepper
+ *              to 87 birds is miserable, so these get a fast numeric field.
+ *   `count`  — a small 1-point tally (eggs, cached food, tucked cards, the food tiebreaker) that
+ *              earns the satisfying +1 Stepper nudge.
+ */
+export type WingspanEntry = 'points' | 'count';
+
 export interface CategoryDef {
   key: keyof WingspanRow;
   label: string;
   /** Compact label for the entry grid. */
   short: string;
   emoji: string;
+  /** Numeric field for big totals vs the +1 Stepper for token tallies. */
+  entry: WingspanEntry;
   help: string;
 }
 
 /** The base six categories — always present, in the order they sit on the real score pad. */
 export const BASE_CATEGORIES: CategoryDef[] = [
-  { key: 'birds', label: 'Birds', short: 'Birds', emoji: '🐦', help: 'Points printed on the birds in your habitats.' },
-  { key: 'bonus', label: 'Bonus cards', short: 'Bonus', emoji: '🎯', help: "Points from your bonus cards' conditions." },
-  { key: 'goals', label: 'End-of-round goals', short: 'Goals', emoji: '🎖️', help: 'Points from the four end-of-round goal tiles.' },
-  { key: 'eggs', label: 'Eggs', short: 'Eggs', emoji: '🥚', help: '1 point per egg on your bird cards.' },
-  { key: 'food', label: 'Cached food', short: 'Cached', emoji: '🌰', help: '1 point per food token cached on your bird cards.' },
-  { key: 'tucked', label: 'Tucked cards', short: 'Tucked', emoji: '🃏', help: '1 point per card tucked under your birds.' },
+  { key: 'birds', label: 'Birds', short: 'Birds', emoji: '🐦', entry: 'points', help: 'Points printed on the birds in your habitats.' },
+  { key: 'bonus', label: 'Bonus cards', short: 'Bonus', emoji: '🎯', entry: 'points', help: "Points from your bonus cards' conditions." },
+  { key: 'goals', label: 'End-of-round goals', short: 'Goals', emoji: '🎖️', entry: 'points', help: 'Points from the four end-of-round goal tiles.' },
+  { key: 'eggs', label: 'Eggs', short: 'Eggs', emoji: '🥚', entry: 'count', help: '1 point per egg on your bird cards.' },
+  { key: 'food', label: 'Cached food', short: 'Cached', emoji: '🌰', entry: 'count', help: '1 point per food token cached on your bird cards.' },
+  { key: 'tucked', label: 'Tucked cards', short: 'Tucked', emoji: '🃏', entry: 'count', help: '1 point per card tucked under your birds.' },
 ];
 
 /** Oceania's Nectar category, shown only when the expansion is toggled on. */
@@ -68,6 +80,7 @@ export const NECTAR_CATEGORY: CategoryDef = {
   label: 'Nectar',
   short: 'Nectar',
   emoji: '🌸',
+  entry: 'points',
   help: 'Nectar majorities scored per habitat (Oceania expansion).',
 };
 
@@ -77,6 +90,7 @@ export const LEFTOVER_CATEGORY: CategoryDef = {
   label: 'Unused food',
   short: 'Food left',
   emoji: '🍽️',
+  entry: 'count',
   help: 'Leftover food tokens settle ties — the most unused food wins. Never added to the score.',
 };
 
@@ -184,4 +198,48 @@ export function describeWingspanRound(
     parts.push(`${p.name} ${scoreRow(row)}`);
   }
   return parts.length ? parts.join(' · ') : 'no scores';
+}
+
+/**
+ * The four Wingspan habitats, in the order a growing flock settles them (Forest → Grassland →
+ * Wetland → Oceania). A player's running total climbs through them as it grows, giving the tally
+ * a sense of place ("your flock has reached the Wetland") without ever relying on colour alone —
+ * every tier carries an emoji and a label. This is Wingspan's costume equivalent of Finspan's
+ * depth zones. `min` is the inclusive floor; tiers are listed richest-last so {@link habitatTier}
+ * can scan from the bottom up.
+ */
+export interface HabitatTier {
+  key: 'forest' | 'grassland' | 'wetland' | 'oceania';
+  label: string;
+  emoji: string;
+  /** Inclusive lower bound, in points. */
+  min: number;
+}
+
+export const HABITAT_TIERS: readonly HabitatTier[] = [
+  { key: 'forest', label: 'Forest', emoji: '🌲', min: 0 },
+  { key: 'grassland', label: 'Grassland', emoji: '🌾', min: 40 },
+  { key: 'wetland', label: 'Wetland', emoji: '💧', min: 70 },
+  { key: 'oceania', label: 'Oceania', emoji: '🌊', min: 100 },
+] as const;
+
+/** A thriving flock — the point total at which the gauge reads brim-full. */
+export const FULL_FLOCK = 120;
+
+/** Which habitat tier a running total currently sits in (negatives/NaN clamp to Forest). */
+export function habitatTier(total: number): HabitatTier {
+  const n = Number(total);
+  let tier = HABITAT_TIERS[0];
+  if (!Number.isFinite(n)) return tier;
+  for (const t of HABITAT_TIERS) {
+    if (n >= t.min) tier = t;
+  }
+  return tier;
+}
+
+/** How full the flock gauge reads, 0–1, for a running total (clamped to {@link FULL_FLOCK}). */
+export function flockFill(total: number): number {
+  const n = Number(total);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return Math.min(1, n / FULL_FLOCK);
 }

--- a/src/lib/games/wingspan/wingspan.test.ts
+++ b/src/lib/games/wingspan/wingspan.test.ts
@@ -3,11 +3,15 @@ import type { Player, Round, RoundContext } from '../../types';
 import { defaultWinners } from '../../types';
 import {
   BASE_CATEGORIES,
+  FULL_FLOCK,
+  HABITAT_TIERS,
   LEFTOVER_CATEGORY,
   NECTAR_CATEGORY,
   describeWingspanRound,
   emptyRow,
   fieldLabel,
+  flockFill,
+  habitatTier,
   isNectarOn,
   scoreRow,
   scoreWingspanRound,
@@ -102,6 +106,64 @@ describe('category configuration', () => {
     expect(isNectarOn({ nectar: true })).toBe(true);
     expect(tracksFood(undefined)).toBe(true); // tracked unless explicitly disabled
     expect(tracksFood({ trackFood: false })).toBe(false);
+  });
+
+  it('splits entry between fast point fields and +1 token steppers', () => {
+    const byKey = Object.fromEntries(scoringCategories({ nectar: true }).map((c) => [c.key, c.entry]));
+    // Big totals get a typeable field...
+    expect(byKey.birds).toBe('points');
+    expect(byKey.bonus).toBe('points');
+    expect(byKey.goals).toBe('points');
+    expect(byKey.nectar).toBe('points');
+    // ...the 1-point tallies keep the stepper nudge.
+    expect(byKey.eggs).toBe('count');
+    expect(byKey.food).toBe('count');
+    expect(byKey.tucked).toBe('count');
+    // The tiebreaker is a token tally too.
+    expect(LEFTOVER_CATEGORY.entry).toBe('count');
+  });
+});
+
+describe('habitatTier', () => {
+  it('lists the four habitats forest → oceania', () => {
+    expect(HABITAT_TIERS.map((t) => t.key)).toEqual(['forest', 'grassland', 'wetland', 'oceania']);
+  });
+
+  it('climbs through the tiers as the flock grows', () => {
+    expect(habitatTier(0).key).toBe('forest');
+    expect(habitatTier(39).key).toBe('forest');
+    expect(habitatTier(40).key).toBe('grassland');
+    expect(habitatTier(69).key).toBe('grassland');
+    expect(habitatTier(70).key).toBe('wetland');
+    expect(habitatTier(99).key).toBe('wetland');
+    expect(habitatTier(100).key).toBe('oceania');
+    expect(habitatTier(999).key).toBe('oceania');
+  });
+
+  it('clamps negatives and NaN to the first habitat', () => {
+    expect(habitatTier(-10).key).toBe('forest');
+    expect(habitatTier(Number.NaN).key).toBe('forest');
+  });
+
+  it('always carries an emoji + label, never colour alone', () => {
+    for (const t of HABITAT_TIERS) {
+      expect(t.emoji.length).toBeGreaterThan(0);
+      expect(t.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('flockFill', () => {
+  it('fills 0 → 1 across a full flock', () => {
+    expect(flockFill(0)).toBe(0);
+    expect(flockFill(FULL_FLOCK / 2)).toBeCloseTo(0.5);
+    expect(flockFill(FULL_FLOCK)).toBe(1);
+  });
+
+  it('clamps a runaway flock and non-finite totals', () => {
+    expect(flockFill(FULL_FLOCK * 3)).toBe(1);
+    expect(flockFill(-50)).toBe(0);
+    expect(flockFill(Number.NaN)).toBe(0);
   });
 });
 


### PR DESCRIPTION
## What & why

Wingspan's scoring was correct, but its editor was still the bare "before" version — badly out of step with its already-improved sibling **Finspan**. It used a different interaction model (a −/+ Stepper on *every* category, painful for 40–100+ pt Birds) and lacked all of Finspan's glanceability and delight. This PR brings Wingspan to full parity with the Finspan category-scoresheet pattern, dressed in Wingspan's own **bird / egg / nectar / habitat** costume.

Scoring math is unchanged — this is entry-UX, live-standings, and delight.

## Changes

- **Faster entry (split input model):** typeable number fields for the big point categories (🐦 Birds, 🎯 Bonus, 🎖️ Goals, 🌸 Nectar); keep the satisfying **+1 Stepper** for the 1-point token tallies (🥚 Eggs, 🌰 Cached food, 🃏 Tucked, 🍽️ Unused food). Exactly Finspan's model.
- **Live "who's ahead" story:** `leaders()` → 👑 crown (`popIn`), gold `.lead` total, a restrained Crown-Gold ring on the leader card, and a `bumpOnChange` pulse when a total changes.
- **New `FlockGauge` signature component:** a per-player bar that fills and climbs through the four habitats 🌲 Forest → 🌾 Grassland → 💧 Wetland → 🌊 Oceania as the flock total grows — mirroring Finspan's `OceanGauge` structure. Teal/earth tints only (never violet or gold), emoji + label never colour alone, `prefers-reduced-motion` safe.
- **One restrained delight beat:** an egg-hatch 🥚→🐣 float when a player's egg count ticks up (the analogue of Finspan's single "＋6 🐠" school burst).
- **Co-leader tie moment:** when leaders are actually tied and food tracking is on, the tiebreak row surfaces a "🍽️ Dead heat — most unused food wins" nudge (text + emoji, never colour alone).
- **Pure, testable helpers** in `logic.ts` (Svelte-free): `habitatTier`, `flockFill`, `FULL_FLOCK`, `HABITAT_TIERS`, plus an `entry: 'points' | 'count'` mapping on categories.
- Fixed two off-scale `border-radius` values to the DESIGN.md token scale (`--radius` / `--radius-sm`).

## Design non-negotiables honored

- One Royal Violet primary action on the play screen (Save round) — no second violet fill.
- Crown Gold only on the leader (crown + gold total + whisper ring). The gauge uses neither gold nor violet.
- Every changing number renders `tabular-nums`, weight 700.
- Touch targets ≥46px; state never signalled by colour alone.
- App chrome untouched — the winner reveal stays the shared `WinnerCelebration`/banner.

## Testing (local)

- `npm run check` → 0 errors, 0 warnings
- `npm run build` → ✓ built
- `npm test` (vitest) → **1222 passed** (Wingspan: 36, up from 29 — added `habitatTier`/`flockFill`/entry-mapping tests mirroring Finspan's gauge tests)