### PR TITLE
chore(sync): update hardened canonical prompts (#114)

### DIFF
--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -11,7 +11,9 @@ Every product change must trace to a GitHub issue and land through a feature bra
 
 1. Verify or create the GitHub issue.
 2. Scan for an existing worktree for the issue; resume it if found.
-3. Otherwise create a worktree from the default branch.
+3. Otherwise prefer an app-native isolated project session/worktree from the default branch. If that
+   capability is unavailable, require a runtime-provided, explicitly approved location allowed by
+   root/scoped authority.
 4. Implement scoped changes on a feature branch.
 5. Commit as `type(scope): description (#N)`.
 6. Run the repo's documented format, lint, type-check, test, and build commands for the affected surface.
@@ -38,13 +40,18 @@ Stopping at a local commit is incomplete. A task is done only when the PR is mer
 
 ## Worktrees
 
-Use git worktrees rather than extra clones.
+Prefer app-native isolated project sessions/worktrees rather than extra clones. Never invent or
+hard-code a sibling worktree path. If app-native isolation is unavailable, the runtime must provide
+an explicitly approved worktree location and root/scoped authority must permit it; otherwise stop.
 
 ```bash
 git worktree list
-git worktree add ../wt-<agent>-<type>-<issue> -b <type>/<short-description>-<issue> origin/<default-branch>
-git worktree remove ../wt-<agent>-<type>-<issue>
+git worktree add <approved-worktree-path> -b <type>/<short-description>-<issue> origin/<default-branch>
+git worktree remove <approved-owned-worktree-path>
 ```
+
+Record the exact branch, path, and creating session before mutation. Remove only worktrees created
+and owned by the current session; never recursively delete a worktree path.
 
 Branch types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `perf`.
 
@@ -70,7 +77,8 @@ Typical coverage:
 - Unit/integration tests for changed behavior.
 - Build/package checks for affected apps or packages.
 
-If any check fails, fix it, rerun the relevant checks, amend or commit, and push again.
+If any check fails, fix it, rerun the relevant checks, create a new scoped commit, and push again.
+Amend only when the user explicitly requests it and applicable authority permits it.
 
 ## Calling reusable workflows
 
@@ -189,8 +197,9 @@ Use `git push --force-with-lease` only after a rebase on your own PR branch. Nev
 For parallel sprint work:
 
 1. Query issues and PRs.
-2. Assign unclaimed issues by labels and file ownership in `AGENTS.md` and `.github/agents/`
-   (`agents/` in the canonical backbone).
+2. Resolve applicable roles from root/scoped `AGENTS.md`, consumer `.github/instructions/`, and
+   declared local routing. A discovered `.github/agents/` file alone does not authorize dispatch;
+   exclude disabled, handoff-only, read-only, and out-of-scope roles.
 3. Track assignments in SQL todos.
 4. Batch small related issues only when they touch the same files and keep the PR under reviewable size.
 5. Publish a merge order for dependent PRs.

--- a/.github/prompts/backlog.prompt.md
+++ b/.github/prompts/backlog.prompt.md
@@ -1,13 +1,28 @@
 ---
 name: backlog
 description: Show the current project status dashboard — issues, PRs, CI, worktrees
-parameters: []
+parameters:
+  - name: recent-days
+    type: integer
+    description: Number of days included in the recently completed issue summary
+    default: 14
+    minimum: 1
+    maximum: 90
+built_ins: []
+agent_dependencies: []
 ---
 <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
 
 # Backlog — Project Status Dashboard
 
 Generate a concise status report for the product repository.
+
+## Runtime Contract
+
+Require parameter interpolation before collecting data. Validate `{{ recent-days }}` as an integer
+within its declared bounds; stop without reporting if interpolation is unavailable or the value is
+invalid. If any bounded query returns exactly its limit, label that section as truncated rather than
+claiming a complete total.
 
 ## Data Collection
 
@@ -17,33 +32,49 @@ Generate a concise status report for the product repository.
 gh issue list --state open --limit 200 --json number,title,labels,milestone,assignees,createdAt,updatedAt
 ```
 
-Categorize issues by owner/agent, priority, and status (unclaimed, in progress, blocked, linked PR).
+Categorize issues by owner, priority, and status. Do not infer issue/PR linkage from branch names,
+worktrees, titles, or issue text.
 
 ### 2. Open Pull Requests
 
 ```bash
-gh pr list --state open --limit 200 --json number,title,headRefName,author,createdAt,updatedAt,statusCheckRollup,mergeable,reviewDecision
+gh pr list --state open --limit 200 --json number,title,headRefName,author,createdAt,updatedAt,statusCheckRollup,mergeable,reviewDecision,closingIssuesReferences
 ```
 
-Report CI status, conflicts, review status, and age for each PR.
+Report CI status, conflicts, review status, and age for each PR. Treat
+`closingIssuesReferences` as the only collected issue/PR linkage for this dashboard.
 
 ### 3. Worktree Status
 
 ```bash
-git worktree list
+git worktree list --porcelain
 ```
 
-For each worktree, identify branch, linked issue/PR, status, and recommendation.
+For each worktree, identify its branch and status. Associate a worktree with a PR only when its
+collected branch exactly matches a collected `headRefName`; do not claim issue linkage without the
+collected PR closing reference.
 
 ### 4. CI Failures
 
 For PRs with failing checks:
 
 ```bash
-gh pr checks <number> --json name,state,conclusion
+gh pr checks <number> --json name,state,bucket,link,workflow
 ```
 
 Group failures by type: format, lint, type-check, build, test, deploy, or other.
+
+### 5. Recently Closed Issues
+
+Compute the ISO date `{{ recent-days }}` days before today using a runtime date facility, then query
+the bounded closed population:
+
+```bash
+gh issue list --state closed --limit 100 --search "closed:>=<YYYY-MM-DD>" --json number,title,closedAt,labels,assignees
+```
+
+Count and list only rows returned by this query. If 100 rows are returned, report "at least 100"
+and mark the result truncated. Never derive "done recently" from open PRs or local branches.
 
 ## Report Format
 
@@ -71,7 +102,7 @@ Group failures by type: format, lint, type-check, build, test, deploy, or other.
 | ... |
 
 ### Summary
-- Done recently: N issues closed
+- Done recently: N issues closed in the last {{ recent-days }} days
 - In progress: N PRs open
 - Blocked: N PRs failing CI or conflicting
 - Backlog: N unclaimed issues

--- a/.github/prompts/bug-bash.prompt.md
+++ b/.github/prompts/bug-bash.prompt.md
@@ -1,0 +1,118 @@
+---
+name: bug-bash
+description: Run a bounded bug discovery, reproduction, fix, and verification campaign
+parameters:
+  - name: scope
+    type: string
+    description: Product area, recent change set, or test surface to investigate
+    default: recent-changes
+  - name: max-findings
+    type: integer
+    description: Maximum verified defects to carry into issue and fix work
+    default: 5
+    minimum: 1
+    maximum: 10
+built_ins:
+  - task
+  - read_agent
+  - list_agents
+  - sql_todos
+agent_dependencies:
+  - qa-tester
+---
+<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
+
+# Bug Bash — Bounded Discovery and Repair
+
+Coordinate a time-boxed workflow across existing roles. This is a task-mode campaign, not a new or
+permanent agent.
+
+## Runtime Contract
+
+This prompt requires Copilot App/CLI parameter interpolation, `task` dispatch, agent polling through
+`read_agent` / `list_agents`, and SQL todos. These are runtime contracts, not repository custom-agent
+slugs. Validate non-empty `{{ scope }}` and validate `{{ max-findings }}` as a positive integer within
+its declared bounds. If interpolation or a required capability is unavailable, stop before dispatch,
+issue creation, or mutation.
+
+## Execution Plan
+
+### 1. Resolve Authority, Roster, and Test Surface
+
+Read root `AGENTS.md`, scoped `AGENTS.md` applicable to `{{ scope }}`, product documentation, and
+applicable consumer `.github/instructions/`. In the canonical backbone, also consult source
+`instructions/`.
+
+Confirm that `qa-tester` is selected and applicable under the local routing overlay. Build the
+implementation roster from known canonical plus declared-local roles, excluding disabled,
+handoff-only, read-only, or out-of-scope roles. File presence in `.github/agents/` alone is not
+dispatch authority. Infrastructure or pre-bootstrap repositories require an explicit local
+infrastructure-safe override; otherwise stop with a read-only test plan.
+
+Define a finite scenario list for `{{ scope }}` from recent changes, critical user paths, existing
+tests, and documented risk. Cap verified findings at `{{ max-findings }}` and track each scenario in
+SQL todos.
+
+### 2. Discover and Reproduce
+
+Dispatch one bounded read-only QA assignment:
+
+```text
+task(
+  agent_type="qa-tester",
+  name="bug-bash-discovery",
+  description="Discover and reproduce bounded defects",
+  prompt="Scope: {{ scope }}
+  Finding limit: {{ max-findings }}
+  Scenarios: <finite scenario list resolved in step 1>
+
+  Test only these scenarios and return at most {{ max-findings }} verified findings. For each
+  candidate include exact reproduction steps, expected/actual behavior, current-code evidence,
+  severity, likely owner, and whether the result was reproduced. Do not modify code."
+)
+```
+
+Use `read_agent` / `list_agents` to collect the result. Deduplicate candidates and discard anything
+not reproducible. Stop discovery once the finding cap is reached; do not expand into unrelated areas.
+
+### 3. File Verified Issues First
+
+Before any fix:
+
+1. Search open and recently closed issues with bounded `gh issue list --limit 100` queries.
+2. File one focused issue per verified, non-duplicate defect using the repository's issue template.
+3. Include reproduction steps, expected/actual behavior, evidence, severity, affected surface,
+   verification plan, and the applicable owner.
+4. Do not close issues manually; fixes must use `Closes #<issue>`.
+
+Remote issue writes must comply with root/scoped authority. If issue creation is unavailable or
+unauthorized, stop with complete issue drafts and do not begin implementation.
+
+### 4. Dispatch Bounded Fixes
+
+Route each issue to exactly one applicable owning role, with no more than three concurrent fixes.
+Each task must:
+
+- Prefer an app-native isolated project session/worktree from the latest default branch.
+- Otherwise use only a runtime-provided, explicitly approved worktree location allowed by local
+  authority; never invent a sibling path or reuse an unowned worktree.
+- Reproduce the defect before changing code, implement the smallest root-cause fix, and add or update
+  regression coverage.
+- Run the repository's affected format/lint/type-check/test/build commands.
+- Commit conventionally with the issue number, push the owned feature branch, and open a focused PR
+  containing `Closes #<issue>`.
+- Self-merge only when root/scoped `AGENTS.md` permits it, the session owns the PR, all required
+  checks are green, the PR is conflict-free, and GitHub reports it mergeable.
+
+Fork, human, shared, unknown, or unauthorized branches remain read-only handoffs.
+
+### 5. Verify Independently and Report
+
+After each fix, have the QA role re-run the original reproduction and relevant regression scenario
+without modifying production code. A passing unit test alone is not enough when the original
+user-visible reproduction can be exercised.
+
+Report scenarios covered, verified defects, duplicate/non-reproducible candidates, issues filed, fix
+PRs and CI/merge status, independent verification, remaining risk, and any `## Needs Human Action`
+handoffs. End the campaign when the finite scenario list or finding cap is exhausted; do not create a
+standing bug-bash role.

--- a/.github/prompts/cleanup.prompt.md
+++ b/.github/prompts/cleanup.prompt.md
@@ -3,30 +3,45 @@ name: cleanup
 description: Clean up the project — prune worktrees, identify stale PRs and issues
 parameters:
   - name: stale-days
+    type: integer
     description: Number of days of inactivity before a PR or issue is considered stale
     default: 30
+    minimum: 1
+    maximum: 365
+built_ins: []
+agent_dependencies: []
 ---
 <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
 
 # Cleanup — Project Hygiene
 
-Identify stale worktrees, PRs, issues, and branches. Do not perform destructive remote operations without human approval.
+Inventory stale worktrees, PRs, issues, and branches before considering any mutation.
+
+## Runtime Contract
+
+Require parameter interpolation and validate `{{ stale-days }}` as an integer within its declared
+bounds. If interpolation is unavailable or the value is invalid, stop before inventory or mutation.
+Read root `AGENTS.md` and applicable scoped `.github/instructions/` first. In the canonical
+backbone, also consult source `instructions/`. Those local authorities decide whether cleanup is
+allowed; use the more restrictive rule.
 
 ## Execution Plan
 
-### 1. Prune Stale Worktrees
+### 1. Audit Worktrees Without Mutation
 
 ```bash
-git worktree list
-git worktree prune
+git worktree list --porcelain
+git worktree prune --dry-run --verbose
 ```
 
-Flag worktrees whose branches are merged, deleted on the remote, or no longer have an open PR. Remove only worktrees you created and can prove are safe.
+Record each worktree's path, branch, cleanliness, owning session, and evidence. Flag stale candidates,
+but do not remove or prune anything. A path or branch name is not ownership proof; the current
+runtime/session registry must show that this session created and owns the worktree.
 
 ### 2. Identify Stale Pull Requests
 
 ```bash
-gh pr list --state open --limit 200 --json number,title,headRefName,author,createdAt,updatedAt,isDraft,statusCheckRollup,mergeable,reviewDecision
+gh pr list --state open --limit 200 --json number,title,headRefName,author,createdAt,updatedAt,isDraft,statusCheckRollup,mergeable,reviewDecision,closingIssuesReferences
 ```
 
 Flag PRs that:
@@ -48,9 +63,12 @@ gh issue list --state open --limit 200 --json number,title,labels,createdAt,upda
 
 Flag issues that:
 
-- Have not been updated in **{{ stale-days }}** days and have no linked PR.
+- Have not been updated in **{{ stale-days }}** days.
 - Are assigned but inactive.
 - Have no labels or missing owner.
+
+Report an issue as linked only when that issue appears in a collected PR's
+`closingIssuesReferences`; never infer linkage.
 
 ### 4. Check for Duplicates
 
@@ -59,19 +77,41 @@ Group issues by similar titles, labels, components, or linked files. Flag likely
 ### 5. Branch Cleanup
 
 ```bash
-git fetch --prune origin
+git fetch origin <default-branch>
 git branch -r --merged origin/<default-branch>
 ```
 
-List remote branches already merged to the default branch. Remote deletion is human-gated unless the repo's rules explicitly grant it.
+List remote branches already merged to the default branch. Do not delete local or remote branches
+during the audit.
 
-### 6. Report
+### 6. Authority Gate and Targeted Cleanup
+
+Present the inventory and determine applicable authority before any cleanup:
+
+1. Proceed only when root/scoped local rules permit cleanup and the user/runtime grants the required
+   authority.
+2. Remove only a specific clean worktree that the current session created and still owns, using its
+   exact runtime-recorded path:
+   ```bash
+   git worktree remove <approved-owned-worktree-path>
+   ```
+3. Never recursively delete a path and never remove an unowned, shared, human-created, or unknown
+   worktree.
+4. `git worktree prune` is repository-wide. Run it only when its dry-run output contains exclusively
+   current-session-owned stale metadata and local authority permits it; otherwise leave the metadata
+   for a human handoff.
+5. Delete a local branch only when the current session owns it, it is fully merged, its worktree has
+   been safely removed, and local authority permits deletion. Remote branch deletion remains
+   human-gated unless local rules explicitly grant the exact operation.
+
+### 7. Report
 
 ```markdown
 ## Cleanup Report
 
 ### Worktrees
-- Pruned: X
+- Eligible session-owned: X
+- Removed after authority gate: X
 - Active: Y
 - Needs manual cleanup: Z
 
@@ -98,6 +138,7 @@ List remote branches already merged to the default branch. Remote deletion is hu
 ### Recommendations
 - [ ] Close or update stale PRs listed above.
 - [ ] Close or relabel stale issues listed above.
-- [ ] Delete merged branches after human approval.
+- [ ] Approve exact session-owned cleanup targets where appropriate.
+- [ ] Delete merged branches only under applicable authority.
 - [ ] Review duplicate candidates.
 ```

--- a/.github/prompts/fix-ci.prompt.md
+++ b/.github/prompts/fix-ci.prompt.md
@@ -2,6 +2,9 @@
 name: fix-ci
 description: Fix all failing CI checks across open PRs
 parameters: []
+built_ins:
+  - task
+agent_dependencies: []
 ---
 <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
 
@@ -9,21 +12,42 @@ parameters: []
 
 Find open PRs with failing checks, diagnose the failures, fix them, and verify the repo's CI recovers.
 
+## Runtime Contract
+
+This prompt requires the Copilot App/CLI `task` dispatch contract. If it is unavailable, stop before
+creating a session/worktree or mutating a branch. Read root `AGENTS.md` and applicable scoped
+`.github/instructions/`; in the canonical backbone, also consult source `instructions/`. Fail closed
+when ownership or mutation authority cannot be proved.
+
 ## Execution Plan
 
 ### 1. Identify Failing PRs
 
 ```bash
-gh pr list --state open --limit 200 --json number,title,headRefName,author,statusCheckRollup
+gh pr list --state open --limit 200 --json number,title,headRefName,headRefOid,headRepositoryOwner,isCrossRepository,author,statusCheckRollup
 ```
 
 Filter to PRs with non-passing checks. For each one:
 
 ```bash
-gh pr checks <number> --json name,state,conclusion,detailsUrl
+gh pr checks <number> --json name,state,bucket,link,workflow
 ```
 
-### 2. Categorize Failures
+### 2. Prove Ownership and Authority
+
+Before session/worktree creation, checkout, rebase, commit, push, or merge, record:
+
+- Exact PR, head repository, head branch, and head OID.
+- Evidence from the runtime/session registry that the current session created and owns the branch,
+  or explicit user authorization assigning that exact branch to this session.
+- The root/scoped rule that permits the intended mutation.
+
+Author name alone is not proof of branch ownership. Fork PRs and human/shared branches are read-only
+handoffs by default. An agent-authored branch from another session is also shared until explicitly
+assigned. If ownership or authority is missing, inspect logs read-only and report the repair; do not
+create a worktree or mutate the branch.
+
+### 3. Categorize Failures
 
 | Failure type | Typical fix |
 | --- | --- |
@@ -34,9 +58,12 @@ gh pr checks <number> --json name,state,conclusion,detailsUrl
 | Test | Fix the broken code or update invalid tests. |
 | Merge conflict | Rebase onto the default branch and resolve safely. |
 
-### 3. Fix Each PR
+### 4. Fix Each Authorized PR
 
-For each failing PR, work in its existing worktree or create one from the PR branch:
+For each authorized, current-session-owned PR, prefer an app-native isolated PR/project session. Do
+not reuse another session's worktree. If app-native isolation is unavailable, require a
+runtime-provided, explicitly approved worktree location that complies with root/scoped authority.
+Never invent a sibling path.
 
 ````
 task(
@@ -51,13 +78,18 @@ Fix CI failures on PR #<number> (branch: <branch>).
 
 ## Workflow
 
-1. **Enter the worktree**
+1. **Open isolated work**
+   - Reconfirm that this session owns the exact branch and OID before mutation.
+   - Prefer the app-native PR/project session.
+   - If the local tracking branch does not exist, create it explicitly from the remote head:
    ```bash
-   git fetch origin <branch>
-   git worktree add ../wt-fix-ci-<number> <branch>
-   cd ../wt-fix-ci-<number>
+   git fetch origin <head-ref>:refs/remotes/origin/<head-ref>
+   git branch --track <local-branch> origin/<head-ref>
    ```
-   If a worktree already exists for this branch, use it instead.
+   - Only in the approved fallback, attach `<local-branch>` at the runtime-provided location:
+   ```bash
+   git worktree add <approved-worktree-path> <local-branch>
+   ```
 
 2. **Read failing logs**
    ```bash
@@ -67,21 +99,25 @@ Fix CI failures on PR #<number> (branch: <branch>).
 3. **Fix the issue**
    - Run the repo's format/lint/type-check/test/build commands relevant to the failing check.
    - Prefer the repo's documented scripts over ad hoc commands.
-   - For conflicts: `git fetch origin <default-branch>` then rebase and resolve only conflicts you understand.
+   - Before editing, require `git status --porcelain` to be empty. Stop on pre-existing changes.
+   - For conflicts, rebase only after rechecking current-session ownership and authority.
 
 4. **Validate locally**
    - Run the repo's lint/format/type-check/test commands that cover the touched files.
-   - Keep the working tree clean.
+   - Inspect the changed path list and reject unexpected files.
 
 5. **Push**
    ```bash
-   git add -A
+   git add -- <repaired-paths>
    git commit -m "fix(ci): resolve <failure-type> (#<issue>)"
    git fetch origin <default-branch>
    git rebase origin/<default-branch>
    git push --force-with-lease origin <branch>
    ```
-   Amend instead of creating a new commit when that is the repo's convention for the PR.
+   Stage only known repaired paths after the clean-tree check. Never amend unless the user explicitly
+   requests it and local authority permits it. Use `--force-with-lease` only when the runtime record
+   still proves this exact branch is current-session-owned and authorized; otherwise stop and hand
+   off.
 
 6. **Verify**
    ```bash
@@ -90,13 +126,14 @@ Fix CI failures on PR #<number> (branch: <branch>).
    ```
 
 7. **Merge or hand off**
-   - Agent-authored PR: self-merge once CI is green and the PR is `MERGEABLE`.
-   - Human-authored PR: leave it green and report that it is ready for the author.
+   - Self-merge only when root/scoped `AGENTS.md` permits it, the current session owns the PR, every
+     required check is green, the PR is conflict-free, and GitHub reports it mergeable.
+   - Fork, human, shared, unowned, or unauthorized PR: leave a read-only handoff.
 """
 )
 ````
 
-### 4. Report
+### 5. Report
 
 ```markdown
 ## CI Fix Report
@@ -112,4 +149,4 @@ Fix CI failures on PR #<number> (branch: <branch>).
 | ... |
 ```
 
-Use `--force-with-lease` only on the PR branch you are repairing. Never use plain `git push --force`.
+Never use plain `git push --force`.

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -3,14 +3,26 @@ name: review
 description: Run code review on all open PRs using parallel review agents
 parameters:
   - name: scope
+    type: string
     description: "Scope of review: 'all' for every open PR, or a comma-separated list of PR numbers"
     default: all
+built_ins:
+  - task
+  - code-review
+agent_dependencies: []
 ---
 <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
 
 # Review — Parallel Code Review for Open PRs
 
 Review all or selected open PRs with read-only review agents.
+
+## Runtime Contract
+
+This prompt requires Copilot App/CLI parameter interpolation plus the `task` dispatcher and built-in
+`code-review` agent type. They are runtime contracts, not repository custom-agent slugs. Validate
+`{{ scope }}` before querying; if interpolation, dispatch, or the review agent is unavailable, stop
+without substituting a repository agent with a similar name.
 
 ## Execution Plan
 
@@ -20,7 +32,8 @@ Review all or selected open PRs with read-only review agents.
 gh pr list --state open --limit 200 --json number,title,headRefName,author,isDraft,additions,deletions,changedFiles,labels
 ```
 
-If `scope` is `all`, review every open PR. Otherwise filter to the requested PR numbers.
+If `{{ scope }}` is `all`, review every open PR. Otherwise parse it as a non-empty, unique,
+comma-separated list of positive PR numbers and reject invalid input before dispatch.
 
 Skip PRs that:
 
@@ -64,7 +77,9 @@ Author: <author>
    ```bash
    gh pr view <number> --json files
    ```
-4. Review changed files against `AGENTS.md` and relevant `instructions/` files.
+4. Review changed files against root/scoped `AGENTS.md` and consumer
+   `.github/instructions/*.instructions.md`. When reviewing this canonical backbone, also consult
+   source `instructions/*.instructions.md`.
 5. Check whether the repo's lint/format/type-check/test expectations were addressed.
 
 ## Output Format
@@ -81,11 +96,14 @@ Author: <author>
 ### Looks Good
 - What is solid
 
-### Verdict: APPROVE / REQUEST_CHANGES / COMMENT
+### Suggested Verdict: APPROVE / REQUEST_CHANGES / COMMENT
 <brief justification>
 ```
 
 Only flag genuine issues. Do not comment on style, formatting, or trivial matters handled by tools.
+The suggested verdict is advisory. Do not submit an approval, request-changes review, comment, merge,
+or other remote mutation unless the active runtime/user is explicitly authorized for that exact
+operation under root/scoped authority.
 """
 )
 ````

--- a/.github/prompts/sprint.prompt.md
+++ b/.github/prompts/sprint.prompt.md
@@ -3,49 +3,84 @@ name: sprint
 description: Deploy N full sprints across agent types in parallel waves
 parameters:
   - name: N
+    type: integer
     description: Number of sprints to execute
+    default: 2
+    minimum: 1
+    maximum: 3
+  - name: max-parallel
+    type: integer
+    description: Maximum concurrent assignments in a sprint wave
     default: 3
+    minimum: 1
+    maximum: 5
+built_ins:
+  - task
+  - read_agent
+  - list_agents
+  - sql_todos
+agent_dependencies: []
 ---
 <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
 
 # Sprint — Fleet Deployment
 
-Deploy **{{ N }}** sprint waves across the product's agent types. Each agent works in its own worktree, opens a PR, watches CI, and self-merges only after the quality gate passes.
+Deploy at most **{{ N }}** bounded sprint waves with no more than **{{ max-parallel }}** concurrent
+assignments per wave.
+
+## Runtime Contract
+
+This prompt requires Copilot App/CLI parameter interpolation, `task` dispatch, agent polling through
+`read_agent` / `list_agents`, and SQL todos. These are runtime contracts, not custom-agent slugs.
+Validate `{{ N }}` and `{{ max-parallel }}` as positive integers within their declared bounds before
+fetching or dispatching. If any required capability or interpolation is unavailable, stop before
+dispatch or mutation.
 
 ## Execution Plan
 
-### 1. Sync and Assess
+### 1. Resolve Local Authority and Applicable Roster
+
+Read root `AGENTS.md`, every scoped `AGENTS.md` applicable to candidate work, and applicable consumer
+`.github/instructions/`. In the canonical backbone, also consult source `instructions/`.
+
+Build the dispatch roster from canonical plus declared-local slugs, then exclude roles that local
+routing marks disabled, read-only for the proposed implementation, handoff-only, outside ownership,
+or otherwise inapplicable. File presence under `.github/agents/` is discovery evidence, not dispatch
+authority. If the repository is infrastructure or pre-bootstrap, dispatch only when a local
+infrastructure-safe override explicitly permits the role and work; otherwise stop with a handoff.
+
+### 2. Sync and Assess
 
 ```bash
 git fetch origin <default-branch>
-gh issue list --state open --limit 200 --json number,title,labels,milestone,assignees
-gh pr list --state open --limit 200 --json number,title,headRefName,statusCheckRollup
+gh issue list --state open --limit 200 --json number,title,labels,milestone,assignees,updatedAt
+gh pr list --state open --limit 200 --json number,title,headRefName,statusCheckRollup,closingIssuesReferences
 ```
 
 - Start from the latest default branch.
 - Query open issues and PRs.
 - Exclude issues already claimed by open PRs.
 
-### 2. Plan Sprint Waves
+### 3. Plan Sprint Waves
 
 For each sprint:
 
-1. Categorize unclaimed issues by labels, affected files, and the ownership tables in `AGENTS.md`
-   and `.github/agents/` (`agents/` in the canonical backbone).
-2. Select one focused issue per available agent type, limiting each wave to the number the repo can safely validate in parallel.
+1. Categorize unclaimed issues using collected `closingIssuesReferences`, labels, affected files,
+   and the resolved local ownership/routing overlay.
+2. Select one focused issue per applicable agent type, capped at `{{ max-parallel }}` assignments.
 3. Batch small related issues only when they touch the same files and keep the PR focused.
 4. Track assignments in SQL todos to prevent double-dispatch.
 5. Publish a recommended merge order for dependent PRs: schema/contracts first, shared APIs next, build/CI config before leaf app or docs work.
 
-### 3. Deploy Agents in Parallel
+### 4. Deploy Agents in Parallel
 
 For each assignment:
 
 ````
 task(
   agent_type="<agent-type>",
-  name="s{{ sprint }}-<agent>-<issue#>",
-  description="Sprint {{ sprint }}: <title>",
+  name="wave-<wave-number>-<agent>-<issue-number>",
+  description="Sprint wave <wave-number>: <title>",
   prompt="""
 You are the <agent-type> for this product repository.
 
@@ -55,12 +90,11 @@ Issue: #<number> — <title>
 
 ## Workflow
 
-1. **Setup worktree**
-   ```bash
-   git fetch origin <default-branch>
-   git worktree add ../wt-<agent>-<type>-<issue#> -b <type>/<short-description>-<issue#> origin/<default-branch>
-   cd ../wt-<agent>-<type>-<issue#>
-   ```
+1. **Open isolated work**
+   - Prefer an app-native isolated project session/worktree created from the current default branch.
+   - Otherwise require a runtime-provided, explicitly approved worktree location allowed by
+     root/scoped authority. Never invent a sibling path.
+   - Record the created session, path, branch, and issue as current-session-owned before mutation.
 
 2. **Implement**
    - Read the issue fully before changing files.
@@ -98,19 +132,21 @@ Issue: #<number> — <title>
    If CI fails, read logs with `gh run view --log-failed`, fix locally, re-validate, and push again.
 
 7. **Self-merge and clean up**
-   Once CI is green and the PR is `MERGEABLE`, merge your own PR if permitted by `AGENTS.md`, then remove the worktree.
+   Self-merge only when root/scoped `AGENTS.md` permits it, this session owns the PR, all required
+   checks are green, the PR is conflict-free, and GitHub reports it mergeable. Remove only the exact
+   worktree created and owned by this session.
 """
 )
 ````
 
-### 4. Monitor Completion
+### 5. Monitor Completion
 
 - Poll agents via `read_agent` / `list_agents`.
 - Update SQL todos as work moves from pending → in_progress → done/blocked.
 - Re-dispatch or manually fix failed agents.
 - Verify every PR has green CI and is mergeable before declaring the sprint complete.
 
-### 5. Repeat and Report
+### 6. Repeat and Report
 
 After all **{{ N }}** waves:
 

--- a/.github/prompts/team.prompt.md
+++ b/.github/prompts/team.prompt.md
@@ -3,11 +3,24 @@ name: team
 description: Deploy specific agent types for targeted work across N sprints
 parameters:
   - name: agents
+    type: agent-list
     description: Comma-separated list of agent types (e.g., backend-engineer, web-engineer, docs-writer)
     default: ''
+    required: true
+    minimum_items: 1
+    maximum_items: 5
   - name: N
+    type: integer
     description: Number of sprints to execute
-    default: 2
+    default: 1
+    minimum: 1
+    maximum: 3
+built_ins:
+  - task
+  - read_agent
+  - list_agents
+  - sql_todos
+agent_dependencies: []
 ---
 <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
 
@@ -15,36 +28,66 @@ parameters:
 
 Deploy only the requested agent types — **{{ agents }}** — for **{{ N }}** sprint waves.
 
+## Runtime Contract
+
+This prompt requires Copilot App/CLI parameter interpolation, `task` dispatch, agent polling through
+`read_agent` / `list_agents`, and SQL todos. These are runtime contracts, not repository custom-agent
+slugs. Before fetching or dispatching, validate `{{ N }}` as a positive integer within its declared
+bounds and parse `{{ agents }}` into 1–5 non-empty, trimmed, unique slugs. If interpolation or any
+required capability is unavailable, stop before dispatch or mutation.
+
 ## Execution Plan
 
-### 1. Sync and Filter
+### 1. Resolve Authority and Validate Requested Roles
+
+Read root `AGENTS.md`, scoped `AGENTS.md` applicable to candidate work, and applicable consumer
+`.github/instructions/`. In the canonical backbone, also consult source `instructions/`.
+
+Every requested slug must be a known canonical role or a declared-local role and must be applicable
+under the repository's local routing/ownership overlay. Presence in `.github/agents/` alone is not
+sufficient. Reject the entire dispatch before work begins if any slug is unknown, disabled,
+handoff-only, read-only for the proposed implementation, outside its ownership scope, or otherwise
+inapplicable. Infrastructure and pre-bootstrap repositories require an explicit local
+infrastructure-safe override for every requested role and assignment.
+
+### 2. Sync and Filter
 
 ```bash
 git fetch origin <default-branch>
-gh issue list --state open --limit 200 --json number,title,labels,milestone,assignees
-gh pr list --state open --limit 200 --json number,title,headRefName,statusCheckRollup
+gh issue list --state open --limit 200 --json number,title,labels,milestone,assignees,updatedAt
+gh pr list --state open --limit 200 --json number,title,headRefName,statusCheckRollup,closingIssuesReferences
 ```
 
-- Parse `agents` into a list of agent types.
-- Map each agent to likely issues using labels, file ownership in `AGENTS.md`, and materialized
-  `.github/agents/` metadata (`agents/` is the backbone-only canonical source).
-- Exclude issues already claimed by open PRs.
+- Map each validated role to likely issues using labels and the resolved local routing/ownership
+  overlay.
+- Exclude issues referenced by collected open-PR `closingIssuesReferences`; do not infer linkage.
 
-### 2. Plan and Deploy
+### 3. Plan and Deploy
 
 For each sprint:
 
 1. Select one focused issue per requested agent type.
-2. Dispatch agents in parallel, one per assignment.
+2. Dispatch agents in parallel, one per assignment:
+   ```text
+   task(
+     agent_type="<validated-agent-slug>",
+     name="team-<wave-number>-<issue-number>",
+     description="Implement issue #<issue-number>",
+     prompt="<focused assignment plus resolved local authority and verification requirements>"
+   )
+   ```
 3. Each agent follows the sprint workflow:
-   - Create/resume a worktree from the default branch.
+   - Prefer an app-native isolated project session/worktree from the latest default branch.
+   - Otherwise use only a runtime-provided, explicitly approved worktree location allowed by local
+     authority; never invent a sibling path or reuse an unowned worktree.
    - Implement with tests and scoped changes.
    - Run the repo's relevant format/lint/type-check/test/build commands.
    - Rebase, push, and create a PR with `Closes #N`.
    - Monitor CI; if it fails, read logs, fix, and re-push.
-   - Self-merge only the agent's own PR once CI is green and the PR is `MERGEABLE`.
+   - Self-merge only when root/scoped `AGENTS.md` permits it, the session owns the PR, all required
+     checks are green, the PR is conflict-free, and GitHub reports it mergeable.
 
-### 3. Monitor and Report
+### 4. Monitor and Report
 
 - Poll completions with `read_agent` / `list_agents`.
 - Track assignments in SQL todos.

--- a/.studio-sync.lock.json
+++ b/.studio-sync.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "backbone": "jrmoulckers/.github",
-  "generatedAt": "2026-08-07T23:31:41.527Z",
+  "generatedAt": "2026-08-08T21:07:36.379Z",
   "entries": {
     ".github/agents/accessibility-reviewer.agent.md": {
       "sourceSha256": "f83d90b50ea87be04935ba849c0a93eda729452a2d7eee81e0cb02b4bf04dae5",
@@ -129,39 +129,44 @@
       "syncedAt": "2026-08-07T15:34:55.223Z"
     },
     ".github/instructions/workflow.instructions.md": {
-      "sourceSha256": "99e4ddf304e4f82320e689bc5d1e7e7c865366285dcd89aa9e96fcc94ea1574b",
-      "targetSha256": "cbda770e489599db2ef182c4c4c2c6645031c51e6e8a058d8dbc56f43fafe15a",
-      "syncedAt": "2026-08-07T23:31:41.513Z"
+      "sourceSha256": "cdf01e74dd016665c60e9974c6524ccd04a33b3d8a6f19631bf6b3e16fa9c5b1",
+      "targetSha256": "cca41b030a9270ab650867fadd9f916ad31625df054dc22d8c10806362ad07e3",
+      "syncedAt": "2026-08-08T21:07:36.376Z"
     },
     ".github/prompts/backlog.prompt.md": {
-      "sourceSha256": "3d89a722994d69217b8489eb44fa6dd265ebc6f3c781f81e5c5ca5122a79d70e",
-      "targetSha256": "bd7ab6ce8db190d8fa04f1d9adc3942d9caf682b93e4ba4728ccc6145b0e5cce",
-      "syncedAt": "2026-08-07T15:34:55.223Z"
+      "sourceSha256": "662578e4e512ac591b86127f50c601283a27b6ce96c9e09b022b833f720fe750",
+      "targetSha256": "a263cf1aa733c06eb0232f3f0224e23874a569fdc28fcb907a8d3183e1d96f88",
+      "syncedAt": "2026-08-08T21:07:36.370Z"
+    },
+    ".github/prompts/bug-bash.prompt.md": {
+      "sourceSha256": "4bf6ca1a98664eeec1bb78081170ef0349b276911a472bf10775788b47f6dff9",
+      "targetSha256": "afdf803330b9e762215a76e44569fc03e04fee112ffb3fed608012ba03686f64",
+      "syncedAt": "2026-08-08T21:07:36.371Z"
     },
     ".github/prompts/cleanup.prompt.md": {
-      "sourceSha256": "9b0e4e4c94e361f8fc59a5a1da99894d8bed4cc06096dcb1f133a77cf68367f7",
-      "targetSha256": "31a1c944acf234a6f64d020a7ec127849e804f89a280198b6157e6950df1ea14",
-      "syncedAt": "2026-08-07T15:34:55.223Z"
+      "sourceSha256": "e20e582589a97845fd2353ea17d13d7497404dfd7246a505f4917acb197dc41d",
+      "targetSha256": "ce2268f2817e972e7b07b2fe1342796059dc341b60251d079f45d7cb4371b0b7",
+      "syncedAt": "2026-08-08T21:07:36.368Z"
     },
     ".github/prompts/fix-ci.prompt.md": {
-      "sourceSha256": "de28cbb2c039690a0c9e1bdd521885db37a9b9c6be4b586167c8e5cf5b1e8256",
-      "targetSha256": "edb6e02eef31dc774db13300eadacae04489ac4942f84d3dfd9eb80b6d7a5cc6",
-      "syncedAt": "2026-08-07T15:34:55.223Z"
+      "sourceSha256": "60ede467eb49f15a8bbf6317e190ed7794d6eb867d0530eb2420b0985bf2cef0",
+      "targetSha256": "b6e8ad2583089b3769ea07e7d4def9933880e97b91a93190f64b1614b46dc161",
+      "syncedAt": "2026-08-08T21:07:36.366Z"
     },
     ".github/prompts/review.prompt.md": {
-      "sourceSha256": "041a14fed45e9b0adb3f9dd69425978b9fc4557c39b01d4c895ea7059362528b",
-      "targetSha256": "060a41b483876e80e910db6fad77c73b4a56c3351b38565e0ca52c4ca4f1af95",
-      "syncedAt": "2026-08-07T15:34:55.222Z"
+      "sourceSha256": "838ee6a06de981a88620933f8954f3ebaf29de109d05e5630f628904c613c559",
+      "targetSha256": "1fd07861be8d0a6ff01f0fa5bd2f06e344fdb85f28b3d5a02f5a7bdd8279aa81",
+      "syncedAt": "2026-08-08T21:07:36.364Z"
     },
     ".github/prompts/sprint.prompt.md": {
-      "sourceSha256": "0a67bd9f21f11074ace583b73da2296e08e7f4cdfadec8598836b5524f24153f",
-      "targetSha256": "ba84857d26fce86cac57e2b245a4c2d683e822fa2307d5a6a74902f07c0cfa18",
-      "syncedAt": "2026-08-07T23:31:41.504Z"
+      "sourceSha256": "bbec1d41cb46bc1ca8d9be5947f8233f49f24b53c91f76181b00226031cd2350",
+      "targetSha256": "5bbe40ad932b83362cf2adabf89f839a2ad464d213c020848a2314a5af7cc422",
+      "syncedAt": "2026-08-08T21:07:36.373Z"
     },
     ".github/prompts/team.prompt.md": {
-      "sourceSha256": "8b9a74df4667c4452707f180e27ae87f9e6553428fbdf1a9989ca0e16592e6dd",
-      "targetSha256": "cf41e4213d1e931c85439b3d7e9abc74366d5eb1e12186f59e2ccd3bf6c8d021",
-      "syncedAt": "2026-08-07T23:31:41.511Z"
+      "sourceSha256": "ad23c3f288955ff4c369d26f846c47c62b8e687c7f9e1683e550bf89335de571",
+      "targetSha256": "350f984d725ae4042418f65e8f91888a12dd651c543060fb6ce4e3e131cf16b4",
+      "syncedAt": "2026-08-08T21:07:36.375Z"
     },
     ".github/skills/accessibility-testing/CHECKLIST.md": {
       "sourceSha256": "3beba6418cb63661b908ed82bb156ecd1fd4b588996f5f0dbdad7443655670ad",


### PR DESCRIPTION
## Summary

Sync Score King to the hardened canonical prompt workflows from `jrmoulckers/.github` commit `dba91d1263da6e11224e123d96907e58b6ba052c`.

## Changes

- Update the six existing selected prompts and add `bug-bash`.
- Sync the canonical workflow instruction and generated lock metadata.
- Keep `rebase-all` intentionally omitted by Score King's explicit prompt selection.
- Preserve the local design agent, product overlay, and deploy workflow.
- Confirm a second exact-member work-directory sync is idempotent with all 54 selected assets unchanged.

## Issues

Closes #114

## Testing

- [x] Canonical prompt integrity validation
- [x] Exact-member sync `--check`
- [x] `npm run check`
- [x] `npm test` (1,302 tests)
- [x] `npm run build`