### PR TITLE
chore(sync): update studio canon (2026-08-09)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,3 +28,71 @@ Non-negotiables pulled from DESIGN.md:
 To evolve the design system, use the **impeccable** skill (e.g. `/impeccable critique`,
 `/impeccable craft`, `/impeccable live`). Re-run `/impeccable document` if the visual
 system drifts so DESIGN.md and the sidecar stay accurate.
+
+<!-- studio:base:start -->
+<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
+
+# GitHub Copilot — JRM Studio orientation
+
+This file orients GitHub Copilot on the **Copilot surfaces**: chat and completions in VS Code,
+`copilot.com`, code review, and the coding agent.
+
+**`AGENTS.md` in the repository root is the authoritative operating guide.** Read it before acting.
+It owns the golden rules, the Definition of Done, the issue-first workflow, and the mandatory
+human-gated operations. This file never restates those rules — where the two could appear to
+conflict, `AGENTS.md` wins.
+
+> Distributed from `jrmoulckers/.github`. Everything outside the `studio:base` markers is
+> repository-local and is never overwritten by the studio sync tool; add repository-specific
+> Copilot orientation there rather than editing inside the managed region.
+
+## Read order
+
+1. **`AGENTS.md`** (root) — the operating guide. Product repositories extend it below the managed
+   region; those local rules layer on top of the shared floor but never relax a human gate.
+2. **The nearest scoped instructions** — `.github/instructions/*.instructions.md` apply by glob to
+   the paths you are editing. A more specific file wins over a more general one.
+3. **Product context** — whatever the repository's own `AGENTS.md` section points you to
+   (architecture notes, ADRs, design or domain docs).
+
+## The installed AI layer
+
+Most of `.github/` is generated and distributed from the `jrmoulckers/.github` backbone. Treat it
+as read-only here:
+
+| Path | What it is | How to use it |
+| --- | --- | --- |
+| `.github/agents/*.agent.md` | Role definitions with explicit boundaries | Delegate specialist work to the matching role instead of improvising one |
+| `.github/skills/<name>/SKILL.md` | Reusable methodology and checklists | Consult the skill whose description matches the task before inventing an approach |
+| `.github/prompts/*.prompt.md` | Repeatable multi-step workflows | Prefer the existing prompt over an ad-hoc plan for the work it covers |
+| `.github/instructions/*.instructions.md` | Path-scoped rules | Applied automatically by glob; obey the most specific match |
+| `agency.toml` | Reviewed MCP servers and tool allowlists | Do not add servers or widen tool grants locally |
+
+**Never edit a generated file to change shared behaviour.** A local edit is detected as drift, is
+skipped on the next sync, and silently strands the repository on a stale copy. Change the canonical
+source in `jrmoulckers/.github` and let it sync. Genuinely repository-specific behaviour belongs in
+the local `AGENTS.md`, a locally authored agent, or a scoped instructions file.
+
+## Working conventions
+
+- **Issue first, PR always.** Read-only research needs no issue; the requirement starts before your
+  first change. A change that ends at a local commit is not done.
+- **Reference, never restate.** Each rule has exactly one canonical owner. Link to it rather than
+  copying its text — duplicated policy drifts and hides which copy is authoritative.
+- **Stay in scope.** Surgical edits only. Do not reformat or refactor code the task did not require.
+- **Verify before claiming done.** Run the repository's own lint, type-check, test, and build
+  commands. Do not report success on unverified work.
+- **Say when you are unsure.** A short clarifying question beats a confident guess on anything
+  touching security, privacy, data, or infrastructure.
+
+## Stop and ask
+
+`AGENTS.md` §"Human-Gated Operations" is the complete, canonical list. Pushing your own feature
+branch and opening a PR are *required* steps — never pause for permission on those. Do stop for
+anything that writes to a shared branch, acts on another author's PR, changes repository settings,
+touches real secrets or credentials, reaches outside the repository root, deletes files in bulk, or
+publishes or deploys.
+
+When a task needs a gated operation and no human is available, finish everything that is
+auto-approved and leave a `## Needs Human Action` note describing exactly what remains and why.
+<!-- studio:base:end -->

--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -87,9 +87,10 @@ Amend only when the user explicitly requests it and applicable authority permits
 ## Calling reusable workflows
 
 Studio product repos call the backbone's reusable workflows at a reviewed immutable commit SHA:
-`uses: jrmoulckers/.github/.github/workflows/reusable-*.yml@<reviewed-commit-sha>`. A documented
-versioned-tag policy is also acceptable only when automation proposes reviewed updates; do not use a
-mutable branch such as `@main`.
+`uses: jrmoulckers/.github/.github/workflows/reusable-*.yml@<reviewed-commit-sha>`. The reference
+must be a full 40-character SHA; branches and tags are rejected. Configure Dependabot, Renovate, or
+equivalent automation to propose SHA update PRs, then review the exact upstream diff and release
+notes. Never resolve a mutable reference during a run.
 
 **A caller `permissions:` block replaces the defaults — it does not add to them.** Every scope you
 omit is set to `none`, and a called workflow can never receive more than its caller holds. So a
@@ -105,7 +106,10 @@ Grant every scope the callee declares:
 | `reusable-ci-web` | `contents: read` |
 | `reusable-perf-budget` | `contents: read` |
 | `reusable-smoke-test` | `contents: read` |
-| `reusable-deploy-preview` | `contents: read` (plus whatever your deploy step needs) |
+| `reusable-deploy-preview` | `contents: read` |
+| `reusable-change-detection` | `contents: read` |
+| `reusable-security-ci` | `contents: read` |
+| `reusable-deploy-pages` | `contents: read`, `pages: write`, and `id-token: write` |
 
 ```yaml
 permissions:
@@ -126,6 +130,9 @@ Rules:
 - If a scope truly cannot be granted, disable the job that needs it instead
   (e.g. `semantic-pr-title: false` for `reusable-ci-lint`).
 - Debug a `startup_failure` with no log by checking caller permissions first.
+- Caller workflows own CI concurrency. Put the concurrency group on the caller workflow so matrix or
+  multi-package reusable jobs do not cancel sibling calls. Canonical Pages deployment is the
+  exception: it serializes repository deployments with `cancel-in-progress: false`.
 
 ### Taking only part of `reusable-ci-lint`
 
@@ -153,6 +160,55 @@ jobs:
 Passing an empty string is the supported opt-out. Leaving a command at its default in a repo that
 has no such script fails the job; duplicating backbone logic locally makes the product repo drift
 from canon.
+
+### Build once and reuse same-run artifacts
+
+`reusable-ci-web` optionally uploads a validated directory when `artifact-name` is set. Preview,
+performance, and smoke jobs accept that exact same-run artifact name. The caller must declare
+`needs` so the producer completes first; consumers do not accept a repository, run ID, or token, so
+they cannot fetch cross-run or cross-repository artifacts.
+
+```yaml
+jobs:
+  web:
+    uses: jrmoulckers/.github/.github/workflows/reusable-ci-web.yml@<reviewed-commit-sha>
+    with:
+      artifact-name: web-build
+      artifact-path: dist
+
+  performance:
+    needs: web
+    uses: jrmoulckers/.github/.github/workflows/reusable-perf-budget.yml@<reviewed-commit-sha>
+    with:
+      artifact-name: ${{ needs.web.outputs.artifact-name }}
+      output-dir: dist
+```
+
+At the caller workflow level, use a ref-scoped group for superseded CI runs:
+
+```yaml
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Never pass an untrusted artifact into a job with secrets or write authority. `reusable-deploy-pages`
+does not accept an arbitrary artifact: its unprivileged build job creates the fixed Pages artifact,
+and its environment-gated deploy job only calls GitHub's deploy action with `pages: write` and
+`id-token: write`.
+
+### Security and preview boundaries
+
+- Reusable commands are trusted repository configuration. Pass literal workflow values, never event
+  titles, branch names, issue text, or other untrusted data.
+- Never use `secrets: inherit`. Canonical PR build, security, preview, performance, smoke, and change
+  detection workflows declare no secrets.
+- Preview canon is artifact-only. The removed `provider`, `preview-command`, `DEPLOY_TOKEN`, and
+  `preview-url` contracts must not be recreated. Provider deployments require a separate reviewed
+  job, a protected environment, explicit secrets, and no PR-controlled arbitrary shell.
+- Lighthouse reports remain private GitHub artifacts by default. Enable
+  `lighthouse-public-upload` only for an intentionally public, unauthenticated URL after accepting
+  that report data will leave GitHub's private artifact boundary.
 
 ### Never vendor a backbone workflow or health file
 

--- a/.github/skills/edge-sync/SKILL.md
+++ b/.github/skills/edge-sync/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: edge-sync
+description: >
+  Offline-first client architecture and data synchronization. Use for topics
+  related to local-first reads and writes, offline mutation queues, delta or
+  incremental sync, conflict resolution strategies, tombstones and soft
+  deletes, sync-state UI, replication, or edge resilience.
+---
+<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
+
+# Edge Sync Skill
+
+## Purpose
+
+This skill covers **client-side offline-first behavior**: treating a local store as the primary
+read/write surface, queueing mutations while disconnected, reconciling divergent copies, and
+surfacing sync state honestly in the UI.
+
+It is stack-agnostic. The patterns apply equally to a browser app over IndexedDB, a native app over
+SQLite, or any client that must stay usable without a network.
+
+## Out of Scope
+
+- Server schema, migrations, row-level authorization, and replication rules → owned by the backend
+  or database role for the repository.
+- Platform build systems, source-set layout, and ORM syntax → use the relevant engineering skill.
+- Threat modeling of the auth and encryption paths → use `security-review-methodology`.
+- Privacy obligations and retention rules that sync must satisfy → use `privacy-compliance`.
+
+## Related Skills
+
+| Skill | Use for |
+| --- | --- |
+| `security-review-methodology` | Reviewing encrypted sync, token handling, and conflict paths |
+| `privacy-compliance` | Erasure, retention, and data-residency obligations sync must honor |
+| `performance-budgets` | Cost of sync work on the main thread and on startup |
+| `ux-testing` | Validating that offline and conflict states are understandable |
+
+## The core principle
+
+**Every read and write goes to the local store. The network is only for synchronization.**
+
+```
+┌──────────────── Client (edge) ─────────────────┐
+│  UI  ⇄  Repositories  ⇄  Local store           │
+│                            ↕                    │
+│                     Mutation queue              │
+│                            ↕                    │
+│                       Sync engine               │
+└────────────────────────────┬───────────────────┘
+                             │  (only crossing)
+┌────────────────────────────┴───────────────────┐
+│  Server: source of truth, authorization,        │
+│  selective replication per authorized scope     │
+└────────────────────────────────────────────────┘
+```
+
+If a UI code path can block on the network, the app is not offline-first. A write must be visible in
+the local store — and therefore on screen — before any request is attempted.
+
+## Sync engine states
+
+Model the connection as an explicit state machine and expose it to the UI:
+
+```
+Disconnected → Connecting → Connected → Syncing → Connected
+     ↑                                      │
+     └──────────────── Error ←──────────────┘
+```
+
+| State | UI obligation |
+| --- | --- |
+| `Connected` | No indicator; this is the normal case |
+| `Syncing` | Subtle, non-blocking progress; never a modal |
+| `Disconnected` | Persistent but unobtrusive offline affordance; the app stays fully usable |
+| `Error` | Explain what failed and offer retry; never fail silently |
+
+Never block interaction on a sync state. Offline is a normal operating mode, not an error.
+
+## Offline mutation queue
+
+Local writes are recorded in a durable, ordered queue and replayed when connectivity returns.
+
+**Requirements:**
+
+- **Durable.** The queue survives a reload or process kill. An in-memory queue silently discards
+  user work on a crash.
+- **Ordered.** Replay preserves causal order; a delete replayed before its create corrupts state.
+- **Deduplicated.** Repeated edits to one entity collapse by key rather than replaying every
+  keystroke.
+- **Bounded retry.** Exponential backoff with a ceiling, then a dead-letter state. Infinite retry of
+  a permanently invalid mutation blocks every mutation behind it.
+- **Observable.** A dead-lettered mutation is surfaced to the user, never dropped quietly.
+
+**Backoff sketch:**
+
+```
+attempt 1 → immediate
+attempt n → min(base × 2^(n-1), cap) + jitter
+n > ceiling → dead-letter, surface to the user
+```
+
+Jitter matters: without it, every client that lost connectivity in the same outage retries in
+lockstep and stampedes the server on recovery.
+
+## Delta sync
+
+Full re-downloads do not scale. Sync incrementally and verify integrity:
+
+- Track a per-collection sequence or cursor.
+- Detect gaps in the sequence rather than assuming contiguity.
+- Validate a checksum before advancing the stored cursor. Advancing on unverified data makes
+  corruption permanent, because the client will never request that range again.
+- On mismatch, fall back to a scoped resync of the affected collection, escalating to a full resync
+  only when scoped recovery fails.
+
+## Soft deletes and tombstones
+
+A hard delete cannot propagate: an absent row is indistinguishable from a row the client has not
+seen yet.
+
+- Delete by marking, not removing.
+- Every replication query filters out deleted records — one unfiltered query resurrects deleted data
+  on every client.
+- Retain tombstones long enough for the slowest realistic client to reconnect; purge on a documented
+  schedule, not never.
+
+## Conflict resolution
+
+Choose a strategy per collection, deliberately. There is no universally correct default.
+
+| Strategy | Use for | Behavior | Main risk |
+| --- | --- | --- | --- |
+| **Last-write-wins** | Simple independent records | Newest timestamp wins | Silent loss of a concurrent edit |
+| **Field-level merge** | Records edited by several people | Reconcile per field; flag genuine collisions | Complexity; needs per-field timestamps |
+| **Client-wins** | Device-local preferences | Local copy always wins | Never converges across devices |
+| **Server-wins** | Administrative or derived data | Remote copy always wins | Discards offline user work |
+
+**Guidance:**
+
+- Default to last-write-wins only for records a single user edits on one device at a time.
+- Use field-level merge for anything collaborative; two people editing different fields of the same
+  record is a merge, not a conflict.
+- Last-write-wins on clock comparison is only as trustworthy as the clocks. Prefer a server-assigned
+  version or a logical clock; device clocks skew, drift, and are user-settable.
+- Never resolve a conflict by silently discarding a user's work when the loss is visible to them —
+  surface it and let them choose.
+
+## Encryption and erasure
+
+When sync carries sensitive fields:
+
+- Encrypt sensitive fields client-side before they enter the queue, so plaintext never crosses the
+  network or lands in server storage.
+- Use an envelope scheme: a per-scope data key wrapped by a rotatable master key. Rotating the
+  wrapping key must not require re-encrypting every record.
+- Support **crypto-shredding** — destroying a scope's data key renders its records unrecoverable
+  everywhere, which is what makes erasure enforceable across replicas you cannot reach.
+- Never log record contents, keys, or tokens from sync paths. Sync code runs constantly and is a
+  prolific source of accidental data leaks.
+
+## Common patterns
+
+### Adding a new synchronized collection
+
+1. Confirm the server includes the collection in the correct authorization scope.
+2. Confirm every replication query filters deleted records.
+3. Choose and register the conflict strategy explicitly — do not inherit a default by accident.
+4. Add mutation-queue handling, including retry and dead-letter behavior for its writes.
+5. Verify an offline write appears in the UI immediately and survives a reload.
+6. Verify a two-device divergence converges to the intended result.
+
+### Testing offline behavior
+
+Sync bugs surface only under conditions that never occur on a fast desktop connection. Test:
+
+| Scenario | What it catches |
+| --- | --- |
+| Write offline, reload, reconnect | Queue durability |
+| Two devices edit the same record while offline | Conflict strategy correctness |
+| Reconnect mid-sync | Partial-batch and cursor-advance handling |
+| Corrupted or gapped sequence | Checksum validation and resync recovery |
+| Permanently rejected mutation | Dead-lettering instead of head-of-line blocking |
+| Delete on one device, edit on another | Tombstone propagation and resurrection bugs |
+
+Multi-device convergence needs a harness that can run two simulated clients against one backend.
+Manual testing reliably misses this class of bug.
+
+## Acceptance checklist
+
+- [ ] Every read and write path targets the local store; no UI path blocks on the network.
+- [ ] The mutation queue is durable, ordered, deduplicated, and bounded by a retry ceiling.
+- [ ] Dead-lettered mutations are surfaced rather than dropped.
+- [ ] Sync cursors advance only after integrity validation.
+- [ ] Deletes are soft, filtered from replication, and their tombstones have a documented lifetime.
+- [ ] Each collection has a deliberately chosen conflict strategy.
+- [ ] Conflict resolution does not rely on unverified device clocks.
+- [ ] Sensitive fields are encrypted before entering the queue; erasure is enforceable.
+- [ ] Sync paths log no record contents, keys, or tokens.
+- [ ] Offline, reconnect, and two-device divergence are covered by automated tests.

--- a/.github/skills/fleet-orchestration/SKILL.md
+++ b/.github/skills/fleet-orchestration/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: fleet-orchestration
+description: >
+  Parallel multi-agent execution across isolated worktrees. Use for topics
+  related to dispatching several agents at once, wave and sprint dispatch,
+  worktree coordination, file-ownership conflicts, parallel PR workflows,
+  CI self-healing loops, rebase-all maintenance, or merge ordering.
+---
+<!-- synced from jrmoulckers/.github — canonical source; do not edit here -->
+
+# Fleet Orchestration Skill
+
+## Purpose
+
+This skill covers **executing already-planned work in parallel**: dispatching multiple agents,
+isolating them in worktrees, keeping them from colliding, healing their CI failures, and landing
+their pull requests in a safe order.
+
+It assumes issues are already shaped and scope is already selected. It is about *running* a wave,
+not deciding what the wave should contain.
+
+## Out of Scope
+
+- Selecting and sequencing the work before dispatch → use `sprint-planning`.
+- Roadmap, milestones, backlog grooming, and release lifecycle → use `project-management`.
+- Issue quality, labels, and duplicate detection before filing → use `issue-management`.
+- The push/PR/merge command sequence itself → owned by `AGENTS.md` and the repository's own
+  workflow documentation. Never restate it here; a stale copy causes avoidable CI failures.
+- Domain implementation inside any app, package, or service → use the relevant engineering skill.
+
+## Related Skills
+
+| Skill | Use for |
+| --- | --- |
+| `sprint-planning` | Selecting and sequencing work before dispatch |
+| `project-management` | Lifecycle and release tracking across a fleet |
+| `issue-management` | Issue quality, scoping, labels, and duplicates |
+| `dev-onboarding` | Environment setup and local tooling orientation |
+
+## When a fleet is the wrong tool
+
+Parallelism has real overhead: worktree setup, CI contention, merge-order reasoning, and rebase
+churn. Dispatch a fleet only when **all** of these hold.
+
+| Condition | Why it matters |
+| --- | --- |
+| Three or more genuinely independent tasks | Below that, sequential work is faster than coordination |
+| Disjoint file ownership | Overlapping edits serialize anyway, with conflicts on top |
+| Each task is individually shippable | A fleet cannot land a change that only makes sense as one PR |
+| Scope is already decided | Planning mid-flight desynchronizes every agent at once |
+
+A single background agent is not a fleet. For solo work, run it synchronously.
+
+## Dispatch algorithm
+
+### 1. Enumerate the candidate work
+
+```bash
+gh issue list --state open --json number,title,labels,milestone --limit 100
+```
+
+### 2. Route each item to an owner
+
+Map by label where a taxonomy exists, otherwise infer from the issue body. Route to the role whose
+`.github/agents/*.agent.md` boundary actually covers the files that must change — ownership is
+defined by the agent definitions, not by this skill.
+
+### 3. Serialize the dependencies
+
+Chains that must never run in parallel:
+
+| Rule | Reason |
+| --- | --- |
+| Schema before its consumers | Clients cannot compile against a shape that does not exist |
+| Shared models before leaf platforms | Every platform consumer reads the shared definition |
+| Design tokens before UI that uses them | Generated token output is an input to the UI build |
+| Architecture decision before implementation | An ADR reversal invalidates finished work |
+
+Cross-layer schema changes are **one serialized task**, not two independent ones.
+
+### 4. Balance into waves
+
+- Prefer a wave you can hold in your head over a maximal one.
+- Order by priority: bugs → security → features → docs → chores.
+- Budget roughly a fifth of wave time for CI failures and rebases; a wave with zero slack stalls.
+- Reserve capacity for non-engineering work so triage and docs do not starve.
+
+### 5. Track dependencies explicitly
+
+```sql
+INSERT INTO todos (id, title, description, status) VALUES
+  ('w1-shared-88', 'Updating shared models (#88)', 'Shared model change other tasks depend on', 'pending'),
+  ('w1-web-443',   'Building the dashboard (#443)', 'Consumes the shared models from #88', 'pending');
+
+INSERT INTO todo_deps (todo_id, depends_on) VALUES ('w1-web-443', 'w1-shared-88');
+```
+
+Query for dispatchable work — pending with no unfinished dependency:
+
+```sql
+SELECT t.id, t.title FROM todos t
+WHERE t.status = 'pending'
+  AND NOT EXISTS (
+    SELECT 1 FROM todo_deps td
+    JOIN todos dep ON td.depends_on = dep.id
+    WHERE td.todo_id = t.id AND dep.status != 'done'
+  );
+```
+
+## Dispatch pattern
+
+Launch every independent agent in the same turn, then wait. Dispatching serially forfeits the only
+benefit of a fleet.
+
+```
+# One turn, all independents:
+task(name: "w1-shared-88", agent_type: "…", mode: "background", prompt: …)
+task(name: "w1-web-443",   agent_type: "…", mode: "background", prompt: …)
+task(name: "w1-docs-446",  agent_type: "…", mode: "background", prompt: …)
+```
+
+For a dependency chain: dispatch the independents, collect results, then dispatch the dependents.
+
+Each agent prompt must be self-contained, because agents share no context:
+
+- The issue number, title, and full body — not a reference to it.
+- The worktree it owns and the branch to create.
+- The files it owns, and an explicit instruction not to touch others.
+- A pointer to the repository's canonical pre-push and PR workflow — never an inline copy.
+- The completion bar: PR open, CI green, `MERGEABLE`, then self-merge.
+
+## Worktree protocol
+
+One agent, one worktree, one branch. Sharing a worktree is the single largest source of fleet
+failure: agents overwrite each other's checkouts and interleave commits onto the wrong branch.
+
+```bash
+git worktree add <worktrees-dir>/<agent>-<issue> -b <type>/<description>-<issue>
+# … agent works, pushes, opens a PR, merges …
+git worktree remove <worktrees-dir>/<agent>-<issue>
+```
+
+Clean up merged worktrees at the end of each wave. Abandoned worktrees accumulate stale branches
+that later rebases must repeatedly reconcile.
+
+## Parallel coordination rules
+
+**File ownership is exclusive.** No two agents in a wave may edit the same file. If a file genuinely
+needs input from two roles, one owns the edit and the other reviews.
+
+**Shared configuration gets a single owner per wave.** Dependency manifests, lockfiles, lint
+configuration, and build configuration are edited by exactly one agent per wave, whichever role owns
+build and delivery. Two agents editing a lockfile in parallel conflict on essentially every run.
+
+**Ordered layers stay serialized.** Where a change crosses a schema or contract boundary, plan it as
+one task with ordered steps rather than parallel tasks with a hopeful merge order.
+
+## CI self-healing loop
+
+```
+push → check CI status and mergeability
+     → green and MERGEABLE?  → self-merge
+     → otherwise             → read the failing logs
+                             → fix locally
+                             → re-run the canonical pre-push sequence
+                             → push, repeat
+```
+
+| Failure | Response |
+| --- | --- |
+| Format or lint | Run the repository's format/lint fix command, commit, push |
+| Type error | Fix the reported error, re-run the type-check, push |
+| Test failure | Fix the test or the code, re-run the affected tests, push |
+| Merge conflict | Fetch and rebase onto the default branch, resolve, push |
+
+A conflicted PR is as blocking as a red one. Both must be cleared before merge.
+
+## Rebase-all maintenance
+
+When the default branch advances mid-wave, reconcile **one worktree at a time**. Batch-rebasing in
+parallel produces interleaved conflict resolutions that are hard to attribute and easy to get wrong.
+
+For each agent-owned branch: fetch, rebase onto the updated default branch, resolve conflicts, run
+the canonical pre-push sequence, then push. `--force-with-lease` is appropriate here — but only on
+the agent's own branch, and only after a successful rebase.
+
+## Execution phases
+
+| Phase | Activity | Exit condition |
+| --- | --- | --- |
+| **Plan** | Enumerate, route, serialize dependencies, record todos | Every task has an owner and known dependencies |
+| **Dispatch** | Launch all independents in one turn | Every independent agent is running |
+| **Monitor** | Collect results, drive CI to green, update todo status | No agent is silently stuck |
+| **Validate** | Confirm every PR is open, green, and `MERGEABLE` | The full check suite passes from a clean checkout |
+| **Handoff** | Merge in dependency order, clean up worktrees | Nothing remains only on a side branch |
+
+Merge in dependency order, never in completion order: a dependent PR merged before its prerequisite
+either breaks the default branch or silently reintroduces the old shape.
+
+## Hard-won lessons
+
+| Lesson | Detail |
+| --- | --- |
+| Never share a worktree | Branch interference is the top cause of fleet failure |
+| Rebase immediately before pushing | Stale branches compound conflicts across the whole wave |
+| Follow the canonical pre-push sequence | Copied or remembered command sequences go stale and fail CI |
+| Treat warnings as errors | Warnings accumulate silently across parallel PRs until CI rejects them |
+| Every PR meets the same bar | Docs and chore PRs follow the same gate as feature PRs |
+| A wave is done when it is merged | Green PRs left unmerged are unfinished work, not finished work |
+
+## Acceptance checklist
+
+- [ ] Every dispatched task had an owner, a worktree, and disjoint file ownership.
+- [ ] Dependencies were serialized, not merged optimistically.
+- [ ] Every PR references its issue and satisfies the repository's Definition of Done.
+- [ ] Every PR is green **and** `MERGEABLE` before any merge.
+- [ ] PRs merged in dependency order.
+- [ ] Worktrees and merged branches cleaned up.
+- [ ] Anything blocked by a human gate left exactly one `## Needs Human Action` note.

--- a/.studio-sync.lock.json
+++ b/.studio-sync.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "backbone": "jrmoulckers/.github",
-  "generatedAt": "2026-08-08T22:39:33.894Z",
+  "generatedAt": "2026-08-09T22:48:46.602Z",
   "entries": {
     ".github/agents/accessibility-reviewer.agent.md": {
       "sourceSha256": "f83d90b50ea87be04935ba849c0a93eda729452a2d7eee81e0cb02b4bf04dae5",
@@ -108,6 +108,11 @@
       "targetSha256": "c11e3f7bccca27ccdedcd7ed54743c484b5208a96ab373d2a0b50be74efcbdf9",
       "syncedAt": "2026-08-07T15:34:55.220Z"
     },
+    ".github/copilot-instructions.md": {
+      "sourceSha256": "997b381ea68e9e081a6bb47b3f395c26d9a78b565c2c2974263b11b08703d932",
+      "targetSha256": "311544714e626b2377a1025ae1e3994cfaac00adff635ef7c5b9d35e33e360fa",
+      "syncedAt": "2026-08-09T22:48:46.599Z"
+    },
     ".github/instructions/agents.instructions.md": {
       "sourceSha256": "70f066ca74342a504f7411fbb21e62012b5b8ce05403ed32e93c3d39d145c8aa",
       "targetSha256": "a772cb8d4790f9ae3763e6b94013000c16fb9192ab184b8ce20c3a297a10e78a",
@@ -129,9 +134,9 @@
       "syncedAt": "2026-08-08T22:39:33.892Z"
     },
     ".github/instructions/workflow.instructions.md": {
-      "sourceSha256": "118a896744ff62a4c1ed99c2a4d83ff1937a94d61a17ed0379ef9a03160b0a34",
-      "targetSha256": "9aaecb7bd0637b91768781c47dc29acee3d3a6cb6e176870ea442be0398cf1af",
-      "syncedAt": "2026-08-08T22:39:33.893Z"
+      "sourceSha256": "b63ec55be43b7ee397910905d076f8d4e3ce5c648cb723a84f33033eac3e7279",
+      "targetSha256": "6dd70bdb2087822aa5f1f7ade4e28714785dc61ce468d4e490d6b57fcdd0da3d",
+      "syncedAt": "2026-08-09T22:48:46.602Z"
     },
     ".github/prompts/backlog.prompt.md": {
       "sourceSha256": "662578e4e512ac591b86127f50c601283a27b6ce96c9e09b022b833f720fe750",
@@ -187,6 +192,16 @@
       "sourceSha256": "186152a23ac83b712e07c589cc1dc37ea9d8e7f17589dc4b535e731817b29a8a",
       "targetSha256": "74df8f5d411a4b609a7d3960dcb11e7cb8431926fe6164b7261c3fcdc4d0f29a",
       "syncedAt": "2026-08-07T23:31:41.452Z"
+    },
+    ".github/skills/edge-sync/SKILL.md": {
+      "sourceSha256": "9f19298b4b1e97dd1af00550ad04ddc4b0f0f894b69bacc898fe8a977bd9544b",
+      "targetSha256": "b9893c29f908f10224369a44a32dfc3315b2b633db4fe1eebec876015dfb71ed",
+      "syncedAt": "2026-08-09T22:48:46.600Z"
+    },
+    ".github/skills/fleet-orchestration/SKILL.md": {
+      "sourceSha256": "e8a1ebe885f80ddfc64fa2974677117328c81900d6e627eab213e776d7adfe04",
+      "targetSha256": "2a09b3780cf9ef2f0836522d75f58c7b991cb220ba469967e25c66d726fd2575",
+      "syncedAt": "2026-08-09T22:48:46.600Z"
     },
     ".github/skills/go-to-market/SKILL.md": {
       "sourceSha256": "e0bddf960967f049fd3c395868bd462ad55d5e6df99a696b4377f686509019ab",


### PR DESCRIPTION
## Studio canon sync — 2026-08-09

Synced from [`jrmoulckers/.github`](https://github.com/jrmoulckers/.github) by the studio sync tool.

### Added (3)

- `.github/copilot-instructions.md`
- `.github/skills/edge-sync/SKILL.md`
- `.github/skills/fleet-orchestration/SKILL.md`

### Updated (1)

- `.github/instructions/workflow.instructions.md`

---
<sub>Native assets are not copied: community-health files are inherited from the backbone `.github` repo, and reusable workflows are called via `uses: jrmoulckers/.github/.github/workflows/*@<reviewed-commit-sha>`. Vendored `@jrm/tokens` files under `vendor/@jrm/tokens/` are generated in `jrmoulckers/studio` and carried here by the sync engine — do not hand-edit them.</sub>
