### PR TITLE
Add Texas Hold'em poker module

### DIFF
--- a/src/lib/games/holdem/BettingBoard.svelte
+++ b/src/lib/games/holdem/BettingBoard.svelte
@@ -1,0 +1,604 @@
+<script lang="ts">
+  import type { ID, RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { haptic } from '../../haptics';
+  import {
+    sidePots,
+    type ActionLogEntry,
+    type HandEvent,
+    type HoldemConfig,
+    type PotLayer,
+    type Street,
+  } from './logic';
+
+  let {
+    ctx,
+    cfg,
+    onSettle,
+  }: {
+    ctx: RoundContext;
+    cfg: HoldemConfig;
+    /** Called with the fully-settled hand the moment showdown resolves. */
+    onSettle: (hand: HandEvent) => void;
+  } = $props();
+
+  interface LiveSeat {
+    id: ID;
+    name: string;
+    color: string;
+    stack: number;
+    committedStreet: number;
+    committedHand: number;
+    folded: boolean;
+    allIn: boolean;
+    acted: boolean;
+    /** No chips at the table — sits the hand out entirely. */
+    out: boolean;
+  }
+
+  const STREETS: Street[] = ['preflop', 'flop', 'turn', 'river'];
+  const STREET_LABEL: Record<Street, string> = {
+    preflop: 'Preflop',
+    flop: 'Flop',
+    turn: 'Turn',
+    river: 'River',
+    showdown: 'Showdown',
+  };
+
+  // Current chips in front of each player = what they bought in plus their net so
+  // far. So full-betting stacks carry across hands with no separate chip ledger.
+  function currentStack(id: ID): number {
+    let invested = 0;
+    for (const r of ctx.rounds) {
+      const e = r.input as HandEvent | { kind: string; playerId?: ID; amount?: number } | undefined;
+      if (e && (e as any).kind === 'buyin' && (e as any).playerId === id)
+        invested += Number((e as any).amount) || 0;
+    }
+    return Math.max(0, Math.round(invested + (ctx.totals[id] ?? 0)));
+  }
+
+  // Button advances one seat per hand played so far.
+  const handsPlayed = $derived(
+    ctx.rounds.filter((r) => (r.input as { kind?: string })?.kind === 'hand').length,
+  );
+
+  let seats = $state<LiveSeat[]>([]);
+  let street = $state<Street>('preflop');
+  let currentBet = $state(0);
+  // svelte-ignore state_referenced_locally
+  let minRaise = $state(cfg.bigBlind || 1);
+  let acting = $state(-1);
+  let buttonIndex = $state(0);
+  let log = $state<ActionLogEntry[]>([]);
+  let phase = $state<'betting' | 'showdown' | 'done'>('betting');
+  let layers = $state<PotLayer[]>([]);
+  let potWinners = $state<Record<number, ID[]>>({});
+  let raiseTo = $state(0);
+  let showRaise = $state(false);
+  let inited = false;
+
+  const n = $derived(seats.length);
+  const inHand = $derived(seats.filter((s) => !s.folded && !s.out));
+  const canAct = $derived(inHand.filter((s) => !s.allIn && s.stack > 0));
+  const pot = $derived(seats.reduce((a, s) => a + s.committedHand, 0));
+  const actingSeat = $derived(acting >= 0 ? seats[acting] : null);
+  const toCall = $derived(actingSeat ? Math.max(0, currentBet - actingSeat.committedStreet) : 0);
+  const callCapped = $derived(actingSeat ? Math.min(toCall, actingSeat.stack) : 0);
+
+  $effect(() => {
+    if (inited) return;
+    inited = true;
+    init();
+  });
+
+  function init() {
+    const players = ctx.players;
+    const nn = players.length;
+    buttonIndex = nn ? handsPlayed % nn : 0;
+    seats = players.map((p) => {
+      const stack = currentStack(p.id);
+      return {
+        id: p.id,
+        name: p.name,
+        color: p.color,
+        stack,
+        committedStreet: 0,
+        committedHand: 0,
+        folded: false,
+        allIn: false,
+        acted: false,
+        out: stack <= 0,
+      };
+    });
+    postBlinds();
+  }
+
+  function idxAfter(from: number, pred: (s: LiveSeat) => boolean): number {
+    for (let k = 1; k <= n; k++) {
+      const i = (from + k) % n;
+      if (pred(seats[i])) return i;
+    }
+    return -1;
+  }
+
+  function postBlinds() {
+    const live = seats.filter((s) => !s.out);
+    if (live.length < 2) {
+      // Not enough chips in play to run a hand — bail to a trivial showdown.
+      goShowdown();
+      return;
+    }
+    // Antes first.
+    if (cfg.ante > 0) for (const s of seats) if (!s.out) commit(s, cfg.ante);
+    // Heads-up: the button is the small blind and acts first preflop.
+    const headsUp = live.length === 2;
+    const sbIndex = headsUp ? buttonIndex : idxAfter(buttonIndex, (s) => !s.out);
+    const bbIndex = idxAfter(sbIndex, (s) => !s.out);
+    if (cfg.smallBlind > 0) commit(seats[sbIndex], cfg.smallBlind);
+    if (cfg.bigBlind > 0) commit(seats[bbIndex], cfg.bigBlind);
+    currentBet = Math.max(cfg.bigBlind, cfg.smallBlind, 0);
+    minRaise = cfg.bigBlind || 1;
+    for (const s of seats) s.acted = false; // blind posters still owe an action (BB option)
+    street = 'preflop';
+    acting = idxAfter(bbIndex, canActPred);
+    if (acting < 0) closeStreet();
+  }
+
+  const canActPred = (s: LiveSeat) =>
+    !s.folded && !s.out && !s.allIn && s.stack > 0 && (!s.acted || s.committedStreet < currentBet);
+
+  /** Move `amount` (capped to stack) from a seat's stack into the pot. */
+  function commit(s: LiveSeat, amount: number) {
+    const put = Math.max(0, Math.min(amount, s.stack));
+    s.stack -= put;
+    s.committedStreet += put;
+    s.committedHand += put;
+    if (s.stack === 0) s.allIn = true;
+  }
+
+  function record(s: LiveSeat, action: ActionLogEntry['action'], amount: number) {
+    log = [...log, { playerId: s.id, street, action, amount }];
+  }
+
+  function advance() {
+    acting = idxAfter(acting, canActPred);
+    if (acting < 0) closeStreet();
+  }
+
+  function fold() {
+    const s = actingSeat;
+    if (!s) return;
+    s.folded = true;
+    s.acted = true;
+    record(s, 'fold', 0);
+    haptic('tick');
+    advance();
+  }
+
+  function checkCall() {
+    const s = actingSeat;
+    if (!s) return;
+    if (callCapped > 0) {
+      commit(s, callCapped);
+      record(s, 'call', callCapped);
+    } else {
+      record(s, 'check', 0);
+    }
+    s.acted = true;
+    haptic('tick');
+    advance();
+  }
+
+  function allIn() {
+    const s = actingSeat;
+    if (!s) return;
+    const put = s.stack;
+    const target = s.committedStreet + put;
+    commit(s, put);
+    record(s, 'allin', put);
+    if (target > currentBet) {
+      const fullRaise = target - currentBet >= minRaise;
+      if (fullRaise) {
+        minRaise = target - currentBet;
+        for (const o of seats) if (o !== s && !o.folded && !o.out && !o.allIn) o.acted = false;
+      }
+      currentBet = target;
+    }
+    s.acted = true;
+    haptic('win');
+    advance();
+  }
+
+  function openRaise() {
+    const s = actingSeat;
+    if (!s) return;
+    const min = Math.min(currentBet + minRaise, s.committedStreet + s.stack);
+    raiseTo = min;
+    showRaise = true;
+  }
+
+  function potFraction(frac: number) {
+    const s = actingSeat;
+    if (!s) return;
+    const call = Math.max(0, currentBet - s.committedStreet);
+    const potAfterCall = pot + call;
+    const target = currentBet + Math.round(frac * potAfterCall);
+    raiseTo = Math.max(currentBet + minRaise, Math.min(target, s.committedStreet + s.stack));
+  }
+
+  function confirmRaise() {
+    const s = actingSeat;
+    if (!s) return;
+    const target = Math.min(Math.max(raiseTo, currentBet + 1), s.committedStreet + s.stack);
+    const add = target - s.committedStreet;
+    commit(s, add);
+    const isAllIn = s.stack === 0;
+    record(s, 'raise', add);
+    const fullRaise = target - currentBet >= minRaise;
+    if (!isAllIn || fullRaise) minRaise = target - currentBet;
+    currentBet = target;
+    for (const o of seats) if (o !== s && !o.folded && !o.out && !o.allIn) o.acted = false;
+    s.acted = true;
+    showRaise = false;
+    haptic('win');
+    advance();
+  }
+
+  function closeStreet() {
+    // Everyone folded but one → that player takes it, no showdown needed.
+    if (inHand.length <= 1) {
+      finalizeSingle();
+      return;
+    }
+    // No more decisions possible (all but one are all-in) → run it to showdown.
+    if (canAct.length <= 1 && inHand.every((s) => s.committedStreet === currentBet || s.allIn)) {
+      goShowdown();
+      return;
+    }
+    const idx = STREETS.indexOf(street);
+    if (idx >= STREETS.length - 1) {
+      goShowdown();
+      return;
+    }
+    // Next street: clear street commitments, reopen action, first active left of button.
+    street = STREETS[idx + 1];
+    currentBet = 0;
+    minRaise = cfg.bigBlind || 1;
+    for (const s of seats) {
+      s.committedStreet = 0;
+      s.acted = false;
+    }
+    acting = idxAfter(buttonIndex, canActPred);
+    if (acting < 0) closeStreet();
+  }
+
+  function order(): ID[] {
+    // Seat order starting left of the button — drives odd-chip tie-breaking.
+    const ids: ID[] = [];
+    for (let k = 1; k <= n; k++) ids.push(seats[(buttonIndex + k) % n].id);
+    return ids;
+  }
+
+  function committedMap(): Record<ID, number> {
+    const m: Record<ID, number> = {};
+    for (const s of seats) if (s.committedHand > 0) m[s.id] = s.committedHand;
+    return m;
+  }
+
+  function finalizeSingle() {
+    const winner = inHand[0];
+    acting = -1;
+    phase = 'done';
+    writeHand([{ amount: pot, winnerIds: winner ? [winner.id] : [] }]);
+  }
+
+  function goShowdown() {
+    acting = -1;
+    const folded = seats.filter((s) => s.folded).map((s) => s.id);
+    layers = sidePots(committedMap(), folded, order());
+    potWinners = {};
+    // Auto-select the sole eligible player for any single-candidate pot.
+    layers.forEach((l, i) => {
+      if (l.eligible.length === 1) potWinners[i] = [...l.eligible];
+    });
+    phase = layers.length ? 'showdown' : 'done';
+    if (!layers.length) writeHand([]);
+  }
+
+  function toggleWinner(layerIdx: number, id: ID) {
+    const cur = potWinners[layerIdx] ?? [];
+    potWinners[layerIdx] = cur.includes(id) ? cur.filter((x) => x !== id) : [...cur, id];
+  }
+
+  const allPotsAwarded = $derived(
+    phase === 'showdown' && layers.every((_, i) => (potWinners[i] ?? []).length > 0),
+  );
+
+  function awardPots() {
+    if (!allPotsAwarded) return;
+    const seq = order();
+    const pots = layers.map((l, i) => {
+      const winners = seq.filter((id) => (potWinners[i] ?? []).includes(id));
+      return {
+        amount: l.amount,
+        winnerIds: winners,
+        label: layers.length > 1 ? (i === 0 ? 'Main pot' : `Side pot ${i}`) : undefined,
+      };
+    });
+    phase = 'done';
+    writeHand(pots);
+    haptic('win');
+  }
+
+  /** Commit the settled hand up to the editor, which the shell then saves. */
+  function writeHand(pots: HandEvent['pots']) {
+    onSettle({
+      kind: 'hand',
+      level: 3,
+      committed: committedMap(),
+      pots,
+      button: seats[buttonIndex]?.id,
+      blinds: { sb: cfg.smallBlind, bb: cfg.bigBlind, ante: cfg.ante },
+      log,
+    });
+  }
+
+  const dealerName = $derived(seats[buttonIndex]?.name ?? '');
+</script>
+
+<div class="board">
+  <div class="topline">
+    <span class="pill">{STREET_LABEL[street]}</span>
+    <span class="pill">🔘 {dealerName}</span>
+    <span class="pill">SB {cfg.smallBlind} / BB {cfg.bigBlind}{cfg.ante ? ` · ante ${cfg.ante}` : ''}</span>
+  </div>
+
+  <div class="pot">
+    <span class="pot-label section-title">Pot</span>
+    <span class="pot-num">{pot.toLocaleString()}</span>
+  </div>
+
+  <ul class="seats">
+    {#each seats as s, i (s.id)}
+      <li class="seat" class:acting={i === acting} class:folded={s.folded} class:out={s.out}>
+        <Avatar name={s.name} color={s.color} size={26} decorative />
+        <span class="nm">
+          {s.name}
+          {#if i === buttonIndex}<span class="dot" title="Dealer">🔘</span>{/if}
+        </span>
+        <span class="tags">
+          {#if s.out}<span class="tag">no chips</span>
+          {:else if s.folded}<span class="tag">folded</span>
+          {:else if s.allIn}<span class="tag allin">all-in</span>
+          {:else if s.committedStreet > 0}<span class="tag bet">{s.committedStreet}</span>{/if}
+        </span>
+        <span class="stack">{s.stack.toLocaleString()}</span>
+      </li>
+    {/each}
+  </ul>
+
+  {#if phase === 'betting' && actingSeat}
+    <div class="turn">
+      <strong>{actingSeat.name}</strong> to act
+    </div>
+    {#if showRaise}
+      <div class="raise">
+        <div class="quick">
+          <button type="button" class="btn small" onclick={() => potFraction(0.5)}>½ pot</button>
+          <button type="button" class="btn small" onclick={() => potFraction(0.75)}>¾ pot</button>
+          <button type="button" class="btn small" onclick={() => potFraction(1)}>Pot</button>
+          <button type="button" class="btn small" onclick={() => (raiseTo = actingSeat.committedStreet + actingSeat.stack)}>Max</button>
+        </div>
+        <div class="raise-row">
+          <Stepper bind:value={raiseTo} min={currentBet + 1} max={actingSeat.committedStreet + actingSeat.stack} step={cfg.bigBlind || 1} label="Raise to" />
+          <button type="button" class="btn primary" onclick={confirmRaise}>Raise to {raiseTo.toLocaleString()}</button>
+        </div>
+        <button type="button" class="btn ghost small" onclick={() => (showRaise = false)}>Cancel</button>
+      </div>
+    {:else}
+      <div class="actions">
+        <button type="button" class="btn danger" onclick={fold}>Fold</button>
+        <button type="button" class="btn" onclick={checkCall}>
+          {callCapped > 0 ? `Call ${callCapped.toLocaleString()}` : 'Check'}
+        </button>
+        {#if actingSeat.stack > callCapped}
+          <button type="button" class="btn primary" onclick={openRaise}>
+            {currentBet > 0 ? 'Raise' : 'Bet'}
+          </button>
+        {/if}
+        <button type="button" class="btn" onclick={allIn}>All-in {actingSeat.stack.toLocaleString()}</button>
+      </div>
+    {/if}
+  {:else if phase === 'showdown'}
+    <div class="showdown">
+      <div class="section-title">Showdown — who wins each pot?</div>
+      {#each layers as l, i (i)}
+        <div class="potlayer">
+          <div class="potlayer-head">
+            <span class="pl-name">{layers.length > 1 ? (i === 0 ? 'Main pot' : `Side pot ${i}`) : 'Pot'}</span>
+            <span class="pl-amt">{l.amount.toLocaleString()}</span>
+          </div>
+          <div class="cands">
+            {#each l.eligible as id (id)}
+              {@const s = seats.find((x) => x.id === id)}
+              <button
+                type="button"
+                class="cand"
+                class:on={(potWinners[i] ?? []).includes(id)}
+                aria-pressed={(potWinners[i] ?? []).includes(id)}
+                onclick={() => toggleWinner(i, id)}
+              >
+                {#if s}<Avatar name={s.name} color={s.color} size={22} decorative />{/if}
+                <span>{s?.name ?? id}</span>
+              </button>
+            {/each}
+          </div>
+        </div>
+      {/each}
+      <button type="button" class="btn primary block" disabled={!allPotsAwarded} onclick={awardPots}>
+        Award {layers.length > 1 ? 'pots' : 'pot'}
+      </button>
+    </div>
+  {:else}
+    <div class="done">✅ Hand settled — tap <strong>Save</strong> to record it.</div>
+  {/if}
+</div>
+
+<style>
+  .board {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .topline {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .pot {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 8px 0;
+  }
+  .pot-num {
+    font-size: 2rem;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .seats {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .seat {
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 8px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    transition: border-color var(--dur-base) var(--ease-standard), opacity var(--dur-base) var(--ease-standard);
+  }
+  .seat.acting {
+    border-color: var(--primary);
+    background: var(--surface-2);
+  }
+  .seat.folded,
+  .seat.out {
+    opacity: 0.5;
+  }
+  .nm {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .stack {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+    min-width: 4em;
+    text-align: right;
+  }
+  .tags {
+    display: inline-flex;
+    gap: 4px;
+  }
+  .tag {
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: var(--radius-pill, 999px);
+    background: var(--surface-3);
+    color: var(--muted);
+  }
+  .tag.bet {
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+  }
+  .tag.allin {
+    color: var(--warn);
+  }
+  .turn {
+    text-align: center;
+    color: var(--muted);
+  }
+  .actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+  .raise {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .quick {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .raise-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .potlayer {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 8px 10px;
+    margin-bottom: 8px;
+  }
+  .potlayer-head {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 6px;
+  }
+  .pl-amt {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .cands {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .cand {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 46px;
+    padding: 4px 14px 4px 6px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill, 999px);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .cand.on {
+    border-color: var(--primary);
+    background: var(--surface-2);
+  }
+  .cand:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .done {
+    text-align: center;
+    color: var(--muted);
+    padding: 8px 0;
+  }
+  .dot {
+    font-size: 0.7em;
+  }
+</style>

--- a/src/lib/games/holdem/HoldemEditor.svelte
+++ b/src/lib/games/holdem/HoldemEditor.svelte
@@ -1,0 +1,392 @@
+<script lang="ts">
+  import type { ID, RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Segmented from '../../components/Segmented.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { haptic } from '../../haptics';
+  import TableBank from './TableBank.svelte';
+  import BettingBoard from './BettingBoard.svelte';
+  import Settlement from './Settlement.svelte';
+  import {
+    investedByPlayer,
+    readConfig,
+    reconcileCashout,
+    scoreHand,
+    toMoney,
+    type HoldemEvent,
+    type HoldemConfig,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: HoldemEvent; ctx: RoundContext } = $props();
+
+  const cfg = $derived<HoldemConfig>(readConfig(ctx.config));
+  const invested = $derived(investedByPlayer(ctx.rounds));
+
+  // The chosen event kind, seeded from the incoming draft (a buy-in by default).
+  // svelte-ignore state_referenced_locally
+  let kind = $state<HoldemEvent['kind']>(input?.kind ?? 'buyin');
+  // For a hand: quick per-hand ('2') vs full street betting ('3'); string for Segmented.
+  // svelte-ignore state_referenced_locally
+  let handMode = $state<'2' | '3'>(readConfig(ctx.config).depth === 'betting' ? '3' : '2');
+
+  // Buy-in draft state.
+  let buyinPlayer = $state<ID>('');
+  let buyinAmount = $state(0);
+  // Per-hand (level 2) draft state.
+  let committed = $state<Record<ID, number>>({});
+  let winners = $state<ID[]>([]);
+  // Cash-out draft state.
+  let counts = $state<Record<ID, number>>({});
+
+  let ready = false;
+  $effect(() => {
+    if (ready) return;
+    ready = true;
+    if (input?.kind === 'buyin') {
+      buyinPlayer = input.playerId || ctx.players[0]?.id || '';
+      buyinAmount = Number(input.amount) || cfg.defaultBuyin;
+    } else {
+      buyinPlayer = ctx.players.find((p) => !(invested[p.id] > 0))?.id ?? ctx.players[0]?.id ?? '';
+      buyinAmount = cfg.defaultBuyin;
+    }
+    for (const p of ctx.players) {
+      committed[p.id] = 0;
+      counts[p.id] = Math.max(0, Math.round((invested[p.id] ?? 0) + (ctx.totals[p.id] ?? 0)));
+    }
+    syncInput();
+  });
+
+  function fmtMoney(amount: number): string {
+    const v = Math.round(toMoney(amount, cfg) * 100) / 100;
+    const body = Number.isInteger(v) ? v.toLocaleString() : v.toFixed(2);
+    return cfg.unit === 'chips' ? body : `$${body}`;
+  }
+
+  /** Order winners by seating so split odd chips are deterministic. */
+  function orderWinners(ids: ID[]): ID[] {
+    return ctx.players.map((p) => p.id).filter((id) => ids.includes(id));
+  }
+
+  // ── Keep the bound draft in lock-step with the active sub-editor ─────────────
+  // Full-betting hands are the exception: BettingBoard pushes its result through
+  // onSettle, so this only maintains buy-in / per-hand / cash-out drafts.
+  function syncInput() {
+    if (kind === 'buyin') {
+      input = { kind: 'buyin', playerId: buyinPlayer, amount: buyinAmount };
+    } else if (kind === 'cashout') {
+      const counted: Record<ID, number> = {};
+      for (const p of ctx.players) counted[p.id] = Number(counts[p.id]) || 0;
+      input = { kind: 'cashout', counts: counted };
+    } else if (handMode === '2') {
+      const c: Record<ID, number> = {};
+      let potTotal = 0;
+      for (const p of ctx.players) {
+        const v = Math.max(0, Math.round(Number(committed[p.id]) || 0));
+        if (v > 0) c[p.id] = v;
+        potTotal += v;
+      }
+      const win = orderWinners(winners.filter((id) => ctx.players.some((p) => p.id === id)));
+      input = {
+        kind: 'hand',
+        level: 2,
+        committed: c,
+        pots: win.length && potTotal > 0 ? [{ amount: potTotal, winnerIds: win }] : [],
+      };
+    }
+  }
+
+  // React to the mode switchers. Track the last applied state so we rebuild the
+  // draft exactly once per real change (never during an unrelated re-render).
+  // svelte-ignore state_referenced_locally
+  let lastKind = kind;
+  // svelte-ignore state_referenced_locally
+  let lastHandMode = handMode;
+  $effect(() => {
+    const k = kind;
+    const hm = handMode;
+    if (k === lastKind && hm === lastHandMode) return;
+    lastKind = k;
+    lastHandMode = hm;
+    if (k === 'hand' && hm === '3') {
+      input = { kind: 'hand', level: 3, committed: {}, pots: [] }; // empty shell; BettingBoard fills it
+    } else {
+      syncInput();
+    }
+    haptic('tick');
+  });
+
+  // Buy-in interactions.
+  function selectBuyin(id: ID) {
+    buyinPlayer = id;
+    syncInput();
+    haptic('tick');
+  }
+  $effect(() => {
+    void buyinAmount;
+    if (kind === 'buyin') syncInput();
+  });
+
+  // Per-hand (level 2) interactions.
+  function toggleWinner(id: ID) {
+    winners = winners.includes(id) ? winners.filter((x) => x !== id) : [...winners, id];
+    syncInput();
+    haptic('tick');
+  }
+  $effect(() => {
+    void JSON.stringify(committed);
+    if (kind === 'hand' && handMode === '2') syncInput();
+  });
+
+  // Cash-out interactions.
+  $effect(() => {
+    void JSON.stringify(counts);
+    if (kind === 'cashout') syncInput();
+  });
+
+  function onHandSettled(hand: HoldemEvent) {
+    input = hand;
+  }
+
+  const potLevel2 = $derived(
+    ctx.players.reduce((a, p) => a + Math.max(0, Math.round(Number(committed[p.id]) || 0)), 0),
+  );
+
+  // Live projection for the bank preview: how this pending event moves each net.
+  const projection = $derived.by<Record<ID, number>>(() => {
+    if (kind === 'hand') {
+      const ev = input;
+      if (ev?.kind === 'hand' && ev.pots.length) return scoreHand(ev);
+      return {};
+    }
+    if (kind === 'cashout') {
+      const out: Record<ID, number> = {};
+      for (const p of ctx.players) {
+        const net = (Number(counts[p.id]) || 0) - (invested[p.id] ?? 0);
+        out[p.id] = net - (ctx.totals[p.id] ?? 0);
+      }
+      return out;
+    }
+    return {}; // buy-in is net-neutral
+  });
+
+  // Final net per player if we cashed out now — feeds the settle-up preview.
+  const finalNet = $derived.by<Record<ID, number>>(() => {
+    const out: Record<ID, number> = {};
+    for (const p of ctx.players) out[p.id] = (Number(counts[p.id]) || 0) - (invested[p.id] ?? 0);
+    return out;
+  });
+
+  const cashoutDiff = $derived(
+    kind === 'cashout' && input?.kind === 'cashout' ? reconcileCashout(input, ctx) : 0,
+  );
+</script>
+
+<div class="holdem stack">
+  <TableBank {ctx} {cfg} {projection} />
+
+  <Segmented
+    label="What happened?"
+    bind:value={kind}
+    options={[
+      { value: 'buyin', label: '💰 Buy-in' },
+      { value: 'hand', label: '♠️ Hand' },
+      { value: 'cashout', label: '🧮 Cash out' },
+    ]}
+  />
+
+  {#if kind === 'buyin'}
+    <div class="pane stack">
+      <span class="section-title">Who's buying in?</span>
+      <div class="chips">
+        {#each ctx.players as p (p.id)}
+          <button
+            type="button"
+            class="pchip"
+            class:on={buyinPlayer === p.id}
+            aria-pressed={buyinPlayer === p.id}
+            onclick={() => selectBuyin(p.id)}
+          >
+            <Avatar name={p.name} color={p.color} size={24} decorative />
+            <span>{p.name}</span>
+            {#if invested[p.id] > 0}<span class="reb">rebuy</span>{/if}
+          </button>
+        {/each}
+      </div>
+      <div class="amount-row">
+        <span class="section-title">Amount</span>
+        <Stepper bind:value={buyinAmount} min={1} step={1} label="Buy-in amount" />
+        <button type="button" class="btn small" onclick={() => (buyinAmount = cfg.defaultBuyin)}>
+          Default {fmtMoney(cfg.defaultBuyin)}
+        </button>
+      </div>
+      <p class="note muted">Buying in doesn't move who's up or down — cash just becomes chips.</p>
+    </div>
+  {:else if kind === 'hand'}
+    <div class="pane stack">
+      <Segmented
+        label="How much detail?"
+        bind:value={handMode}
+        options={[
+          { value: '2', label: 'Quick' },
+          { value: '3', label: 'Full betting' },
+        ]}
+      />
+
+      {#if handMode === '2'}
+        <span class="section-title">Chips each player put in — then tap the winner(s)</span>
+        <ul class="hand-rows">
+          {#each ctx.players as p (p.id)}
+            <li class="hrow" class:win={winners.includes(p.id)}>
+              <button
+                type="button"
+                class="star"
+                class:on={winners.includes(p.id)}
+                aria-pressed={winners.includes(p.id)}
+                aria-label={`${p.name} wins`}
+                onclick={() => toggleWinner(p.id)}
+              >{winners.includes(p.id) ? '⭐' : '☆'}</button>
+              <Avatar name={p.name} color={p.color} size={24} decorative />
+              <span class="nm">{p.name}</span>
+              <Stepper bind:value={committed[p.id]} min={0} step={cfg.bigBlind || 1} label={`${p.name} chips in`} />
+            </li>
+          {/each}
+        </ul>
+        <div class="pot-line">
+          <span class="section-title">Pot</span>
+          <span class="pot-val">{potLevel2.toLocaleString()}</span>
+        </div>
+      {:else}
+        <BettingBoard {ctx} {cfg} onSettle={onHandSettled} />
+      {/if}
+    </div>
+  {:else}
+    <div class="pane stack">
+      <span class="section-title">Final chip counts</span>
+      <ul class="hand-rows">
+        {#each ctx.players as p (p.id)}
+          <li class="hrow">
+            <Avatar name={p.name} color={p.color} size={24} decorative />
+            <span class="nm">{p.name}</span>
+            <Stepper bind:value={counts[p.id]} min={0} step={cfg.bigBlind || 1} label={`${p.name} final chips`} />
+          </li>
+        {/each}
+      </ul>
+      {#if Math.round(cashoutDiff) !== 0}
+        <p class="warn-note" role="status">
+          ⚠️ Counts are off by {fmtMoney(Math.abs(cashoutDiff))}
+          {cashoutDiff > 0 ? 'more' : 'less'} than the buy-ins. Recount, or save anyway if someone left with chips.
+        </p>
+      {/if}
+      <Settlement net={finalNet} players={ctx.players} {cfg} />
+    </div>
+  {/if}
+</div>
+
+<style>
+  .holdem {
+    gap: 12px;
+  }
+  .pane {
+    gap: 10px;
+  }
+  .chips,
+  .hand-rows {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .hand-rows {
+    flex-direction: column;
+  }
+  .pchip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 46px;
+    padding: 4px 14px 4px 6px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill, 999px);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .pchip.on {
+    border-color: var(--primary);
+    background: var(--surface-2);
+  }
+  .pchip:focus-visible,
+  .star:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .reb {
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .amount-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+  .hrow {
+    display: grid;
+    grid-template-columns: auto auto 1fr auto;
+    align-items: center;
+    gap: 10px;
+    padding: 4px 6px;
+    border-radius: var(--radius-sm);
+  }
+  .hrow.win {
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+  }
+  .star {
+    background: transparent;
+    border: 0;
+    font-size: 1.3rem;
+    line-height: 1;
+    cursor: pointer;
+    width: 46px;
+    height: 46px;
+  }
+  .nm {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .pot-line,
+  .pot-val {
+    font-variant-numeric: tabular-nums;
+  }
+  .pot-line {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    padding-top: 4px;
+  }
+  .pot-val {
+    font-weight: 800;
+    font-size: 1.15rem;
+  }
+  .note {
+    font-size: 0.85rem;
+    margin: 0;
+  }
+  .warn-note {
+    margin: 0;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--warn) 14%, var(--surface));
+    border: 1px solid color-mix(in srgb, var(--warn) 45%, var(--border));
+    font-size: 0.9rem;
+  }
+</style>

--- a/src/lib/games/holdem/Settlement.svelte
+++ b/src/lib/games/holdem/Settlement.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  import type { ID } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import { haptic } from '../../haptics';
+  import { settle, toMoney, type HoldemConfig, type Transfer } from './logic';
+
+  let {
+    net,
+    players,
+    cfg,
+  }: {
+    /** Net position per player in the tracking unit (+ = is owed). */
+    net: Record<ID, number>;
+    players: { id: ID; name: string; color: string }[];
+    cfg: HoldemConfig;
+  } = $props();
+
+  const transfers = $derived<Transfer[]>(settle(net));
+  const nameOf = (id: ID) => players.find((p) => p.id === id)?.name ?? '—';
+  const playerOf = (id: ID) => players.find((p) => p.id === id);
+
+  // Locally-tracked "handed over the cash" state — a table nicety, not persisted.
+  let paid = $state<Record<string, boolean>>({});
+  const key = (t: Transfer) => `${t.from}>${t.to}`;
+  function togglePaid(t: Transfer) {
+    const k = key(t);
+    paid[k] = !paid[k];
+    if (paid[k]) haptic('win');
+  }
+
+  function fmtMoney(amount: number): string {
+    const v = Math.round(toMoney(amount, cfg) * 100) / 100;
+    const body = Number.isInteger(v) ? v.toLocaleString() : v.toFixed(2);
+    return cfg.unit === 'chips' ? `${body} chips` : `$${body}`;
+  }
+</script>
+
+<div class="settle">
+  <div class="section-title">💸 Settle up</div>
+  {#if transfers.length === 0}
+    <p class="even muted">All square — nobody owes anybody. 🤝</p>
+  {:else}
+    <ul class="pays">
+      {#each transfers as t (key(t))}
+        {@const from = playerOf(t.from)}
+        {@const to = playerOf(t.to)}
+        <li>
+          <button
+            type="button"
+            class="pay"
+            class:done={paid[key(t)]}
+            aria-pressed={paid[key(t)]}
+            onclick={() => togglePaid(t)}
+          >
+            <span class="who">
+              {#if from}<Avatar name={from.name} color={from.color} size={24} />{/if}
+              <span class="nm">{nameOf(t.from)}</span>
+            </span>
+            <span class="arrow" aria-label="pays">→</span>
+            <span class="who">
+              {#if to}<Avatar name={to.name} color={to.color} size={24} />{/if}
+              <span class="nm">{nameOf(t.to)}</span>
+            </span>
+            <span class="amt">{fmtMoney(t.amount)}</span>
+            <span class="check" aria-hidden="true">{paid[key(t)] ? '✓' : ''}</span>
+          </button>
+        </li>
+      {/each}
+    </ul>
+    <p class="hint muted">Tap a line once the cash changes hands.</p>
+  {/if}
+</div>
+
+<style>
+  .settle {
+    margin-top: 4px;
+  }
+  .even {
+    margin: 6px 2px;
+  }
+  .pays {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .pay {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr auto auto;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 6px 12px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+    text-align: left;
+    transition: background var(--dur-base) var(--ease-standard), opacity var(--dur-base) var(--ease-standard);
+  }
+  .pay:active {
+    transform: translateY(1px);
+  }
+  .pay:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .pay.done {
+    opacity: 0.55;
+  }
+  .pay.done .nm,
+  .pay.done .amt {
+    text-decoration: line-through;
+  }
+  .who {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+  .nm {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .arrow {
+    color: var(--muted);
+    font-weight: 700;
+  }
+  .amt {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .check {
+    width: 1.2em;
+    color: var(--good);
+    font-weight: 800;
+  }
+  .hint {
+    margin: 8px 2px 0;
+    font-size: 0.85rem;
+  }
+</style>

--- a/src/lib/games/holdem/TableBank.svelte
+++ b/src/lib/games/holdem/TableBank.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import type { ID, RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import { investedByPlayer, toMoney, type HoldemConfig } from './logic';
+
+  let {
+    ctx,
+    cfg,
+    projection = {},
+  }: {
+    ctx: RoundContext;
+    cfg: HoldemConfig;
+    /** Optional per-player preview delta for the event being composed. */
+    projection?: Record<ID, number>;
+  } = $props();
+
+  const invested = $derived(investedByPlayer(ctx.rounds));
+
+  /** Net now = the player's running total (net position in the tracking unit). */
+  function netNow(id: ID): number {
+    return (ctx.totals[id] ?? 0) + (projection[id] ?? 0);
+  }
+
+  function fmtMoney(amount: number): string {
+    const v = Math.round(toMoney(amount, cfg) * 100) / 100;
+    const body = Number.isInteger(v) ? v.toLocaleString() : v.toFixed(2);
+    return cfg.unit === 'chips' ? body : `$${body}`;
+  }
+  function fmtSigned(amount: number): string {
+    const v = Math.round(toMoney(amount, cfg) * 100) / 100;
+    const body = Number.isInteger(Math.abs(v)) ? Math.abs(v).toLocaleString() : Math.abs(v).toFixed(2);
+    const money = cfg.unit === 'chips' ? body : `$${body}`;
+    if (v > 0) return `+${money}`;
+    if (v < 0) return `−${money}`;
+    return money;
+  }
+
+  // The chip leader — biggest net right now. Gets the 👑 (Crown Gold), scarce by design.
+  const leaderId = $derived.by(() => {
+    let best: ID | null = null;
+    let bestV = -Infinity;
+    for (const p of ctx.players) {
+      const v = netNow(p.id);
+      if (v > bestV) {
+        bestV = v;
+        best = p.id;
+      }
+    }
+    // Only crown a real, positive lead (no crown when everyone's even at 0).
+    return bestV > 0 ? best : null;
+  });
+
+  const onTable = $derived(
+    ctx.players.reduce((s, p) => s + (invested[p.id] ?? 0) + (ctx.totals[p.id] ?? 0), 0),
+  );
+</script>
+
+<section class="bank" aria-label="Table bank">
+  <header class="bank-head">
+    <span class="section-title">On the table</span>
+    <span class="on-table">{fmtMoney(onTable)}</span>
+  </header>
+  <ul class="rows">
+    {#each ctx.players as p (p.id)}
+      {@const net = netNow(p.id)}
+      <li class="brow" class:leader={leaderId === p.id}>
+        <Avatar name={p.name} color={p.color} size={26} />
+        <span class="name">{p.name}{#if leaderId === p.id}<span class="crown" title="Chip leader"> 👑</span>{/if}</span>
+        <span class="stat">
+          <span class="lbl">in</span>
+          <span class="val">{fmtMoney(invested[p.id] ?? 0)}</span>
+        </span>
+        <span
+          class="net"
+          class:up={net > 0}
+          class:down={net < 0}
+          title={net > 0 ? 'Up' : net < 0 ? 'Down' : 'Even'}
+        >{fmtSigned(net)}</span>
+      </li>
+    {/each}
+  </ul>
+</section>
+
+<style>
+  .bank {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 10px 12px;
+  }
+  .bank-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 6px;
+  }
+  .on-table {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .brow {
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    align-items: center;
+    gap: 10px;
+    padding: 5px 6px;
+    border-radius: var(--radius-sm);
+  }
+  .brow.leader {
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+  }
+  .name {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .crown {
+    color: var(--accent-ink);
+  }
+  .stat {
+    display: inline-flex;
+    gap: 6px;
+    align-items: baseline;
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+  .stat .val {
+    font-variant-numeric: tabular-nums;
+    color: var(--text);
+    font-weight: 600;
+  }
+  .net {
+    min-width: 4.5em;
+    text-align: right;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .net.up {
+    color: var(--good);
+  }
+  .net.down {
+    color: var(--bad);
+  }
+</style>

--- a/src/lib/games/holdem/holdem.test.ts
+++ b/src/lib/games/holdem/holdem.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from 'vitest';
+import type { ID, Player, RoundContext } from '../../types';
+import {
+  investedByPlayer,
+  readConfig,
+  reconcileCashout,
+  scoreEvent,
+  scoreHand,
+  settle,
+  sidePots,
+  splitPot,
+  toMoney,
+  validateEvent,
+  type CashoutEvent,
+  type HandEvent,
+  type HoldemEvent,
+} from './logic';
+
+const player = (id: string, name = id): Player => ({ id, name, color: '#7c5cff', createdAt: 0 });
+
+/** Build a RoundContext with prior rounds + totals for cashout/scoring tests. */
+function ctxWith(players: Player[], events: HoldemEvent[], totals: Record<ID, number> = {}): RoundContext {
+  const rounds = events.map((input, index) => ({
+    id: `r${index}`,
+    gameId: 'g',
+    index,
+    input,
+    deltas: {},
+    createdAt: index,
+  }));
+  return {
+    game: { id: 'g' } as RoundContext['game'],
+    players,
+    config: {},
+    roundIndex: events.length,
+    totals,
+    rounds,
+  };
+}
+
+const sum = (r: Record<ID, number>) => Object.values(r).reduce((a, v) => a + v, 0);
+
+describe('readConfig', () => {
+  it('applies defaults and clamps', () => {
+    const cfg = readConfig({});
+    expect(cfg.unit).toBe('dollars');
+    expect(cfg.defaultBuyin).toBe(20);
+    expect(cfg.chipsPerUnit).toBeGreaterThanOrEqual(1);
+  });
+
+  it('reads a chips-with-value tournament config', () => {
+    const cfg = readConfig({
+      unit: 'chipsWithValue',
+      chipsPerUnit: 50,
+      mode: 'tournament',
+      depth: 'betting',
+      smallBlind: 25,
+      bigBlind: 50,
+    });
+    expect(cfg.unit).toBe('chipsWithValue');
+    expect(cfg.chipsPerUnit).toBe(50);
+    expect(cfg.mode).toBe('tournament');
+    expect(cfg.depth).toBe('betting');
+  });
+
+  it('converts chips to money only when chipsWithValue', () => {
+    expect(toMoney(500, readConfig({ unit: 'chips' }))).toBe(500);
+    expect(toMoney(500, readConfig({ unit: 'chipsWithValue', chipsPerUnit: 100 }))).toBe(5);
+  });
+});
+
+describe('splitPot', () => {
+  it('splits evenly', () => {
+    expect(splitPot(90, ['a', 'b', 'c'])).toEqual({ a: 30, b: 30, c: 30 });
+  });
+
+  it('gives odd chips to the earliest winners', () => {
+    expect(splitPot(100, ['a', 'b', 'c'])).toEqual({ a: 34, b: 33, c: 33 });
+  });
+
+  it('handles a single winner and empty winners', () => {
+    expect(splitPot(120, ['a'])).toEqual({ a: 120 });
+    expect(splitPot(120, [])).toEqual({});
+  });
+});
+
+describe('sidePots', () => {
+  it('makes one pot when everyone contributes equally', () => {
+    const pots = sidePots({ a: 100, b: 100, c: 100 }, [], ['a', 'b', 'c']);
+    expect(pots).toEqual([{ amount: 300, eligible: ['a', 'b', 'c'] }]);
+  });
+
+  it('creates a side pot for a short all-in', () => {
+    // a is all-in for 50; b and c put in 200 each.
+    const pots = sidePots({ a: 50, b: 200, c: 200 }, [], ['a', 'b', 'c']);
+    expect(pots).toEqual([
+      { amount: 150, eligible: ['a', 'b', 'c'] }, // main: 50 each
+      { amount: 300, eligible: ['b', 'c'] }, // side: 150 each from b,c
+    ]);
+    expect(pots.reduce((s, p) => s + p.amount, 0)).toBe(450);
+  });
+
+  it('keeps folded chips in the pot but drops folded eligibility', () => {
+    // c folded after committing 200; a all-in 50, b calls 200.
+    const pots = sidePots({ a: 50, b: 200, c: 200 }, ['c'], ['a', 'b', 'c']);
+    expect(pots).toEqual([
+      { amount: 150, eligible: ['a', 'b'] },
+      { amount: 300, eligible: ['b'] },
+    ]);
+  });
+
+  it('layers three distinct all-in sizes', () => {
+    const pots = sidePots({ a: 20, b: 60, c: 100 }, [], ['a', 'b', 'c']);
+    expect(pots).toEqual([
+      { amount: 60, eligible: ['a', 'b', 'c'] }, // 20 each
+      { amount: 80, eligible: ['b', 'c'] }, // 40 each
+      { amount: 40, eligible: ['c'] }, // 40 from c
+    ]);
+  });
+});
+
+describe('scoreHand', () => {
+  it('is zero-sum: winner gains what losers put in', () => {
+    const event: HandEvent = {
+      kind: 'hand',
+      level: 2,
+      committed: { a: 50, b: 50, c: 50 },
+      pots: [{ amount: 150, winnerIds: ['a'] }],
+    };
+    const delta = scoreHand(event);
+    expect(delta).toEqual({ a: 100, b: -50, c: -50 });
+    expect(sum(delta)).toBe(0);
+  });
+
+  it('awards a split pot with the odd chip', () => {
+    const event: HandEvent = {
+      kind: 'hand',
+      level: 2,
+      committed: { a: 33, b: 33, c: 35 },
+      pots: [{ amount: 101, winnerIds: ['a', 'b'] }],
+    };
+    const delta = scoreHand(event);
+    expect(sum(delta)).toBe(0);
+    expect(delta.a).toBe(51 - 33); // 51 = ceil half of 101
+    expect(delta.b).toBe(50 - 33);
+    expect(delta.c).toBe(-35);
+  });
+
+  it('settles a multi-pot all-in showdown zero-sum', () => {
+    const committed = { a: 50, b: 200, c: 200 };
+    const pots = sidePots(committed, [], ['a', 'b', 'c']);
+    const event: HandEvent = {
+      kind: 'hand',
+      level: 3,
+      committed,
+      pots: [
+        { amount: pots[0].amount, winnerIds: ['a'] }, // short stack wins main
+        { amount: pots[1].amount, winnerIds: ['b'] }, // b wins the side
+      ],
+    };
+    const delta = scoreHand(event);
+    expect(sum(delta)).toBe(0);
+    expect(delta.a).toBe(150 - 50); // +100
+    expect(delta.b).toBe(300 - 200); // +100
+    expect(delta.c).toBe(-200);
+  });
+});
+
+describe('scoreEvent', () => {
+  it('buy-ins are net-neutral', () => {
+    const players = [player('a'), player('b')];
+    const event: HoldemEvent = { kind: 'buyin', playerId: 'a', amount: 20 };
+    expect(scoreEvent(event, ctxWith(players, []))).toEqual({});
+  });
+
+  it('cashout lands running totals exactly on net (ledger-only night)', () => {
+    const players = [player('a'), player('b')];
+    const events: HoldemEvent[] = [
+      { kind: 'buyin', playerId: 'a', amount: 20 },
+      { kind: 'buyin', playerId: 'b', amount: 20 },
+    ];
+    // No hands tracked, so totals are still 0 going into cashout.
+    const cashout: CashoutEvent = { kind: 'cashout', counts: { a: 35, b: 5 } };
+    const delta = scoreEvent(cashout, ctxWith(players, events, { a: 0, b: 0 }));
+    expect(delta).toEqual({ a: 15, b: -15 }); // a up 15, b down 15
+    expect(sum(delta)).toBe(0);
+  });
+
+  it('cashout reconciles on top of tracked hands', () => {
+    const players = [player('a'), player('b')];
+    const events: HoldemEvent[] = [
+      { kind: 'buyin', playerId: 'a', amount: 20 },
+      { kind: 'buyin', playerId: 'b', amount: 20 },
+    ];
+    // A hand already pushed a's total to +10, b to −10.
+    const cashout: CashoutEvent = { kind: 'cashout', counts: { a: 35, b: 5 } };
+    const delta = scoreEvent(cashout, ctxWith(players, events, { a: 10, b: -10 }));
+    // Final net is a:+15, b:−15; deltas top up from the tracked totals.
+    expect(delta).toEqual({ a: 5, b: -5 });
+  });
+});
+
+describe('investedByPlayer', () => {
+  it('sums buy-ins and rebuys, ignoring hands and cashouts', () => {
+    const rounds = [
+      { input: { kind: 'buyin', playerId: 'a', amount: 20 } },
+      { input: { kind: 'buyin', playerId: 'a', amount: 20 } },
+      { input: { kind: 'buyin', playerId: 'b', amount: 40 } },
+      { input: { kind: 'cashout', counts: { a: 0 } } },
+    ];
+    expect(investedByPlayer(rounds)).toEqual({ a: 40, b: 40 });
+  });
+});
+
+describe('settle', () => {
+  it('produces a minimal set of transfers that clears every net', () => {
+    const net: Record<string, number> = { a: 45, b: -20, c: -25 };
+    const transfers = settle(net);
+    // Each debtor pays a, at most n-1 transfers.
+    expect(transfers.length).toBeLessThanOrEqual(2);
+    const paidToA = transfers.filter((t) => t.to === 'a').reduce((s, t) => s + t.amount, 0);
+    expect(paidToA).toBe(45);
+    for (const id of Object.keys(net)) {
+      const out = transfers.filter((t) => t.from === id).reduce((s, t) => s + t.amount, 0);
+      const inc = transfers.filter((t) => t.to === id).reduce((s, t) => s + t.amount, 0);
+      expect(inc - out).toBeCloseTo(net[id], 5);
+    }
+  });
+
+  it('handles multiple creditors and debtors', () => {
+    const net: Record<string, number> = { a: 30, b: 20, c: -15, d: -35 };
+    const transfers = settle(net);
+    expect(transfers.length).toBeLessThanOrEqual(3);
+    for (const id of Object.keys(net)) {
+      const out = transfers.filter((t) => t.from === id).reduce((s, t) => s + t.amount, 0);
+      const inc = transfers.filter((t) => t.to === id).reduce((s, t) => s + t.amount, 0);
+      expect(inc - out).toBeCloseTo(net[id], 5);
+    }
+  });
+
+  it('drops rounding dust and returns nothing when even', () => {
+    expect(settle({ a: 0, b: 0 })).toEqual([]);
+    expect(settle({ a: 0.001, b: -0.001 })).toEqual([]);
+  });
+});
+
+describe('validateEvent', () => {
+  const players = [player('a'), player('b'), player('c')];
+  const ctx = ctxWith(players, []);
+
+  it('rejects a zero buy-in and an unknown player', () => {
+    expect(validateEvent({ kind: 'buyin', playerId: 'a', amount: 0 }, ctx)).toMatch(/more than 0/);
+    expect(validateEvent({ kind: 'buyin', playerId: 'z', amount: 20 }, ctx)).toMatch(/buying in/);
+  });
+
+  it('accepts a valid buy-in', () => {
+    expect(validateEvent({ kind: 'buyin', playerId: 'a', amount: 20 }, ctx)).toBeNull();
+  });
+
+  it('requires the pot to equal chips in', () => {
+    const bad: HandEvent = {
+      kind: 'hand',
+      level: 2,
+      committed: { a: 50, b: 50 },
+      pots: [{ amount: 80, winnerIds: ['a'] }],
+    };
+    expect(validateEvent(bad, ctx)).toMatch(/equal the chips/);
+  });
+
+  it('requires a winner and non-empty pot', () => {
+    expect(
+      validateEvent({ kind: 'hand', level: 2, committed: { a: 10 }, pots: [] }, ctx),
+    ).toMatch(/who wins/);
+    expect(
+      validateEvent({ kind: 'hand', level: 2, committed: {}, pots: [{ amount: 0, winnerIds: ['a'] }] }, ctx),
+    ).toMatch(/No chips/);
+  });
+
+  it('accepts a balanced hand', () => {
+    const ok: HandEvent = {
+      kind: 'hand',
+      level: 2,
+      committed: { a: 50, b: 50 },
+      pots: [{ amount: 100, winnerIds: ['a'] }],
+    };
+    expect(validateEvent(ok, ctx)).toBeNull();
+  });
+
+  it('validates cashout counts', () => {
+    expect(validateEvent({ kind: 'cashout', counts: {} }, ctx)).toMatch(/final chip counts/);
+    expect(validateEvent({ kind: 'cashout', counts: { a: -5 } }, ctx)).toMatch(/negative/);
+    expect(validateEvent({ kind: 'cashout', counts: { a: 10, b: 30 } }, ctx)).toBeNull();
+  });
+});
+
+describe('reconcileCashout', () => {
+  it('is zero when chips match buy-ins and signed otherwise', () => {
+    const players = [player('a'), player('b')];
+    const events: HoldemEvent[] = [
+      { kind: 'buyin', playerId: 'a', amount: 20 },
+      { kind: 'buyin', playerId: 'b', amount: 20 },
+    ];
+    const ctx = ctxWith(players, events);
+    expect(reconcileCashout({ kind: 'cashout', counts: { a: 25, b: 15 } }, ctx)).toBe(0);
+    expect(reconcileCashout({ kind: 'cashout', counts: { a: 25, b: 10 } }, ctx)).toBe(-5);
+  });
+});

--- a/src/lib/games/holdem/index.ts
+++ b/src/lib/games/holdem/index.ts
@@ -1,0 +1,175 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { holdemStats } from './stats';
+import {
+  investedByPlayer,
+  readConfig,
+  scoreEvent,
+  toMoney,
+  validateEvent,
+  type HoldemConfig,
+  type HoldemEvent,
+} from './logic';
+
+// One entry point for importers (editor, stats) even though the pure model lives
+// in ./logic.
+export {
+  readConfig,
+  scoreEvent,
+  toMoney,
+  validateEvent,
+  type HoldemConfig,
+  type HoldemEvent,
+} from './logic';
+
+/** Money-ish formatter for round summaries — a "$" prefix only in dollar modes. */
+function fmtAmount(amount: number, cfg: HoldemConfig): string {
+  const money = toMoney(amount, cfg);
+  const rounded = Math.round(money * 100) / 100;
+  const body = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(2);
+  return cfg.unit === 'chips' ? body : `$${body}`;
+}
+
+export const holdem: GameModule = {
+  id: 'holdem',
+  name: "Texas Hold'em",
+  tagline: 'Post the blinds. Rake the pot. Settle up.',
+  emoji: '♠️',
+  keywords: ['poker', 'holdem', "hold 'em", 'cards', 'chips', 'buy-in', 'cash game', 'tournament', 'betting'],
+  minPlayers: 2,
+  maxPlayers: 12,
+
+  configFields: [
+    {
+      key: 'unit',
+      label: 'Track in',
+      type: 'select',
+      default: 'dollars',
+      options: [
+        { value: 'dollars', label: 'Dollars ($)' },
+        { value: 'chips', label: 'Chips only' },
+        { value: 'chipsWithValue', label: 'Chips with a cash value' },
+      ],
+      help: 'How buy-ins and pots are entered — and how the final settle-up reads.',
+    },
+    {
+      key: 'chipsPerUnit',
+      label: 'Chips per $1',
+      type: 'number',
+      default: 100,
+      min: 1,
+      max: 100000,
+      step: 1,
+      help: 'Only used when tracking chips with a cash value.',
+    },
+    { key: 'defaultBuyin', label: 'Default buy-in', type: 'number', default: 20, min: 1, step: 1 },
+    { key: 'rebuys', label: 'Allow rebuys', type: 'boolean', default: true },
+    {
+      key: 'depth',
+      label: 'Track hands',
+      type: 'select',
+      default: 'ledger',
+      options: [
+        { value: 'ledger', label: 'Buy-ins only (settle at the end)' },
+        { value: 'perhand', label: 'Per hand — tap the winner + pot' },
+        { value: 'betting', label: 'Full betting — run every street' },
+      ],
+      help: 'The default flow for a new hand. You can still change it hand to hand.',
+    },
+    {
+      key: 'mode',
+      label: 'Format',
+      type: 'select',
+      default: 'cash',
+      options: [
+        { value: 'cash', label: 'Cash game' },
+        { value: 'tournament', label: 'Tournament' },
+      ],
+    },
+    {
+      key: 'startingStack',
+      label: 'Starting stack (chips)',
+      type: 'number',
+      default: 1000,
+      min: 1,
+      step: 50,
+      help: 'Chips a player brings into a full-betting hand.',
+    },
+    { key: 'smallBlind', label: 'Small blind', type: 'number', default: 5, min: 0, step: 1 },
+    { key: 'bigBlind', label: 'Big blind', type: 'number', default: 10, min: 0, step: 1 },
+    { key: 'ante', label: 'Ante', type: 'number', default: 0, min: 0, step: 1 },
+    {
+      key: 'blindMinutes',
+      label: 'Minutes per blind level',
+      type: 'number',
+      default: 15,
+      min: 1,
+      max: 120,
+      step: 1,
+      help: 'Tournament level timer length.',
+    },
+  ],
+
+  // Open-ended: a poker night runs until the table cashes out and settles up.
+  maxRounds: () => null,
+
+  createRoundInput: (ctx: RoundContext): HoldemEvent => {
+    // Default the next event to a buy-in for the first player still needing chips,
+    // pre-filled with the table's default buy-in. The editor switches event kinds.
+    const cfg = readConfig(ctx.config);
+    const invested = investedByPlayer(ctx.rounds);
+    const next = ctx.players.find((p) => !(invested[p.id] > 0)) ?? ctx.players[0];
+    return { kind: 'buyin', playerId: next?.id ?? '', amount: cfg.defaultBuyin };
+  },
+
+  validateRound: (input: HoldemEvent, ctx: RoundContext): string | null => validateEvent(input, ctx),
+
+  scoreRound: (input: HoldemEvent, ctx: RoundContext): Record<ID, number> => scoreEvent(input, ctx),
+
+  describeRound: (round: Round, players): string => {
+    const event = round.input as HoldemEvent | undefined;
+    const name = (id: ID) => players.find((p) => p.id === id)?.name ?? '—';
+    // describeRound has no config in scope; read amounts as raw units (no "$"
+    // guess) so the summary stays correct in every mode.
+    const amt = (n: number) => Math.round(n).toLocaleString();
+    if (!event) return '';
+    switch (event.kind) {
+      case 'buyin':
+        return `💰 ${name(event.playerId)} bought in ${amt(event.amount)}`;
+      case 'hand': {
+        const pot = event.pots.reduce((a, p) => a + (Number(p.amount) || 0), 0);
+        const winners = Array.from(new Set(event.pots.flatMap((p) => p.winnerIds)))
+          .map(name)
+          .join(' & ');
+        return `♠️ ${winners} won ${amt(pot)}`;
+      }
+      case 'cashout': {
+        const parts = Object.keys(event.counts).map((id) => `${name(id)} ${amt(event.counts[id])}`);
+        return `🧮 Cash out · ${parts.join(' · ')}`;
+      }
+    }
+  },
+
+  help: [
+    "Texas Hold'em — the app is your dealer's ledger, not the cards. Keep the real",
+    'cards and chips on the table; the phone tracks the money and settles up.',
+    '',
+    'Track at any granularity:',
+    '• Buy-ins only — log each buy-in/rebuy, count chips at the end, get the settle-up.',
+    '• Per hand — tap who won and the pot; standings update live.',
+    '• Full betting — run preflop/flop/turn/river; calls, all-ins and side-pots are',
+    '  worked out for you, then tap the winner of each pot.',
+    '',
+    'Buy-ins never change who is up or down — cash becomes chips at par. Chips only',
+    'move when a hand is settled. At the end, "Cash out" counts everyone up and shows',
+    'the shortest list of "who pays whom".',
+    '',
+    'Blinds, antes and a tournament level timer appear when you turn on full betting',
+    'or tournament mode.',
+  ].join('\n'),
+
+  stats: holdemStats,
+
+  RoundEditor,
+  editorLoader: () => import('./HoldemEditor.svelte'),
+};

--- a/src/lib/games/holdem/logic.ts
+++ b/src/lib/games/holdem/logic.ts
@@ -1,0 +1,431 @@
+import type { ID, RoundContext } from '../../types';
+
+/**
+ * Pure, Svelte-free Texas Hold'em model — the dealer's ledger, not a card
+ * simulator. Real cards + chips stay on the table; this tracks the *money*: what
+ * each player buys in for, how chips move when a hand is settled, and — the whole
+ * point — a minimal "who owes whom" settlement at the end. No I/O, no DOM, so the
+ * engine, editor and stats share one testable source of truth.
+ *
+ * ## How it maps onto Score King's engine
+ * The generic engine is `round -> per-player deltas -> accumulating totals`. Here
+ * **one round = one ledger event**, and a player's running **total = their net
+ * position** in the tracking unit (dollars or chips):
+ *
+ * - **buyin**  — cash becomes chips at par, so net is unchanged: delta `0` for
+ *   everyone. The amount is stored so we can tally what each player invested.
+ * - **hand**   — chips move between players (zero-sum): delta = winnings − what
+ *   you put in this hand. Built at any granularity (a tapped winner, or a full
+ *   street-by-street run that produces side-pots).
+ * - **cashout** — final chip counts reconcile the books: a player's delta is set
+ *   so their running total lands exactly on `finalChips − invested`, whatever
+ *   was (or wasn't) tracked hand-by-hand along the way.
+ *
+ * Chips are conserved, so across a whole session every delta set sums to 0, and
+ * the settlement below always balances.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** How a table keeps score, and therefore how settlement is displayed. */
+export type Unit = 'dollars' | 'chips' | 'chipsWithValue';
+
+/** Default new-hand flow. Any single hand can still be escalated in the editor. */
+export type Depth = 'ledger' | 'perhand' | 'betting';
+
+export type Mode = 'cash' | 'tournament';
+
+export interface HoldemConfig {
+  /** What amounts are entered in; `chipsWithValue` converts to money for settle-up. */
+  unit: Unit;
+  /** Chips per one money unit — only meaningful when `unit === 'chipsWithValue'`. */
+  chipsPerUnit: number;
+  /** Pre-filled amount for the one-tap "+ Buy-in" / rebuy button. */
+  defaultBuyin: number;
+  /** Starting stack for full-betting hands (chips brought into a hand). */
+  startingStack: number;
+  /** Whether rebuys are offered between hands. */
+  rebuys: boolean;
+  /** Default granularity of a new hand. */
+  depth: Depth;
+  /** Cash (open-ended) vs tournament (play down to one stack). */
+  mode: Mode;
+  smallBlind: number;
+  bigBlind: number;
+  ante: number;
+  /** Minutes per blind level (tournament level timer). */
+  blindMinutes: number;
+}
+
+const DEFAULTS: HoldemConfig = {
+  unit: 'dollars',
+  chipsPerUnit: 100,
+  defaultBuyin: 20,
+  startingStack: 1000,
+  rebuys: true,
+  depth: 'ledger',
+  mode: 'cash',
+  smallBlind: 5,
+  bigBlind: 10,
+  ante: 0,
+  blindMinutes: 15,
+};
+
+function num(v: unknown, fallback: number): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function readConfig(config: Record<string, unknown>): HoldemConfig {
+  const unitRaw = String(config.unit);
+  const unit: Unit =
+    unitRaw === 'chips' || unitRaw === 'chipsWithValue' ? (unitRaw as Unit) : 'dollars';
+  const depthRaw = String(config.depth);
+  const depth: Depth =
+    depthRaw === 'perhand' || depthRaw === 'betting' ? (depthRaw as Depth) : 'ledger';
+  const mode: Mode = String(config.mode) === 'tournament' ? 'tournament' : 'cash';
+  return {
+    unit,
+    chipsPerUnit: Math.max(1, Math.trunc(num(config.chipsPerUnit, DEFAULTS.chipsPerUnit))),
+    defaultBuyin: Math.max(0, num(config.defaultBuyin, DEFAULTS.defaultBuyin)),
+    startingStack: Math.max(1, Math.trunc(num(config.startingStack, DEFAULTS.startingStack))),
+    rebuys: config.rebuys === undefined ? DEFAULTS.rebuys : !!config.rebuys,
+    depth,
+    mode,
+    smallBlind: Math.max(0, num(config.smallBlind, DEFAULTS.smallBlind)),
+    bigBlind: Math.max(0, num(config.bigBlind, DEFAULTS.bigBlind)),
+    ante: Math.max(0, num(config.ante, DEFAULTS.ante)),
+    blindMinutes: Math.max(1, Math.trunc(num(config.blindMinutes, DEFAULTS.blindMinutes))),
+  };
+}
+
+/** Convert a base-unit amount to money for display (only differs when chipsWithValue). */
+export function toMoney(amount: number, cfg: HoldemConfig): number {
+  return cfg.unit === 'chipsWithValue' ? amount / cfg.chipsPerUnit : amount;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Round events
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One awarded pot (main or side): its size and who splits it. */
+export interface PotResult {
+  amount: number;
+  /** Winners, ordered first-to-act (left of the button) so odd chips break left. */
+  winnerIds: ID[];
+  /** Optional label for the history summary ("Side pot", "Main"). */
+  label?: string;
+}
+
+/** A single logged action during a full-betting hand (Level 3), for replay/audit. */
+export interface ActionLogEntry {
+  playerId: ID;
+  street: Street;
+  action: BetAction;
+  /** Chips put in by this action (call/bet/raise/all-in), 0 for check/fold. */
+  amount: number;
+}
+
+/** A buy-in or rebuy — money becomes chips at par, so it never moves net. */
+export interface BuyinEvent {
+  kind: 'buyin';
+  playerId: ID;
+  amount: number;
+}
+
+/** A settled hand: what each player put in, and how the pot(s) were awarded. */
+export interface HandEvent {
+  kind: 'hand';
+  /** 2 = tapped winner + contributions, 3 = full street-by-street run. */
+  level: 2 | 3;
+  /** Chips each player committed to the pot this hand. */
+  committed: Record<ID, number>;
+  /** Awarded pots (one for level 2, one-or-more side-pots for level 3). */
+  pots: PotResult[];
+  /** Present for level 3: dealer button + blinds context and the action log. */
+  button?: ID;
+  blinds?: { sb: number; bb: number; ante: number };
+  log?: ActionLogEntry[];
+}
+
+/** Final chip counts (for all players or just those leaving), reconciling the books. */
+export interface CashoutEvent {
+  kind: 'cashout';
+  counts: Record<ID, number>;
+}
+
+export type HoldemEvent = BuyinEvent | HandEvent | CashoutEvent;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Full-betting types (Level 3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type Street = 'preflop' | 'flop' | 'turn' | 'river' | 'showdown';
+export type BetAction = 'fold' | 'check' | 'call' | 'bet' | 'raise' | 'allin';
+
+/** A player's live state within one full-betting hand. */
+export interface Seat {
+  playerId: ID;
+  /** Chips remaining in front of the player. */
+  stack: number;
+  /** Chips committed on the current street. */
+  committedStreet: number;
+  /** Chips committed across the whole hand so far. */
+  committedHand: number;
+  folded: boolean;
+  allIn: boolean;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Side-pot algorithm — the part home games always get wrong
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A pot layer: its size and the players eligible to win it (contributed & not folded). */
+export interface PotLayer {
+  amount: number;
+  eligible: ID[];
+}
+
+/**
+ * Split all committed chips into a main pot and any side-pots created by all-ins
+ * of differing sizes. Folded players' chips still *fund* the pots but can never
+ * win them. Adjacent layers with an identical eligible set are merged so the
+ * result is the minimal set of distinct pots.
+ *
+ * @param committed  chips each player put in across the whole hand
+ * @param folded     ids of players who folded (chips stay in, eligibility lost)
+ * @param order      seat order (left of button first) — orders `eligible` for
+ *                   deterministic odd-chip breaking at showdown
+ */
+export function sidePots(
+  committed: Record<ID, number>,
+  folded: Iterable<ID>,
+  order?: ID[],
+): PotLayer[] {
+  const foldedSet = new Set(folded);
+  const seq = order ?? Object.keys(committed);
+  // Work on a copy we can peel down layer by layer, in seat order.
+  const remain = new Map<ID, number>();
+  for (const id of seq) remain.set(id, Math.max(0, Math.round(committed[id] ?? 0)));
+  // Include any contributor not named in `order`, so nothing is dropped.
+  for (const id of Object.keys(committed)) {
+    if (!remain.has(id)) remain.set(id, Math.max(0, Math.round(committed[id] ?? 0)));
+  }
+
+  const layers: PotLayer[] = [];
+  for (;;) {
+    // Smallest positive remaining contribution defines the next layer height.
+    let m = Infinity;
+    for (const v of remain.values()) if (v > 0 && v < m) m = v;
+    if (!Number.isFinite(m)) break;
+
+    let amount = 0;
+    const eligible: ID[] = [];
+    for (const [id, v] of remain) {
+      if (v <= 0) continue;
+      remain.set(id, v - m);
+      amount += m;
+      if (!foldedSet.has(id)) eligible.push(id);
+    }
+    layers.push({ amount, eligible });
+  }
+
+  // Merge adjacent layers whose eligible sets match — a single logical pot.
+  const merged: PotLayer[] = [];
+  for (const layer of layers) {
+    const prev = merged[merged.length - 1];
+    if (prev && sameSet(prev.eligible, layer.eligible)) prev.amount += layer.amount;
+    else merged.push({ amount: layer.amount, eligible: [...layer.eligible] });
+  }
+  return merged;
+}
+
+function sameSet(a: ID[], b: ID[]): boolean {
+  if (a.length !== b.length) return false;
+  const s = new Set(a);
+  return b.every((x) => s.has(x));
+}
+
+/**
+ * Evenly split a pot among its winners, awarding any odd remainder one chip at a
+ * time to the earliest-acting winners (already ordered left of the button). Pure
+ * integer math so chips never leak.
+ */
+export function splitPot(amount: number, winnerIds: ID[]): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  const n = winnerIds.length;
+  if (n === 0) return out;
+  const whole = Math.floor(amount / n);
+  let rem = amount - whole * n;
+  for (const id of winnerIds) {
+    out[id] = (out[id] ?? 0) + whole + (rem > 0 ? 1 : 0);
+    if (rem > 0) rem--;
+  }
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hand scoring — net chip delta per player for one settled hand
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Net chips per player for a settled hand: winnings from every awarded pot minus
+ * what they committed. Zero-sum whenever the pots' total equals the chips put in
+ * (always true for pots derived from contributions / {@link sidePots}).
+ */
+export function scoreHand(event: HandEvent): Record<ID, number> {
+  const delta: Record<ID, number> = {};
+  for (const [id, amt] of Object.entries(event.committed)) {
+    delta[id] = (delta[id] ?? 0) - (Math.round(amt) || 0);
+  }
+  for (const pot of event.pots) {
+    const shares = splitPot(Math.round(pot.amount) || 0, pot.winnerIds);
+    for (const [id, s] of Object.entries(shares)) delta[id] = (delta[id] ?? 0) + s;
+  }
+  return delta;
+}
+
+/** Total chips a player has invested so far (sum of their buy-ins / rebuys). */
+export function investedByPlayer(rounds: { input: unknown }[]): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const r of rounds) {
+    const e = r.input as HoldemEvent | undefined;
+    if (e?.kind === 'buyin') out[e.playerId] = (out[e.playerId] ?? 0) + (Number(e.amount) || 0);
+  }
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Engine glue: score one event into per-player deltas
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Per-player deltas for one ledger event, in the tracking unit. `buyin` moves
+ * nothing (net-neutral); `hand` applies the zero-sum chip swing; `cashout` snaps
+ * each named player's running total onto `finalChips − invested` so the books
+ * reconcile no matter how much was tracked hand-by-hand.
+ */
+export function scoreEvent(event: HoldemEvent, ctx: RoundContext): Record<ID, number> {
+  switch (event.kind) {
+    case 'buyin':
+      return {}; // net-neutral: chips in == cash in
+    case 'hand':
+      return scoreHand(event);
+    case 'cashout': {
+      const invested = investedByPlayer(ctx.rounds);
+      const out: Record<ID, number> = {};
+      for (const [id, count] of Object.entries(event.counts)) {
+        const net = (Number(count) || 0) - (invested[id] ?? 0);
+        const before = ctx.totals[id] ?? 0;
+        out[id] = net - before; // land the running total exactly on net
+      }
+      return out;
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Settlement — the headline "who owes whom"
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface Transfer {
+  from: ID;
+  to: ID;
+  amount: number;
+}
+
+/**
+ * Turn a set of net positions (must sum to ~0) into a *minimal* list of payments
+ * that settles everyone up. Greedy: repeatedly send the biggest debtor's whole
+ * debt to the biggest creditor, which yields at most n−1 transfers — the fewest
+ * anyone has to hand over cash. Works in integer hundredths to dodge float drift.
+ *
+ * @param net       net position per player, in the tracking unit (+ = is owed)
+ * @param minAmount payments strictly below this are dropped as rounding dust
+ */
+export function settle(net: Record<ID, number>, minAmount = 0.005): Transfer[] {
+  const cents = (v: number) => Math.round(v * 100);
+  const creditors: { id: ID; v: number }[] = [];
+  const debtors: { id: ID; v: number }[] = [];
+  for (const [id, raw] of Object.entries(net)) {
+    const c = cents(raw);
+    if (c > 0) creditors.push({ id, v: c });
+    else if (c < 0) debtors.push({ id, v: -c });
+  }
+  // Largest first so the biggest imbalances clear in the fewest hops.
+  creditors.sort((a, b) => b.v - a.v);
+  debtors.sort((a, b) => b.v - a.v);
+
+  const transfers: Transfer[] = [];
+  let i = 0;
+  let j = 0;
+  const floor = cents(minAmount);
+  while (i < debtors.length && j < creditors.length) {
+    const pay = Math.min(debtors[i].v, creditors[j].v);
+    if (pay > 0 && pay >= floor) {
+      transfers.push({ from: debtors[i].id, to: creditors[j].id, amount: pay / 100 });
+    }
+    debtors[i].v -= pay;
+    creditors[j].v -= pay;
+    if (debtors[i].v <= 0) i++;
+    if (creditors[j].v <= 0) j++;
+  }
+  return transfers;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Return null when the event is recordable, else a short human-readable reason. */
+export function validateEvent(event: HoldemEvent, ctx: RoundContext): string | null {
+  switch (event.kind) {
+    case 'buyin': {
+      if (!ctx.players.some((p) => p.id === event.playerId)) return 'Pick who is buying in.';
+      if (!(Number(event.amount) > 0)) return 'Buy-in must be more than 0.';
+      return null;
+    }
+    case 'hand': {
+      const committedTotal = Object.values(event.committed).reduce(
+        (a, v) => a + (Number(v) || 0),
+        0,
+      );
+      if (committedTotal <= 0) return 'No chips in the pot yet.';
+      if (Object.values(event.committed).some((v) => Number(v) < 0))
+        return 'Bets cannot be negative.';
+      if (event.pots.length === 0 || event.pots.some((p) => p.winnerIds.length === 0))
+        return 'Pick who wins the pot.';
+      const potTotal = event.pots.reduce((a, p) => a + (Number(p.amount) || 0), 0);
+      if (Math.round(potTotal) !== Math.round(committedTotal))
+        return 'Pot awarded must equal the chips put in.';
+      return null;
+    }
+    case 'cashout': {
+      const ids = Object.keys(event.counts);
+      if (ids.length === 0) return 'Enter final chip counts to settle up.';
+      if (Object.values(event.counts).some((v) => !Number.isFinite(Number(v)) || Number(v) < 0))
+        return 'Chip counts cannot be negative.';
+      return null;
+    }
+  }
+}
+
+/**
+ * Do the final chip counts reconcile with the money put on the table? Chips are
+ * conserved, so a healthy count matches total buy-ins exactly. Returns the signed
+ * difference (counted − invested) for the *counted* players; the editor surfaces a
+ * gentle "off by N" nudge without blocking the save. Non-zero is legitimate when a
+ * player pocketed or lost chips, so it's a warning, never an error.
+ */
+export function reconcileCashout(event: CashoutEvent, ctx: RoundContext): number {
+  const invested = investedByPlayer(ctx.rounds);
+  let counted = 0;
+  let owed = 0;
+  for (const id of Object.keys(event.counts)) {
+    counted += Number(event.counts[id]) || 0;
+    owed += invested[id] ?? 0;
+  }
+  return counted - owed;
+}

--- a/src/lib/games/holdem/stats.ts
+++ b/src/lib/games/holdem/stats.ts
@@ -1,0 +1,123 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt, fmtPct, fmtSigned } from '../../stats/format';
+import { readConfig, toMoney, type HoldemConfig, type HoldemEvent } from './logic';
+
+interface HoldemAgg {
+  /** Net across all sessions, in money units (converted per that game's config). */
+  net: number;
+  /** Total money bought in (the "ATM" — how much they kept reloading). */
+  invested: number;
+  buyins: number;
+  handsWon: number;
+  handsPlayed: number;
+  biggestPot: number;
+  biggestHandWin: number;
+}
+
+/**
+ * Poker stats, derived purely from each session's ledger events. Everything is
+ * normalized to money via each game's own {@link toMoney}, so a chips-only table
+ * and a dollars table read on one leaderboard. A player "played" a hand when they
+ * committed chips to it; they "won" it when they took any pot. Pure — no Svelte —
+ * so it is unit-testable and safe for the stats engine to import.
+ */
+export function holdemStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const cfgOf = new Map<ID, HoldemConfig>(games.map((g) => [g.id, readConfig(g.config)]));
+
+  const per = new Map<ID, HoldemAgg>();
+  const get = (id: ID): HoldemAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = {
+        net: 0,
+        invested: 0,
+        buyins: 0,
+        handsWon: 0,
+        handsPlayed: 0,
+        biggestPot: 0,
+        biggestHandWin: 0,
+      };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const event = r.input as HoldemEvent | undefined;
+    if (!event) continue;
+    const cfg = cfgOf.get(r.gameId);
+    const money = (n: number) => (cfg ? toMoney(n, cfg) : n);
+
+    if (event.kind === 'buyin') {
+      const id = canonical(event.playerId);
+      const a = get(id);
+      a.invested += money(Number(event.amount) || 0);
+      a.buyins += 1;
+      continue;
+    }
+
+    if (event.kind === 'hand') {
+      const pot = money(event.pots.reduce((s, p) => s + (Number(p.amount) || 0), 0));
+      // Who committed chips this hand = who played it.
+      for (const [pid, amt] of Object.entries(event.committed)) {
+        if ((Number(amt) || 0) > 0) get(canonical(pid)).handsPlayed += 1;
+      }
+      // Net per winner from this hand (winnings − their own commitment).
+      const winners = new Set(event.pots.flatMap((p) => p.winnerIds).map(canonical));
+      const wonBy = new Map<ID, number>();
+      for (const p of event.pots) {
+        const share = (Number(p.amount) || 0) / Math.max(1, p.winnerIds.length);
+        for (const w of p.winnerIds) wonBy.set(canonical(w), (wonBy.get(canonical(w)) ?? 0) + share);
+      }
+      for (const id of winners) {
+        const a = get(id);
+        a.handsWon += 1;
+        a.biggestPot = Math.max(a.biggestPot, pot);
+        const committed = money(Number(event.committed[id] ?? 0) || 0);
+        const netWin = money(wonBy.get(id) ?? 0) - committed;
+        a.biggestHandWin = Math.max(a.biggestHandWin, netWin);
+      }
+      continue;
+    }
+    // cashout events don't add stats directly; net comes from the game totals below.
+  }
+
+  // Net per player comes straight from the recorded deltas (already in the game's
+  // unit), summed and converted to money for a mixed-table leaderboard.
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const cfg = cfgOf.get(r.gameId);
+    for (const [pid, d] of Object.entries(r.deltas)) {
+      get(canonical(pid)).net += cfg ? toMoney(Number(d) || 0, cfg) : Number(d) || 0;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [
+      { key: 'net', label: 'Net', value: fmtSigned(Math.round(a.net)), emoji: a.net >= 0 ? '📈' : '📉' },
+      { key: 'invested', label: 'Bought in', value: fmtInt(a.invested), emoji: '💰' },
+      {
+        key: 'winRate',
+        label: 'Hands won',
+        value: a.handsPlayed ? fmtPct(a.handsWon / a.handsPlayed) : '—',
+        sub: a.handsPlayed ? `${fmtInt(a.handsWon)} of ${fmtInt(a.handsPlayed)}` : undefined,
+        emoji: '🃏',
+      },
+    ];
+    if (a.biggestPot > 0)
+      metrics.push({ key: 'bigpot', label: 'Biggest pot', value: fmtInt(a.biggestPot), emoji: '🏆' });
+    perPlayer[id] = metrics;
+  }
+
+  // A light global flourish: the single biggest pot anyone dragged all night.
+  const global: Metric[] = [];
+  let bigPot = 0;
+  for (const [, a] of per) bigPot = Math.max(bigPot, a.biggestPot);
+  if (bigPot > 0) global.push({ key: 'bigpot', label: 'Biggest pot', value: fmtInt(bigPot), emoji: '🏆' });
+
+  return { perPlayer, global: global.length ? global : undefined };
+}


### PR DESCRIPTION
## ♠️ Texas Hold'em

Adds Texas Hold'em to Score King. The phone acts as the **dealer's ledger** — real cards and chips stay on the table while the app tracks buy-ins, runs betting, and produces a minimal **"who owes whom" settle-up**.

### Three interoperable granularity levels (switchable per hand)
1. **Buy-in ledger** — log buy-ins/rebuys, count chips at the end, get the settle-up.
2. **Quick per-hand** — chips in + tap the winner(s).
3. **Full betting** — preflop→river with auto call amounts, all-ins, and **side-pots**, then tap each pot's winner.

### Engine mapping
One round = one ledger event (`buyin` / `hand` / `cashout`); per-player deltas always sum to zero (buy-ins are net-neutral). No engine or registry changes needed — the module is auto-discovered.

### Files (`src/lib/games/holdem/`)
- `logic.ts` — pure model: side-pot peeling, greedy min-transfer settlement, hand scoring, validation, cash-out reconciliation
- `index.ts` — `GameModule` wiring (config, validate/score, describe, help, stats)
- `HoldemEditor.svelte` — routes buy-in / hand / cash-out with a live bank preview
- `TableBank.svelte`, `BettingBoard.svelte`, `Settlement.svelte`, `stats.ts`
- `holdem.test.ts` — 27 tests

### Design (DESIGN.md)
Crown Gold reserved for the chip leader 👑 only; one Royal-Violet action per view; `tabular-nums` on every number; ≥46px touch targets; state co-signaled with text + sign, never color alone.

### Verification
- ✅ `svelte-check`: 0 errors, 0 warnings
- ✅ Full suite: **1302 tests pass** (49 files, incl. registry)
- ✅ `vite build` succeeds

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>