### PR TITLE
chore(sync): update studio canon (2026-08-10)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# studio:base:start
+# synced from jrmoulckers/.github — canonical source; do not edit here
+# Normalize every detected text file to LF in the index and working tree.
+# Git's automatic text detection leaves binary files byte-for-byte unchanged.
+* text=auto eol=lf
+# studio:base:end

--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -102,18 +102,20 @@ Grant every scope the callee declares:
 
 | Reusable workflow | Scopes the caller must grant |
 | --- | --- |
-| `reusable-ci-lint` | `contents: read` **and `pull-requests: read`** (Semantic PR Title job) |
-| `reusable-ci-web` | `contents: read` |
-| `reusable-perf-budget` | `contents: read` |
-| `reusable-smoke-test` | `contents: read` |
-| `reusable-deploy-preview` | `contents: read` |
+| `reusable-ci-lint` | `contents: read`, **`packages: read`**, **and `pull-requests: read`** (Semantic PR Title job) |
+| `reusable-ci-web` | `contents: read`, `packages: read` |
+| `reusable-perf-budget` | `contents: read`, `packages: read` |
+| `reusable-smoke-test` | `contents: read`, `packages: read` |
+| `reusable-native-smoke-test` | `contents: read`, `packages: read` (the web job; the other platform jobs need only `contents: read`) |
+| `reusable-deploy-preview` | `contents: read`, `packages: read` |
 | `reusable-change-detection` | `contents: read` |
 | `reusable-security-ci` | `contents: read` |
-| `reusable-deploy-pages` | `contents: read`, `pages: write`, and `id-token: write` |
+| `reusable-deploy-pages` | `contents: read`, `packages: read`, `pages: write`, and `id-token: write` |
 
 ```yaml
 permissions:
   contents: read
+  packages: read          # required by every Node-installing reusable workflow
   pull-requests: read      # required by reusable-ci-lint
 
 jobs:
@@ -161,6 +163,36 @@ Passing an empty string is the supported opt-out. Leaving a command at its defau
 has no such script fails the job; duplicating backbone logic locally makes the product repo drift
 from canon.
 
+### Smoke testing a native-first release
+
+`reusable-smoke-test` is web-shaped: one job, a Node toolchain, and an optional HTTPS probe against
+a deployed site. Use `reusable-native-smoke-test` instead when a release ships native artifacts and
+a green web check would leave Android, iOS, or Windows unvalidated.
+
+It runs `validate`, then one job per selected platform, then a `summary` that reduces the verdicts
+to a single `result` output a release workflow can gate on. Unselected platforms are reported as
+skipped and count as a pass; a selected platform that fails, fails the run.
+
+```yaml
+permissions:
+  contents: read
+  packages: read          # the web job installs Node dependencies
+
+jobs:
+  smoke:
+    uses: jrmoulckers/.github/.github/workflows/reusable-native-smoke-test.yml@<reviewed-commit-sha>
+    with:
+      version: ${{ github.ref_name }}
+      platforms: android,ios,web
+      ios-scheme: ExampleApp
+      package-manager: pnpm
+      build-command: pnpm --filter web build
+```
+
+Narrow `platforms` on non-release runs: the iOS and Windows jobs use macOS and Windows runners,
+which bill at a higher rate than Linux. Remote build caches are not accepted — builds run cold and
+Gradle's cache is read-only, so a release is validated from source rather than from a cache.
+
 ### Build once and reuse same-run artifacts
 
 `reusable-ci-web` optionally uploads a validated directory when `artifact-name` is set. Preview,
@@ -201,14 +233,76 @@ and its environment-gated deploy job only calls GitHub's deploy action with `pag
 
 - Reusable commands are trusted repository configuration. Pass literal workflow values, never event
   titles, branch names, issue text, or other untrusted data.
-- Never use `secrets: inherit`. Canonical PR build, security, preview, performance, smoke, and change
-  detection workflows declare no secrets.
+- Never use `secrets: inherit`. `NODE_AUTH_TOKEN` is the only secret any canonical reusable workflow
+  accepts, it is optional, and it must be passed explicitly when it is passed at all. When it is
+  omitted the workflow falls back to the job's `GITHUB_TOKEN`.
 - Preview canon is artifact-only. The removed `provider`, `preview-command`, `DEPLOY_TOKEN`, and
   `preview-url` contracts must not be recreated. Provider deployments require a separate reviewed
   job, a protected environment, explicit secrets, and no PR-controlled arbitrary shell.
 - Lighthouse reports remain private GitHub artifacts by default. Enable
   `lighthouse-public-upload` only for an intentionally public, unauthenticated URL after accepting
   that report data will leave GitHub's private artifact boundary.
+
+### Installing from a private registry
+
+`reusable-ci-lint`, `reusable-ci-web`, `reusable-deploy-pages`, `reusable-deploy-preview`,
+`reusable-perf-budget`, `reusable-smoke-test`, and `reusable-native-smoke-test` accept optional
+`registry-url` and
+`registry-scope` inputs plus an optional `NODE_AUTH_TOKEN` secret. Leave all three unset and the
+run is unchanged: `actions/setup-node` ignores an empty `registry-url` entirely and writes no
+`.npmrc`, and no token is placed in the install step's environment.
+
+For GitHub Packages this is zero-config — pass no secret at all:
+
+```yaml
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  web:
+    uses: jrmoulckers/.github/.github/workflows/reusable-ci-web.yml@<reviewed-commit-sha>
+    with:
+      package-manager: pnpm
+      registry-url: https://npm.pkg.github.com
+      registry-scope: '@jrmoulckers'
+```
+
+`NODE_AUTH_TOKEN` resolves as `secrets.NODE_AUTH_TOKEN || github.token`, so the job's
+`GITHUB_TOKEN` is used unless the caller passes its own. Grant the consuming repository read access
+to each package under the package's **Manage Actions access** settings; GitHub recommends this over
+storing a PAT. Pass an explicit secret only for a registry `GITHUB_TOKEN` cannot reach:
+
+```yaml
+    secrets:
+      NODE_AUTH_TOKEN: ${{ secrets.MY_REGISTRY_PAT }}
+```
+
+Rules and interactions:
+
+- `packages: read` is required for `GITHUB_TOKEN` to read a GitHub Packages package at all, and a
+  caller `permissions:` block must grant it or the run fails at startup.
+- `registry-scope` requires `registry-url`. Setting `registry-url` without a scope replaces the
+  **default** registry for every package and emits a warning.
+- `actions/setup-node` writes its `.npmrc` to `$RUNNER_TEMP/.npmrc` and exports
+  `NPM_CONFIG_USERCONFIG`, so it is **user**-level config. A repo's own committed `.npmrc` is
+  **project**-level and outranks it on every key it sets, for both npm and pnpm. A project `.npmrc`
+  that points the same scope at a different registry wins and the install still fails; either delete
+  that line or keep it byte-identical. A project `.npmrc` that only sets unrelated keys is fine.
+- pnpm reads `NPM_CONFIG_USERCONFIG` and expands `${NODE_AUTH_TOKEN}` the same way npm does, so no
+  extra pnpm-specific step is needed. `setup-node` always exports `NODE_AUTH_TOKEN` (a placeholder
+  when the secret is absent), which keeps pnpm's env-expansion from erroring.
+- The token reaches the install step only when `registry-url` is set. A run that does not configure
+  a private registry gets an empty `NODE_AUTH_TOKEN`, so a `GITHUB_TOKEN` is never exposed to
+  dependency lifecycle scripts on the default path. A consequence worth knowing: passing
+  `NODE_AUTH_TOKEN` *without* `registry-url` has no effect, because there is no `.npmrc` to consume
+  it.
+- `reusable-security-ci` needs none of this. `npm audit` and `pnpm audit` send the bulk advisory
+  request to the **default** registry, never to a scoped one, so a private scoped package in the
+  lockfile does not trigger a `401`. Pointing the *default* registry at GitHub Packages does break
+  audit, but with `ENDPOINT_NOT_EXISTS` (no audit endpoint) rather than an auth error — a token
+  would not fix it. Note that audit does transmit private package names and versions to the default
+  registry.
 
 ### Never vendor a backbone workflow or health file
 
@@ -225,6 +319,15 @@ product repo must contain **no copy of its own**:
   version for that repo. GitHub prefers a repo's own health file over the one inherited from
   `jrmoulckers/.github`, so a verbatim copy overrides the inherited file and freezes it at the day
   it was copied.
+
+  If you *are* overriding deliberately — because the repo needs product-specific security content
+  that cannot live in canon — that is allowed, but you own the consequence: the file is a fork with
+  no update path, and canon changes will never reach it. Re-read canon when it moves.
+  **Do not restate canon's policy in your own words in order to differ from it in one place**; check
+  first whether canon already offers a variant you can select. Its security policy defines two
+  support postures precisely so that a continuously-deployed product can *select* the right one
+  rather than file a deviation against the other
+  ([ADR-0010](https://github.com/jrmoulckers/.github/blob/main/docs/architecture/0010-selectable-support-postures.md)).
 
 In both cases a local copy is **worse than having nothing**, and the sync engine cannot rescue you
 — it never writes native kinds, so it can neither update the copy nor report it as drift. If you

--- a/.studio-sync.lock.json
+++ b/.studio-sync.lock.json
@@ -1,8 +1,13 @@
 {
   "version": 1,
   "backbone": "jrmoulckers/.github",
-  "generatedAt": "2026-08-09T22:48:46.602Z",
+  "generatedAt": "2026-08-10T08:27:56.413Z",
   "entries": {
+    ".gitattributes": {
+      "sourceSha256": "4be6041de14159436002446da3193a178a4defa235fe71585c04002d070d80c7",
+      "targetSha256": "a591a7816b02daf54849d69af18396ff6175f24de0b06d0a1def97d0b5a9274a",
+      "syncedAt": "2026-08-10T08:27:56.409Z"
+    },
     ".github/agents/accessibility-reviewer.agent.md": {
       "sourceSha256": "f83d90b50ea87be04935ba849c0a93eda729452a2d7eee81e0cb02b4bf04dae5",
       "targetSha256": "f616ea0dbb9d4fc8414ea502196b4b6dd1da7a3e67e0c71b65c0352fabb1d38a",
@@ -111,7 +116,7 @@
     ".github/copilot-instructions.md": {
       "sourceSha256": "997b381ea68e9e081a6bb47b3f395c26d9a78b565c2c2974263b11b08703d932",
       "targetSha256": "311544714e626b2377a1025ae1e3994cfaac00adff635ef7c5b9d35e33e360fa",
-      "syncedAt": "2026-08-09T22:48:46.599Z"
+      "syncedAt": "2026-08-10T08:27:56.409Z"
     },
     ".github/instructions/agents.instructions.md": {
       "sourceSha256": "70f066ca74342a504f7411fbb21e62012b5b8ce05403ed32e93c3d39d145c8aa",
@@ -134,9 +139,9 @@
       "syncedAt": "2026-08-08T22:39:33.892Z"
     },
     ".github/instructions/workflow.instructions.md": {
-      "sourceSha256": "b63ec55be43b7ee397910905d076f8d4e3ce5c648cb723a84f33033eac3e7279",
-      "targetSha256": "6dd70bdb2087822aa5f1f7ade4e28714785dc61ce468d4e490d6b57fcdd0da3d",
-      "syncedAt": "2026-08-09T22:48:46.602Z"
+      "sourceSha256": "5f9ac806833620e496f4a13c8efa0494b90a3a43a5ff887c3d6d9d75477626cd",
+      "targetSha256": "6cea1057721f85a69713c5bd0c99706418dfe549ae07a07bfabe7ac646da435f",
+      "syncedAt": "2026-08-10T08:27:56.412Z"
     },
     ".github/prompts/backlog.prompt.md": {
       "sourceSha256": "662578e4e512ac591b86127f50c601283a27b6ce96c9e09b022b833f720fe750",
@@ -196,12 +201,12 @@
     ".github/skills/edge-sync/SKILL.md": {
       "sourceSha256": "9f19298b4b1e97dd1af00550ad04ddc4b0f0f894b69bacc898fe8a977bd9544b",
       "targetSha256": "b9893c29f908f10224369a44a32dfc3315b2b633db4fe1eebec876015dfb71ed",
-      "syncedAt": "2026-08-09T22:48:46.600Z"
+      "syncedAt": "2026-08-10T08:27:56.411Z"
     },
     ".github/skills/fleet-orchestration/SKILL.md": {
       "sourceSha256": "e8a1ebe885f80ddfc64fa2974677117328c81900d6e627eab213e776d7adfe04",
       "targetSha256": "2a09b3780cf9ef2f0836522d75f58c7b991cb220ba469967e25c66d726fd2575",
-      "syncedAt": "2026-08-09T22:48:46.600Z"
+      "syncedAt": "2026-08-10T08:27:56.411Z"
     },
     ".github/skills/go-to-market/SKILL.md": {
       "sourceSha256": "e0bddf960967f049fd3c395868bd462ad55d5e6df99a696b4377f686509019ab",


### PR DESCRIPTION
## Studio canon sync — 2026-08-10

Synced from [`jrmoulckers/.github`](https://github.com/jrmoulckers/.github) by the studio sync tool.

### Added (4)

- `.github/copilot-instructions.md`
- `.gitattributes`
- `.github/skills/edge-sync/SKILL.md`
- `.github/skills/fleet-orchestration/SKILL.md`

### Updated (1)

- `.github/instructions/workflow.instructions.md`

---
<sub>Native assets are not copied: community-health files are inherited from the backbone `.github` repo, and reusable workflows are called via `uses: jrmoulckers/.github/.github/workflows/*@<reviewed-commit-sha>`. Vendored `@jrm/tokens` files under `vendor/@jrm/tokens/` are generated in `jrmoulckers/studio` and carried here by the sync engine — do not hand-edit them.</sub>
