### PR TITLE
ci(workflows): consolidate delivery pipelines (#118)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
       node-version: '22'
       package-manager: npm
       audit-command: npm audit --omit=dev --audit-level=high
+      run-dependency-review: false
 
   performance:
     name: Performance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    name: Lint policy
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: jrmoulckers/.github/.github/workflows/reusable-ci-lint.yml@97ff60ec21321563fa0fc7ba80015261e7dcd6fa
+    with:
+      node-version: '22'
+      package-manager: npm
+      lint-command: ''
+      format-check-command: ''
+
+  web:
+    name: Web
+    permissions:
+      contents: read
+    uses: jrmoulckers/.github/.github/workflows/reusable-ci-web.yml@97ff60ec21321563fa0fc7ba80015261e7dcd6fa
+    with:
+      node-version: '22'
+      package-manager: npm
+      typecheck-command: npm run check
+      test-command: npm test
+      build-command: npm run build
+      artifact-name: score-king-web
+      artifact-path: dist
+      artifact-retention-days: 1
+
+  relay-typecheck:
+    name: Relay typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: relay/package-lock.json
+
+      - name: Install relay dependencies
+        run: npm ci --prefix relay
+
+      - name: Typecheck relay
+        run: npm --prefix relay run typecheck
+
+  security:
+    name: Security
+    permissions:
+      contents: read
+    uses: jrmoulckers/.github/.github/workflows/reusable-security-ci.yml@97ff60ec21321563fa0fc7ba80015261e7dcd6fa
+    with:
+      node-version: '22'
+      package-manager: npm
+      audit-command: npm audit --omit=dev --audit-level=high
+
+  performance:
+    name: Performance
+    needs: web
+    permissions:
+      contents: read
+    uses: jrmoulckers/.github/.github/workflows/reusable-perf-budget.yml@97ff60ec21321563fa0fc7ba80015261e7dcd6fa
+    with:
+      artifact-name: score-king-web
+      output-dir: dist
+      bundle-budget-kb: 2048

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,38 +3,30 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+    paths:
+      - .github/workflows/deploy.yml
+      - index.html
+      - package-lock.json
+      - package.json
+      - public/**
+      - src/**
+      - svelte.config.js
+      - tsconfig*.json
+      - vite.config.ts
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: true
+permissions: {}
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - run: npm run build
-      - uses: actions/upload-pages-artifact@v5
-        with:
-          path: dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v5
+  pages:
+    name: Build and deploy Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: jrmoulckers/.github/.github/workflows/reusable-deploy-pages.yml@97ff60ec21321563fa0fc7ba80015261e7dcd6fa
+    with:
+      node-version: '22'
+      package-manager: npm
+      build-command: npm run build
+      output-dir: dist


### PR DESCRIPTION
## Summary

Consolidates Score King's CI and GitHub Pages delivery on the reviewed studio reusable workflows.

## Changes

- Adds pull-request and `main` CI with pinned lint/title, web, security, and performance reusable workflows.
- Preserves the relay TypeScript check in a local, immutable-action job.
- Refactors Pages delivery to the pinned reusable deploy workflow, with no workflow-level write permissions.
- Cancels superseded PR CI runs and retains CNAME, SPA fallback, and PWA build output.
- Leaves the provider-managed `dynamic/copilot-swe-agent/copilot` workflow unchanged as an external audit surface.

## Security

- All reusable callers pin `97ff60ec21321563fa0fc7ba80015261e7dcd6fa`; local actions pin full commit SHAs.
- Callers use explicit job-level permissions and do not inherit secrets.
- Production package audit remains gated at high severity; secret scanning covers the relevant Git history.

## Issues

Closes #118

## Testing

- [x] `npm run check`
- [x] `npm test` (49 files, 1,302 tests)
- [x] `npm run build`
- [x] `npm --prefix relay run typecheck`
- [x] Production dependency audit and immutable workflow-reference checks
- [x] Built artifact: 1,511 KiB / 2,048 KiB, CNAME preserved, `404.html` matches `index.html`, PWA manifest/service worker present

## Needs Human Action

Repository settings were not changed:

- GitHub reports `main` as unprotected. An administrator must add branch protection or a ruleset and select the new stable CI checks if they should be required before future merges.
- Dependency review is disabled because GitHub reports that the repository dependency graph is not enabled. An administrator must enable the dependency graph under **Settings > Security > Advanced Security** before `run-dependency-review` can be safely turned on.

Pages is already configured for GitHub Actions (`build_type: workflow`) with HTTPS enforcement, and the `github-pages` environment branch policy allows only `main`.
