### PR TITLE
Wyrmspan: harmonize with improved Wingspan/Finspan siblings 🐉

### DIFF
--- a/src/lib/games/wyrmspan/HoardGauge.svelte
+++ b/src/lib/games/wyrmspan/HoardGauge.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  /**
+   * Wyrmspan's signature "grow your hoard" gauge — a horizontal bar that fills left→right with a
+   * player's running total and burrows deeper through the lair (Nest → Cavern → Treasure Vault →
+   * Dragon's Hoard) as it grows. Pure per-game costume: it never touches the app chrome, never
+   * uses Royal Violet (the one primary action lives on the play screen) or Crown Gold (reserved
+   * for the leader), and always co-signals the lair with an emoji + label, never colour alone.
+   *
+   * Motion is a flourish, not a gate: the fill glides and a faint ember shimmer drifts across it,
+   * but both are dropped under reduced motion — the bar still shows its final fill and lair
+   * instantly. Mirrors Wingspan's FlockGauge and Finspan's OceanGauge so the trio feels of a piece.
+   */
+  import { hoardTier, hoardFill } from './logic';
+  import { prefersReducedMotion } from '../../motion';
+
+  let { total = 0 }: { total?: number } = $props();
+
+  const tier = $derived(hoardTier(total));
+  const fill = $derived(hoardFill(total));
+  const reduced = prefersReducedMotion();
+</script>
+
+<div class="gauge" class:reduced>
+  <div
+    class="lair tier-{tier.key}"
+    role="img"
+    aria-label={`Lair: ${tier.label}, ${total} VP`}
+  >
+    <div class="fill" style="--fill: {fill}">
+      <span class="ember" aria-hidden="true"></span>
+    </div>
+  </div>
+  <span class="tier" aria-hidden="true">
+    <span class="temoji">{tier.emoji}</span>{tier.label}
+  </span>
+</div>
+
+<style>
+  .gauge {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .lair {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    height: 14px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    overflow: hidden;
+    /* The lair tint is a contained decorative accent — clearly ember/gem, never the brand
+       violet or the leader's gold. Each tier burrows the fill deeper toward the gem-lit hoard. */
+    --g1: #fdba74;
+    --g2: #fb923c;
+  }
+  .lair.tier-cavern {
+    --g1: #fb923c;
+    --g2: #f43f5e;
+  }
+  .lair.tier-vault {
+    --g1: #f43f5e;
+    --g2: #d946ef;
+  }
+  .lair.tier-hoard {
+    --g1: #d946ef;
+    --g2: #a855f7;
+  }
+  .fill {
+    position: relative;
+    height: 100%;
+    width: 100%;
+    border-radius: 999px;
+    background: linear-gradient(90deg, var(--g1), var(--g2));
+    transform: scaleX(var(--fill, 0));
+    transform-origin: left center;
+    transition: transform 0.45s cubic-bezier(0.22, 0.61, 0.36, 1);
+  }
+  /* A drifting highlight so the bar reads as a glimmering hoard, not a bare progress bar. */
+  .ember {
+    position: absolute;
+    inset: 0;
+    border-radius: 999px;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      color-mix(in srgb, #ffffff 34%, transparent) 45%,
+      transparent 70%
+    );
+    background-size: 220% 100%;
+    animation: drift 2.6s linear infinite;
+  }
+  .tier {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex: none;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--muted);
+    white-space: nowrap;
+  }
+  .temoji {
+    font-size: 0.85rem;
+  }
+  .reduced .fill {
+    transition: none;
+  }
+  .reduced .ember {
+    animation: none;
+    background-position: 0 0;
+  }
+  @keyframes drift {
+    from {
+      background-position: 120% 0;
+    }
+    to {
+      background-position: -120% 0;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .fill {
+      transition: none;
+    }
+    .ember {
+      animation: none;
+    }
+  }
+</style>

--- a/src/lib/games/wyrmspan/WyrmspanEditor.svelte
+++ b/src/lib/games/wyrmspan/WyrmspanEditor.svelte
@@ -2,106 +2,194 @@
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
   import Stepper from '../../components/Stepper.svelte';
+  import HoardGauge from './HoardGauge.svelte';
+  import { leaders } from '../../scoring';
+  import { bumpOnChange, popIn, animateMotion } from '../../motion';
+  import { wyrmspan } from './index';
   import {
+    DRAGON_TIEBREAK,
     activeCategories,
     categoryVP,
+    emptyRow,
     scoreRow,
+    tracksDragons,
     type WyrmspanConfig,
     type WyrmspanInput,
+    type WyrmspanRow,
   } from './logic';
 
   let { input = $bindable(), ctx }: { input: WyrmspanInput; ctx: RoundContext } = $props();
 
-  const config = $derived<Partial<WyrmspanConfig>>({ scoreLeftover: ctx.config.scoreLeftover !== false });
-  const cats = $derived(activeCategories(config));
-
-  const totals = $derived(
-    Object.fromEntries(ctx.players.map((p) => [p.id, scoreRow(input.rows[p.id], config)])) as Record<
-      string,
-      number
-    >,
-  );
-
-  // Provisional leader = the one player strictly ahead (and above zero). Crown Gold is
-  // reserved for the leader/winner, so a tie or an all-zero sheet shows no crown yet.
-  const leaderId = $derived.by(() => {
-    let best = 0;
-    let who: string | null = null;
-    let tie = false;
-    for (const p of ctx.players) {
-      const t = totals[p.id];
-      if (t > best) {
-        best = t;
-        who = p.id;
-        tie = false;
-      } else if (t === best && best > 0) {
-        tie = true;
-      }
-    }
-    return tie ? null : who;
+  const config = $derived<Partial<WyrmspanConfig>>({
+    scoreLeftover: ctx.config.scoreLeftover !== false,
+    trackDragons: ctx.config.trackDragons !== false,
   });
+  const cats = $derived(activeCategories(config));
+  // The big printed-VP totals get a fast numeric field; the +1 token tallies keep the Stepper
+  // nudge; the leftover bundle sits apart with its live "1 VP per 4 → +N" conversion.
+  const pointCats = $derived(cats.filter((c) => c.kind === 'vp'));
+  const tokenCats = $derived(cats.filter((c) => c.kind === 'count'));
+  const leftoverCat = $derived(cats.find((c) => c.kind === 'bundle'));
+  const showDragons = $derived(tracksDragons(config));
 
   let showHelp = $state(false);
+
+  // Keep the draft's shape in sync with the current players, so every field always has a real
+  // number to bind to — even for a player who joined after this scoresheet draft was created.
+  // Mirrors the improved Wingspan/Finspan editors.
+  $effect(() => {
+    if (!input.rows) input.rows = {};
+    const base = emptyRow();
+    for (const p of ctx.players) {
+      const row = input.rows[p.id];
+      if (!row) {
+        input.rows[p.id] = emptyRow();
+        continue;
+      }
+      for (const k of Object.keys(base) as (keyof WyrmspanRow)[]) {
+        if (typeof row[k] !== 'number') row[k] = base[k];
+      }
+    }
+  });
+
+  function total(id: string): number {
+    return scoreRow(input.rows?.[id], config);
+  }
+
+  // Live totals + the app's shared "who's pulled ahead" rule, so the biggest hoard wears the
+  // crown (and only the crown's Gold) — and nobody is crowned at an all-tied-at-zero table.
+  const totals = $derived(Object.fromEntries(ctx.players.map((p) => [p.id, total(p.id)])));
+  const leaderSet = $derived(leaders(totals, ctx.players.map((p) => p.id)));
+  // A genuine dead heat: two or more players share the lead. Time to settle it with dragons.
+  const deadHeat = $derived(leaderSet.size > 1);
+
+  /**
+   * A one-shot "🥚→🐉 hatch!" bubble that floats up when a player's egg count ticks up — the
+   * hoard's most satisfying tally (an egg cracks into a wyrmling). Motion-only decoration, so
+   * under reduced motion {@link animateMotion} resolves instantly and the bubble is removed with
+   * no movement. Mirrors Wingspan's egg-hatch and Finspan's school-forms beats.
+   */
+  function eggHatch(node: HTMLElement, value: number | undefined) {
+    let prev = Number(value) || 0;
+    return {
+      update(next: number | undefined) {
+        const v = Number(next) || 0;
+        if (v > prev) {
+          const b = document.createElement('span');
+          b.className = 'burst';
+          b.textContent = '🥚→🐉';
+          b.setAttribute('aria-hidden', 'true');
+          node.appendChild(b);
+          animateMotion(
+            b,
+            { opacity: [0, 1, 0], transform: ['translateY(2px)', 'translateY(-14px)', 'translateY(-28px)'] },
+            { duration: 0.7, ease: 'easeOut' },
+          ).finished.finally(() => b.remove());
+        }
+        prev = v;
+      },
+    };
+  }
 </script>
 
 <div class="stack">
   <div class="row spread">
-    <span class="pill">🐉 Final scoresheet</span>
-    <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
-      Categories
+    <span class="pill">Tally the hoard · game end 🐉</span>
+    <button
+      type="button"
+      class="btn small ghost"
+      onclick={() => (showHelp = !showHelp)}
+      aria-expanded={showHelp}
+    >
+      Scoring
     </button>
   </div>
 
   {#if showHelp}
-    <pre class="help">{cats.map((c) => `${c.emoji} ${c.label} — ${c.help}`).join('\n')}</pre>
+    <pre class="help">{wyrmspan.help}</pre>
   {/if}
 
   {#each ctx.players as p (p.id)}
-    {@const row = input.rows[p.id]}
-    {@const lead = leaderId === p.id}
-    <div class="prow">
-      <div class="row spread phead">
-        <span class="row" style="gap: 8px">
-          <Avatar name={p.name} color={p.color} />
-          <strong>{p.name}</strong>
-        </span>
-        <span class="total" class:lead>
-          {#if lead}<span aria-hidden="true">👑</span><span class="sr-only">leading</span>{/if}
-          <span class="num">{totals[p.id]}</span>
-          <span class="unit">VP</span>
-        </span>
-      </div>
+    {@const row = input.rows?.[p.id]}
+    {#if row}
+      {@const isLeader = leaderSet.has(p.id)}
+      <div class="prow" class:leader={isLeader}>
+        <div class="row spread phead">
+          <span class="who">
+            <Avatar name={p.name} color={p.color} />
+            <strong>{p.name}</strong>
+            {#if isLeader}
+              <span class="crown" title="Biggest hoard" aria-hidden="true" use:popIn>👑</span>
+              <span class="sr-only">Biggest hoard</span>
+            {/if}
+          </span>
+          <span class="total" class:lead={isLeader}>
+            <span class="totnum" use:bumpOnChange={total(p.id)}>{total(p.id)}</span><span class="unit"
+              >VP</span
+            >
+          </span>
+        </div>
 
-      <div class="cats">
-        {#each cats as cat (cat.key)}
-          {@const vp = categoryVP(cat, row[cat.key])}
-          <label class="cat">
-            <span class="cat-label">
-              <span class="emoji" aria-hidden="true">{cat.emoji}</span>
-              <span class="cat-name">
-                {cat.short}
-                {#if cat.kind === 'bundle'}
-                  <small class="sub">1 VP per {cat.per} · +{vp}</small>
-                {/if}
-              </span>
-            </span>
-            {#if cat.kind === 'vp'}
+        <HoardGauge total={total(p.id)} />
+
+        <div class="grid">
+          {#each pointCats as c (c.key)}
+            <label class="cell">
+              <span class="clabel"><span class="cemoji" aria-hidden="true">{c.emoji}</span>{c.short}</span>
               <input
-                class="vpinput"
+                class="pts"
                 type="number"
                 min="0"
                 step="1"
                 inputmode="numeric"
-                bind:value={row[cat.key]}
-                aria-label={cat.label}
+                aria-label={`${p.name} ${c.label}`}
+                bind:value={row[c.key]}
               />
-            {:else}
-              <Stepper bind:value={row[cat.key]} min={0} />
-            {/if}
-          </label>
-        {/each}
+            </label>
+          {/each}
+        </div>
+
+        <div class="grid tokens">
+          {#each tokenCats as c (c.key)}
+            <div class="cell" use:eggHatch={c.key === 'eggs' ? row.eggs : undefined}>
+              <span class="clabel"><span class="cemoji" aria-hidden="true">{c.emoji}</span>{c.short}</span>
+              <Stepper bind:value={row[c.key]} min={0} max={999} label={`${p.name} ${c.label}`} />
+            </div>
+          {/each}
+        </div>
+
+        {#if leftoverCat}
+          {@const lc = leftoverCat}
+          <div class="leftover">
+            <div class="cell">
+              <span class="clabel">
+                <span class="cemoji" aria-hidden="true">{lc.emoji}</span>{lc.short}
+              </span>
+              <Stepper bind:value={row[lc.key]} min={0} max={999} label={`${p.name} ${lc.label}`} />
+            </div>
+            <span class="convert">1 VP per {lc.per} · +{categoryVP(lc, row[lc.key])}</span>
+          </div>
+        {/if}
+
+        {#if showDragons}
+          <div class="tiebreak" class:heat={deadHeat && isLeader}>
+            <div class="cell">
+              <span class="clabel">
+                <span class="cemoji" aria-hidden="true">{DRAGON_TIEBREAK.emoji}</span>{DRAGON_TIEBREAK.short}
+              </span>
+              <Stepper bind:value={row.dragonCount} min={0} max={999} label={`${p.name} ${DRAGON_TIEBREAK.label}`} />
+            </div>
+            <span class="tienote">
+              {#if deadHeat && isLeader}
+                🐉 Dead heat — most visible dragons wins
+              {:else}
+                Breaks ties · not scored
+              {/if}
+            </span>
+          </div>
+        {/if}
       </div>
-    </div>
+    {/if}
   {/each}
 </div>
 
@@ -109,95 +197,151 @@
   .prow {
     background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: 12px;
+    border-radius: var(--radius);
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  /* The biggest hoard: a restrained Crown-Gold ring around the leader's card — the crown and
+     gold total already carry the meaning, so the ring stays a whisper, never a gold block. */
+  .prow.leader {
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+    background: color-mix(in srgb, var(--accent) 6%, var(--surface-2));
   }
   .phead {
-    margin-bottom: 8px;
+    margin: 0;
+  }
+  .who {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .who strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .crown {
+    flex: none;
+    font-size: 1rem;
+    line-height: 1;
   }
   .total {
     display: inline-flex;
     align-items: baseline;
     gap: 4px;
-    font-variant-numeric: tabular-nums;
+    flex: none;
     font-weight: 800;
+    font-size: 1.5rem;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
   }
-  .total .num {
-    font-size: 1.15rem;
+  .totnum {
+    font-variant-numeric: tabular-nums;
   }
-  .total .unit {
+  /* Gold reserved for the leader/winner number, per the Crown-Gold rule. */
+  .total.lead {
+    color: var(--accent-ink);
+  }
+  .unit {
     font-size: 0.72rem;
-    font-weight: 700;
+    font-weight: 600;
     color: var(--muted);
   }
-  .total.lead .unit {
-    color: inherit;
+  .grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px 18px;
   }
-  .cats {
+  /* The +1 token tallies sit a touch quieter than the big printed-VP fields above them. */
+  .grid.tokens {
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    border: 1px solid var(--border);
+  }
+  .cell {
+    position: relative;
     display: flex;
     flex-direction: column;
+    gap: 6px;
   }
-  .cat {
-    display: flex;
+  .clabel {
+    display: inline-flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    min-height: 52px;
-    padding: 4px 0;
-    margin: 0;
-    /* override the global block label so rows sit inline */
-    color: var(--text);
-    font-size: 1rem;
+    gap: 5px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--muted);
   }
-  .cat + .cat {
+  .cemoji {
+    font-size: 0.95rem;
+  }
+  .pts {
+    width: 88px;
+    height: 46px;
+    text-align: center;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+  /* The floating "🥚→🐉 hatch" beat. Positioned over its cell; pointer-inert so it never blocks
+     the next tap. Motion-only — animateMotion drops it instantly under reduced motion. */
+  .cell :global(.burst) {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--good);
+    pointer-events: none;
+    white-space: nowrap;
+  }
+  /* The leftover-items step: its own row with a live "→ +N VP" conversion so the 1-per-4
+     bundling is never a mystery. */
+  .leftover {
+    display: flex;
+    align-items: flex-end;
+    gap: 14px;
+    padding-top: 12px;
     border-top: 1px solid var(--border);
   }
-  .cat-label {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    min-width: 0;
-  }
-  .cat-label .emoji {
-    font-size: 1.25rem;
-    line-height: 1;
-    flex: none;
-  }
-  .cat-name {
-    display: flex;
-    flex-direction: column;
-    line-height: 1.2;
-  }
-  .cat-name .sub {
-    font-size: 0.72rem;
+  .convert {
+    font-size: 0.75rem;
     color: var(--muted);
+    padding-bottom: 12px;
     font-variant-numeric: tabular-nums;
   }
-  .vpinput {
-    width: 92px;
-    text-align: center;
-    flex: none;
-    font-variant-numeric: tabular-nums;
+  .tiebreak {
+    display: flex;
+    align-items: flex-end;
+    gap: 14px;
+    padding-top: 12px;
+    border-top: 1px dashed var(--border);
+  }
+  .tienote {
+    font-size: 0.75rem;
+    color: var(--muted);
+    padding-bottom: 12px;
+  }
+  /* When the leaders are actually tied, the dragon count becomes the decider — call it out in
+     words + emoji (never colour alone) on the tied leaders' cards. */
+  .tiebreak.heat .tienote {
+    color: var(--text);
     font-weight: 700;
-    /* hide the native spinners — keyboard + typing is the input here */
-    appearance: textfield;
-    -moz-appearance: textfield;
-  }
-  .vpinput::-webkit-outer-spin-button,
-  .vpinput::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    appearance: none;
-    margin: 0;
   }
   .help {
     white-space: pre-wrap;
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     padding: 12px;
     font-size: 0.85rem;
     margin: 0;
     font-family: inherit;
     color: var(--muted);
+    line-height: 1.5;
   }
 </style>

--- a/src/lib/games/wyrmspan/index.ts
+++ b/src/lib/games/wyrmspan/index.ts
@@ -13,7 +13,10 @@ import {
 export type { WyrmspanConfig, WyrmspanInput, WyrmspanRow } from './logic';
 
 function cfg(config: Record<string, unknown>): Partial<WyrmspanConfig> {
-  return { scoreLeftover: config.scoreLeftover !== false };
+  return {
+    scoreLeftover: config.scoreLeftover !== false,
+    trackDragons: config.trackDragons !== false,
+  };
 }
 
 export const wyrmspan: GameModule = {
@@ -35,6 +38,13 @@ export const wyrmspan: GameModule = {
       type: 'boolean',
       default: true,
       help: 'The final "excess items" step. Coins always score 1 VP each; turn this off to skip counting the odds and ends.',
+    },
+    {
+      key: 'trackDragons',
+      label: 'Track visible dragons (tiebreaker)',
+      type: 'boolean',
+      default: true,
+      help: 'Wyrmspan breaks ties by the most visible dragons on your mat. Capture each player’s dragon count — it settles ties but never adds to the score.',
     },
   ],
 
@@ -68,12 +78,13 @@ export const wyrmspan: GameModule = {
 
   help: [
     'Wyrmspan — the dragon-hoard cousin of Wingspan. One final scoresheet: add up every',
-    'category, and the highest total reigns. 🐉',
+    'category, and the biggest hoard reigns. 🐉',
     '',
-    'Enter each player’s end-game totals:',
+    'Tally each player’s end-game hoard:',
     ...activeCategories({ scoreLeftover: true }).map((c) => `${c.emoji} ${c.label} — ${c.help}`),
     '',
-    'Tiebreaker: most visible dragons on your mat (not tucked). Still tied? Share the crown.',
+    'Tiebreaker: most visible dragons on your mat (not tucked). Tied totals show as co-leaders,',
+    'so settle a dead heat at the table with the dragon count. Still tied? Share the crown. 👑',
   ].join('\n'),
 
   stats: wyrmspanStats,

--- a/src/lib/games/wyrmspan/logic.ts
+++ b/src/lib/games/wyrmspan/logic.ts
@@ -14,6 +14,8 @@ import type { ID } from '../../types';
 export interface WyrmspanConfig {
   /** Include the "leftover items" category (1 VP per 4 spare resources/cards). */
   scoreLeftover: boolean;
+  /** Capture each player's visible dragons to settle ties (default on). Never scores VP. */
+  trackDragons: boolean;
 }
 
 /** One player's final tally — a raw entry per scoring category (never negative). */
@@ -36,6 +38,8 @@ export interface WyrmspanRow {
   coins: number;
   /** Other leftover items (resources + dragon/cave cards) — 1 VP per 4, rounded down. */
   leftover: number;
+  /** Visible dragons on your mat — the tiebreaker only, never added to the score. */
+  dragonCount: number;
 }
 
 export interface WyrmspanInput {
@@ -157,6 +161,27 @@ const BY_KEY: Record<WyrmspanField, WyrmspanCategory> = Object.fromEntries(
   WYRMSPAN_CATEGORIES.map((c) => [c.key, c]),
 ) as Record<WyrmspanField, WyrmspanCategory>;
 
+/**
+ * The visible-dragons tiebreaker — captured on the sheet, shown apart, and never scored.
+ * Wyrmspan breaks a tied total by who has the most *visible* dragons on their mat (tucked
+ * dragons don't count). Mirrors Wingspan's leftover-food tiebreaker so the two siblings share
+ * one interaction model.
+ */
+export const DRAGON_TIEBREAK: WyrmspanCategory = {
+  key: 'dragonCount',
+  label: 'Visible dragons',
+  short: 'Dragons on mat',
+  emoji: '🐉',
+  kind: 'count',
+  per: 1,
+  help: 'Visible dragons on your mat (not tucked) settle ties — the most dragons wins. Never added to the score.',
+};
+
+/** Tiebreaker tracking defaults ON — only an explicit `false` turns the visible-dragons column off. */
+export function tracksDragons(config?: Partial<WyrmspanConfig>): boolean {
+  return config?.trackDragons !== false;
+}
+
 /** A fresh, all-zero tally. */
 export function emptyRow(): WyrmspanRow {
   return {
@@ -169,6 +194,7 @@ export function emptyRow(): WyrmspanRow {
     tucked: 0,
     coins: 0,
     leftover: 0,
+    dragonCount: 0,
   };
 }
 
@@ -221,10 +247,55 @@ export function validateRow(row: WyrmspanRow | undefined, name = 'A player'): st
     const raw = Number(row[cat.key]);
     if (Number.isFinite(raw) && raw < 0) return `${name}: ${cat.label} can't be negative.`;
   }
+  const dragons = Number(row.dragonCount);
+  if (Number.isFinite(dragons) && dragons < 0) return `${name}: ${DRAGON_TIEBREAK.label} can't be negative.`;
   return null;
 }
 
 /** Look a category up by key (handy for the editor + stats). */
 export function category(key: WyrmspanField): WyrmspanCategory {
   return BY_KEY[key];
+}
+
+/**
+ * The dragon's lair, shallow → deep. A running hoard total climbs through these caves as it
+ * grows, giving the tally a sense of place ("you've reached the Treasure Vault") without ever
+ * relying on colour alone — every tier carries an emoji and a label. Wyrmspan's costume
+ * equivalent of Wingspan's habitats and Finspan's depth zones. `min` is the inclusive floor;
+ * tiers are listed richest-last so {@link hoardTier} can scan from the bottom up.
+ */
+export interface HoardTier {
+  key: 'nest' | 'cavern' | 'vault' | 'hoard';
+  label: string;
+  emoji: string;
+  /** Inclusive lower bound, in VP. */
+  min: number;
+}
+
+export const HOARD_TIERS: readonly HoardTier[] = [
+  { key: 'nest', label: 'Nest', emoji: '🥚', min: 0 },
+  { key: 'cavern', label: 'Cavern', emoji: '🪨', min: 40 },
+  { key: 'vault', label: 'Treasure Vault', emoji: '💎', min: 70 },
+  { key: 'hoard', label: "Dragon's Hoard", emoji: '🐲', min: 100 },
+] as const;
+
+/** A legendary hoard — the VP total at which the gauge reads brim-full. */
+export const FULL_HOARD = 130;
+
+/** Which lair tier a running hoard total currently sits in (negatives/NaN clamp to Nest). */
+export function hoardTier(total: number): HoardTier {
+  const n = Number(total);
+  let tier = HOARD_TIERS[0];
+  if (!Number.isFinite(n)) return tier;
+  for (const t of HOARD_TIERS) {
+    if (n >= t.min) tier = t;
+  }
+  return tier;
+}
+
+/** How full the hoard gauge reads, 0–1, for a running total (clamped to {@link FULL_HOARD}). */
+export function hoardFill(total: number): number {
+  const n = Number(total);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return Math.min(1, n / FULL_HOARD);
 }

--- a/src/lib/games/wyrmspan/wyrmspan.test.ts
+++ b/src/lib/games/wyrmspan/wyrmspan.test.ts
@@ -6,10 +6,15 @@ import {
   categoryVP,
   category,
   cleanValue,
+  DRAGON_TIEBREAK,
   emptyRow,
+  FULL_HOARD,
+  hoardFill,
+  hoardTier,
   leftoverEnabled,
   scoreRow,
   scoreWyrmspan,
+  tracksDragons,
   validateRow,
   WYRMSPAN_CATEGORIES,
   type WyrmspanInput,
@@ -33,6 +38,7 @@ const FULL: WyrmspanRow = {
   tucked: 4,
   coins: 5,
   leftover: 11,
+  dragonCount: 6,
 };
 
 describe('wyrmspan categories', () => {
@@ -170,6 +176,64 @@ describe('validateRow', () => {
     expect(err).toContain('Vera');
     expect(err).toContain('Eggs');
   });
+  it('rejects a negative dragon-count tiebreaker', () => {
+    const err = validateRow(row({ dragonCount: -3 }), 'Milo');
+    expect(err).toContain('Milo');
+    expect(err).toContain('Visible dragons');
+  });
+});
+
+describe('visible-dragons tiebreaker', () => {
+  it('emptyRow seeds a zero dragon count', () => {
+    expect(emptyRow().dragonCount).toBe(0);
+  });
+  it('is never added to the score', () => {
+    // Two identical hoards; only the (non-scoring) dragon count differs.
+    expect(scoreRow(row({ dragons: 20, dragonCount: 8 }))).toBe(20);
+    expect(scoreRow(row({ dragons: 20, dragonCount: 0 }))).toBe(20);
+  });
+  it('is not one of the scoring categories', () => {
+    expect(WYRMSPAN_CATEGORIES.map((c) => c.key)).not.toContain('dragonCount');
+    expect(DRAGON_TIEBREAK.key).toBe('dragonCount');
+    expect(DRAGON_TIEBREAK.label.length).toBeGreaterThan(0);
+    expect(DRAGON_TIEBREAK.emoji.length).toBeGreaterThan(0);
+    expect(DRAGON_TIEBREAK.help.length).toBeGreaterThan(0);
+  });
+});
+
+describe('tracksDragons', () => {
+  it('defaults on (missing / empty / explicit true)', () => {
+    expect(tracksDragons(undefined)).toBe(true);
+    expect(tracksDragons({})).toBe(true);
+    expect(tracksDragons({ trackDragons: true })).toBe(true);
+  });
+  it('is off only when explicitly disabled', () => {
+    expect(tracksDragons({ trackDragons: false })).toBe(false);
+  });
+});
+
+describe('hoard lair tiers', () => {
+  it('climbs Nest → Cavern → Treasure Vault → Dragon\u2019s Hoard at the tier floors', () => {
+    expect(hoardTier(0).key).toBe('nest');
+    expect(hoardTier(39).key).toBe('nest');
+    expect(hoardTier(40).key).toBe('cavern');
+    expect(hoardTier(69).key).toBe('cavern');
+    expect(hoardTier(70).key).toBe('vault');
+    expect(hoardTier(99).key).toBe('vault');
+    expect(hoardTier(100).key).toBe('hoard');
+    expect(hoardTier(500).key).toBe('hoard');
+  });
+  it('clamps negatives and junk to the Nest', () => {
+    expect(hoardTier(-10).key).toBe('nest');
+    expect(hoardTier(NaN).key).toBe('nest');
+  });
+  it('fills 0→1, empty at zero and brim-full past a legendary hoard', () => {
+    expect(hoardFill(0)).toBe(0);
+    expect(hoardFill(-5)).toBe(0);
+    expect(hoardFill(FULL_HOARD / 2)).toBeCloseTo(0.5);
+    expect(hoardFill(FULL_HOARD)).toBe(1);
+    expect(hoardFill(FULL_HOARD + 50)).toBe(1);
+  });
 });
 
 // --- The assembled GameModule (index.ts) ---------------------------------------
@@ -216,6 +280,12 @@ describe('wyrmspan module', () => {
 
   it('exposes the leftover variant toggle, defaulting on', () => {
     const toggle = wyrmspan.configFields?.find((f) => f.key === 'scoreLeftover');
+    expect(toggle?.type).toBe('boolean');
+    expect(toggle?.default).toBe(true);
+  });
+
+  it('exposes the track-dragons tiebreaker toggle, defaulting on', () => {
+    const toggle = wyrmspan.configFields?.find((f) => f.key === 'trackDragons');
     expect(toggle?.type).toBe('boolean');
     expect(toggle?.default).toBe(true);
   });


### PR DESCRIPTION
## What & why

Wyrmspan is the **final game** in the 25-game improvement initiative, and it was the plainest of the three end-game category-scoresheet siblings. Wingspan and Finspan were already improved into a rich, shared pattern (running-total gauge, live crown/co-leaders, themed tally burst, surfaced tiebreaker); Wyrmspan had none of it. This PR brings Wyrmspan up to that exact pattern — dressed in a **dragon / hoard / cave** costume — so a player who knows Finspan/Wingspan instantly gets Wyrmspan.

## Changes

**`HoardGauge.svelte` (new)** — a running-total fill bar that burrows the lair as the hoard grows: 🥚 Nest → 🪨 Cavern → 💎 Treasure Vault → 🐲 Dragon's Hoard. A faithful sibling of `FlockGauge`/`OceanGauge`: contained ember/gem tint (never Royal Violet or Crown Gold), emoji + label co-signal (never colour alone), glide/shimmer dropped under reduced motion.

**`WyrmspanEditor.svelte` (rewrite to the sibling pattern)**
- Shared `leaders()` set → co-leaders **both** crowned; restrained Crown-Gold ring + faint wash on the leading card (previously a tie showed *no* crown at all).
- `bumpOnChange` on the live total, `popIn` on the crown.
- Grouped entry: fast numeric fields for the four printed-VP totals, a quieter +1-token stepper panel (eggs/cached/tucked/coins), and the leftover step in its own row with a live **"1 VP per 4 · +N"** conversion.
- **🥚→🐉 hatch** burst floats up when a player's egg count ticks up (motion-only, instant under reduced motion).
- Self-healing draft `$effect` so late-joining players always have a full row; dragon-hoard microcopy; help popover uses the module `help`.

**Visible-dragons tiebreaker** — mirrors Wingspan's food tiebreaker: a new **non-scoring** `dragonCount` column + a `trackDragons` toggle (default on). Surfaces as "Breaks ties · not scored", and on a dead heat lights up **"🐉 Dead heat — most visible dragons wins"** on the tied leaders' cards.

**`logic.ts` stays pure/testable** — `hoardTier`/`hoardFill`/`FULL_HOARD`, `DRAGON_TIEBREAK`, `tracksDragons`, `dragonCount` in `emptyRow` + validation. The tiebreaker is never added to the score.

## Design non-negotiables honored
Crown Gold for leader/winner only · one Royal Violet primary action (lives on the play screen, not the editor) · depth via the surface ramp · `tabular-nums` on every changing number · ≥46px targets · never colour alone · `prefers-reduced-motion` respected · app chrome unchanged (personality via emoji, copy, gauge costume, and the hatch beat).

## Verification (local)
- `npm run check` — 0 errors, 0 warnings
- `npx vitest run` — **1232 passed** (Wyrmspan suite 33 → 43)
- `npm run build` — clean