### PR TITLE
chore(sync): adopt consolidated canonical policy (#116)

### DIFF
--- a/.github/instructions/agents.instructions.md
+++ b/.github/instructions/agents.instructions.md
@@ -9,6 +9,12 @@ You are working in canonical `agents/` or a consumer's materialized `.github/age
 reusable custom agents and their operating boundaries. Author canonical changes under `agents/`;
 consumer `.github/agents/` copies are generated and must not be edited directly.
 
+The canonical schema below applies to backbone `agents/*.agent.md` and their generated consumer
+copies. A member's `localAgents` names product-owned roles or explicit replacements that are not
+copied. Those local files may use documented local schema extensions, additional frontmatter keys,
+sections, tools, or a locally documented flat schema when root/scoped `AGENTS.md` says so; this
+shared instruction does not make the canonical schema exclusive for declared local roles.
+
 ## Agent File Schema
 
 - Each file represents exactly one role and is named `<kebab-case-name>.agent.md`; frontmatter `name` must match the filename stem.
@@ -28,18 +34,26 @@ consumer `.github/agents/` copies are generated and must not be edited directly.
 - Use one clear role per file. Do not combine implementation, review, and product ownership in one agent.
 - Keep `primary_paths` aligned with `AGENTS.md`; paths must exist or be called out as net-new in File Ownership.
 - Grant `edit` only to agents that change files. Review-only agents may use `shell` for read-only verification but must not have `edit`.
-- Bare `@kebab-case` references are reserved for canonical agent names and are integrity-checked.
-  Write GitHub account names as links or code without a bare `@` handle.
+- Bare `@kebab-case` references resolve only to selected canonical names or names declared through
+  the member's `localAgents`; both are integrity-checked for selection closure. Write GitHub account
+  names as links or code without a bare `@` handle.
 - Declare skill dependencies in the **Related skills** block and prompt dependencies as "the
   `<name>` prompt"; both forms are integrity-checked against each member's selected assets.
+- A canonical slug and a local slug must never both be selected. A same-slug local replacement is
+  valid only when `localAgents` declares it and the member's explicit canonical selection omits it.
 
 ## Content Expectations
 
 Include the standard sections used by existing agents: Role, Capabilities, File Ownership, Workflow, Planning & Verification, Technical Context, Boundaries, and Human-Gated Operations.
 
-Reference `workflow.instructions.md` and `AGENTS.md` instead of copying long global procedures that can drift.
+Reference the applicable root/local `AGENTS.md` and selected workflow or infrastructure-operations
+instruction instead of copying long procedures that can drift.
 
 Make capabilities product-agnostic by default. Product repos may add stack, platform, domain, and ownership details in their own `AGENTS.md` or scoped instructions.
+
+Root/local `AGENTS.md` and more-specific scoped instructions override shared defaults for routing,
+schema extensions, paths, tools, and operational authority. They may not silently relax mandatory
+human gates.
 
 ## Boundaries
 

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: 'docs/**,**/*.md'
+applyTo: 'docs/**,*.md,**/README.md'
 ---
 <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
 
@@ -7,11 +7,22 @@ applyTo: 'docs/**,**/*.md'
 
 Write documentation for humans first: clear, concise, accessible, and actionable.
 
+This scope intentionally covers `docs/**`, root Markdown policy such as `AGENTS.md`, and nested
+`README.md` files. It does not blanket-match every Markdown asset under `agents/`, `prompts/`,
+`skills/`, or `instructions/`.
+
+Root/local `AGENTS.md` and a more-specific scoped instruction override these shared defaults when
+they apply to the same file. Generated assets are not local editing surfaces: consumer
+`.github/agents/`, `.github/prompts/`, `.github/skills/`, and `.github/instructions/` copies remain
+upstream-owned even when a nearby README is locally authored.
+
 ## Structure
 
 - `docs/` is the default home for product documentation.
 - Architecture Decision Records belong in `docs/architecture/` unless a product repo specifies another ADR location.
-- Agent, skill, prompt, and instruction documentation lives beside those assets at repo root unless a product repo overrides the layout.
+- Canonical agent, skill, prompt, and instruction documentation lives beside source assets under
+  `agents/`, `skills/`, `prompts/`, and `instructions/`; consumer materializations live under the
+  corresponding `.github/` paths and are read-only.
 - Follow ownership in `AGENTS.md` and specialist agent files for substantive changes.
 
 ## Guidelines

--- a/.github/instructions/skills.instructions.md
+++ b/.github/instructions/skills.instructions.md
@@ -1,15 +1,24 @@
 ---
-applyTo: 'skills/**'
+applyTo: 'skills/**,.github/skills/**'
 ---
 <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
 
 # Instructions for Skill Authoring
 
-You are working in `skills/`, which contains reusable, product-agnostic task playbooks and durable domain guidance.
+Canonical skills are authored under `skills/` in `jrmoulckers/.github` and materialized under
+`.github/skills/` in opted-in consumers.
+
+- Edit `skills/` only in the canonical backbone.
+- Treat consumer `.github/skills/` copies as generated, upstream-owned, read-only assets. Route a
+  reusable change to the backbone and resync it; put product-specific guidance in a documented local
+  skill or scoped instruction instead.
+- Root/local `AGENTS.md` and more-specific scoped instructions decide product applicability and may
+  narrow these shared defaults.
 
 ## Skill File Schema
 
-- Each skill lives at `skills/<skill-name>/SKILL.md`; frontmatter `name` must match `<skill-name>`.
+- Each canonical skill lives at `skills/<skill-name>/SKILL.md` and materializes as
+  `.github/skills/<skill-name>/SKILL.md`; frontmatter `name` must match `<skill-name>`.
 - Frontmatter includes a concise `description` with trigger language: "Use for topics related to ...".
 - Start the body with `# <Skill Name> Skill`, then include `## Purpose` and `## Out of Scope` before detailed guidance.
 - Keep each skill focused on durable knowledge, decision trees, checklists, examples, and constraints that apply across products.

--- a/.github/instructions/tokens.instructions.md
+++ b/.github/instructions/tokens.instructions.md
@@ -1,11 +1,25 @@
 ---
-applyTo: '**/tokens/**,**/*.tokens.json'
+applyTo: 'tokens/**,packages/tokens/**,vendor/@jrm/tokens/**,**/vendor/@jrm/tokens/**,**/*.tokens.json'
 ---
 <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
 
 # Instructions for Design Tokens
 
-Use these rules for design-token sources, token JSON, and generated token outputs.
+Use these rules for design-token source trees, token JSON, and generated outputs in the repository
+that owns them. A local product overlay wins when it identifies the actual source, generated,
+`dist/**`, or `vendor/**` paths for that repository.
+
+## Ownership
+
+- Source files are edited only in the owning token repository and path. For shared `@jrm/tokens`,
+  that owner is `jrmoulckers/studio`; this backbone only records the sync contract.
+- `dist/**`, generated files, and `vendor/**` are outputs, never alternate source trees. Do not
+  hand-edit them.
+- In consumer repositories, generated, vendored, provenance-stamped, and sync-owned token outputs
+  are always read-only. Route a source change to the Studio/token owner, regenerate there, then use
+  the studio sync flow to update consumers.
+- A consumer-specific token belongs in the source path named by that product's root/scoped
+  authority, not inside `vendor/@jrm/tokens` or another synced output.
 
 ## Token System Rules
 
@@ -19,6 +33,7 @@ Use these rules for design-token sources, token JSON, and generated token output
 ## Generated Output Rules
 
 - Do not hand-edit generated token outputs.
-- Update token sources/configuration, rerun the repo's token generator, and commit regenerated files in their owning paths.
+- In the owning repository only, update token sources/configuration, rerun its documented generator,
+  and commit regenerated files in their owning output paths.
 - Keep source token files focused by tier/domain to reduce conflicts during parallel work.
 - Do not introduce product-specific brand values into the shared layer unless the token is explicitly generic or configurable.

--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -3,9 +3,11 @@ applyTo: '**'
 ---
 <!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
 
-# Issue-First Development Workflow
+# Change Delivery Workflow
 
-Every product change must trace to a GitHub issue and land through a feature branch and PR.
+Read-only research, audits, and planning do not require an issue when they make no repository
+change. Before the first repository change, verify or create an issue; every repository change must
+trace to that issue and land through a feature branch and PR.
 
 ## Default Workflow
 
@@ -21,10 +23,12 @@ Every product change must trace to a GitHub issue and land through a feature bra
 8. Push the feature branch and create a PR with `Closes #N`.
 9. Verify the PR exists with `gh pr view`.
 10. Monitor CI and mergeability until checks are green and the PR is `MERGEABLE`.
-11. Self-merge only PRs you authored when the quality gate passes and `AGENTS.md` permits it.
+11. Self-merge only PRs you authored when the quality gate passes and local `AGENTS.md` permits it.
 12. Remove the worktree after merge.
 
-Stopping at a local commit is incomplete. A task is done only when the PR is merged, or when a green, mergeable PR clearly documents a `## Needs Human Action` blocker.
+Stopping at a local commit is incomplete. A change is done only when the PR is merged, or when a
+green, mergeable PR clearly documents a `## Needs Human Action` blocker. Local `AGENTS.md` decides
+self-merge and operational authority; this instruction never expands either.
 
 ## Definition of Done
 
@@ -82,8 +86,10 @@ Amend only when the user explicitly requests it and applicable authority permits
 
 ## Calling reusable workflows
 
-Studio product repos call the backbone's reusable workflows with
-`uses: jrmoulckers/.github/.github/workflows/reusable-*.yml@main`.
+Studio product repos call the backbone's reusable workflows at a reviewed immutable commit SHA:
+`uses: jrmoulckers/.github/.github/workflows/reusable-*.yml@<reviewed-commit-sha>`. A documented
+versioned-tag policy is also acceptable only when automation proposes reviewed updates; do not use a
+mutable branch such as `@main`.
 
 **A caller `permissions:` block replaces the defaults — it does not add to them.** Every scope you
 omit is set to `none`, and a called workflow can never receive more than its caller holds. So a
@@ -108,7 +114,7 @@ permissions:
 
 jobs:
   lint:
-    uses: jrmoulckers/.github/.github/workflows/reusable-ci-lint.yml@main
+    uses: jrmoulckers/.github/.github/workflows/reusable-ci-lint.yml@<reviewed-commit-sha>
     with:
       package-manager: pnpm
 ```
@@ -138,7 +144,7 @@ permissions:
 
 jobs:
   pr-title:
-    uses: jrmoulckers/.github/.github/workflows/reusable-ci-lint.yml@main
+    uses: jrmoulckers/.github/.github/workflows/reusable-ci-lint.yml@<reviewed-commit-sha>
     with:
       lint-command: ''
       format-check-command: ''
@@ -155,7 +161,7 @@ through the sync engine, which resolves and reports them but never writes a file
 product repo must contain **no copy of its own**:
 
 - **No `.github/workflows/reusable-*.yml`.** Call the backbone's with
-  `uses: jrmoulckers/.github/.github/workflows/reusable-*.yml@main`, never
+  `uses: jrmoulckers/.github/.github/workflows/reusable-*.yml@<reviewed-commit-sha>`, never
   `uses: ./.github/workflows/reusable-*.yml`. A vendored copy is a silent fork: upstream fixes never
   reach it and nothing flags the divergence.
 - **No `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `PULL_REQUEST_TEMPLATE.md`,

--- a/.studio-sync.lock.json
+++ b/.studio-sync.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "backbone": "jrmoulckers/.github",
-  "generatedAt": "2026-08-08T21:07:36.379Z",
+  "generatedAt": "2026-08-08T22:39:33.894Z",
   "entries": {
     ".github/agents/accessibility-reviewer.agent.md": {
       "sourceSha256": "f83d90b50ea87be04935ba849c0a93eda729452a2d7eee81e0cb02b4bf04dae5",
@@ -109,29 +109,29 @@
       "syncedAt": "2026-08-07T15:34:55.220Z"
     },
     ".github/instructions/agents.instructions.md": {
-      "sourceSha256": "0e737985167bf67c48c296a649f2192670cf23072bfec916bd667ac9858e9cff",
-      "targetSha256": "5125da3954a45a46060e861e13075e6445cd1acc9422d16e53c8713ec3e80ec7",
-      "syncedAt": "2026-08-07T23:31:41.517Z"
+      "sourceSha256": "70f066ca74342a504f7411fbb21e62012b5b8ce05403ed32e93c3d39d145c8aa",
+      "targetSha256": "a772cb8d4790f9ae3763e6b94013000c16fb9192ab184b8ce20c3a297a10e78a",
+      "syncedAt": "2026-08-08T22:39:33.888Z"
     },
     ".github/instructions/docs.instructions.md": {
-      "sourceSha256": "e3abf5e92b341f3cac288a921ef5f2676290e9e8de7e6ed2fe3f8b596665c970",
-      "targetSha256": "599f82c2a6edb5559cb3324fe81e4f7019a8d108aa0d9ceabf1e121473fe89ab",
-      "syncedAt": "2026-08-07T15:34:55.223Z"
+      "sourceSha256": "bb072694458d15a359bf7797cf081c821b0a91505be5da647a11eaba5c412b39",
+      "targetSha256": "6e0eb456aa7802230c6783dde741278a0f2831bebb90dad6a3aec2256a48a948",
+      "syncedAt": "2026-08-08T22:39:33.889Z"
     },
     ".github/instructions/skills.instructions.md": {
-      "sourceSha256": "15b6cd3175e3f71c23b03d481dbe3b6f81bf222026cd9748e5b14d1f0cd0a6e8",
-      "targetSha256": "8c92e3c6436ded3fe6d66c6512c1577838cedb5c4e814a4cef9ead5ede7031ec",
-      "syncedAt": "2026-08-07T15:34:55.223Z"
+      "sourceSha256": "6271f97c927a53ebe9de2d50d8d2de4b9f6b1904379c5c870498ca7a046e818a",
+      "targetSha256": "849a3c2e360cdd69b3b1f68aaab5b16f46f87268fa3a541e62793a627e45d7aa",
+      "syncedAt": "2026-08-08T22:39:33.891Z"
     },
     ".github/instructions/tokens.instructions.md": {
-      "sourceSha256": "221fee8b3ab139b52d3b55cdc23bb1522da2cf1c4c88eb66b3cf138f62153002",
-      "targetSha256": "cc203e133af9f36ceddb804bb430116640e20a9576f49047e49e0a0e3dba05a3",
-      "syncedAt": "2026-08-07T15:34:55.223Z"
+      "sourceSha256": "9f4057f4cb29336105e7fdcd01191302167cff4cc9c43553416b28910772b51a",
+      "targetSha256": "88b251762e6cb19d28ec0e5e672f8caf778ebfe58066558d0bb0507fe56f7dff",
+      "syncedAt": "2026-08-08T22:39:33.892Z"
     },
     ".github/instructions/workflow.instructions.md": {
-      "sourceSha256": "cdf01e74dd016665c60e9974c6524ccd04a33b3d8a6f19631bf6b3e16fa9c5b1",
-      "targetSha256": "cca41b030a9270ab650867fadd9f916ad31625df054dc22d8c10806362ad07e3",
-      "syncedAt": "2026-08-08T21:07:36.376Z"
+      "sourceSha256": "118a896744ff62a4c1ed99c2a4d83ff1937a94d61a17ed0379ef9a03160b0a34",
+      "targetSha256": "9aaecb7bd0637b91768781c47dc29acee3d3a6cb6e176870ea442be0398cf1af",
+      "syncedAt": "2026-08-08T22:39:33.893Z"
     },
     ".github/prompts/backlog.prompt.md": {
       "sourceSha256": "662578e4e512ac591b86127f50c601283a27b6ce96c9e09b022b833f720fe750",
@@ -264,14 +264,14 @@
       "syncedAt": "2026-08-07T15:34:55.222Z"
     },
     "AGENTS.md": {
-      "sourceSha256": "d6d722c2435fa74ec0ed07230c40243df4eeddc6295fe57d6053947bbc558f64",
-      "targetSha256": "d8ca2874bceec3f3f1a5068df06f2d12c53aaa227c5e93caef1c84d76612fe4a",
-      "syncedAt": "2026-08-07T23:31:41.388Z"
+      "sourceSha256": "06c07af49b0234f194414caf3fef7c15fc9e2ee93dde2c23231a16b2070c6275",
+      "targetSha256": "8d8e14c1193b620a04cccc4bcd19ad435e7c93016c5303bc44b1962dc7bf3ef7",
+      "syncedAt": "2026-08-08T22:39:33.868Z"
     },
     "agency.toml": {
-      "sourceSha256": "281f6b5cf11d21b51acd26d139cb10d6ca9526f4844e4bac8ce8b759d9a5049e",
-      "targetSha256": "c5dc520a8bd3a4414bff540c4c00796ad1dbe4c43422731845ec07881911ef35",
-      "syncedAt": "2026-08-07T15:34:55.220Z"
+      "sourceSha256": "b097fc1ca3d98462ac07d6ba013858773a3c4eee4d98262f8373223709286e1a",
+      "targetSha256": "c07e8341261e1451d416c1f8644a937d3f7f067794929474f21a5a48eba161da",
+      "syncedAt": "2026-08-08T22:39:33.870Z"
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,8 @@ keeps them consistent.
    `${VARS}` or placeholders (`YOUR_API_KEY_HERE`) and ship a `.env.example`. If you find a
    secret that would be committed, stop and flag it.
 2. **Issue-first, PR-always.** Every change references an issue and lands as a PR. A task that
-   ends at a local commit is **incomplete**.
+   ends at a local commit is **incomplete**. Read-only research does not need an issue when it makes
+   no repository change; the issue requirement begins before the first change.
 3. **Stay in scope.** Make surgical, intentional edits. Don't reformat or "clean up" unrelated
    code. Don't work outside the repository root.
 4. **Document decisions.** Non-trivial structural or design choices get an ADR in
@@ -86,9 +87,10 @@ commands). Merge conflicts carry the same weight as red CI — resolve them befo
 
 ## Tooling (MCP)
 
-Shared MCP servers are declared in `agency.toml`: `context7` (library docs),
-`playwright` (browser automation), `sequential-thinking`, and `memory`. Product repos may add
-their own.
+Pinned MCP servers are declared in `agency.toml`. Intrinsically bounded Context7 documentation and
+sequential-thinking tools are enabled by default; Playwright browser automation and persistent
+memory are documented, pinned opt-ins until the consuming host's tool-filter enforcement is
+verified. Product repos may define a narrower local runtime policy.
 
 ## Human-Gated Operations (MANDATORY)
 
@@ -138,8 +140,12 @@ Scope-specific rules live alongside the code — read the relevant one before wo
 - `agents/*.agent.md` in this backbone, materialized as `.github/agents/*.agent.md` in consumers —
   role definitions and boundaries. Consumer copies are generated; product-specific stack/path/risk
   overlays belong in the product's root `AGENTS.md` or scoped instructions.
-- `skills/<name>/SKILL.md` — reusable task playbooks; read the relevant one before acting.
-- `instructions/*.instructions.md` — path-scoped coding standards.
+- `skills/<name>/SKILL.md` in this backbone is canonical; opted-in consumers read the generated,
+  upstream-owned `.github/skills/<name>/SKILL.md` materialization.
+- `instructions/*.instructions.md` in this backbone is canonical; opted-in consumers read generated,
+  upstream-owned `.github/instructions/*.instructions.md` copies. Root/local `AGENTS.md` and
+  more-specific scoped instructions override shared defaults without relaxing mandatory human
+  gates.
 <!-- studio:base:end -->
 
 # Score King product overlay

--- a/agency.toml
+++ b/agency.toml
@@ -1,6 +1,10 @@
 # synced from jrmoulckers/.github — canonical source; do not edit here
 [mcps.servers]
-context7 = { args = ["-y", "@upstash/context7-mcp@latest"], command = "npx", tools = ["*"], type = "stdio" }
-playwright = { args = ["-y", "@anthropic/mcp-server-playwright"], command = "npx", tools = ["*"], type = "stdio" }
-sequential-thinking = { args = ["-y", "@modelcontextprotocol/server-sequential-thinking"], command = "npx", tools = ["*"], type = "stdio" }
-memory = { args = ["-y", "@modelcontextprotocol/server-memory"], command = "npx", tools = ["*"], type = "stdio" }
+context7 = { args = ["-y", "@upstash/context7-mcp@4.0.0"], command = "npx", tools = ["resolve-library-id", "query-docs"], type = "stdio" }
+sequential-thinking = { args = ["-y", "@modelcontextprotocol/server-sequential-thinking@2026.7.4"], command = "npx", tools = ["sequentialthinking"], type = "stdio" }
+
+# The consuming host's enforcement of agency.toml tool allowlists is not yet documented. Keep
+# browser control and persistent-memory mutation disabled by default. A local runtime may opt in
+# only after proving that it exposes exactly the reviewed list and recording that policy locally.
+# playwright = { args = ["-y", "@playwright/mcp@0.0.79"], command = "npx", tools = ["browser_navigate", "browser_navigate_back", "browser_snapshot", "browser_take_screenshot", "browser_find", "browser_click", "browser_fill_form", "browser_type", "browser_select_option", "browser_press_key", "browser_hover", "browser_wait_for", "browser_tabs", "browser_close", "browser_console_messages"], type = "stdio" }
+# memory = { args = ["-y", "@modelcontextprotocol/server-memory@2026.7.4"], command = "npx", tools = ["read_graph", "search_nodes", "open_nodes"], type = "stdio" }


### PR DESCRIPTION
## Summary

Sync Score King to the consolidated canonical instruction and agency policy from `jrmoulckers/.github` commit `85fda85e212ddafdfc025a6a75f74fbe68bf23fc`.

## Changes

- Update the five selected instruction profiles: agents, docs, skills, tokens, and workflow.
- Adopt the pinned, bounded `agency.toml` MCP policy.
- Preserve the local design agent, Score King `AGENTS.md` overlay, Copilot design instructions, and deploy workflow.
- Retain exactly 22 agents (21 canonical plus the local design replacement), 15 skills, and seven prompts with `rebase-all` excluded.
- Refresh canonical lock metadata after an exact-member work-directory sync without `--force`.

## Issues

Closes #116

## Testing

- [x] Canonical sync validator suite (117 tests)
- [x] Exact-member sync idempotence (54 unchanged)
- [x] Exact-member sync `--check` (no drift)
- [x] `npm run check`
- [x] `npm test` (1,302 tests)
- [x] `npm run build`
- [x] `npm --prefix relay run typecheck`
- [x] `git diff --check`