### PR TITLE
Cornhole: real 2v2 with a Volleyball-style team builder

### DIFF
--- a/src/lib/games/cornhole/CornholeEditor.svelte
+++ b/src/lib/games/cornhole/CornholeEditor.svelte
@@ -1,62 +1,87 @@
 <script lang="ts">
   import type { RoundContext } from '../../types';
   import Avatar from '../../components/Avatar.svelte';
+  import { PALETTE } from '../../util';
+  import { haptic } from '../../haptics';
   import { bumpOnChange, popIn } from '../../motion';
   import BagTossRow from './BagTossRow.svelte';
   import RaceToTarget from './RaceToTarget.svelte';
+  import { sideDnd } from './drag';
   import {
     BAGS_PER_SIDE,
     bustRisk,
+    cloneTeams,
     type CornholeInput,
+    type CornholeTeam,
     isFourBagger,
+    MAX_PER_SIDE,
+    normalizeInput,
     readConfig,
     scoreCornhole,
     sideRaw,
+    sideTotal,
     tossFlavor,
   } from './logic';
 
   let { input = $bindable(), ctx }: { input: CornholeInput; ctx: RoundContext } = $props();
 
+  // Upgrade a legacy round (player-keyed `sides`, no team lineup) in place the moment it
+  // opens for editing, so binding to teams/throws always has something to write to.
+  $effect(() => {
+    if (!Array.isArray(input.teams) || input.teams.length < 2) {
+      const norm = normalizeInput(input, ctx.players);
+      input.teams = norm.teams;
+      input.throws = norm.throws;
+    }
+  });
+
   const n = $derived(ctx.roundIndex + 1);
   const cfg = $derived(readConfig(ctx.config));
-  const sideNoun = $derived(cfg.format === '2v2' ? 'Team' : 'Side');
-  const ids = $derived(ctx.players.map((p) => p.id) as [string, string]);
-  const outcome = $derived(scoreCornhole([ids[0], ids[1]], input, ctx.totals, cfg));
-  const gainer = $derived(ctx.players.find((p) => p.id === outcome.gainerId) ?? null);
+  const pool = $derived(ctx.players);
+  const playerById = $derived(new Map(pool.map((p) => [p.id, p])));
+
+  const teams = $derived(input.teams ?? []);
+  const throws = $derived(input.throws ?? {});
+  const teamA = $derived(teams[0]);
+  const teamB = $derived(teams[1]);
+
+  const outcome = $derived(scoreCornhole(teams, throws, ctx.totals, cfg));
+  const gainer = $derived(teams.find((t) => t.id === outcome.gainerTeamId) ?? null);
 
   function bag(id: string): { inHole: number; onBoard: number } {
-    return input.sides[id] ?? { inHole: 0, onBoard: 0 };
+    return throws[id] ?? { inHole: 0, onBoard: 0 };
   }
   function raw(id: string): number {
     return sideRaw(bag(id));
   }
-  function totalBefore(id: string): number {
-    return Number(ctx.totals[id]) || 0;
-  }
   function four(id: string): boolean {
     return isFourBagger(bag(id));
   }
+  function teamGain(t: CornholeTeam | undefined): number {
+    const m = t?.memberIds?.[0];
+    return m ? outcome.deltas[m] ?? 0 : 0;
+  }
 
-  // Who's reigning right now (before this frame). A tie has no leader — Crown Gold
-  // only ever marks a side that's actually ahead.
+  // Who's reigning right now (before this frame). A tie has no leader — Crown Gold only
+  // ever marks the side that's actually ahead.
   const leaderId = $derived.by(() => {
-    const [aId, bId] = ids;
-    const ta = totalBefore(aId);
-    const tb = totalBefore(bId);
-    if (ta > tb) return aId;
-    if (tb > ta) return bId;
+    const ta = sideTotal(teamA, ctx.totals);
+    const tb = sideTotal(teamB, ctx.totals);
+    if (ta > tb) return teamA?.id ?? null;
+    if (tb > ta) return teamB?.id ?? null;
     return null;
   });
 
   const lanes = $derived(
-    ctx.players.map((p) => ({
-      id: p.id,
-      name: p.name,
-      color: p.color,
-      total: totalBefore(p.id),
-      gain: outcome.deltas[p.id] ?? 0,
-      isLeader: p.id === leaderId,
-      danger: bustRisk(totalBefore(p.id), cfg),
+    teams.map((t) => ({
+      id: t.id,
+      name: t.name,
+      emoji: t.emoji,
+      color: t.color,
+      total: sideTotal(t, ctx.totals),
+      gain: teamGain(t),
+      isLeader: t.id === leaderId,
+      danger: bustRisk(sideTotal(t, ctx.totals), cfg),
     })),
   );
 
@@ -68,22 +93,69 @@
       bRaw: outcome.bRaw,
       busted: outcome.busted,
       fourBaggerName:
-        four(ids[0]) !== four(ids[1])
-          ? four(ids[0])
-            ? ctx.players[0]!.name
-            : ctx.players[1]!.name
+        teamA && teamB && four(teamA.id) !== four(teamB.id)
+          ? four(teamA.id)
+            ? teamA.name
+            : teamB.name
           : null,
-      bothFourBaggers: four(ids[0]) && four(ids[1]),
+      bothFourBaggers: !!teamA && !!teamB && four(teamA.id) && four(teamB.id),
       seed: ctx.roundIndex,
     }),
   );
 
-  // A stable key for the flavor beat, so the status line re-pops only when the
-  // narrated result actually changes (not on every keystroke of the same result).
+  // A stable key for the flavor beat, so the status line re-pops only when the narrated
+  // result actually changes (not on every keystroke of the same result).
   const flavorKey = $derived(`${flavor.emoji}|${flavor.text}`);
+
+  // ── Team management ────────────────────────────────────────────────────────
+  let managing = $state(false);
+  let selectedMember = $state<string | null>(null);
+
+  const EMOJIS = ['🌽', '🎒', '🏆', '🔥', '⚡', '💥', '🦅', '🐺', '🦁', '🐝', '🚜', '🍺', '🌭', '⭐', '🎯', '👑'];
+
+  function commit(next: CornholeTeam[]) {
+    input.teams = next;
+  }
+  function updateTeam(id: string, patch: Partial<CornholeTeam>) {
+    commit(teams.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+  }
+  function cycleEmoji(t: CornholeTeam) {
+    const i = EMOJIS.indexOf(t.emoji);
+    updateTeam(t.id, { emoji: EMOJIS[(i + 1) % EMOJIS.length] ?? '🌽' });
+  }
+  /** Move a player onto a side, removing them from the other side first. */
+  function moveMember(memberId: string | null, toTeamId: string | null) {
+    if (!memberId || !toTeamId) {
+      selectedMember = null;
+      return;
+    }
+    const next = cloneTeams(teams).map((t) => ({
+      ...t,
+      memberIds: t.memberIds.filter((m) => m !== memberId),
+    }));
+    const dest = next.find((t) => t.id === toTeamId);
+    if (dest) dest.memberIds = [...dest.memberIds, memberId];
+    commit(next);
+    selectedMember = null;
+    haptic('tick');
+  }
+  function toggleSelect(memberId: string) {
+    selectedMember = selectedMember === memberId ? null : memberId;
+  }
+  /** Drop-zone target -> moveMember. Zones report the side's team id. */
+  function onDrop(playerId: string, target: string) {
+    moveMember(playerId, target);
+  }
+  function overCap(t: CornholeTeam): boolean {
+    return t.memberIds.length > MAX_PER_SIDE;
+  }
+
+  const assignedIds = $derived(new Set(teams.flatMap((t) => t.memberIds)));
+  const benchIds = $derived(pool.map((p) => p.id).filter((id) => !assignedIds.has(id)));
+  const selectedName = $derived(selectedMember ? playerById.get(selectedMember)?.name ?? '' : '');
 </script>
 
-<div class="stack">
+<div class="stack" use:sideDnd={{ onMove: onDrop }}>
   <RaceToTarget {lanes} target={cfg.target} />
 
   <div class="showdown" class:wash={!gainer} class:bust={outcome.busted}>
@@ -103,40 +175,141 @@
       <span class="craw" class:beaten={outcome.bRaw < outcome.aRaw} class:tie={outcome.aRaw === outcome.bRaw}>{outcome.bRaw}</span>
       <span class="carrow">→</span>
       {#if gainer}
-        <span class="cnet">{gainer.name} keeps <strong>+{outcome.net}</strong></span>
+        <span class="cnet">{gainer.emoji} {gainer.name} keeps <strong>+{outcome.net}</strong></span>
       {:else}
         <span class="cnet muted">cancels to nothing</span>
       {/if}
     </div>
   </div>
 
-  {#each ctx.players as p, i (p.id)}
+  {#each teams as t, i (t.id)}
     {#if i === 1}<div class="vs" aria-hidden="true">vs</div>{/if}
-    <div class="side" class:scoring={outcome.gainerId === p.id}>
+    <div class="side" class:scoring={outcome.gainerTeamId === t.id} style={`--tc:${t.color}`}>
       <div class="row spread shead">
-        <span class="row who" style="gap: 8px">
-          <Avatar name={p.name} color={p.color} />
+        <span class="row who" style="gap: 10px">
+          <span class="temoji" style={`--tc:${t.color}`} aria-hidden="true">{t.emoji}</span>
           <span class="name">
-            <span class="overline">{sideNoun} {i === 0 ? 'A' : 'B'}</span>
-            <strong>{p.name}</strong>
+            <span class="overline">Side {i === 0 ? 'A' : 'B'}</span>
+            <strong>{t.name}</strong>
+            <span class="roster">
+              {#each t.memberIds as m (m)}
+                {@const p = playerById.get(m)}
+                {#if p}<Avatar name={p.name} color={p.color} size={18} />{/if}
+              {/each}
+            </span>
           </span>
         </span>
         <span class="frame">
-          {#if four(p.id)}
+          {#if four(t.id)}
             <span class="fourbag" use:popIn>💣 Four-bagger!</span>
           {/if}
-          <span class="fpts">🌽 <strong>{raw(p.id)}</strong> pts</span>
+          <span class="fpts">🌽 <strong>{raw(t.id)}</strong> pts</span>
         </span>
       </div>
 
-      <BagTossRow bind:bag={input.sides[p.id]} label={p.name} />
+      {#if input.throws?.[t.id]}
+        <BagTossRow bind:bag={input.throws[t.id]} label={t.name} />
+      {/if}
     </div>
   {/each}
 
-  <p class="hint muted">
-    Tap each bag to place it — <strong>🕳️ Drano</strong> (+3), <strong>🫘 Woody</strong> (+1),
-    or <strong>🌱 Grass</strong> (0). {BAGS_PER_SIDE} bags a side; only the higher side scores the difference.
-  </p>
+  <div class="row spread foot">
+    <p class="hint muted">
+      Tap each bag — <strong>🕳️ Drano</strong> (+3), <strong>🫘 Woody</strong> (+1),
+      <strong>🌱 Grass</strong> (0). {BAGS_PER_SIDE} a side; only the higher side scores the difference.
+    </p>
+    <button type="button" class="linklike" onclick={() => (managing = !managing)} aria-expanded={managing}>
+      {managing ? '✕ Done' : '⚙ Sides'}
+    </button>
+  </div>
+
+  <!-- ── Build the two sides ── -->
+  {#if managing}
+    <div class="manage stack">
+      {#if selectedMember}
+        <div class="movebar" aria-live="polite">
+          <span class="mvlabel">Move <strong>{selectedName}</strong> to</span>
+          <div class="mvtargets">
+            {#each teams as t (t.id)}
+              <button type="button" class="mvbtn" onclick={() => moveMember(selectedMember, t.id)}>
+                <span aria-hidden="true">{t.emoji}</span> {t.name}
+              </button>
+            {/each}
+            <button type="button" class="mvbtn ghost" onclick={() => (selectedMember = null)}>Cancel</button>
+          </div>
+        </div>
+      {:else}
+        <p class="draghint"><span aria-hidden="true">✋</span> Drag players between the two sides — or tap one to pick a side.</p>
+      {/if}
+
+      {#each teams as t, i (t.id)}
+        <div class="tcard" data-drop={t.id} style={`--tc:${t.color}`}>
+          <div class="tcard-head">
+            <button type="button" class="temoji btn-emoji" style={`--tc:${t.color}`} onclick={() => cycleEmoji(t)} aria-label="Change side emoji" title="Tap to change emoji">{t.emoji}</button>
+            <span class="overline side-tag">Side {i === 0 ? 'A' : 'B'}</span>
+            <input class="tnameinput" value={t.name} oninput={(e) => updateTeam(t.id, { name: e.currentTarget.value })} aria-label={`Side ${i === 0 ? 'A' : 'B'} name`} maxlength="24" />
+            <span class="tcount" class:over={overCap(t)}>{t.memberIds.length}/{MAX_PER_SIDE}</span>
+          </div>
+
+          <div class="palette" role="group" aria-label="Side colour">
+            {#each PALETTE as c (c)}
+              <button type="button" class="dot" class:sel={t.color === c} style={`background:${c}`} onclick={() => updateTeam(t.id, { color: c })} aria-label="Set side colour"></button>
+            {/each}
+          </div>
+
+          <div class="chips dropzone">
+            {#each t.memberIds as m (m)}
+              {@const p = playerById.get(m)}
+              {#if p}
+                <button
+                  type="button"
+                  class="chip draggable"
+                  class:sel={selectedMember === m}
+                  data-player-id={m}
+                  data-player-name={p.name}
+                  data-player-color={p.color}
+                  onclick={() => toggleSelect(m)}
+                >
+                  <span class="grip" aria-hidden="true">⠿</span>
+                  <Avatar name={p.name} color={p.color} size={20} />
+                  <span>{p.name}</span>
+                </button>
+              {/if}
+            {/each}
+            {#if t.memberIds.length === 0}
+              <span class="muted xs emptyhint">Drop a player here</span>
+            {/if}
+          </div>
+        </div>
+      {/each}
+
+      {#if benchIds.length}
+        <div class="bench-area">
+          <div class="section-lbl">🪑 Not on a side yet — everyone must play</div>
+          <div class="chips">
+            {#each benchIds as m (m)}
+              {@const p = playerById.get(m)}
+              {#if p}
+                <button
+                  type="button"
+                  class="chip draggable"
+                  class:sel={selectedMember === m}
+                  data-player-id={m}
+                  data-player-name={p.name}
+                  data-player-color={p.color}
+                  onclick={() => toggleSelect(m)}
+                >
+                  <span class="grip" aria-hidden="true">⠿</span>
+                  <Avatar name={p.name} color={p.color} size={20} />
+                  <span>{p.name}</span>
+                </button>
+              {/if}
+            {/each}
+          </div>
+        </div>
+      {/if}
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -281,5 +454,243 @@
     font-size: 0.8rem;
     margin: 2px 2px 0;
     line-height: 1.5;
+  }
+
+  /* ── Side header team badge (mirrors the lane emoji) ── */
+  .temoji {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 999px;
+    font-size: 1.05rem;
+    background: color-mix(in srgb, var(--tc, var(--brand)) 22%, var(--surface-3));
+    border: 1px solid color-mix(in srgb, var(--tc, var(--brand)) 45%, var(--border));
+    flex: none;
+  }
+  .roster {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    margin-top: 3px;
+  }
+
+  /* ── Footer / manage toggle ── */
+  .foot {
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: flex-end;
+  }
+  .foot .hint {
+    flex: 1 1 200px;
+  }
+  .linklike {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--fg);
+    font-weight: 700;
+    font-size: 0.82rem;
+    padding: 9px 12px;
+    min-height: 46px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .linklike[aria-expanded='true'] {
+    background: var(--surface-3);
+  }
+
+  /* ── Team builder ── mirrors the volleyball roster idiom. */
+  .manage {
+    padding: 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .draghint {
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--muted);
+  }
+  .movebar {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
+  .mvlabel {
+    font-size: 0.85rem;
+  }
+  .mvtargets {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .mvbtn {
+    min-height: 46px;
+    padding: 8px 14px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--fg);
+    font-weight: 700;
+    cursor: pointer;
+  }
+  .mvbtn.ghost {
+    color: var(--muted);
+  }
+
+  .tcard {
+    padding: 12px;
+    background: var(--surface);
+    border: 1px solid color-mix(in srgb, var(--tc, var(--brand)) 40%, var(--border));
+    border-radius: var(--radius);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .tcard.drop-hot {
+    border-color: var(--tc, var(--brand));
+    background: color-mix(in srgb, var(--tc, var(--brand)) 12%, var(--surface));
+  }
+  .tcard-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .btn-emoji {
+    cursor: pointer;
+  }
+  .side-tag {
+    flex: none;
+  }
+  .tnameinput {
+    flex: 1 1 120px;
+    min-width: 100px;
+    min-height: 46px;
+    padding: 8px 10px;
+    font-weight: 800;
+    font-size: 0.95rem;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--fg);
+  }
+  .tcount {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    font-size: 0.8rem;
+    color: var(--muted);
+    flex: none;
+  }
+  .tcount.over {
+    color: var(--bad);
+  }
+  .palette {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .dot {
+    width: 26px;
+    height: 26px;
+    border-radius: 999px;
+    border: 2px solid transparent;
+    cursor: pointer;
+    padding: 0;
+  }
+  .dot.sel {
+    border-color: var(--fg);
+    box-shadow: 0 0 0 2px var(--surface);
+  }
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .dropzone {
+    min-height: 52px;
+    padding: 8px;
+    border: 1px dashed var(--border);
+    border-radius: var(--radius-sm);
+    align-content: flex-start;
+    align-items: center;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 6px 12px 6px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: var(--fg);
+    font-weight: 700;
+    font-size: 0.88rem;
+    cursor: grab;
+    touch-action: none;
+  }
+  .chip.sel {
+    border-color: var(--brand);
+    background: color-mix(in srgb, var(--brand) 16%, var(--surface-2));
+  }
+  .grip {
+    color: var(--muted);
+    font-size: 0.9rem;
+    cursor: grab;
+  }
+  .emptyhint {
+    align-self: center;
+  }
+  .xs {
+    font-size: 0.76rem;
+  }
+  .bench-area {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .section-lbl {
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .chip,
+    .tcard {
+      transition: none;
+    }
+    :global(.ch-drag-ghost) {
+      transition: none;
+    }
+  }
+
+  /* Floating drag ghost + grabbing cursor (global — appended to <body>). */
+  :global(.ch-drag-ghost) {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1000;
+    pointer-events: none;
+    padding: 8px 14px;
+    border-radius: 999px;
+    font-weight: 700;
+    font-size: 0.85rem;
+    color: #fff;
+    background: color-mix(in srgb, var(--ghost-color, #7c5cff) 92%, #000);
+    border: 1px solid color-mix(in srgb, #fff 30%, transparent);
+    box-shadow: var(--shadow);
+    transition: transform 0.04s linear;
+  }
+  :global(body.ch-dragging) {
+    cursor: grabbing;
   }
 </style>

--- a/src/lib/games/cornhole/RaceToTarget.svelte
+++ b/src/lib/games/cornhole/RaceToTarget.svelte
@@ -16,6 +16,8 @@
     id: string;
     name: string;
     color: string;
+    /** Optional side emoji — shown instead of an initials avatar for a team side. */
+    emoji?: string;
     total: number;
     /** Projected point change from the frame being entered (may be negative on a bust). */
     gain: number;
@@ -42,7 +44,11 @@
     <div class="lane" class:leader={l.isLeader} class:danger={l.danger}>
       <div class="lhead">
         <span class="who">
-          <Avatar name={l.name} color={l.color} size={22} />
+          {#if l.emoji}
+            <span class="temoji" style={`--tc:${l.color}`} aria-hidden="true">{l.emoji}</span>
+          {:else}
+            <Avatar name={l.name} color={l.color} size={22} />
+          {/if}
           <span class="nm">{l.name}</span>
         </span>
         <span class="score" class:lead={l.isLeader}>
@@ -134,6 +140,20 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  /* Side badge — the team's emoji on a tint of its own colour. Identity reads through
+     the emoji + name, never colour alone. */
+  .temoji {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    flex: none;
+    border-radius: 999px;
+    font-size: 1rem;
+    background: color-mix(in srgb, var(--tc, var(--primary)) 20%, var(--surface-3));
+    border: 1px solid color-mix(in srgb, var(--tc, var(--primary)) 45%, var(--border));
   }
   .score {
     display: inline-flex;

--- a/src/lib/games/cornhole/cornhole.test.ts
+++ b/src/lib/games/cornhole/cornhole.test.ts
@@ -10,42 +10,66 @@ import {
   type BagState,
   type CornholeConfig,
   type CornholeInput,
+  type CornholeTeam,
+  type SideThrow,
   cycleBag,
+  defaultTeams,
   isFourBagger,
   isWon,
+  makeTeam,
+  normalizeInput,
   readConfig,
   scoreCornhole,
   sideRaw,
+  sideTotal,
   slotsFromThrow,
   throwFromSlots,
   tossFlavor,
 } from './logic';
 
-const DEFAULT: CornholeConfig = { target: 21, bust: false, winBy: 1, format: '1v1' };
+const DEFAULT: CornholeConfig = { target: 21, bust: false, winBy: 1 };
 
 function player(id: ID, name: string): Player {
   return { id, name, color: '#7c5cff', createdAt: 0 };
 }
+function throwOf(inHole: number, onBoard: number): SideThrow {
+  return { inHole, onBoard };
+}
+/** Two fixed-id sides for direct-scoring tests (Side A = ta, Side B = tb). */
+function team(id: string, memberIds: string[], name = id): CornholeTeam {
+  return { id, name, emoji: '🌽', color: '#7c5cff', memberIds };
+}
+/** Score two single-member sides — the 1v1 path, keyed the new (team) way. */
+function score1v1(a: [number, number], b: [number, number], totals: Record<ID, number>, cfg = DEFAULT) {
+  const teams = [team('ta', ['a']), team('tb', ['b'])];
+  const throws = { ta: throwOf(a[0], a[1]), tb: throwOf(b[0], b[1]) };
+  return scoreCornhole(teams, throws, totals, cfg);
+}
+
 function ctxOf(
   totals: Record<ID, number>,
   config: Record<string, unknown> = {},
+  players: Player[] = [player('a', 'Aces'), player('b', 'Bombers')],
   roundIndex = 0,
 ): RoundContext {
   return {
     game: {} as Game,
-    players: [player('a', 'Aces'), player('b', 'Bombers')],
+    players,
     config,
     roundIndex,
     totals,
     rounds: [],
   };
 }
-function input(a: [number, number], b: [number, number]): CornholeInput {
+/** A legacy (pre-team-builder) round input, bags keyed by PLAYER id. */
+function legacyInput(a: [number, number], b: [number, number]): CornholeInput {
+  return { sides: { a: throwOf(a[0], a[1]), b: throwOf(b[0], b[1]) } };
+}
+/** A team round input for the two sides A/B with fixed ids. */
+function teamInput(aM: string[], bM: string[], a: [number, number], b: [number, number]): CornholeInput {
   return {
-    sides: {
-      a: { inHole: a[0], onBoard: a[1] },
-      b: { inHole: b[0], onBoard: b[1] },
-    },
+    teams: [team('ta', aM, 'Side A'), team('tb', bM, 'Side B')],
+    throws: { ta: throwOf(a[0], a[1]), tb: throwOf(b[0], b[1]) },
   };
 }
 
@@ -77,17 +101,54 @@ describe('cornhole: cancellation', () => {
   });
 
   it('resolves the canonical example: A 7, B 4 -> A +3, B +0', () => {
-    const out = scoreCornhole(['a', 'b'], input([2, 1], [1, 1]), { a: 0, b: 0 }, DEFAULT);
+    const out = score1v1([2, 1], [1, 1], { a: 0, b: 0 });
     expect(out.deltas).toEqual({ a: 3, b: 0 });
-    expect(out.gainerId).toBe('a');
+    expect(out.gainerTeamId).toBe('ta');
     expect(out.net).toBe(3);
     expect(out.busted).toBe(false);
   });
 
   it('a wash leaves both sides unchanged', () => {
-    const out = scoreCornhole(['a', 'b'], input([1, 0], [1, 0]), { a: 5, b: 5 }, DEFAULT);
+    const out = score1v1([1, 0], [1, 0], { a: 5, b: 5 });
     expect(out.deltas).toEqual({ a: 0, b: 0 });
-    expect(out.gainerId).toBeNull();
+    expect(out.gainerTeamId).toBeNull();
+  });
+});
+
+describe('cornhole: 2v2 teams — cancellation mirrored to both partners', () => {
+  it('the whole winning side banks the identical net; the losing side banks 0', () => {
+    // Side A (a,c) throws 7, Side B (b,d) throws 4 -> A +3, mirrored to a AND c.
+    const teams = [team('ta', ['a', 'c']), team('tb', ['b', 'd'])];
+    const throws = { ta: throwOf(2, 1), tb: throwOf(1, 1) };
+    const out = scoreCornhole(teams, throws, { a: 0, c: 0, b: 0, d: 0 }, DEFAULT);
+    expect(out.gainerTeamId).toBe('ta');
+    expect(out.net).toBe(3);
+    expect(out.deltas).toEqual({ a: 3, c: 3, b: 0, d: 0 });
+  });
+
+  it('a 2v2 scores identically to the same 1v1 frame (net is the same either way)', () => {
+    const solo = score1v1([3, 0], [1, 0], { a: 0, b: 0 });
+    const dubs = scoreCornhole(
+      [team('ta', ['a', 'c']), team('tb', ['b', 'd'])],
+      { ta: throwOf(3, 0), tb: throwOf(1, 0) },
+      { a: 0, c: 0, b: 0, d: 0 },
+      DEFAULT,
+    );
+    expect(solo.net).toBe(dubs.net);
+    expect(dubs.deltas).toEqual({ a: 6, c: 6, b: 0, d: 0 });
+  });
+
+  it('bust pulls the whole scoring side back to 15 together', () => {
+    const bustCfg: CornholeConfig = { ...DEFAULT, bust: true };
+    // Side A partners share a total of 20; a 6-point frame would hit 26 -> bust to 15.
+    const out = scoreCornhole(
+      [team('ta', ['a', 'c']), team('tb', ['b', 'd'])],
+      { ta: throwOf(2, 0), tb: throwOf(0, 0) },
+      { a: 20, c: 20, b: 12, d: 12 },
+      bustCfg,
+    );
+    expect(out.busted).toBe(true);
+    expect(out.deltas).toEqual({ a: -5, c: -5, b: 0, d: 0 });
   });
 });
 
@@ -95,30 +156,27 @@ describe('cornhole: bust variant (reset to 15)', () => {
   const bustCfg: CornholeConfig = { ...DEFAULT, bust: true };
 
   it('overshooting the target drops the scoring side to 15', () => {
-    // A at 20, sinks two bags (6) vs nothing -> would hit 26 -> bust to 15.
-    const out = scoreCornhole(['a', 'b'], input([2, 0], [0, 0]), { a: 20, b: 12 }, bustCfg);
+    const out = score1v1([2, 0], [0, 0], { a: 20, b: 12 }, bustCfg);
     expect(out.busted).toBe(true);
     expect(out.deltas.a).toBe(-5); // 20 -> 15
     expect(20 + out.deltas.a).toBe(15);
   });
 
   it('a bust from below 15 still lands exactly on 15', () => {
-    // A at 14, four-bagger (12) -> 26 -> bust to 15 (net delta +1).
-    const out = scoreCornhole(['a', 'b'], input([4, 0], [0, 0]), { a: 14, b: 3 }, bustCfg);
+    const out = score1v1([4, 0], [0, 0], { a: 14, b: 3 }, bustCfg);
     expect(out.busted).toBe(true);
     expect(out.deltas.a).toBe(1);
     expect(14 + out.deltas.a).toBe(15);
   });
 
   it('landing exactly on the target is a win, never a bust', () => {
-    // A at 18, sinks one bag (3) -> exactly 21.
-    const out = scoreCornhole(['a', 'b'], input([1, 0], [0, 0]), { a: 18, b: 10 }, bustCfg);
+    const out = score1v1([1, 0], [0, 0], { a: 18, b: 10 }, bustCfg);
     expect(out.busted).toBe(false);
     expect(18 + out.deltas.a).toBe(21);
   });
 
   it('with bust off, the side simply sails past the target', () => {
-    const out = scoreCornhole(['a', 'b'], input([2, 0], [0, 0]), { a: 20, b: 12 }, DEFAULT);
+    const out = score1v1([2, 0], [0, 0], { a: 20, b: 12 }, DEFAULT);
     expect(out.busted).toBe(false);
     expect(20 + out.deltas.a).toBe(26);
   });
@@ -138,6 +196,14 @@ describe('cornhole: win detection', () => {
     expect(isWon({ a: 24, b: 12 }, DEFAULT)).toBe(true); // over the top counts (no bust)
   });
 
+  it('reads the two-side race from mirrored 2v2 totals (dedup distinct sides)', () => {
+    // Partners share a side total, so 4 player totals still resolve to two sides.
+    expect(isWon({ a: 21, c: 21, b: 15, d: 15 }, DEFAULT)).toBe(true);
+    expect(isWon({ a: 20, c: 20, b: 19, d: 19 }, DEFAULT)).toBe(false);
+    // A perfectly level 2v2 (one distinct total) is never a win.
+    expect(isWon({ a: 21, c: 21, b: 21, d: 21 }, DEFAULT)).toBe(false);
+  });
+
   it('win-by margin keeps the game alive until the lead is big enough', () => {
     const winBy2: CornholeConfig = { ...DEFAULT, winBy: 2 };
     expect(isWon({ a: 21, b: 20 }, winBy2)).toBe(false);
@@ -153,40 +219,106 @@ describe('cornhole: win detection', () => {
 
 describe('cornhole: config parsing', () => {
   it('fills sensible defaults', () => {
-    expect(readConfig({})).toEqual({ target: 21, bust: false, winBy: 1, format: '1v1' });
+    expect(readConfig({})).toEqual({ target: 21, bust: false, winBy: 1 });
   });
   it('coerces and guards raw values', () => {
-    expect(readConfig({ target: '15', bust: true, winBy: 0, format: '2v2' })).toEqual({
+    expect(readConfig({ target: '15', bust: true, winBy: 0 })).toEqual({
       target: 15,
       bust: true,
       winBy: 1, // clamped up from 0
-      format: '2v2',
     });
-    expect(readConfig({ format: 'nonsense' }).format).toBe('1v1');
+  });
+});
+
+describe('cornhole: team model', () => {
+  it('splits a pool into two even-ish contiguous sides (A gets the extra)', () => {
+    const [a2, b2] = defaultTeams(['a', 'b']);
+    expect(a2!.memberIds).toEqual(['a']);
+    expect(b2!.memberIds).toEqual(['b']);
+    const [a4, b4] = defaultTeams(['a', 'b', 'c', 'd']);
+    expect(a4!.memberIds).toEqual(['a', 'b']);
+    expect(b4!.memberIds).toEqual(['c', 'd']);
+    const [a3, b3] = defaultTeams(['a', 'b', 'c']);
+    expect(a3!.memberIds).toEqual(['a', 'b']);
+    expect(b3!.memberIds).toEqual(['c']);
+  });
+
+  it('brands each side and gives it a stable-shaped identity', () => {
+    const t = makeTeam(0, ['a']);
+    expect(t.name).toBeTruthy();
+    expect(t.emoji).toBeTruthy();
+    expect(t.color).toMatch(/^#/);
+    expect(t.memberIds).toEqual(['a']);
+  });
+
+  it('sideTotal reads a side score off any member (they are mirrored)', () => {
+    const t = team('ta', ['a', 'c']);
+    expect(sideTotal(t, { a: 12, c: 12, b: 3 })).toBe(12);
+    expect(sideTotal(undefined, { a: 1 })).toBe(0);
+  });
+
+  it('normalizeInput passes through a team round untouched', () => {
+    const inp = teamInput(['a', 'c'], ['b', 'd'], [2, 0], [1, 0]);
+    const { teams, throws } = normalizeInput(inp, [player('a', 'A'), player('b', 'B')]);
+    expect(teams.map((t) => t.id)).toEqual(['ta', 'tb']);
+    expect(throws.ta).toEqual({ inHole: 2, onBoard: 0 });
+    expect(throws.tb).toEqual({ inHole: 1, onBoard: 0 });
+  });
+
+  it('normalizeInput upgrades a legacy round into two named single-member sides', () => {
+    const players = [player('a', 'Aces'), player('b', 'Bombers')];
+    const { teams, throws } = normalizeInput(legacyInput([2, 1], [1, 1]), players);
+    expect(teams).toHaveLength(2);
+    expect(teams[0]!.memberIds).toEqual(['a']);
+    expect(teams[1]!.memberIds).toEqual(['b']);
+    expect(teams[0]!.name).toBe('Aces');
+    expect(teams[1]!.name).toBe('Bombers');
+    // Old per-player bags carry across onto each synthesized side.
+    expect(sideRaw(throws[teams[0]!.id])).toBe(7);
+    expect(sideRaw(throws[teams[1]!.id])).toBe(4);
   });
 });
 
 describe('cornhole: module wiring', () => {
-  it('is a two-sided, higher-wins game with the right identity', () => {
+  it('is a two-to-four player, higher-wins team game with the right identity', () => {
     expect(cornhole.id).toBe('cornhole');
     expect(cornhole.minPlayers).toBe(2);
-    expect(cornhole.maxPlayers).toBe(2);
+    expect(cornhole.maxPlayers).toBe(4);
+    expect(cornhole.teams).toBe(true);
     expect(cornhole.lowerIsBetter).toBeFalsy();
   });
 
-  it('seeds an empty throw for each side', () => {
+  it('seeds two sides with an empty throw each', () => {
     const draft = cornhole.createRoundInput(ctxOf({ a: 0, b: 0 })) as CornholeInput;
-    expect(draft.sides.a).toEqual({ inHole: 0, onBoard: 0 });
-    expect(draft.sides.b).toEqual({ inHole: 0, onBoard: 0 });
+    expect(draft.teams).toHaveLength(2);
+    for (const t of draft.teams!) {
+      expect(t.memberIds).toHaveLength(1);
+      expect(draft.throws![t.id]).toEqual({ inHole: 0, onBoard: 0 });
+    }
   });
 
-  it('scoreRound routes through cancellation + config', () => {
-    const deltas = cornhole.scoreRound(input([3, 0], [1, 0]), ctxOf({ a: 0, b: 0 }));
+  it('carries the previous round teams forward for 2v2', () => {
+    const four = [player('a', 'A'), player('b', 'B'), player('c', 'C'), player('d', 'D')];
+    const ctx = ctxOf({ a: 0, b: 0, c: 0, d: 0 }, {}, four);
+    const draft = cornhole.createRoundInput(ctx) as CornholeInput;
+    expect(draft.teams).toHaveLength(2);
+    expect(draft.teams!.flatMap((t) => t.memberIds).sort()).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('scoreRound routes a legacy input through cancellation + config', () => {
+    const deltas = cornhole.scoreRound(legacyInput([3, 0], [1, 0]), ctxOf({ a: 0, b: 0 }));
     expect(deltas).toEqual({ a: 6, b: 0 }); // 9 vs 3 -> A +6
   });
 
+  it('scoreRound routes a 2v2 team input, mirroring the net to partners', () => {
+    const four = [player('a', 'A'), player('b', 'B'), player('c', 'C'), player('d', 'D')];
+    const ctx = ctxOf({ a: 0, b: 0, c: 0, d: 0 }, {}, four);
+    const deltas = cornhole.scoreRound(teamInput(['a', 'c'], ['b', 'd'], [3, 0], [1, 0]), ctx);
+    expect(deltas).toEqual({ a: 6, c: 6, b: 0, d: 0 });
+  });
+
   it('scoreRound honors the bust config from ctx', () => {
-    const deltas = cornhole.scoreRound(input([2, 0], [0, 0]), ctxOf({ a: 20, b: 0 }, { bust: true }));
+    const deltas = cornhole.scoreRound(legacyInput([2, 0], [0, 0]), ctxOf({ a: 20, b: 0 }, { bust: true }));
     expect(20 + deltas.a).toBe(15);
   });
 
@@ -197,17 +329,146 @@ describe('cornhole: module wiring', () => {
 
   it('validateRound rejects more than four bags a side', () => {
     const ctx = ctxOf({ a: 0, b: 0 });
-    expect(cornhole.validateRound(input([3, 2], [0, 0]), ctx)).toMatch(/bags per round/i);
-    expect(cornhole.validateRound(input([-1, 0], [0, 0]), ctx)).toMatch(/negative/i);
-    expect(cornhole.validateRound(input([BAGS_PER_SIDE, 0], [1, 3]), ctx)).toBeNull();
+    expect(cornhole.validateRound(teamInput(['a'], ['b'], [3, 2], [0, 0]), ctx)).toMatch(/bags per round/i);
+    expect(cornhole.validateRound(teamInput(['a'], ['b'], [BAGS_PER_SIDE, 0], [1, 3]), ctx)).toBeNull();
   });
 
-  it('describeRound narrates the cancelled result', () => {
+  it('validateRound enforces the team shape (both sides filled, cap of two, no dupes)', () => {
+    const two = ctxOf({ a: 0, b: 0 });
+    // Empty side (both players stacked on Side A, within the cap).
+    expect(cornhole.validateRound(teamInput(['a', 'b'], [], [0, 0], [0, 0]), two)).toMatch(/at least one player/i);
+
+    const four = [player('a', 'A'), player('b', 'B'), player('c', 'C'), player('d', 'D')];
+    const ctx = ctxOf({ a: 0, b: 0, c: 0, d: 0 }, {}, four);
+    // Over the cap.
+    expect(cornhole.validateRound(teamInput(['a', 'b', 'c'], ['d'], [0, 0], [0, 0]), ctx)).toMatch(/up to 2 players/i);
+    // Unassigned player.
+    expect(cornhole.validateRound(teamInput(['a'], ['b'], [0, 0], [0, 0]), ctx)).toMatch(/isn't on a side/i);
+    // A clean 2v2 passes.
+    expect(cornhole.validateRound(teamInput(['a', 'c'], ['b', 'd'], [0, 0], [0, 0]), ctx)).toBeNull();
+  });
+
+  it('describeRound narrates the cancelled result with the winning side', () => {
     const players = [player('a', 'Aces'), player('b', 'Bombers')];
-    const round = { input: input([2, 1], [1, 1]) } as unknown as Round;
-    expect(cornhole.describeRound!(round, players)).toBe('🌽 Aces +3 · 7–4');
-    const washed = { input: input([1, 0], [1, 0]) } as unknown as Round;
+    const round = { input: teamInput(['a'], ['b'], [2, 1], [1, 1]) } as unknown as Round;
+    expect(cornhole.describeRound!(round, players)).toBe('🌽 🌽 Side A +3 · 7–4');
+    const washed = { input: teamInput(['a'], ['b'], [1, 0], [1, 0]) } as unknown as Round;
     expect(cornhole.describeRound!(washed, players)).toMatch(/Wash/);
+  });
+
+  it('describeRound still narrates a legacy round with the player names', () => {
+    const players = [player('a', 'Aces'), player('b', 'Bombers')];
+    const round = { input: legacyInput([2, 1], [1, 1]) } as unknown as Round;
+    expect(cornhole.describeRound!(round, players)).toBe('🌽 🎒 Aces +3 · 7–4');
+  });
+});
+
+describe('cornhole: tactile bag-slot model', () => {
+  it('expands counts into a positional row — holes, then boards, then ground', () => {
+    expect(slotsFromThrow({ inHole: 2, onBoard: 1 })).toEqual(['hole', 'hole', 'board', 'ground']);
+    expect(slotsFromThrow({ inHole: 0, onBoard: 0 })).toEqual(['ground', 'ground', 'ground', 'ground']);
+    expect(slotsFromThrow({ inHole: 4, onBoard: 0 })).toEqual(['hole', 'hole', 'hole', 'hole']);
+  });
+
+  it('folds a row of slots back into in-hole / on-board counts', () => {
+    expect(throwFromSlots(['hole', 'ground', 'board', 'hole'])).toEqual({ inHole: 2, onBoard: 1 });
+    expect(throwFromSlots(['ground', 'ground', 'ground', 'ground'])).toEqual({ inHole: 0, onBoard: 0 });
+  });
+
+  it('round-trips counts through the slot model', () => {
+    for (const t of [{ inHole: 0, onBoard: 0 }, { inHole: 1, onBoard: 2 }, { inHole: 4, onBoard: 0 }, { inHole: 0, onBoard: 3 }]) {
+      expect(throwFromSlots(slotsFromThrow(t))).toEqual(t);
+    }
+  });
+
+  it('clamps junk counts and never emits more than the row length', () => {
+    expect(slotsFromThrow({ inHole: -3, onBoard: 1 })).toEqual(['board', 'ground', 'ground', 'ground']);
+    expect(slotsFromThrow(undefined)).toEqual(['ground', 'ground', 'ground', 'ground']);
+    expect(slotsFromThrow({ inHole: 9, onBoard: 9 })).toHaveLength(BAGS_PER_SIDE);
+  });
+
+  it('a tap climbs a bag in value and wraps: ground → board → hole → ground', () => {
+    expect(cycleBag('ground')).toBe('board');
+    expect(cycleBag('board')).toBe('hole');
+    expect(cycleBag('hole')).toBe('ground');
+    // Four taps on one bag returns it to where it started.
+    let s: BagState = 'ground';
+    for (let i = 0; i < 3; i++) s = cycleBag(s);
+    expect(s).toBe('ground');
+  });
+
+  it('scores each landing spot: hole 3, board 1, ground 0', () => {
+    expect(bagValue('hole')).toBe(3);
+    expect(bagValue('board')).toBe(1);
+    expect(bagValue('ground')).toBe(0);
+  });
+});
+
+describe('cornhole: four-bagger + bust risk', () => {
+  it('flags a four-bagger only when all four bags are in the hole', () => {
+    expect(isFourBagger({ inHole: 4, onBoard: 0 })).toBe(true);
+    expect(isFourBagger({ inHole: 3, onBoard: 1 })).toBe(false);
+    expect(isFourBagger({ inHole: 0, onBoard: 4 })).toBe(false);
+    expect(isFourBagger(undefined)).toBe(false);
+  });
+
+  it('bust risk lights up only within a big frame of overshooting', () => {
+    const cfg = { target: 21, bust: true };
+    expect(bustRisk(10, cfg)).toBe(true); // 10 + 12 = 22 > 21
+    expect(bustRisk(9, cfg)).toBe(false); // 9 + 12 = 21, not over
+    expect(bustRisk(21, cfg)).toBe(false); // already at the target
+    expect(bustRisk(0, cfg)).toBe(false); // miles away
+  });
+
+  it('bust risk is off without the bust rule or a target above 15', () => {
+    expect(bustRisk(18, { target: 21, bust: false })).toBe(false);
+    expect(bustRisk(14, { target: 15, bust: true })).toBe(false);
+  });
+});
+
+describe('cornhole: toss flavor (pure, deterministic)', () => {
+  const base = { net: 3, aRaw: 7, bRaw: 4, busted: false, fourBaggerName: null, bothFourBaggers: false, seed: 0 };
+
+  it('leads with the bust when a side overcooks it', () => {
+    const f = tossFlavor({ ...base, gainerName: 'Aces', busted: true });
+    expect(f.emoji).toBe('💥');
+    expect(f.tone).toBe('bad');
+    expect(f.text).toMatch(/bust/i);
+  });
+
+  it('celebrates a four-bagger', () => {
+    const f = tossFlavor({ ...base, gainerName: 'Aces', net: 12, fourBaggerName: 'Aces' });
+    expect(f.emoji).toBe('💣');
+    expect(f.tone).toBe('good');
+    expect(f.text).toMatch(/four-bagger/i);
+  });
+
+  it('washes when both sides four-bag', () => {
+    const f = tossFlavor({ ...base, gainerName: null, net: 0, fourBaggerName: null, bothFourBaggers: true });
+    expect(f.emoji).toBe('🧺');
+    expect(f.tone).toBe('muted');
+  });
+
+  it('narrates a plain wash and a total whiff', () => {
+    const wash = tossFlavor({ ...base, gainerName: null, net: 0 });
+    expect(wash.emoji).toBe('🧺');
+    expect(wash.tone).toBe('muted');
+    const whiff = tossFlavor({ ...base, gainerName: null, net: 0, aRaw: 0, bRaw: 0 });
+    expect(whiff.tone).toBe('muted');
+    expect(whiff.text).toMatch(/nothing|whiff/i);
+  });
+
+  it('narrates a normal scoring frame with the gainer and net', () => {
+    const f = tossFlavor({ ...base, gainerName: 'Bombers', net: 2 });
+    expect(f.tone).toBe('good');
+    expect(f.text).toContain('Bombers');
+    expect(f.text).toContain('+2');
+  });
+
+  it('is deterministic for the same inputs', () => {
+    const a = tossFlavor({ ...base, gainerName: 'Aces', net: 5, seed: 3 });
+    const b = tossFlavor({ ...base, gainerName: 'Aces', net: 5, seed: 3 });
+    expect(a).toEqual(b);
   });
 });
 

--- a/src/lib/games/cornhole/drag.ts
+++ b/src/lib/games/cornhole/drag.ts
@@ -1,0 +1,160 @@
+/**
+ * Pointer-based drag-and-drop for the cornhole side builder — works with mouse *and*
+ * touch (native HTML5 DnD is unreliable on touch, so we drive it from pointer events).
+ * Adapted from the volleyball roster DnD; kept gesture-friendly:
+ *
+ *  - A press that never moves past {@link THRESHOLD} is *not* a drag, so the chip's
+ *    native click still fires (that's the accessible tap-to-move path).
+ *  - A real drag moves a floating ghost, highlights the drop zone under the pointer,
+ *    and on release reports `(playerId, target)`. The click that the browser fires
+ *    after the pointer sequence is swallowed so a drop never also selects.
+ *
+ * Drop zones are any element carrying `data-drop="<teamId>"`. Draggable chips carry
+ * `data-player-id="<id>"`. The action is placed once on a container; zones are matched
+ * globally via `elementFromPoint`, so a chip can be dragged onto either side card.
+ */
+
+export interface SideDndParams {
+  /** Called on a successful drop. `target` is a team id. */
+  onMove: (playerId: string, target: string) => void;
+}
+
+const THRESHOLD = 6; // px of travel before a press becomes a drag
+
+export function sideDnd(node: HTMLElement, params: SideDndParams) {
+  let current = params;
+
+  let pointerId: number | null = null;
+  let sourceId: string | null = null;
+  let startX = 0;
+  let startY = 0;
+  let dragging = false;
+  let ghost: HTMLDivElement | null = null;
+  let hotZone: Element | null = null;
+  let suppressClick = false;
+
+  const reduceMotion = () =>
+    typeof window !== 'undefined' &&
+    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
+  function onPointerDown(e: PointerEvent) {
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    const chip = (e.target as Element | null)?.closest('[data-player-id]') as HTMLElement | null;
+    if (!chip || !node.contains(chip)) return;
+    const id = chip.dataset.playerId;
+    if (!id) return;
+
+    sourceId = id;
+    pointerId = e.pointerId;
+    startX = e.clientX;
+    startY = e.clientY;
+    dragging = false;
+
+    window.addEventListener('pointermove', onPointerMove, { passive: false });
+    window.addEventListener('pointerup', onPointerUp);
+    window.addEventListener('pointercancel', onPointerUp);
+  }
+
+  function beginDrag(label: string, color: string) {
+    dragging = true;
+    ghost = document.createElement('div');
+    ghost.className = 'ch-drag-ghost';
+    ghost.textContent = label;
+    ghost.style.setProperty('--ghost-color', color || '#7c5cff');
+    if (reduceMotion()) ghost.style.transition = 'none';
+    document.body.appendChild(ghost);
+    document.body.classList.add('ch-dragging');
+  }
+
+  function moveGhost(x: number, y: number) {
+    if (ghost) ghost.style.transform = `translate(${x}px, ${y}px) translate(-50%, -150%)`;
+  }
+
+  function setHot(zone: Element | null) {
+    if (zone === hotZone) return;
+    hotZone?.classList.remove('drop-hot');
+    hotZone = zone;
+    hotZone?.classList.add('drop-hot');
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (e.pointerId !== pointerId || !sourceId) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+
+    if (!dragging) {
+      if (Math.hypot(dx, dy) < THRESHOLD) return;
+      const chip = node.querySelector<HTMLElement>(`[data-player-id="${cssEscape(sourceId)}"]`);
+      const label = chip?.dataset.playerName || chip?.textContent?.trim() || 'Player';
+      const color = chip?.dataset.playerColor || '';
+      beginDrag(label, color);
+    }
+
+    e.preventDefault(); // stop touch scroll once we're really dragging
+    moveGhost(e.clientX, e.clientY);
+    const under = document.elementFromPoint(e.clientX, e.clientY);
+    setHot(under?.closest('[data-drop]') ?? null);
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (e.pointerId !== pointerId) return;
+    window.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', onPointerUp);
+    window.removeEventListener('pointercancel', onPointerUp);
+
+    const wasDragging = dragging;
+    const src = sourceId;
+    const target = hotZone?.getAttribute('data-drop') ?? null;
+    cleanup();
+
+    if (wasDragging) {
+      // Whether or not it landed on a zone, this pointer sequence was a drag, so
+      // don't let the trailing click select the chip.
+      suppressClick = true;
+      requestAnimationFrame(() => (suppressClick = false));
+      if (src && target) current.onMove(src, target);
+    }
+  }
+
+  function cleanup() {
+    ghost?.remove();
+    ghost = null;
+    setHot(null);
+    document.body.classList.remove('ch-dragging');
+    dragging = false;
+    sourceId = null;
+    pointerId = null;
+  }
+
+  function onClickCapture(e: MouseEvent) {
+    if (suppressClick) {
+      e.stopPropagation();
+      e.preventDefault();
+      suppressClick = false;
+    }
+  }
+
+  node.addEventListener('pointerdown', onPointerDown);
+  node.addEventListener('click', onClickCapture, true);
+
+  return {
+    update(next: SideDndParams) {
+      current = next;
+    },
+    destroy() {
+      node.removeEventListener('pointerdown', onPointerDown);
+      node.removeEventListener('click', onClickCapture, true);
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', onPointerUp);
+      window.removeEventListener('pointercancel', onPointerUp);
+      cleanup();
+    },
+  };
+}
+
+/** Minimal CSS.escape fallback for attribute selectors (ids are uuids, but be safe). */
+function cssEscape(value: string): string {
+  const g = globalThis as unknown as { CSS?: { escape?: (v: string) => string } };
+  if (g.CSS?.escape) return g.CSS.escape(value);
+  return value.replace(/["\\\]]/g, '\\$&');
+}

--- a/src/lib/games/cornhole/index.ts
+++ b/src/lib/games/cornhole/index.ts
@@ -4,17 +4,33 @@ import { cornholeStats } from './stats';
 import {
   BAGS_PER_SIDE,
   cancel,
+  cloneTeams,
   type CornholeInput,
+  type CornholeTeam,
+  defaultTeams,
   emptyThrow,
   isWon,
+  MAX_PER_SIDE,
+  normalizeInput,
   readConfig,
   scoreCornhole,
   sideRaw,
 } from './logic';
 
-/** The two seats are the two sides — first is Side A, second is Side B. */
-function sideIds(ctx: RoundContext): [ID, ID] {
-  return [ctx.players[0]?.id, ctx.players[1]?.id];
+/** Recorded rounds in play order that carry a team lineup. */
+function teamedRounds(ctx: RoundContext): CornholeInput[] {
+  return [...ctx.rounds]
+    .sort((a, b) => a.index - b.index)
+    .map((r) => r.input as CornholeInput)
+    .filter((i): i is CornholeInput => !!i && Array.isArray(i.teams) && i.teams.length >= 2);
+}
+
+/** The two sides for the next round: carry the last round's teams forward, else seed fresh. */
+function carryTeams(ctx: RoundContext): CornholeTeam[] {
+  const rounds = teamedRounds(ctx);
+  const last = rounds[rounds.length - 1];
+  if (last?.teams?.length) return cloneTeams(last.teams);
+  return defaultTeams(ctx.players.map((p) => p.id));
 }
 
 export const cornhole: GameModule = {
@@ -22,64 +38,79 @@ export const cornhole: GameModule = {
   name: 'Cornhole',
   tagline: 'Toss the bags. Cancel & climb to 21.',
   emoji: '🌽',
-  keywords: ['bags', 'bag toss', 'corn toss', 'baggo', 'cornhole', 'tailgate', 'backyard'],
-  // Two sides — 1v1 or 2v2. Each seat is a side, so the board shows two scores to 21.
+  keywords: ['bags', 'bag toss', 'corn toss', 'baggo', 'cornhole', 'tailgate', 'backyard', '2v2', 'doubles', 'teams'],
+  // Two sides, each a team of one or two players — a solo duel (1v1) or partners (2v2).
+  // Build the sides from the player pool; the board shows two scores racing to 21.
   minPlayers: 2,
-  maxPlayers: 2,
+  maxPlayers: 4,
+  teams: true,
   configFields: [
     { key: 'target', label: 'Play to', type: 'number', default: 21, min: 11, max: 51, help: 'First side to reach this wins. Backyard standard is 21.' },
     { key: 'bust', label: 'Bust — overshoot and you drop to 15', type: 'boolean', default: false, help: 'Blow past the target and your side tumbles back to 15. Land it exactly to win.' },
     { key: 'winBy', label: 'Win by', type: 'number', default: 1, min: 1, max: 5, help: 'Margin needed to close it out. 1 = first side to the target takes it.' },
-    {
-      key: 'format',
-      label: 'Sides',
-      type: 'select',
-      default: '1v1',
-      options: [
-        { value: '1v1', label: 'Singles (1v1)' },
-        { value: '2v2', label: 'Doubles (2v2)' },
-      ],
-      help: 'Flavor only — solo duel or partners, it is always two sides racing to the target.',
-    },
   ],
 
-  createRoundInput: (ctx: RoundContext): CornholeInput => ({
-    sides: Object.fromEntries(ctx.players.map((p) => [p.id, emptyThrow()])),
-  }),
+  createRoundInput: (ctx: RoundContext): CornholeInput => {
+    const teams = carryTeams(ctx);
+    const throws = Object.fromEntries(teams.map((t) => [t.id, emptyThrow()]));
+    return { teams, throws };
+  },
 
   validateRound: (input: CornholeInput, ctx: RoundContext): string | null => {
-    if (ctx.players.length !== 2) return 'Cornhole is played by exactly two sides.';
-    for (const p of ctx.players) {
-      const t = input.sides?.[p.id];
-      const inHole = Math.trunc(Number(t?.inHole) || 0);
-      const onBoard = Math.trunc(Number(t?.onBoard) || 0);
-      if (inHole < 0 || onBoard < 0) return `${p.name}: bag counts can't be negative.`;
+    const { teams, throws } = normalizeInput(input, ctx.players);
+    if (teams.length !== 2) return 'Cornhole is played by exactly two sides.';
+
+    const assigned = teams.flatMap((t) => t.memberIds);
+    if (new Set(assigned).size !== assigned.length) return 'A player can only be on one side.';
+
+    const byId = new Map(ctx.players.map((p) => [p.id, p]));
+    for (const [i, t] of teams.entries()) {
+      const label = t.name || `Side ${i === 0 ? 'A' : 'B'}`;
+      if (t.memberIds.length === 0) return `${label} needs at least one player.`;
+      if (t.memberIds.length > MAX_PER_SIDE) return `${label}: up to ${MAX_PER_SIDE} players a side (got ${t.memberIds.length}).`;
+
+      const bag = throws[t.id];
+      const inHole = Math.trunc(Number(bag?.inHole) || 0);
+      const onBoard = Math.trunc(Number(bag?.onBoard) || 0);
+      if (inHole < 0 || onBoard < 0) return `${label}: bag counts can't be negative.`;
       if (inHole + onBoard > BAGS_PER_SIDE) {
-        return `${p.name}: only ${BAGS_PER_SIDE} bags per round (got ${inHole + onBoard}).`;
+        return `${label}: only ${BAGS_PER_SIDE} bags per round (got ${inHole + onBoard}).`;
       }
+    }
+
+    // Every selected player must be on a side (nobody benched — everyone tosses).
+    for (const p of ctx.players) {
+      if (!assigned.includes(p.id)) return `${byId.get(p.id)?.name ?? 'A player'} isn't on a side yet.`;
     }
     return null;
   },
 
-  scoreRound: (input: CornholeInput, ctx: RoundContext): Record<ID, number> =>
-    scoreCornhole(sideIds(ctx), input, ctx.totals, readConfig(ctx.config)).deltas,
+  scoreRound: (input: CornholeInput, ctx: RoundContext): Record<ID, number> => {
+    const { teams, throws } = normalizeInput(input, ctx.players);
+    return scoreCornhole(teams, throws, ctx.totals, readConfig(ctx.config)).deltas;
+  },
 
   isFinished: (totals, { config }) => isWon(totals, readConfig(config)),
 
   describeRound: (round: Round, players: Player[]): string => {
     const input = round.input as CornholeInput;
-    const [a, b] = players;
+    const { teams, throws } = normalizeInput(input, players);
+    const [a, b] = teams;
     if (!a || !b) return '🌽 —';
-    const aRaw = sideRaw(input.sides?.[a.id]);
-    const bRaw = sideRaw(input.sides?.[b.id]);
+    const aRaw = sideRaw(throws[a.id]);
+    const bRaw = sideRaw(throws[b.id]);
     const { gainer, net } = cancel(aRaw, bRaw);
+    const label = (t: CornholeTeam): string => `${t.emoji} ${t.name}`;
     if (!gainer) return `🌽 Wash · ${aRaw}–${bRaw}`;
-    const name = gainer === 'a' ? a.name : b.name;
-    return `🌽 ${name} +${net} · ${aRaw}–${bRaw}`;
+    const win = gainer === 'a' ? a : b;
+    return `🌽 ${label(win)} +${net} · ${aRaw}–${bRaw}`;
   },
 
   help: [
     'Cornhole — cancellation scoring, two sides, first to 21.',
+    '',
+    'Build your two sides from the player pool: a solo duel (1v1) or partners (2v2).',
+    'Give each side a name, emoji and colour, then drag players onto Side A or Side B.',
     '',
     'Each round both sides toss their 4 bags:',
     '• In the hole (a "drano") = 3 points',
@@ -88,7 +119,7 @@ export const cornhole: GameModule = {
     '',
     'The two sides then CANCEL: only the higher side scores, and only the',
     'difference. Side A gets 7, Side B gets 4 → A scores +3, B scores 0. A tie',
-    'is a "wash" — nobody scores.',
+    'is a "wash" — nobody scores. In doubles the whole side banks the net together.',
     '',
     'First side to the target (21 by default) wins. Land it exactly for the',
     'cleanest finish.',

--- a/src/lib/games/cornhole/logic.ts
+++ b/src/lib/games/cornhole/logic.ts
@@ -1,10 +1,14 @@
 import type { ID } from '../../types';
+import { PALETTE, uid } from '../../util';
 
 /**
  * Pure Cornhole scoring — no Svelte, no I/O, fully unit-testable. `index.ts` and the
  * editor import from here so the exact math the game plays is the exact math the tests
- * exercise. Cornhole is a two-SIDE game (1v1 or 2v2); in this app each side is one
- * "player" seat, so the board always shows two scores racing to the target.
+ * exercise. Cornhole is a two-SIDE game: Side A vs Side B, cancellation to a target.
+ * Each side is a *team* of one or two players (1v1 or 2v2) built with the team builder,
+ * so the board always shows two scores racing to the target. The two teammates on a
+ * side share the side's running total, so the generic per-player scoreboard reads the
+ * race correctly (a side's members tie at that side's score).
  */
 
 /** Bag in the hole ("drano" / "cornhole"). */
@@ -26,32 +30,55 @@ export interface SideThrow {
   onBoard: number;
 }
 
-/** A round's input: each side's bags, keyed by that side's player id. */
-export interface CornholeInput {
-  sides: Record<ID, SideThrow>;
+/**
+ * A branded side: an identity (name / emoji / color) plus a roster of member (player)
+ * ids. Cornhole has exactly two — Side A and Side B — each holding one or two players.
+ * Mirrors the Volleyball team model so the two games feel like siblings.
+ */
+export interface CornholeTeam {
+  id: string;
+  name: string;
+  emoji: string;
+  color: string;
+  memberIds: string[];
 }
 
-export type CornholeFormat = '1v1' | '2v2';
+/**
+ * A round's input. New (team-builder) shape carries the two sides as branded teams and
+ * their bags keyed by TEAM id. The legacy `sides` field (bags keyed by PLAYER id, from
+ * before the team builder) is kept read-only so old saved games still describe & stat
+ * correctly and stay editable.
+ */
+export interface CornholeInput {
+  /** The two sides for this round (Side A, Side B) as branded teams. */
+  teams?: CornholeTeam[];
+  /** Each side's bags this round, keyed by TEAM id. */
+  throws?: Record<ID, SideThrow>;
+  /** Legacy: each side's bags keyed by PLAYER id (pre-team-builder). Read-only compat. */
+  sides?: Record<ID, SideThrow>;
+}
 
 /** Normalized, validated config the scorer actually runs on. */
 export interface CornholeConfig {
   target: number;
   bust: boolean;
   winBy: number;
-  format: CornholeFormat;
 }
 
 /** Full result of resolving one round — deltas plus the pieces the UI narrates. */
 export interface RoundOutcome {
-  /** Per-side point deltas to apply this round (the loser/wash side is 0). */
+  /**
+   * Per-PLAYER point deltas to apply this round. The scoring side's net is mirrored to
+   * every member of that side (so teammates share the side total); everyone else is 0.
+   */
   deltas: Record<ID, number>;
-  /** Raw round points for side A (first seat) before cancellation. */
+  /** Raw round points for side A (first team) before cancellation. */
   aRaw: number;
-  /** Raw round points for side B (second seat) before cancellation. */
+  /** Raw round points for side B (second team) before cancellation. */
   bRaw: number;
-  /** The side that scored this round, or null on a wash (tie). */
-  gainerId: ID | null;
-  /** Net points the leader won this round (after cancellation, before bust). */
+  /** The team id that scored this round, or null on a wash (tie). */
+  gainerTeamId: ID | null;
+  /** Net points the leading side won this round (after cancellation, before bust). */
   net: number;
   /** True when the bust rule pulled the scoring side back to {@link BUST_TO}. */
   busted: boolean;
@@ -65,13 +92,95 @@ export function readConfig(config: Record<string, unknown> = {}): CornholeConfig
     target,
     bust: config.bust === true,
     winBy,
-    format: config.format === '2v2' ? '2v2' : '1v1',
   };
 }
 
 /** A fresh, empty throw for one side. */
 export function emptyThrow(): SideThrow {
   return { inHole: 0, onBoard: 0 };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Team model — two branded sides you build from the player pool, mirroring the
+// Volleyball team builder. Cornhole always has exactly two sides; each holds one
+// or two players (1v1 or 2v2). Pure and Svelte-free so the editor and tests agree.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The most players allowed on one side (doubles). */
+export const MAX_PER_SIDE = 2;
+
+/** Whimsical default branding for the two sides, backyard bag-toss flavored. */
+const SIDE_NAMES = ['Bag Slingers', 'Corn Stars'];
+const SIDE_EMOJIS = ['🎒', '🌽'];
+
+/** Build a fresh side with default branding for slot `i` (0 = Side A, 1 = Side B). */
+export function makeTeam(i: number, memberIds: string[] = []): CornholeTeam {
+  return {
+    id: uid(),
+    name: SIDE_NAMES[i % SIDE_NAMES.length] ?? `Side ${String.fromCharCode(65 + i)}`,
+    emoji: SIDE_EMOJIS[i % SIDE_EMOJIS.length] ?? '🌽',
+    color: PALETTE[i % PALETTE.length] ?? '#7c5cff',
+    memberIds: [...memberIds],
+  };
+}
+
+/** A deep-ish clone so a carried-forward roster edit never mutates a past round. */
+export function cloneTeams(teams: CornholeTeam[]): CornholeTeam[] {
+  return teams.map((t) => ({ ...t, memberIds: [...t.memberIds] }));
+}
+
+/**
+ * Seed the two sides from a player pool: split it into two even-ish contiguous
+ * halves (Side A gets the first half). 2 players → 1v1, 4 → 2v2, 3 → 2v1.
+ */
+export function defaultTeams(pool: string[]): CornholeTeam[] {
+  const half = Math.ceil(pool.length / 2);
+  return [makeTeam(0, pool.slice(0, half)), makeTeam(1, pool.slice(half))];
+}
+
+/** A clean throw with clamped, non-negative integer bag counts. */
+function normThrow(t: SideThrow | undefined): SideThrow {
+  return { inHole: bags(t?.inHole), onBoard: bags(t?.onBoard) };
+}
+
+/**
+ * Resolve any round input (new team shape or legacy player-keyed `sides`) into the
+ * canonical `{ teams, throws }` the scorer and editor run on. Legacy rounds become two
+ * single-member sides seeded from the lineup, with their old bags carried across — so
+ * pre-team-builder games stay describable, statable, and editable.
+ */
+export function normalizeInput(
+  input: CornholeInput | undefined,
+  players: { id: string; name?: string }[],
+): { teams: CornholeTeam[]; throws: Record<ID, SideThrow> } {
+  const src = input ?? {};
+
+  if (src.teams && src.teams.length >= 1) {
+    const teams = cloneTeams(src.teams);
+    const throws: Record<ID, SideThrow> = {};
+    for (const t of teams) throws[t.id] = normThrow(src.throws?.[t.id]);
+    return { teams, throws };
+  }
+
+  // Legacy shape: `sides` keyed by player id, each player its own single-member side.
+  // Name each synthesized side after its player so old games still read faithfully.
+  const legacy = src.sides ?? {};
+  const teams = players.map((p, i) => {
+    const t = makeTeam(i, [p.id]);
+    if (p.name) t.name = p.name;
+    return t;
+  });
+  const throws: Record<ID, SideThrow> = {};
+  teams.forEach((t) => {
+    throws[t.id] = normThrow(legacy[t.memberIds[0] ?? '']);
+  });
+  return { teams, throws };
+}
+
+/** A side's current race total — mirrored across its members, so any member reads it. */
+export function sideTotal(team: CornholeTeam | undefined, totals: Record<ID, number>): number {
+  const m = team?.memberIds?.[0];
+  return m ? Number(totals[m]) || 0 : 0;
 }
 
 /** Clamp a bag count to a sane non-negative integer. */
@@ -110,44 +219,55 @@ export function applyBust(
 }
 
 /**
- * Resolve a round for the two sides (in seat order). `totals` are the cumulative
- * scores BEFORE this round, needed so the bust rule can reset the scoring side.
+ * Resolve a round for the two sides (in team order). `totals` are the cumulative
+ * scores BEFORE this round, needed so the bust rule can reset the scoring side. The
+ * scoring side's net is mirrored to every one of its members, so teammates share the
+ * side total and the per-player scoreboard reads the two-side race correctly.
  */
 export function scoreCornhole(
-  ids: [ID, ID],
-  input: CornholeInput,
+  teams: CornholeTeam[],
+  throws: Record<ID, SideThrow>,
   totals: Record<ID, number>,
   cfg: CornholeConfig,
 ): RoundOutcome {
-  const [aId, bId] = ids;
-  const aRaw = sideRaw(input.sides?.[aId]);
-  const bRaw = sideRaw(input.sides?.[bId]);
+  const a = teams[0];
+  const b = teams[1];
+  const aRaw = sideRaw(throws[a?.id ?? '']);
+  const bRaw = sideRaw(throws[b?.id ?? '']);
   const { gainer, net } = cancel(aRaw, bRaw);
 
-  const deltas: Record<ID, number> = { [aId]: 0, [bId]: 0 };
-  let gainerId: ID | null = null;
+  const deltas: Record<ID, number> = {};
+  for (const t of teams) for (const m of t.memberIds) deltas[m] = 0;
+
+  let gainerTeamId: ID | null = null;
   let busted = false;
 
   if (gainer) {
-    gainerId = gainer === 'a' ? aId : bId;
-    const { delta, busted: b } = applyBust(Number(totals[gainerId]) || 0, net, cfg);
-    deltas[gainerId] = delta;
-    busted = b;
+    const win = gainer === 'a' ? a : b;
+    gainerTeamId = win?.id ?? null;
+    const { delta, busted: bt } = applyBust(sideTotal(win, totals), net, cfg);
+    for (const m of win?.memberIds ?? []) deltas[m] = delta;
+    busted = bt;
   }
 
-  return { deltas, aRaw, bRaw, gainerId, net, busted };
+  return { deltas, aRaw, bRaw, gainerTeamId, net, busted };
 }
 
 /**
  * True once a side has won: it has reached the target AND leads by at least `winBy`.
- * With the default `winBy` of 1 this is simply "first side to the target".
+ * With the default `winBy` of 1 this is simply "first side to the target". Operates on
+ * the *distinct* side totals — teammates share a side's total, so 4 mirrored player
+ * totals still resolve to a two-side race, and a level game (one distinct total) is
+ * never a win.
  */
 export function isWon(totals: Record<ID, number>, cfg: CornholeConfig): boolean {
-  const vals = Object.values(totals);
+  const vals = Object.values(totals).map((v) => Number(v) || 0);
   if (vals.length === 0) return false;
-  const sorted = [...vals].sort((x, y) => y - x);
-  const top = sorted[0] ?? 0;
-  const second = sorted.length > 1 ? (sorted[1] ?? 0) : -Infinity;
+  const distinct = [...new Set(vals)].sort((x, y) => y - x);
+  const top = distinct[0] ?? 0;
+  // With a single distinct value the sides are level (lead 0) when more than one side
+  // is present; a lone total (one side only) has no rival, so it stands unopposed.
+  const second = distinct.length > 1 ? distinct[1]! : vals.length > 1 ? top : -Infinity;
   return top >= cfg.target && top - second >= cfg.winBy;
 }
 

--- a/src/lib/games/cornhole/stats.ts
+++ b/src/lib/games/cornhole/stats.ts
@@ -1,7 +1,7 @@
 import type { ID } from '../../types';
 import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
 import { fmtInt, fmtPct } from '../../stats/format';
-import { BAGS_PER_SIDE, type CornholeInput, sideRaw } from './logic';
+import { BAGS_PER_SIDE, type CornholeInput, type SideThrow, sideRaw } from './logic';
 
 interface SideAgg {
   /** Bags sunk in the hole ("dranos"). */
@@ -12,21 +12,27 @@ interface SideAgg {
   fourBaggers: number;
   /** Rounds this side threw in. */
   rounds: number;
+  /** Canonical player ids that made up this side (one for singles, two for doubles). */
+  members: Set<ID>;
 }
 
 /**
  * Cornhole stats from each round's recorded bags. Pure and dependency-free (mirrors the
  * module's own `sideRaw`), so a finished game contributes stats the same way it scores.
- * Every "player" here is a SIDE (1v1 or 2v2), matching how the game is modeled.
+ * A side's bags are credited to every player on that side, so in doubles both partners
+ * carry the side's dranos and four-baggers — matching how the side banks its score. Global
+ * totals count each side once. Legacy rounds (before the team builder) treated each side as
+ * a single player, so their player-keyed `sides` map is read as one-member sides.
  */
 export function cornholeStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
   const gameIds = new Set(games.map((g) => g.id));
-  const per = new Map<ID, SideAgg>();
-  const get = (id: ID): SideAgg => {
-    let a = per.get(id);
+  // Aggregated per SIDE (team). Keyed by team id (new shape) or player id (legacy).
+  const per = new Map<string, SideAgg>();
+  const get = (key: string): SideAgg => {
+    let a = per.get(key);
     if (!a) {
-      a = { inHole: 0, onBoard: 0, fourBaggers: 0, rounds: 0 };
-      per.set(id, a);
+      a = { inHole: 0, onBoard: 0, fourBaggers: 0, rounds: 0, members: new Set() };
+      per.set(key, a);
     }
     return a;
   };
@@ -37,32 +43,65 @@ export function cornholeStats({ games, rounds, canonical }: GameStatsInput): Gam
   for (const r of rounds) {
     if (!gameIds.has(r.gameId)) continue;
     const input = r.input as CornholeInput | undefined;
-    if (!input?.sides) continue;
+    if (!input) continue;
+
+    // Resolve each round into (sideKey, members[], throw) tuples for both shapes.
+    const sides: { key: string; members: ID[]; bag: SideThrow | undefined }[] = [];
+    if (Array.isArray(input.teams) && input.teams.length) {
+      for (const t of input.teams) {
+        sides.push({ key: t.id, members: t.memberIds.map(canonical), bag: input.throws?.[t.id] });
+      }
+    } else if (input.sides) {
+      for (const [pid, bag] of Object.entries(input.sides)) {
+        const id = canonical(pid);
+        sides.push({ key: id, members: [id], bag });
+      }
+    } else {
+      continue;
+    }
 
     const raws: number[] = [];
-    for (const [pid, t] of Object.entries(input.sides)) {
-      const id = canonical(pid);
-      const a = get(id);
-      const inHole = Math.max(0, Math.trunc(Number(t?.inHole) || 0));
-      const onBoard = Math.max(0, Math.trunc(Number(t?.onBoard) || 0));
+    for (const s of sides) {
+      const a = get(s.key);
+      const inHole = Math.max(0, Math.trunc(Number(s.bag?.inHole) || 0));
+      const onBoard = Math.max(0, Math.trunc(Number(s.bag?.onBoard) || 0));
       a.inHole += inHole;
       a.onBoard += onBoard;
       a.rounds += 1;
       if (inHole >= BAGS_PER_SIDE) a.fourBaggers += 1;
-      raws.push(sideRaw(t));
+      for (const m of s.members) a.members.add(m);
+      raws.push(sideRaw(s.bag));
     }
 
     scoredRounds += 1;
     if (raws.length === 2 && raws[0] === raws[1]) washes += 1;
   }
 
-  const perPlayer: Record<ID, Metric[]> = {};
+  // Expand each side's aggregate onto its members for the per-player metrics.
+  const perId = new Map<ID, SideAgg>();
+  const mergeInto = (id: ID, a: SideAgg) => {
+    let m = perId.get(id);
+    if (!m) {
+      m = { inHole: 0, onBoard: 0, fourBaggers: 0, rounds: 0, members: new Set([id]) };
+      perId.set(id, m);
+    }
+    m.inHole += a.inHole;
+    m.onBoard += a.onBoard;
+    m.fourBaggers += a.fourBaggers;
+    m.rounds += a.rounds;
+  };
+
   let totalInHole = 0;
   let totalFourBaggers = 0;
-
-  for (const [id, a] of per) {
+  for (const a of per.values()) {
+    // Global counts each side once (not once per member).
     totalInHole += a.inHole;
     totalFourBaggers += a.fourBaggers;
+    for (const id of a.members) mergeInto(id, a);
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of perId) {
     const metrics: Metric[] = [];
     if (a.inHole) metrics.push({ key: 'ch_hole', label: 'Bags in the hole', value: fmtInt(a.inHole), emoji: '🕳️' });
     if (a.fourBaggers) metrics.push({ key: 'ch_four', label: 'Four-baggers', value: fmtInt(a.fourBaggers), emoji: '💣' });


### PR DESCRIPTION
## What & why

Cornhole could only ever add **two** people — each "side" was a single seat and the 1v1/2v2 `format` config was flavour only. This makes Cornhole play **real 1v1 and 2v2**: add up to four players and assign them to the two sides with a **team builder that mirrors the Volleyball game** (named sides with emoji + colour, drag/tap to assign), while keeping Cornhole's two-side **cancellation-to-target** scoring exactly as it was.

## Approach

Each of the two sides is now a branded **team** of 1–2 players. The scoring math is unchanged — Side A raw vs Side B raw → cancel → the higher side keeps the net → optional bust → win-by to target. The only change is *keying*: throws are keyed by team id, and the winning side's net is **mirrored to every member** so the generic per-player scoreboard reads the two-side race correctly (partners tie at the side's total).

## Changes

- **`logic.ts`** — team-aware `CornholeInput` (`teams` + team-keyed `throws`); team model (`makeTeam` / `cloneTeams` / `defaultTeams`); `normalizeInput` handling new **and** legacy player-keyed shapes; team-keyed `scoreCornhole` mirroring the net to members; dedup-aware `isWon` so mirrored 2v2 totals still resolve a two-side race (a level game is never a win). Dropped the flavour-only `format`.
- **`index.ts`** — `maxPlayers: 4`, `teams: true`, carry the previous round's sides forward (else seed an even split), team-aware `validateRound` (exactly two sides, ≤2 per side, no dupes, everyone assigned, ≤4 bags) / `scoreRound` / `describeRound`, all with a legacy fallback.
- **`CornholeEditor.svelte`** — a "⚙ Sides" builder with two drop-zone cards, **drag-and-drop + tap-to-move** assignment, emoji cycle and colour palette, member avatars, and RaceToTarget lanes per side. Preserves the bag-toss / race-to-21 costume from #86. One primary action, Crown Gold reserved for the leader, sides co-signalled by emoji + name + avatars, ≥46px targets, reduced-motion honoured.
- **`drag.ts`** (new) — pointer-based DnD for the side builder (touch + mouse), adapted from Volleyball.
- **`stats.ts`** — credit a side's bags to each member; legacy fallback.
- **`RaceToTarget.svelte`** — optional team emoji badge.

## Backward compatibility

Stored `round.deltas` already drive historical totals, so past games keep their scores. Legacy in-progress games are upgraded in place by `normalizeInput` (two single-member sides named after the players), so History, Stats and editing never break.

## Testing (local)

- `npm run check` — 0 errors / 0 warnings
- `npm test` — **1262 passing** (66 in Cornhole, incl. 1v1 scores identically to before, 2v2 cancellation + mirrored deltas, team validation, dedup `isWon`, legacy describe/normalize)
- `npm run build` — succeeds
- `npm run dev` — hand-checked adding four players into two sides scoring to 21, plus a 1v1 sanity pass