### PR TITLE
Improve the Hearts game experience

### DIFF
--- a/src/lib/components/ReplicaBoard.svelte
+++ b/src/lib/components/ReplicaBoard.svelte
@@ -277,7 +277,14 @@
             <tr class:flash={r.id === justLandedId}>
               <td>{r.index + 1}</td>
               {#each replica.players as p (p.id)}
-                <td class="num">{fmt(r.deltas[p.id])}</td>
+                {@const cell = gmodule.roundCellTone?.(r, p.id) ?? null}
+                <td
+                  class="num"
+                  class:tone-bad={cell?.tone === 'bad'}
+                  class:tone-good={cell?.tone === 'good'}
+                  class:tone-warn={cell?.tone === 'warn'}
+                  title={cell?.label}
+                >{fmt(r.deltas[p.id])}</td>
               {/each}
             </tr>
           {/each}
@@ -433,6 +440,18 @@
     flex: none;
     font-size: 0.8rem;
     color: var(--muted);
+  }
+  /* Per-round emphasis a game module can request (Hearts flags the Queen-taker),
+     mirroring the host scorecard. The value is the primary signal; hue reinforces
+     it and the cell's title carries the reason for pointer + assistive tech. */
+  .matrix .num.tone-bad {
+    color: var(--bad);
+  }
+  .matrix .num.tone-good {
+    color: var(--good);
+  }
+  .matrix .num.tone-warn {
+    color: var(--warn);
   }
   /* Round-saved pulse on the newest scorecard row — the host shows the same Win-Green
      confirmation (GamePlay), so relay/nearby guests get identical feedback. The row is

--- a/src/lib/games/hearts/HeartsEditor.svelte
+++ b/src/lib/games/hearts/HeartsEditor.svelte
@@ -6,15 +6,20 @@
   import { hearts } from './index';
   import HeartsMeter from './HeartsMeter.svelte';
   import MoonRise from './MoonRise.svelte';
+  import PassRibbon from './PassRibbon.svelte';
   import {
     HEARTS_TOTAL,
+    QUEEN_POINTS,
+    endgameInfo,
     heartsRemaining,
     heartsTotal,
     outcomeFor,
+    passingFor,
     previewDelta,
     readConfig,
     shooter,
     type HeartsInput,
+    type MoonRule,
   } from './logic';
 
   let { input = $bindable(), ctx }: { input: HeartsInput; ctx: RoundContext } = $props();
@@ -23,12 +28,29 @@
   const variantJack = $derived(cfg.variantJack);
   const ids = $derived(ctx.players.map((p) => p.id));
 
+  const pass = $derived(cfg.passing ? passingFor(ctx.roundIndex, ids.length) : null);
+
+  // How close the game is to ending, from the standings going into this hand. The
+  // strip stays hidden early and only surfaces as the finish nears (or a single
+  // hand could trip it), so the shoot-the-moon call gains real stakes late-game.
+  const endgame = $derived(endgameInfo(ctx.totals, ids, ctx.config));
+  const atRiskName = $derived(ctx.players.find((p) => p.id === endgame.atRiskId)?.name ?? '');
+  const showEndgame = $derived(
+    endgame.imminent || endgame.reached || endgame.atRiskTotal >= endgame.end * 0.6,
+  );
+
   const placed = $derived(heartsTotal(input));
   const remaining = $derived(heartsRemaining(input));
+  // The full penalty pool for the meter: hearts placed + the Queen's 13 once she lands.
+  const points = $derived(placed + (input.queen ? QUEEN_POINTS : 0));
   const moon = $derived(shooter(input));
   const moonName = $derived(ctx.players.find((p) => p.id === moon)?.name ?? '');
+  // The shooter's live pick for this round, falling back to the game default.
+  const effMoon = $derived<MoonRule>(
+    input.moonRule === 'subtract' || input.moonRule === 'add26' ? input.moonRule : cfg.moonRule,
+  );
   const swing = $derived(
-    cfg.moonRule === 'subtract' ? `${moonName} takes −26` : 'everyone else takes +26',
+    effMoon === 'subtract' ? `${moonName} takes −26` : 'everyone else takes +26',
   );
 
   const previews = $derived(
@@ -63,7 +85,7 @@
   function setQueen(id: string) {
     const on = input.queen !== id;
     input.queen = on ? id : null;
-    if (on) haptic('tick'); // a small beat of dread as the Lady lands
+    if (on) haptic('tick'); // a small beat of dread as the Queen lands
   }
   function setJack(id: string) {
     input.jack = input.jack === id ? null : id;
@@ -72,24 +94,72 @@
   function takeRest(id: string) {
     if (remaining <= 0) return;
     input.hearts[id] = Math.min(HEARTS_TOTAL, (Number(input.hearts[id]) || 0) + remaining);
+    // "The rest" sweeps up the still-unclaimed ♠Q too; an explicit pick stands.
+    if (input.queen === null) input.queen = id;
     haptic('tick');
   }
   function shootMoon(id: string) {
     for (const p of ctx.players) input.hearts[p.id] = p.id === id ? HEARTS_TOTAL : 0;
     input.queen = id;
+    // Seed the per-round choice from the game default the first time a moon lands.
+    if (input.moonRule !== 'add26' && input.moonRule !== 'subtract') input.moonRule = cfg.moonRule;
+  }
+  function setMoonRule(rule: MoonRule) {
+    input.moonRule = rule;
+    haptic('tick');
+  }
+  // Whether the draft holds anything worth clearing — gates the "Clear hand" reset
+  // so it only appears once you've started entering, never on an untouched round.
+  const dirty = $derived(placed > 0 || input.queen !== null || input.jack !== null);
+  function clearHand() {
+    for (const id of ids) input.hearts[id] = 0;
+    input.queen = null;
+    input.jack = null;
+    input.moonRule = undefined; // drop any per-round moon pick with the rest of the hand
+    haptic('undo'); // a gentle reversal beat — the whole hand goes back to zero
   }
 </script>
 
 <div class="stack sky-stage">
   <MoonRise token={moonToken} />
 
-  <HeartsMeter {placed} moonReady={!!moon} />
+  {#if pass}
+    <PassRibbon info={pass} hand={ctx.roundIndex + 1} />
+  {/if}
+
+  <HeartsMeter {points} moonReady={!!moon} />
+
+  {#if showEndgame}
+    <div class="endgame" class:hot={endgame.imminent || endgame.reached} role="status">
+      <span class="ic" aria-hidden="true"
+        >{endgame.reached ? '🏁' : endgame.imminent ? '⚠️' : '🎯'}</span
+      >
+      <span class="txt">
+        {#if endgame.reached}
+          <strong>{atRiskName} reached {endgame.end}</strong> — this game can finish now.
+        {:else if endgame.imminent}
+          <strong>One hand could end it.</strong>
+          {atRiskName} is at <span class="num">{endgame.atRiskTotal}</span> — just
+          <span class="num">{endgame.toEnd}</span> from the {endgame.end} that ends the game.
+        {:else}
+          Ends at {endgame.end} · {atRiskName} is closest at
+          <span class="num">{endgame.atRiskTotal}</span>
+          <span class="dim">({endgame.toEnd} to go)</span>
+        {/if}
+      </span>
+    </div>
+  {/if}
 
   <div class="row spread wrap">
     <span class="muted hint">Fewer points is better — dodge the ♥ and the ♠Q.</span>
-    <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
-      {showHelp ? 'Hide rules' : 'How to play'}
-    </button>
+    <span class="row" style="gap: 8px">
+      {#if dirty}
+        <button type="button" class="btn small ghost" onclick={clearHand}>Clear hand</button>
+      {/if}
+      <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+        {showHelp ? 'Hide rules' : 'How to play'}
+      </button>
+    </span>
   </div>
 
   {#if showHelp}
@@ -99,7 +169,23 @@
   {#if moon}
     <div class="moon-banner" role="status">
       <span class="ic" aria-hidden="true">🌙</span>
-      <span><strong>{moonName} is shooting the moon!</strong> — {swing}.</span>
+      <div class="moon-body">
+        <span><strong>{moonName} is shooting the moon!</strong> — {swing}.</span>
+        <div class="moon-choice" role="group" aria-label="How this moon scores">
+          <button
+            type="button"
+            class="btn small ghost"
+            aria-pressed={effMoon === 'add26'}
+            onclick={() => setMoonRule('add26')}
+          >Everyone else +26</button>
+          <button
+            type="button"
+            class="btn small ghost"
+            aria-pressed={effMoon === 'subtract'}
+            onclick={() => setMoonRule('subtract')}
+          >{moonName} takes −26</button>
+        </div>
+      </div>
     </div>
   {/if}
 
@@ -135,7 +221,7 @@
           class="btn small ghost grow"
           onclick={() => takeRest(p.id)}
           disabled={remaining <= 0}
-          title="Give every unplaced heart to {p.name}"
+          title="Give every unplaced heart (and the ♠Q if unclaimed) to {p.name}"
         >
           ♥ Took the rest{remaining > 0 ? ` (${remaining})` : ''}
         </button>
@@ -150,7 +236,7 @@
           onclick={() => setQueen(p.id)}
         >
           <span class="glyph">♠Q</span>
-          <span class="sub">the Lady · +13</span>
+          <span class="sub">the Queen · +13</span>
         </button>
         {#if variantJack}
           <button
@@ -172,7 +258,7 @@
           title="{p.name} took all 13 hearts and the ♠Q"
         >
           <span class="glyph">🌙</span>
-          <span class="sub">shoot</span>
+          <span class="sub">Shot the moon</span>
         </button>
       </div>
     </div>
@@ -188,7 +274,7 @@
   }
   .moon-banner {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 10px;
     padding: 10px 12px;
     border: 1px solid var(--primary);
@@ -199,6 +285,64 @@
   .moon-banner .ic {
     font-size: 1.3rem;
     line-height: 1;
+  }
+  .moon-body {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+  }
+  /* The shooter's call: everyone-else +26 vs take −26 yourself. A segmented pair;
+     the active choice reads in Royal Violet as an accent (border + tint + weight),
+     co-signalled by aria-pressed, never colour alone. */
+  .moon-choice {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .moon-choice .btn[aria-pressed='true'] {
+    border-color: var(--primary);
+    color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 14%, transparent);
+    font-weight: 700;
+  }
+  /* Endgame tension: a quiet "the finish is near" line that escalates to caution
+     amber when a single hand could end it. Co-signalled by the 🎯/⚠️/🏁 icon and
+     the bold copy, never hue alone. */
+  .endgame {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: var(--surface-2);
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  .endgame .ic {
+    font-size: 1.05rem;
+    line-height: 1;
+    flex: none;
+  }
+  .endgame .txt strong {
+    color: var(--text);
+  }
+  .endgame .num {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .endgame .dim {
+    font-variant-numeric: tabular-nums;
+  }
+  .endgame.hot {
+    border-color: color-mix(in srgb, var(--warn) 60%, var(--border));
+    background: color-mix(in srgb, var(--warn) 12%, var(--surface-2));
+    color: var(--text);
+  }
+  .endgame.hot .num {
+    color: color-mix(in srgb, var(--warn) 85%, var(--text));
   }
   .prow {
     position: relative;
@@ -270,7 +414,7 @@
     font-weight: 500;
     font-size: 0.72rem;
   }
-  /* The Lady is the bad card — dread reads in semantic coral, never gold. */
+  /* The Queen is the bad card — dread reads in semantic coral, never gold. */
   .toggle.queen.on {
     background: color-mix(in srgb, var(--bad) 20%, var(--surface));
     border-color: var(--bad);

--- a/src/lib/games/hearts/HeartsMeter.svelte
+++ b/src/lib/games/hearts/HeartsMeter.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { HEARTS_TOTAL } from './logic';
+  import { HEARTS_TOTAL, QUEEN_POINTS } from './logic';
 
   /**
    * Hearts' per-game "costume": a slim ribbon at the top of the round editor that
-   * reads the 13 hearts as a waxing moon. As hearts get handed out the moon fills
+   * reads the hand's 26 penalty points as a waxing moon — the 13 hearts (1 pt each)
+   * plus the Queen of Spades (13 pts). As points get handed out the moon fills
    * (🌑 → 🌕); the count and the "left to place" copy carry the real meaning, so
    * the glyph is reinforcement, never the only signal. When one player is holding
    * every heart *and* the Queen, the ribbon flips to its charged "Set for a moon
@@ -11,31 +12,33 @@
    * touches the shared chrome. No animation, so nothing to gate for reduced motion.
    */
   let {
-    placed = 0,
+    points = 0,
     moonReady = false,
-  }: { placed?: number; moonReady?: boolean } = $props();
+  }: { points?: number; moonReady?: boolean } = $props();
 
-  const left = $derived(Math.max(0, HEARTS_TOTAL - placed));
-  const over = $derived(placed > HEARTS_TOTAL);
+  // 26 penalty points ride on every hand: 13 hearts + the 13-point Queen.
+  const TOTAL = HEARTS_TOTAL + QUEEN_POINTS;
+  const left = $derived(Math.max(0, TOTAL - points));
+  const over = $derived(points > TOTAL);
 
-  // Map hearts placed (0..13) onto the eight lunar glyphs, waxing to full.
+  // Map penalty points (0..26) onto the eight lunar glyphs, waxing to full.
   const PHASES = ['🌑', '🌒', '🌒', '🌓', '🌓', '🌔', '🌔', '🌕'];
   const phase = $derived(
-    moonReady || placed >= HEARTS_TOTAL
+    moonReady || points >= TOTAL
       ? '🌕'
-      : PHASES[Math.min(PHASES.length - 1, Math.round((placed / HEARTS_TOTAL) * (PHASES.length - 1)))],
+      : PHASES[Math.min(PHASES.length - 1, Math.round((points / TOTAL) * (PHASES.length - 1)))],
   );
 
-  const pct = $derived(Math.min(100, (placed / HEARTS_TOTAL) * 100));
+  const pct = $derived(Math.min(100, (points / TOTAL) * 100));
 
   const caption = $derived(
     moonReady
       ? 'Set for a moon shot'
       : over
-        ? `${placed - HEARTS_TOTAL} too many hearts`
+        ? `${points - TOTAL} too many points`
         : left === 0
-          ? 'All 13 hearts placed'
-          : `${left} heart${left === 1 ? '' : 's'} left to place`,
+          ? 'All 26 points placed'
+          : `${left} point${left === 1 ? '' : 's'} left to place`,
   );
 </script>
 
@@ -44,7 +47,7 @@
   <div class="body">
     <div class="cap">
       <span class="label">{caption}</span>
-      <span class="count">{placed}/{HEARTS_TOTAL} ♥</span>
+      <span class="count">{points}/{TOTAL} pts</span>
     </div>
     <div class="track" aria-hidden="true">
       <div class="fill" style="transform: scaleX({pct / 100})"></div>

--- a/src/lib/games/hearts/PassRibbon.svelte
+++ b/src/lib/games/hearts/PassRibbon.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import type { PassInfo } from './logic';
+
+  /**
+   * Hearts' pre-deal ritual, worn as a slim costume strip above the round editor:
+   * a reminder of which way the three cards pass this hand (left → right → across →
+   * hold, rotating). Pure flavor + table aid — it never touches scoring. The glyph
+   * co-signals the arrow, but the label and hint carry the real meaning, so it reads
+   * fine for color-blind players and screen readers alike. Static (no animation),
+   * so there's nothing to gate for reduced motion.
+   */
+  let { info, hand }: { info: PassInfo; hand: number } = $props();
+</script>
+
+<div class="pass" class:hold={info.direction === 'hold'}>
+  <span class="badge" aria-hidden="true">{info.glyph}</span>
+  <div class="body">
+    <div class="cap">
+      <span class="label">{info.label}</span>
+      <span class="hand">Hand {hand}</span>
+    </div>
+    <span class="hint">{info.hint}</span>
+  </div>
+</div>
+
+<style>
+  .pass {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+  }
+  .badge {
+    flex: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 10px;
+    background: var(--surface-3);
+    font-size: 1.15rem;
+    line-height: 1;
+  }
+  /* A hold hand keeps its cards — quiet it down so the arrows read as the active state. */
+  .pass.hold .badge {
+    background: var(--surface);
+    color: var(--muted);
+  }
+  .body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .cap {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .label {
+    font-weight: 700;
+    font-size: 0.9rem;
+  }
+  .hand {
+    font-size: 0.75rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+  .hint {
+    font-size: 0.76rem;
+    color: var(--muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/src/lib/games/hearts/hearts.test.ts
+++ b/src/lib/games/hearts/hearts.test.ts
@@ -5,10 +5,13 @@ import {
   HEARTS_TOTAL,
   baseDelta,
   emptyInput,
+  endgameInfo,
   heartsRemaining,
   heartsTotal,
   isFinished,
   outcomeFor,
+  passCycle,
+  passingFor,
   previewDelta,
   readConfig,
   scoreRound,
@@ -35,15 +38,52 @@ function input(
 // ── config ───────────────────────────────────────────────────────────────
 describe('readConfig', () => {
   it('applies defaults', () => {
-    expect(readConfig({})).toEqual({ endScore: 100, variantJack: false, moonRule: 'add26' });
+    expect(readConfig({})).toEqual({
+      endScore: 100,
+      variantJack: false,
+      moonRule: 'add26',
+      passing: true,
+    });
   });
   it('reads overrides and clamps moonRule to a known value', () => {
     expect(readConfig({ endScore: 50, variantJack: true, moonRule: 'subtract' })).toEqual({
       endScore: 50,
       variantJack: true,
       moonRule: 'subtract',
+      passing: true,
     });
     expect(readConfig({ moonRule: 'nonsense' }).moonRule).toBe('add26');
+  });
+  it('treats passing as on unless explicitly disabled', () => {
+    expect(readConfig({}).passing).toBe(true);
+    expect(readConfig({ passing: true }).passing).toBe(true);
+    expect(readConfig({ passing: false }).passing).toBe(false);
+  });
+});
+
+// ── passing ritual ─────────────────────────────────────────────────────────
+describe('passing', () => {
+  it('rotates left → right → across → hold for a four-handed table', () => {
+    expect(passCycle(4)).toEqual(['left', 'right', 'across', 'hold']);
+    expect(passingFor(0, 4).direction).toBe('left');
+    expect(passingFor(1, 4).direction).toBe('right');
+    expect(passingFor(2, 4).direction).toBe('across');
+    expect(passingFor(3, 4).direction).toBe('hold');
+    expect(passingFor(4, 4).direction).toBe('left'); // wraps every 4 hands
+  });
+  it('drops "across" when the table is not four-handed', () => {
+    expect(passCycle(3)).toEqual(['left', 'right', 'hold']);
+    expect(passCycle(5)).toEqual(['left', 'right', 'hold']);
+    expect(passingFor(2, 3).direction).toBe('hold');
+    expect(passingFor(3, 3).direction).toBe('left'); // wraps every 3 hands
+    expect(passingFor(0, 6).direction).toBe('left');
+  });
+  it('carries a glyph, label and a 3-card hint that co-signal the direction', () => {
+    const left = passingFor(0, 4);
+    expect(left.glyph).toBeTruthy();
+    expect(left.label).toMatch(/left/i);
+    expect(left.hint).toMatch(/3 cards/i);
+    expect(passingFor(3, 4).label).toMatch(/hold/i);
   });
 });
 
@@ -75,6 +115,10 @@ describe('validateRound', () => {
   it('flags too many hearts', () => {
     const msg = validateRound(input({ a: 10, b: 5, c: 0, d: 0 }, 'a'), P4, {});
     expect(msg).toMatch(/2 too many/);
+  });
+  it('frames the shortfall against the 26-point hand', () => {
+    const msg = validateRound(input({ a: 5, b: 3, c: 0, d: 0 }, 'a'), P4, {});
+    expect(msg).toMatch(/Must total 26/);
   });
   it('requires the Queen to be assigned', () => {
     const msg = validateRound(input({ a: 13, b: 0, c: 0, d: 0 }, null), P4, {});
@@ -132,6 +176,24 @@ describe('scoreRound', () => {
       d: 26,
     });
   });
+
+  it("a per-round moon pick overrides the game's default rule", () => {
+    const base = input({ a: 13, b: 0, c: 0, d: 0 }, 'a');
+    // Round says "shooter −26" even though the game default is add26.
+    expect(scoreRound({ ...base, moonRule: 'subtract' }, IDS, { moonRule: 'add26' })).toEqual({
+      a: -26,
+      b: 0,
+      c: 0,
+      d: 0,
+    });
+    // …and the reverse: round says add26 over a subtract default.
+    expect(scoreRound({ ...base, moonRule: 'add26' }, IDS, { moonRule: 'subtract' })).toEqual({
+      a: 0,
+      b: 26,
+      c: 26,
+      d: 26,
+    });
+  });
 });
 
 // ── previews & outcomes ────────────────────────────────────────────────────
@@ -160,6 +222,36 @@ describe('isFinished', () => {
     expect(isFinished({ a: 100, b: 40 }, {})).toBe(true);
     expect(isFinished({ a: 99, b: 40 }, {})).toBe(false);
     expect(isFinished({ a: 55, b: 40 }, { endScore: 50 })).toBe(true);
+  });
+});
+
+// ── endgame tension ──────────────────────────────────────────────────────────
+describe('endgameInfo', () => {
+  it('is quiet at the start (nobody near the finish)', () => {
+    const e = endgameInfo({ a: 0, b: 0, c: 0, d: 0 }, IDS, {});
+    expect(e).toMatchObject({ end: 100, atRiskTotal: 0, toEnd: 100, imminent: false, reached: false });
+  });
+  it('flags the highest total as the seat racing to end it', () => {
+    const e = endgameInfo({ a: 40, b: 62, c: 10, d: 0 }, IDS, {});
+    expect(e.atRiskId).toBe('b');
+    expect(e.atRiskTotal).toBe(62);
+    expect(e.toEnd).toBe(38);
+    expect(e.imminent).toBe(false); // 38 is more than one hand away
+  });
+  it('turns imminent once a single hand (≤26) could finish it', () => {
+    expect(endgameInfo({ a: 80, b: 20 }, ['a', 'b'], {}).imminent).toBe(true);
+    expect(endgameInfo({ a: 74, b: 20 }, ['a', 'b'], {}).imminent).toBe(true); // exactly 26 to go
+    expect(endgameInfo({ a: 73, b: 20 }, ['a', 'b'], {}).imminent).toBe(false); // 27 to go
+  });
+  it('reports reached (not imminent) when a seat is already at the end', () => {
+    const e = endgameInfo({ a: 100, b: 20 }, ['a', 'b'], {});
+    expect(e).toMatchObject({ toEnd: 0, reached: true, imminent: false });
+  });
+  it('honors a custom end score and ignores negative totals for the risk seat', () => {
+    expect(endgameInfo({ a: 45, b: 10 }, ['a', 'b'], { endScore: 50 }).toEnd).toBe(5);
+    const e = endgameInfo({ a: -26, b: 5 }, ['a', 'b'], {});
+    expect(e.atRiskId).toBe('b');
+    expect(e.atRiskTotal).toBe(5);
   });
 });
 
@@ -193,10 +285,22 @@ describe('hearts module', () => {
     expect(HEARTS_TOTAL).toBe(13);
   });
 
-  it('describeRound summarizes a moon and an ordinary round', () => {
+  it('describeRound summarizes a moon, a crashed moon, and an ordinary round', () => {
     const moon = { input: input({ a: 13, b: 0, c: 0, d: 0 }, 'a') } as never;
     expect(hearts.describeRound!(moon, P4)).toMatch(/shot the moon/);
+    // Took the Queen and 12 of 13 hearts = 25 points: a moon missed by one card.
+    const crashed = { input: input({ a: 12, b: 1, c: 0, d: 0 }, 'a') } as never;
+    expect(hearts.describeRound!(crashed, P4)).toMatch(/☄️ A crashed a moon — 25/);
     const ordinary = { input: input({ a: 4, b: 4, c: 4, d: 1 }, 'd', 'a') } as never;
-    expect(hearts.describeRound!(ordinary, P4)).toMatch(/♠Q D · ♦J A/);
+    expect(hearts.describeRound!(ordinary, P4)).toMatch(/💔 D \+14 · ♦J A/);
+  });
+
+  it('roundCellTone marks the Queen-taker, but not a moon shooter', () => {
+    const ordinary = { input: input({ a: 4, b: 4, c: 4, d: 1 }, 'a') } as never;
+    expect(hearts.roundCellTone!(ordinary, 'a')).toMatchObject({ tone: 'bad' });
+    expect(hearts.roundCellTone!(ordinary, 'b')).toBeNull();
+    // A moon flips scoring, so the Queen-taker (the shooter) isn't flagged.
+    const moon = { input: input({ a: 13, b: 0, c: 0, d: 0 }, 'a') } as never;
+    expect(hearts.roundCellTone!(moon, 'a')).toBeNull();
   });
 });

--- a/src/lib/games/hearts/index.ts
+++ b/src/lib/games/hearts/index.ts
@@ -2,6 +2,7 @@ import type { GameModule, ID, Round, RoundContext } from '../../types';
 import { RoundEditor } from '../editor';
 import { heartsStats } from './stats';
 import {
+  describeRound as describeHeartsRound,
   emptyInput,
   isFinished as heartsFinished,
   scoreRound as scoreHearts,
@@ -10,7 +11,7 @@ import {
   type HeartsInput,
 } from './logic';
 
-export type { HeartsInput, HeartsConfig, MoonRule } from './logic';
+export type { HeartsInput, HeartsConfig, MoonRule, PassDirection, PassInfo } from './logic';
 
 export const hearts: GameModule = {
   id: 'hearts',
@@ -39,7 +40,14 @@ export const hearts: GameModule = {
         { value: 'add26', label: 'Everyone else +26' },
         { value: 'subtract', label: 'Shooter −26' },
       ],
-      help: 'Take all 13 hearts and the ♠Q to shoot the moon and flip the round on its head.',
+      help: 'Take all 13 hearts and the ♠Q to shoot the moon and flip the round on its head. Sets the default; the shooter can flip it for that round as they enter it.',
+    },
+    {
+      key: 'passing',
+      label: 'Show the passing direction each hand',
+      type: 'boolean',
+      default: true,
+      help: 'Hearts passes 3 cards before each deal — left, right, across, then a hold — rotating every hand. A reminder shows whose way the cards go. Turn off if your group doesn’t pass.',
     },
   ],
 
@@ -54,14 +62,17 @@ export const hearts: GameModule = {
 
   isFinished: (totals, { config }) => heartsFinished(totals, config),
 
-  describeRound: (round: Round, players): string => {
-    const input = round.input as HeartsInput;
-    const name = (id: ID | null) => players.find((p) => p.id === id)?.name ?? '?';
-    const moon = shooter(input);
-    if (moon) return `🌙 ${name(moon)} shot the moon`;
-    const parts: string[] = [`♠Q ${name(input.queen)}`];
-    if (input.jack) parts.push(`♦J ${name(input.jack)}`);
-    return parts.join(' · ');
+  describeRound: (round: Round, players): string =>
+    describeHeartsRound(round.input as HeartsInput, players),
+
+  // Per-round scorecard emphasis: mark whoever ate the Queen in coral (a heavy
+  // hand), but not when they shot the moon — a moon flips the round, so the Queen
+  // is a triumph there, not a penalty. Co-signalled by a title/AT label, and only
+  // the per-round view (deltas) asks for it, never the running totals.
+  roundCellTone: (round: Round, playerId: ID) => {
+    const input = round.input as HeartsInput | undefined;
+    if (!input || shooter(input)) return null;
+    return input.queen === playerId ? { tone: 'bad', label: 'Took the ♠Q (+13)' } : null;
   },
 
   help: [

--- a/src/lib/games/hearts/logic.ts
+++ b/src/lib/games/hearts/logic.ts
@@ -19,6 +19,12 @@ export interface HeartsInput {
   queen: ID | null;
   /** Who took the Jack of Diamonds (♦J, −10) — Omnibus variant only. */
   jack: ID | null;
+  /**
+   * The shooter's pick for how a moon scores *this* round, overriding the game's
+   * default `moonRule`. Only meaningful when someone shot the moon; absent on
+   * ordinary rounds and on games saved before per-round choice existed.
+   */
+  moonRule?: MoonRule;
 }
 
 export type MoonRule = 'add26' | 'subtract';
@@ -27,12 +33,15 @@ export interface HeartsConfig {
   endScore: number;
   variantJack: boolean;
   moonRule: MoonRule;
+  /** Show the rotating pass direction each hand (left → right → across → hold). */
+  passing: boolean;
 }
 
 export const DEFAULT_CONFIG: HeartsConfig = {
   endScore: 100,
   variantJack: false,
   moonRule: 'add26',
+  passing: true,
 };
 
 /** Points in play each round: 13 hearts + the ♠Q. */
@@ -52,7 +61,53 @@ export function readConfig(config: Record<string, unknown> = {}): HeartsConfig {
     endScore: numOr(config.endScore, DEFAULT_CONFIG.endScore),
     variantJack: !!config.variantJack,
     moonRule: moon,
+    // Default on (standard Hearts passes); only an explicit `false` turns it off,
+    // so games saved before this option existed still show the ritual.
+    passing: config.passing !== false,
   };
+}
+
+// ── Passing ritual ───────────────────────────────────────────────────────────
+// Hearts' signature rhythm: before each deal you pass 3 cards, and the direction
+// rotates hand to hand. Purely informational (it never touches scoring) — the app
+// just reminds the table which way the cards go this deal, because everyone forgets.
+
+export type PassDirection = 'left' | 'right' | 'across' | 'hold';
+
+export interface PassInfo {
+  direction: PassDirection;
+  /** A co-signal glyph (never color alone) — an arrow, or a raised hand for a hold. */
+  glyph: string;
+  /** Short label, e.g. "Pass left" / "Hold — no pass". */
+  label: string;
+  /** One-line reminder of who receives your three cards this deal. */
+  hint: string;
+}
+
+const PASS_META: Record<PassDirection, Omit<PassInfo, 'direction'>> = {
+  left: { glyph: '←', label: 'Pass left', hint: 'Pass 3 cards to the player on your left' },
+  right: { glyph: '→', label: 'Pass right', hint: 'Pass 3 cards to the player on your right' },
+  across: { glyph: '↔', label: 'Pass across', hint: 'Pass 3 cards to the player across from you' },
+  hold: { glyph: '✋', label: 'Hold — no pass', hint: 'Keep your hand — no passing this deal' },
+};
+
+/**
+ * The passing cycle for a table of `playerCount`. Four-handed Hearts is the
+ * canonical left → right → across → hold; with any other count "across" has no
+ * clean seat, so we honestly drop it to left → right → hold.
+ */
+export function passCycle(playerCount: number): PassDirection[] {
+  return playerCount === 4
+    ? ['left', 'right', 'across', 'hold']
+    : ['left', 'right', 'hold'];
+}
+
+/** Which way cards pass on a given (0-based) hand, for a given table size. */
+export function passingFor(handIndex: number, playerCount: number): PassInfo {
+  const cycle = passCycle(playerCount);
+  const i = (((handIndex % cycle.length) + cycle.length) % cycle.length) || 0;
+  const direction = cycle[i];
+  return { direction, ...PASS_META[direction] };
 }
 
 /** A fresh, empty round with every player on zero hearts and no cards claimed. */
@@ -118,9 +173,14 @@ export function scoreRound(
   const moon = shooter(input);
   if (!moon) return base;
 
+  // The shooter may flip how the moon scores this round; fall back to the game
+  // default when the round carries no explicit choice.
+  const rule: MoonRule =
+    input.moonRule === 'subtract' || input.moonRule === 'add26' ? input.moonRule : cfg.moonRule;
+
   const out: Record<ID, number> = {};
   for (const id of playerIds) {
-    if (cfg.moonRule === 'subtract') {
+    if (rule === 'subtract') {
       out[id] = id === moon ? -MOON_POINTS : base[id];
     } else {
       out[id] = id === moon ? 0 : base[id] + MOON_POINTS;
@@ -153,8 +213,8 @@ export function validateRound(
   if (total !== HEARTS_TOTAL) {
     const left = HEARTS_TOTAL - total;
     return left > 0
-      ? `${left} more heart${left === 1 ? '' : 's'} to place (hearts must total 13).`
-      : `That's ${-left} too many hearts (they must total 13).`;
+      ? `${left} more heart${left === 1 ? '' : 's'} to assign. Must total 26.`
+      : `That's ${-left} too many heart${-left === 1 ? '' : 's'}. Must total 26.`;
   }
   if (!input.queen) return 'Assign the Queen of Spades (♠Q) to whoever took her.';
   if (cfg.variantJack && !input.jack) {
@@ -174,7 +234,7 @@ export interface Outcome {
 /**
  * A one-glance read of how a player fared this round, for the outcome tag beside
  * their preview. Co-signals with the numeric delta (never color alone): a moon,
- * eating the Lady, a spotless dodge, or an ordinary points haul.
+ * eating the Queen, a spotless dodge, or an ordinary points haul.
  */
 export function outcomeFor(
   input: HeartsInput,
@@ -189,9 +249,56 @@ export function outcomeFor(
       : { kind: 'points', emoji: '☄️', label: 'mooned' };
   }
   const delta = previewDelta(input, id, playerIds, config);
-  if (input.queen === id) return { kind: 'lady', emoji: '💔', label: 'took the Lady' };
+  if (input.queen === id) return { kind: 'lady', emoji: '💔', label: 'took the Queen' };
   if (delta <= 0) return { kind: 'clean', emoji: '😇', label: 'clean' };
   return { kind: 'points', emoji: '♥️', label: `+${delta}` };
+}
+
+// ── Round storytelling ───────────────────────────────────────────────────────
+// The history table remembers each hand as a single, evocative line. Lead with
+// the drama — a moon, or the gut-punch "crashed moon" (went for all 26 and missed
+// by one heart, eating 25) — otherwise name who took the Queen and how heavy their
+// hand landed, with the ♦J noted when the Omnibus variant is in play.
+
+/**
+ * A compact one-liner summarizing a saved round, for the round history. Pure; the
+ * module's `describeRound` just resolves ids to names through this.
+ */
+export function describeRound(
+  input: HeartsInput,
+  players: readonly { id: ID; name: string }[],
+): string {
+  const name = (id: ID | null) => players.find((p) => p.id === id)?.name ?? '?';
+  if (!input?.hearts) return 'no cards';
+
+  const moon = shooter(input);
+  if (moon) return `🌙 ${name(moon)} shot the moon`;
+
+  const heartsOf = (id: ID) => numOr(input.hearts[id], 0) || 0;
+  const jackOn = input.jack != null;
+  const pointsFor = (id: ID) =>
+    heartsOf(id) +
+    (input.queen === id ? QUEEN_POINTS : 0) -
+    (jackOn && input.jack === id ? JACK_POINTS : 0);
+  const signed = (n: number) => (n >= 0 ? `+${n}` : `${n}`);
+
+  // Crashed a moon: took the Queen and all but one heart (25 points) — the whole
+  // load bar a single card. The most-retold story at any Hearts table.
+  if (input.queen && heartsOf(input.queen) >= HEARTS_TOTAL - 1) {
+    return `☄️ ${name(input.queen)} crashed a moon — ${pointsFor(input.queen)}`;
+  }
+
+  const parts: string[] = [];
+  if (input.queen) {
+    parts.push(`💔 ${name(input.queen)} ${signed(pointsFor(input.queen))}`);
+  } else {
+    // No Queen on record (legacy/partial round): fall back to the heaviest pile.
+    const top = [...players].sort((a, b) => heartsOf(b.id) - heartsOf(a.id))[0];
+    if (top && heartsOf(top.id) > 0) return `♥️ ${name(top.id)} +${heartsOf(top.id)}`;
+    return 'no points';
+  }
+  if (jackOn) parts.push(`♦J ${name(input.jack)}`);
+  return parts.join(' · ');
 }
 
 /** True when any player has reached the end score and the game can wrap. */
@@ -201,4 +308,57 @@ export function isFinished(
 ): boolean {
   const end = readConfig(config).endScore;
   return Object.values(totals).some((t) => t >= end);
+}
+
+// ── Endgame tension ──────────────────────────────────────────────────────────
+// Hearts ends the moment anyone reaches the end score — and because lower wins,
+// the player with the *highest* total is the one racing to end everyone's game
+// (while losing it). Surfacing how close that is turns the shoot-the-moon call
+// into a real gamble: is a +26 swing worth it when someone's one hand from home?
+
+export interface EndgameInfo {
+  /** The score that ends the game (endScore from config). */
+  end: number;
+  /** The seat with the highest total — the one who'll trip the finish. Null if empty. */
+  atRiskId: ID | null;
+  /** That seat's current total (0 when there's no one / no points yet). */
+  atRiskTotal: number;
+  /** Points from the finish for that seat (end − highest), never negative. */
+  toEnd: number;
+  /** True once a single hand — a moon is worth 26 — could reach the end. */
+  imminent: boolean;
+  /** True when a seat has already hit the end: this game finishes on the next save. */
+  reached: boolean;
+}
+
+/**
+ * How close the game is to ending, computed from the standings *going into* a hand.
+ * Pure; the editor maps `atRiskId` to a name for its endgame strip.
+ */
+export function endgameInfo(
+  totals: Record<ID, number>,
+  playerIds: readonly ID[],
+  config: Record<string, unknown>,
+): EndgameInfo {
+  const end = readConfig(config).endScore;
+  let atRiskId: ID | null = null;
+  let atRiskTotal = 0;
+  let seen = false;
+  for (const id of playerIds) {
+    const t = numOr(totals[id], 0) || 0;
+    if (!seen || t > atRiskTotal) {
+      atRiskTotal = t;
+      atRiskId = id;
+      seen = true;
+    }
+  }
+  const toEnd = Math.max(0, end - atRiskTotal);
+  return {
+    end,
+    atRiskId,
+    atRiskTotal,
+    toEnd,
+    imminent: toEnd > 0 && toEnd <= MOON_POINTS,
+    reached: seen && atRiskTotal >= end,
+  };
 }

--- a/src/lib/games/hearts/stats.ts
+++ b/src/lib/games/hearts/stats.ts
@@ -1,18 +1,26 @@
 import type { ID } from '../../types';
 import { shooter, type HeartsInput } from './logic';
 import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
-import { fmtPct } from '../../stats/format';
+import { fmtAvg, fmtInt, fmtPct } from '../../stats/format';
 
 interface HeartsAgg {
   moons: number;
   queens: number;
   clean: number;
   rounds: number;
+  /** Hands counted toward point averages — excludes moons, which flip scoring. */
+  scored: number;
+  /** Penalty points taken across scored hands. */
+  points: number;
+  /** Most points taken in a single (non-moon) hand. */
+  worst: number;
 }
 
 /**
  * Hearts stats from each round's recorded hearts/♠Q. Lower-is-better, so a
  * "clean" round = took zero points. Pure; mirrors the module's own `shooter()`.
+ * Moons are counted on their own but left out of the points averages, since
+ * shooting the moon inverts the round and a raw 26 there isn't a "bad hand".
  */
 export function heartsStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
   const gameIds = new Set(games.map((g) => g.id));
@@ -20,7 +28,7 @@ export function heartsStats({ games, rounds, canonical }: GameStatsInput): GameS
   const get = (id: ID): HeartsAgg => {
     let a = per.get(id);
     if (!a) {
-      a = { moons: 0, queens: 0, clean: 0, rounds: 0 };
+      a = { moons: 0, queens: 0, clean: 0, rounds: 0, scored: 0, points: 0, worst: 0 };
       per.set(id, a);
     }
     return a;
@@ -31,6 +39,7 @@ export function heartsStats({ games, rounds, canonical }: GameStatsInput): GameS
     const input = r.input as HeartsInput | undefined;
     if (!input?.hearts) continue;
     const queenId = input.queen ? canonical(input.queen) : null;
+    const moon = shooter(input);
     for (const [pid, h] of Object.entries(input.hearts)) {
       const id = canonical(pid);
       const a = get(id);
@@ -39,8 +48,14 @@ export function heartsStats({ games, rounds, canonical }: GameStatsInput): GameS
       if (tookQueen) a.queens += 1;
       const points = (Number(h) || 0) + (tookQueen ? 13 : 0);
       if (points === 0) a.clean += 1;
+      // A moon flips the round on its head, so its raw 26 isn't a heavy hand —
+      // keep it out of the "points eaten" averages.
+      if (!moon) {
+        a.scored += 1;
+        a.points += points;
+        if (points > a.worst) a.worst = points;
+      }
     }
-    const moon = shooter(input);
     if (moon) get(canonical(moon)).moons += 1;
   }
 
@@ -53,6 +68,10 @@ export function heartsStats({ games, rounds, canonical }: GameStatsInput): GameS
     if (a.queens) metrics.push({ key: 'h_queen', label: '♠Q taken', value: `${a.queens}`, emoji: '♠️' });
     if (a.rounds) {
       metrics.push({ key: 'h_clean', label: 'Clean rounds', value: fmtPct(a.clean / a.rounds), emoji: '😇' });
+    }
+    if (a.scored) {
+      metrics.push({ key: 'h_avg', label: 'Avg per hand', value: fmtAvg(a.points / a.scored), emoji: '♥️' });
+      metrics.push({ key: 'h_worst', label: 'Worst hand', value: fmtInt(a.worst), emoji: '😱' });
     }
     if (metrics.length) perPlayer[id] = metrics;
   }

--- a/src/lib/stats/engine.test.ts
+++ b/src/lib/stats/engine.test.ts
@@ -338,5 +338,24 @@ describe('heartsStats', () => {
     expect(out.perPlayer?.['A'].find((m) => m.key === 'h_moon')?.value).toBe('1');
     expect(out.perPlayer?.['A'].find((m) => m.key === 'h_queen')?.value).toBe('1');
     expect(out.global?.[0]).toMatchObject({ key: 'h_moon_all', value: '1' });
+    // A moon flips the round, so it's excluded from the points averages.
+    expect(out.perPlayer?.['A'].find((m) => m.key === 'h_worst')).toBeUndefined();
+    expect(out.perPlayer?.['A'].find((m) => m.key === 'h_avg')).toBeUndefined();
+  });
+
+  it('reports worst hand and average points per hand (moons excluded)', () => {
+    const games = [mkGame({ id: 'h2', type: 'hearts', playerIds: ['A', 'B', 'C'], roundCount: 3 })];
+    const rounds = [
+      mkRound('h2', 0, {}, { hearts: { A: 10, B: 3, C: 0 }, queen: 'A', jack: null }), // A: 23
+      mkRound('h2', 1, {}, { hearts: { A: 0, B: 5, C: 8 }, queen: 'C', jack: null }), // A: 0
+      mkRound('h2', 2, {}, { hearts: { B: 13, A: 0, C: 0 }, queen: 'B', jack: null }), // moon (B), skipped
+    ];
+    const out = heartsStats({ games, rounds, players: [], canonical: (id) => id });
+    const a = out.perPlayer?.['A'] ?? [];
+    expect(a.find((m) => m.key === 'h_worst')?.value).toBe('23');
+    expect(a.find((m) => m.key === 'h_avg')?.value).toBe('11.5');
+    // B shot the moon in round 2 — that hand is left out of B's average.
+    expect(out.perPlayer?.['B'].find((m) => m.key === 'h_avg')?.value).toBe('4');
+    expect(out.perPlayer?.['B'].find((m) => m.key === 'h_moon')?.value).toBe('1');
   });
 });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -204,6 +204,16 @@ export interface GameModule {
   /** Short summary of a recorded round for the history table. */
   describeRound?(round: Round, players: Player[]): string;
   /**
+   * Optional per-cell emphasis for the round-by-round scorecard (per-round view
+   * only). Lets a game flag one player's result in a round — e.g. Hearts marks
+   * whoever ate the Queen. Pure; returns a semantic tone (plus an optional label
+   * used as a title / assistive-tech cue) or null for the default neutral cell.
+   */
+  roundCellTone?(
+    round: Round,
+    playerId: ID,
+  ): { tone: 'good' | 'bad' | 'warn'; label?: string } | null;
+  /**
    * Optional game-specific stats over this game's finished games. Pure, no I/O —
    * mirrors {@link describeRound}: a new game contributes stats the same way it
    * contributes scoring. The stats engine injects this via the registry so it

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -632,7 +632,14 @@
             <tr class:flash={r.id === justSavedId}>
               <td>{r.index + 1}</td>
               {#each orderedPlayers as p (p.id)}
-                <td class="num">{showRunning ? (runningTotals[r.id]?.[p.id] ?? 0) : fmt(r.deltas[p.id])}</td>
+                {@const cell = !showRunning && module ? (module.roundCellTone?.(r, p.id) ?? null) : null}
+                <td
+                  class="num"
+                  class:tone-bad={cell?.tone === 'bad'}
+                  class:tone-good={cell?.tone === 'good'}
+                  class:tone-warn={cell?.tone === 'warn'}
+                  title={cell?.label}
+                >{showRunning ? (runningTotals[r.id]?.[p.id] ?? 0) : fmt(r.deltas[p.id])}</td>
               {/each}
               <td class="acts">
                 {#if game.status === 'active'}
@@ -818,6 +825,18 @@
   }
   .matrix .num {
     font-variant-numeric: tabular-nums;
+  }
+  /* Per-round emphasis a game module can request (Hearts flags the Queen-taker).
+     The value itself is the primary signal; the hue reinforces it, and a title
+     on the cell carries the reason for pointer + assistive tech. */
+  .matrix .num.tone-bad {
+    color: var(--bad);
+  }
+  .matrix .num.tone-good {
+    color: var(--good);
+  }
+  .matrix .num.tone-warn {
+    color: var(--warn);
   }
   .matrix tfoot td,
   .matrix tfoot th {


### PR DESCRIPTION
A focused deep dive into the Hearts costume, plus a round of scoring/phrasing refinements. All per-game flavour stays inside Hearts; shared chrome is only extended through generic, game-agnostic hooks.

## Experience
- Passing ritual (`PassRibbon`) and an endgame-tension line in the editor.
- "Clear hand" reset that only appears once a hand is started.
- Richer round storytelling and Hearts stats.

## Scoring & phrasing
- **26-point meter:** reframed around penalty points (13 hearts + the Queen's 13), so it only fills when the whole hand is placed.
- Validation now reads **"`<#>` more heart(s) to assign. Must total 26."**
- **"the Lady" → "the Queen"** throughout; the moon toggle now reads **"Shot the moon"**.
- **"Took the rest"** also claims the ♠Q when she's still unclaimed (never overrides an explicit pick).
- **Per-round moon choice:** the shooter picks *"everyone else +26"* or *"takes −26"* for that hand. The config `moonRule` stays the default; the round can override it.

## Scorecard
- New generic **`GameModule.roundCellTone`** hook. Hearts flags whoever ate the ♠Q in coral — with a `title` co-signal so state isn't colour-alone — and suppresses it on a moon (a moon flips the round, so the Queen is a triumph there).
- Applied in both the host scorecard (`GamePlay`) and the guest/relay recap (`ReplicaBoard`).

## Verification
- `npm run check`: 0 errors / 0 warnings
- `npm run build`: clean
- **1275 tests passing** (includes new coverage for the per-round moon override, the "Must total 26" copy, and `roundCellTone`)

Merging deploys to GitHub Pages via `deploy.yml`.