### PR TITLE
docs(authority): reference centralized Product authority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,7 @@ cannot relax the studio safety or human-gated operation rules above.
 | `relay/**` | `@backend-engineer` | Owns the stateless WebSocket service and validates every message at the client/service trust boundary; never persist or expose game data. |
 | `ARCHITECTURE.md` | `@architect` | Owns the cross-client target architecture, contracts, and trust-boundary decisions. |
 | `.github/workflows/deploy.yml` | `@devops-engineer` | Owns GitHub Pages delivery, permissions, action pinning, and deployment gates. |
-| `PRODUCT.md`, `DESIGN.md`, `.impeccable/design.json`, `.github/copilot-instructions.md` | local `@design-engineer` | Owns product design direction, tokens, and component specifications. Web implementation remains with `@web-engineer`. |
+| `PRODUCT.md`, `DESIGN.md`, `.impeccable/design.json`, `.github/copilot-instructions.md` | local `@design-engineer` | Owns Score King's *expression* of the system, not the authority for it. Product direction — users, purpose, promise, and the value and trust posture — is Product's (`PROD-STRAT-001`); token, theme, and component contracts are Studio's (`STUDIO-FND-001`, `STUDIO-TOK-001`, `STUDIO-TOK-002`, `STUDIO-CMP-001`). This role composes those contracts into Score King's per-game costume and keeps `PRODUCT.md` citing the obligations it satisfies; it does not restyle, fork, or redefine them. Escalate to Product for direction changes and to Studio for design-system changes. Web implementation remains with `@web-engineer`. |
 
 The local `@design-engineer` also co-owns design-token declarations in `src/app.css`; coordinate
 edits there with `@web-engineer` because that file is consumed by the web client.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -18,10 +18,10 @@ and no fear of losing data. Players and history are shared across games, so regu
 
 ## Product Purpose
 
-> Satisfies `PROD-STRAT-001`, `PROD-STRAT-003`. The local-first data posture and the optional,
-> opt-in OneDrive backup also satisfy `PROD-COMP-002` (game data stays on the device unless the
-> player chooses otherwise) and `PROD-COMP-008` (backup is off by default, granular, and
-> disconnectable no less easily than it is connected).
+> Satisfies `PROD-STRAT-001`. The local-first data posture and the optional, opt-in OneDrive
+> backup also satisfy `PROD-COMP-002` (game data stays on the device unless the player chooses
+> otherwise) and `PROD-COMP-008` (backup is off by default, granular, and disconnectable no less
+> easily than it is connected).
 
 Score King is a local-first, installable PWA that keeps score for card & party games so
 the math and bookkeeping disappear into the night. Each game is a self-contained,

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,6 +6,8 @@ product
 
 ## Users
 
+> Satisfies `PROD-STRAT-001`.
+
 People keeping score during live, in-person card & party games — Hearts, Skull King,
 a generic Tally, with more on the way. The person holding the phone is mid-game: at a
 table, often one-handed, sometimes in dim lighting, frequently offline, and usually
@@ -15,6 +17,11 @@ and no fear of losing data. Players and history are shared across games, so regu
 (game-night groups, families) come back to the same roster and leaderboard.
 
 ## Product Purpose
+
+> Satisfies `PROD-STRAT-001`, `PROD-STRAT-003`. The local-first data posture and the optional,
+> opt-in OneDrive backup also satisfy `PROD-COMP-002` (game data stays on the device unless the
+> player chooses otherwise) and `PROD-COMP-008` (backup is off by default, granular, and
+> disconnectable no less easily than it is connected).
 
 Score King is a local-first, installable PWA that keeps score for card & party games so
 the math and bookkeeping disappear into the night. Each game is a self-contained,
@@ -26,6 +33,8 @@ winning — and never think about the tool itself.
 
 ## Brand Personality
 
+> Satisfies `PROD-STRAT-001`.
+
 Whimsical, Easy, Game-Night Energy. The voice is friendly and light, never corporate or
 verbose. The 👑 "King" motif, emoji-forward game tiles, and a purple-and-gold palette
 carry the warmth and fun; the interaction underneath stays effortless, uncluttered, and
@@ -33,6 +42,9 @@ predictable. Personality shows up in the motif, the copy, and small moments — 
 noise, decoration, or redundancy.
 
 ## Anti-references
+
+> Satisfies `PROD-STRAT-001` — naming the failure modes makes the trust and value posture
+> reviewable.
 
 This should never feel cluttered, confusing, verbose, corporate, sterile, redundant,
 ad-ridden, or inconsistent. Specifically NOT:
@@ -44,32 +56,43 @@ ad-ridden, or inconsistent. Specifically NOT:
 
 ## Design Principles
 
+> Score King's local expression of `PROD-STRAT-001` and of Studio's design contract
+> (`STUDIO-FND-001`). Rules already carried centrally are cited, not restated.
+
 - **The tool disappears into the table.** The fastest path from "round happened" to
   "score entered" wins. Minimal taps, big targets, glanceable standings. If a screen
   makes someone look down from the game for longer than necessary, it's too much.
-- **Local-first is a trust contract.** Instant saves and full offline reliability are
-  non-negotiable. Nothing — sync, network, accounts — is ever allowed to stand between a
-  player and recording the score.
+- **Local-first is a trust contract.** Score King's instance of `PROD-STRAT-001`: instant saves
+  and full offline reliability are the trust constraints no growth or convenience decision may
+  weaken. Nothing — sync, network, accounts — is ever allowed to stand between a player and
+  recording the score.
 - **Whimsy, never clutter.** Personality lives in the motif, the copy, and small
   moments. It is never an excuse for noise, decoration, redundant controls, or anything
   that slows the core loop.
-- **One vocabulary across every game.** A new game module should feel instantly familiar:
-  the same buttons, the same round-entry rhythm, the same scoreboard. Consistency is the
-  feature that lets the app grow without growing confusing.
-- **Respect everyone at the table.** Inclusive and readable by default (color-blind-safe,
-  reduced-motion, one-handed, legible in dim light), and respectful of the social moment —
-  privacy when the phone is set down, shared visibility when the table wants it.
+- **One vocabulary across every game.** Per `STUDIO-CMP-001` and `STUDIO-TOK-002`, game modules
+  compose the shared component contracts and bind to semantic tokens rather than restyling or
+  forking them. Locally that means a new game module inherits the same buttons, the same
+  round-entry rhythm, and the same scoreboard — consistency is the feature that lets the app
+  grow without growing confusing.
+- **Respect everyone at the table.** Accessibility conformance is central (`STUDIO-A11Y-001`,
+  `STUDIO-A11Y-002`); what is score-king-specific is the social moment — privacy when the phone
+  is set down, shared visibility when the table wants it, and legibility while the device is
+  propped, passed, or held one-handed in a dim room.
 
 ## Accessibility & Inclusion
 
+> Satisfies `PROD-CONTENT-005`. Score King owns the obligation and the accommodations below;
+> Studio owns the interface expression and the conformance floor (`STUDIO-A11Y-001`,
+> `STUDIO-A11Y-002`).
+
 Practical WCAG AA as the floor, with deliberate accommodations surfaced in Settings:
 
-- **Color-blind support.** Color-blind-safe player colors and palette options; never rely
-  on color alone to convey standing, win/loss, or state.
+- **Color-blind support.** Color-blind-safe player colors and palette options, so standing,
+  win/loss, and state stay distinguishable to every player at the table.
 - **Accessibility settings hub.** A dedicated place in Settings for ability accommodations
   (contrast, text size, motion, color) rather than burying them.
-- **Reduced motion.** Honor `prefers-reduced-motion` and offer an explicit in-app toggle;
-  every animation needs a calm, instant alternative.
+- **Reduced motion.** Every animation needs a calm, instant alternative; the in-app override is
+  Score King's instance of `STUDIO-A11Y-002`.
 - **OLED-friendly dark mode.** A true-black option so the app is comfortable and
   battery-kind on OLED screens in dim rooms.
 - **One-handed first.** Primary actions sit in the thumb zone; the app is usable held in

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -57,7 +57,8 @@ ad-ridden, or inconsistent. Specifically NOT:
 ## Design Principles
 
 > Score King's local expression of `PROD-STRAT-001` and of Studio's design contract
-> (`STUDIO-FND-001`). Rules already carried centrally are cited, not restated.
+> (`STUDIO-FND-001`). Citations name the central obligation a rule answers to; the local
+> wording is kept because it is the score-king-specific detail that obligation does not carry.
 
 - **The tool disappears into the table.** The fastest path from "round happened" to
   "score entered" wins. Minimal taps, big targets, glanceable standings. If a screen
@@ -74,10 +75,11 @@ ad-ridden, or inconsistent. Specifically NOT:
   forking them. Locally that means a new game module inherits the same buttons, the same
   round-entry rhythm, and the same scoreboard — consistency is the feature that lets the app
   grow without growing confusing.
-- **Respect everyone at the table.** Accessibility conformance is central (`STUDIO-A11Y-001`,
-  `STUDIO-A11Y-002`); what is score-king-specific is the social moment — privacy when the phone
-  is set down, shared visibility when the table wants it, and legibility while the device is
-  propped, passed, or held one-handed in a dim room.
+- **Respect everyone at the table.** Per `STUDIO-A11Y-001` and `STUDIO-A11Y-002`: inclusive and
+  readable by default (color-blind-safe, reduced-motion, one-handed, legible in dim light), and
+  respectful of the social moment — privacy when the phone is set down, shared visibility when
+  the table wants it. One-handed reach and dim-room legibility are local obligations; the central
+  principles cover contrast and accessibility modes, not the table ergonomics.
 
 ## Accessibility & Inclusion
 
@@ -87,12 +89,12 @@ ad-ridden, or inconsistent. Specifically NOT:
 
 Practical WCAG AA as the floor, with deliberate accommodations surfaced in Settings:
 
-- **Color-blind support.** Color-blind-safe player colors and palette options, so standing,
-  win/loss, and state stay distinguishable to every player at the table.
+- **Color-blind support.** Color-blind-safe player colors and palette options; never rely
+  on color alone to convey standing, win/loss, or state (`STUDIO-A11Y-001`).
 - **Accessibility settings hub.** A dedicated place in Settings for ability accommodations
   (contrast, text size, motion, color) rather than burying them.
-- **Reduced motion.** Every animation needs a calm, instant alternative; the in-app override is
-  Score King's instance of `STUDIO-A11Y-002`.
+- **Reduced motion.** Honor `prefers-reduced-motion` and offer an explicit in-app toggle
+  (`STUDIO-A11Y-002`); every animation needs a calm, instant alternative.
 - **OLED-friendly dark mode.** A true-black option so the app is comfortable and
   battery-kind on OLED screens in dim rooms.
 - **One-handed first.** Primary actions sit in the thumb zone; the app is usable held in

--- a/README.md
+++ b/README.md
@@ -309,6 +309,22 @@ GitHub Pages serves a single custom domain, so per‑game subdomains like
 
 ---
 
+## 🏛️ Product authority
+
+Product obligations and outcomes are defined in
+[jrmoulckers/product](https://github.com/jrmoulckers/product) and consumed here **by reference,
+not by copy**. Cite obligations by stable ID (for example `PROD-REL-001`), and pin to a commit SHA
+when the exact wording matters. Roadmaps, metrics, experiments, and compliance evidence stay in
+this repository and cite the obligation they satisfy — see [`PRODUCT.md`](PRODUCT.md) for Score
+King's own product definition.
+
+Engineering mechanisms are defined in
+[jrmoulckers/engineering](https://github.com/jrmoulckers/engineering), design and interface in
+[jrmoulckers/studio](https://github.com/jrmoulckers/studio), and automation and shared agent
+assets in [jrmoulckers/.github](https://github.com/jrmoulckers/.github).
+
+---
+
 ## 📄 License
 
 Personal project — all rights reserved for now.


### PR DESCRIPTION
## Summary

Makes Score King a consumer of centralized Product authority **by reference, not by copy**, and
corrects an authority-boundary error in the local `@design-engineer` ownership row. No principle
text is copied into this repository — obligations are cited by stable ID, and every cited ID was
read in full against source before citing.

## Changes

**`README.md`** — new `## 🏛️ Product authority` section naming `jrmoulckers/product` (obligations),
`jrmoulckers/engineering` (mechanisms), `jrmoulckers/studio` (design and interface), and
`jrmoulckers/.github` (automation and shared agent assets).

**`PRODUCT.md`** — stays here as the per-application instance. Each section now cites the
obligation it satisfies; no local content is removed.

| Section | Obligation |
| --- | --- |
| Users | `PROD-STRAT-001` |
| Product Purpose | `PROD-STRAT-001`; local-first + opt-in OneDrive backup also `PROD-COMP-002`, `PROD-COMP-008` |
| Brand Personality | `PROD-STRAT-001` |
| Anti-references | `PROD-STRAT-001` |
| Design Principles | `PROD-STRAT-001`, `STUDIO-FND-001` |
| Accessibility & Inclusion | `PROD-CONTENT-005`; interface expression `STUDIO-A11Y-001`, `STUDIO-A11Y-002` |

Rules that answer to a central principle now cite it inline (`STUDIO-CMP-001` / `STUDIO-TOK-002`
for "One vocabulary across every game"; `STUDIO-A11Y-001` / `STUDIO-A11Y-002` for the
accessibility rules), while keeping the local wording — the citation attributes authority, it
does not substitute for the score-king-specific detail the obligation does not carry. One-handed
reach and dim-room legibility in particular are local obligations that no central principle
covers.

**`AGENTS.md`** — the `@design-engineer` row previously claimed ownership of "product design
direction, tokens, and component specifications", conflating three authorities. Rewritten so the
local role owns Score King's *expression* of the system: product direction is Product's
(`PROD-STRAT-001`), token/theme/component contracts are Studio's (`STUDIO-FND-001`,
`STUDIO-TOK-001`, `STUDIO-TOK-002`, `STUDIO-CMP-001`), and the local role composes them rather
than restyling, forking, or redefining them. The boundary language is taken from `STUDIO-CMP-001`'s
own verification and handoff clauses. Edited below `studio:base:end`; the synced region is
untouched.

`DESIGN.md` and `.impeccable/design.json` content is unchanged — only the ownership description
moved.

## Citations deliberately not made

- **`PROD-BUS-003` on Users** — the template suggests it, but BUS-003 requires market claims
  grounded in dated evidence, and that section is currently an unlabeled assumption. Left uncited
  as a real gap rather than papered over.
- **`PROD-STRAT-003` on Product Purpose** — its verification clause about "the capability that
  remains if an optional dependency is unavailable" is a required field of a *roadmap milestone*
  record, not a free-standing rule. Purpose states no milestones, so the obligation has nothing to
  bind. The offline/backup posture is already covered exactly by `PROD-COMP-002` and
  `PROD-COMP-008`. STRAT-003 becomes the right citation if a roadmap section is added later.

## Issues

Closes #120

## Testing

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm test` — 1302 tests passed (49 files)
- [x] `npm run build` — succeeded
- [x] Full CI green on the final commit
