### PR TITLE
Perf: speed up Blood on the Clocktower editor

### DIFF
--- a/src/lib/games/botc/ExecutionToll.svelte
+++ b/src/lib/games/botc/ExecutionToll.svelte
@@ -12,9 +12,23 @@
   let { token = 0 }: { token?: number } = $props();
 
   const reduced = prefersReducedMotion();
+  // Every glyph animates for 1.1s; unmount just after so no `will-change`
+  // compositor layer lingers to pin the GPU.
+  const LIFE_MS = 1300;
+
+  let playing = $state(false);
+  let seen = 0;
+  $effect(() => {
+    const t = token;
+    if (reduced || t <= 0 || t === seen) return;
+    seen = t;
+    playing = true;
+    const id = setTimeout(() => (playing = false), LIFE_MS);
+    return () => clearTimeout(id);
+  });
 </script>
 
-{#if !reduced && token > 0}
+{#if playing}
   {#key token}
     <div class="toll" aria-hidden="true">
       <div class="wash"></div>

--- a/src/lib/games/botc/PhaseSky.svelte
+++ b/src/lib/games/botc/PhaseSky.svelte
@@ -14,10 +14,30 @@
 
   const reduced = prefersReducedMotion();
   const COUNT = 14;
+  // Longest glyph run: mote delay (≤0.4s) + duration (≤1.6s) plus a small margin.
+  const LIFE_MS = 2100;
+
+  // Play only for the animation's lifetime, then unmount. Leaving the overlay
+  // mounted keeps every mote/orb's `will-change` compositor layer alive forever,
+  // pinning the GPU and making the whole editor sluggish. Resetting to inert
+  // once the run finishes releases those layers. Reduced motion never plays.
+  let playing = $state(false);
+  let seen = 0;
+  $effect(() => {
+    const t = token;
+    if (reduced || t <= 0 || t === seen) return;
+    seen = t;
+    playing = true;
+    const id = setTimeout(() => (playing = false), LIFE_MS);
+    return () => clearTimeout(id);
+  });
 
   // Deterministic pseudo-random seeded by token (mirrors MoonRise / CoinBurst).
+  // Only derived while playing, so an unrelated editor change never rebuilds it.
   const motes = $derived(
-    Array.from({ length: COUNT }, (_, i) => {
+    !playing
+      ? []
+      : Array.from({ length: COUNT }, (_, i) => {
       const rand = (n: number) =>
         (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
       const night = ['✦', '✧', '⋆', '·', '✦'];
@@ -36,7 +56,7 @@
   );
 </script>
 
-{#if !reduced && token > 0}
+{#if playing}
   {#key token}
     <div class="sky-wrap" class:day={kind === 'day'} aria-hidden="true">
       <div class="wash"></div>

--- a/src/lib/games/botc/TownVerdict.svelte
+++ b/src/lib/games/botc/TownVerdict.svelte
@@ -14,9 +14,27 @@
 
   const reduced = prefersReducedMotion();
   const COUNT = 12;
+  // Longest run: spark delay (≤0.48s) + duration (≤1.3s) and the 1.8s evil wash.
+  const LIFE_MS = 2000;
+
+  // Play for the animation's lifetime only, then unmount — otherwise every
+  // spark/orb keeps a `will-change` compositor layer alive forever, pinning the
+  // GPU. Reduced motion never plays.
+  let playing = $state(false);
+  let seen = 0;
+  $effect(() => {
+    const t = token;
+    if (reduced || t <= 0 || t === seen) return;
+    seen = t;
+    playing = true;
+    const id = setTimeout(() => (playing = false), LIFE_MS);
+    return () => clearTimeout(id);
+  });
 
   const sparks = $derived(
-    Array.from({ length: COUNT }, (_, i) => {
+    !playing
+      ? []
+      : Array.from({ length: COUNT }, (_, i) => {
       const rand = (n: number) =>
         (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
       const good = ['✦', '✧', '⋆', '·'];
@@ -36,7 +54,7 @@
   );
 </script>
 
-{#if !reduced && token > 0}
+{#if playing}
   {#key token}
     <div class="verdict" class:evil={team === 'evil'} aria-hidden="true">
       <div class="wash"></div>


### PR DESCRIPTION
## Bottleneck

The Blood on the Clocktower editor (`src/lib/games/botc/`) felt sluggish to interact with — typing, toggling alive/dead, switching phases, recording a winner all felt laggy — even after PR #104 removed the reactive-loop freeze.

The real cost was a **pinned GPU**, not per-keystroke reactivity. The three atmosphere overlays — `PhaseSky`, `ExecutionToll`, and `TownVerdict` — mounted the first time their animation `token` went above `0` and then **stayed in the DOM forever** (`{#if token > 0}` never returns to false; `{#key token}` recreates but never removes). Every animated glyph declares `will-change: transform, opacity`:

- `PhaseSky` — 14 motes + 1 orb
- `TownVerdict` — 12 sparks + 1 orb
- `ExecutionToll` — bell + skull

`will-change` forces the browser to keep a **dedicated compositor layer alive permanently** for each element, even after the finite animation has ended. Because `PhaseSky` fires on mount *and* on every phase change, ~15 permanently-composited layers pinned the GPU from the moment a botc game opened; recording a winner and executions added more. That constant compositor pressure made every interaction feel laggy.

## Fix

Each overlay now tracks an internal `playing` flag:

- Set `true` when `token` changes, and reset to `false` via a `setTimeout` tied to the animation's lifetime (`$effect` with cleanup that clears the timer).
- Glyph arrays (`motes` / `sparks`) are `$derived` **only while playing**, so an unrelated editor change never rebuilds them.
- The overlay **unmounts entirely** once the run finishes, releasing every `will-change` / compositor layer back to the browser.

Reduced motion still renders nothing and does zero derived work. All intended visuals are unchanged: the dusk↔dawn `PhaseSky` on phase change, the execution toll, and the verdict reveal all still play in full.

## Verify (local)

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 1234 passed (48 files)
- `npm run build` — success

No design-system changes: no restyled shell, Crown Gold untouched, reduced-motion honored.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>