### PR TITLE
Bump deploy workflow actions off deprecated Node 20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,14 +18,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -37,4 +37,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
The Pages deploy on `main` logged a Node 20 deprecation warning: `actions/checkout@v4`, `actions/setup-node@v4`, and `actions/upload-artifact@v4` (nested in `upload-pages-artifact@v3`) are being forced onto Node 24.

This moves the `deploy.yml` workflow to actions that natively run on Node 24:

| Action | Before | After | `runs.using` |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | **v7** | node24 |
| `actions/setup-node` | v4 | **v7** | node24 |
| `actions/upload-pages-artifact` | v3 | **v5** | composite → `upload-artifact@v7` |
| `actions/deploy-pages` | v4 | **v5** | node24 |

`deploy-pages` wasn't in the warning, but it's bumped too so it stays aligned with the newer artifact format that `upload-pages-artifact@v5` produces.

Merging re-runs the deploy on the bumped actions.