### PR TITLE
Fix: Blood on the Clocktower editor freeze (infinite reactive loop)

### DIFF
--- a/src/lib/games/botc/BotcEditor.svelte
+++ b/src/lib/games/botc/BotcEditor.svelte
@@ -55,8 +55,14 @@
   let verdictTeam = $state<Team>('good');
 
   // Open each phase with its dusk↔dawn sky (once per editor mount / phase).
+  // Guard on the previous phase so the bump fires only when the phase actually
+  // changes — an unconditional `skyToken += 1` would read-and-write the same
+  // state every run and spin into an infinite effect loop (mirrors Hearts).
+  let prevPhase = -1;
   $effect(() => {
-    ctx.roundIndex;
+    const idx = ctx.roundIndex;
+    if (idx === prevPhase) return;
+    prevPhase = idx;
     skyToken += 1;
   });
 

--- a/src/lib/games/botc/botc.test.ts
+++ b/src/lib/games/botc/botc.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
 import type { Game, ID, Player, Round, RoundContext } from '../../types';
 import {
   aliveCount,
@@ -30,6 +31,7 @@ import {
   type PlayerState,
 } from './logic';
 import { botc } from './index';
+import BotcEditor from './BotcEditor.svelte';
 import { botcStats } from './stats';
 
 const player = (id: string, name = id): Player => ({ id, name, color: '#7c5cff', createdAt: 0 });
@@ -471,3 +473,35 @@ describe('botcStats', () => {
     expect(merged.perPlayer?.['B']?.find((m) => m.key === 'botc_exec')?.value).toBe('1');
   });
 });
+
+// ── Editor render — a live Grimoire must never spin ──────────────────────────
+
+describe('BotcEditor render smoke test', () => {
+  // Regression guard for the freeze from PR #83: the phase-sky `$effect` bumped
+  // its animation token unconditionally on every run, reading and writing the
+  // same reactive state and spinning into `effect_update_depth_exceeded`.
+  // Mounting the real editor and flushing effects would hang (throw) if it
+  // returned. It must settle for both a night and a day phase.
+  function mountPhase(roundIndex: number) {
+    const ids = ['a', 'b', 'c', 'd', 'e'];
+    const inp = input({ states: initialRoster(ids) });
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const comp = mount(BotcEditor, {
+      target,
+      props: { input: inp, ctx: ctxFor(ids, { roundIndex }) },
+    });
+    flushSync();
+    unmount(comp);
+    target.remove();
+  }
+
+  it('mounts a night phase without an infinite reactive loop', () => {
+    expect(() => mountPhase(0)).not.toThrow();
+  });
+
+  it('mounts a day phase without an infinite reactive loop', () => {
+    expect(() => mountPhase(1)).not.toThrow();
+  });
+});
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,9 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 // Kept isolated from vite.config.ts on purpose: no PWA/service-worker build here.
 export default defineConfig({
   plugins: [svelte()],
+  // Resolve the browser build of Svelte so component-mount tests (e.g. editor
+  // smoke tests) run the client runtime instead of the server renderer.
+  resolve: { conditions: ['browser'] },
   test: {
     include: ['src/**/*.{test,spec}.ts'],
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

Blood on the Clocktower (`botc`) froze the tab the moment its editor opened — a regression from #83.

## Root cause

`BotcEditor.svelte` opened each phase with a dusk↔dawn `PhaseSky` overlay driven by an animation token:

```js
$effect(() => {
  ctx.roundIndex;
  skyToken += 1;
});
```

`skyToken += 1` **reads and writes** the same `$state` on every run. That makes the effect depend on `skyToken` while also mutating it, so it re-triggered itself endlessly, throwing `effect_update_depth_exceeded` (Svelte 5 "Maximum update depth exceeded") and pinning the CPU as soon as the editor mounted.

The sibling Hearts editor uses the same one-shot-token idiom correctly: it guards the bump with a previous-value check so the self-write settles after one pass.

## Fix

Guard the bump on the previous phase index so `skyToken` is bumped only when the phase actually changes, breaking the self-dependency while preserving the intended #83 behavior (dusk/dawn PhaseSky on phase change):

```js
let prevPhase = -1;
$effect(() => {
  const idx = ctx.roundIndex;
  if (idx === prevPhase) return;
  prevPhase = idx;
  skyToken += 1;
});
```

No shell restyle; execution toll, verdict reveal, and private role reveal are untouched. Reduced-motion, Crown Gold usage, touch targets and `tabular-nums` are unaffected.

## Regression guard

Added an editor render smoke test (`botc.test.ts`) that mounts the real `BotcEditor` for a night and a day phase and flushes effects — it would throw/hang if the loop returned. Configured vitest to resolve Svelte's browser build so component mounts run the client runtime.

## Verification (local)

- `npm test` → **1234 passed** (48 files)
- `npm run check` → **0 errors, 0 warnings**
- `npm run build` → succeeds

The new smoke test reproduces the freeze before the fix (`effect_update_depth_exceeded`, ~17s hang) and passes after (~0.1s).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>