### PR TITLE
docs(copilot): drop design policy duplicated from AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,17 +13,9 @@ This project has committed design context. **Read these before changing any UI:*
 - **`.impeccable/design.json`** — machine-readable sidecar (tonal ramps, shadows, motion,
   live component snippets) consumed by the impeccable design skill.
 
-Non-negotiables pulled from DESIGN.md:
-
-- **Royal Violet** (`#7c5cff`) marks exactly one primary action per screen; **Crown Gold**
-  (`#ffd166`) is reserved for the leader and the winner — never buttons or decoration.
-- Build depth by climbing the surface ramp (`surface` → `surface-2` → `surface-3`), not by
-  stacking shadows. One Soft Lift shadow only. Glass (backdrop blur) only on the top app
-  bar and bottom tab bar.
-- Render every changing number with `tabular-nums`; keep touch targets ≥46px (one-handed,
-  dim-light use); never signal state with color alone; honor `prefers-reduced-motion`.
-- Keep the chrome identical game to game — express per-game personality through emoji,
-  copy, and accent moments, not by restyling the shell.
+The binding design non-negotiables are **not** repeated here. Root `AGENTS.md`
+§"Product design constraints" owns them, and `DESIGN.md` carries the full rationale and
+token-level detail. Read both before changing any UI.
 
 To evolve the design system, use the **impeccable** skill (e.g. `/impeccable critique`,
 `/impeccable craft`, `/impeccable live`). Re-run `/impeccable document` if the visual


### PR DESCRIPTION
## Summary

The studio sync (#123) inserted the canonical `<!-- studio:base -->` managed region into
`.github/copilot-instructions.md` and deliberately preserved every pre-existing repo-local line
around it. This removes the one piece of that preserved content that duplicated policy already
owned elsewhere.

The local "Non-negotiables pulled from DESIGN.md" list restated, near-verbatim, root `AGENTS.md`
§"Product design constraints" — which itself derives from `DESIGN.md`. Three copies of the same
rules (Royal Violet one-primary-per-screen, Crown Gold reserved for leader/winner, the surface ramp
and single Soft Lift shadow, the glass-chrome rule, ≥46px targets, `tabular-nums`, never color
alone, `prefers-reduced-motion`) means the next `DESIGN.md` change silently creates a contradictory
source of truth for every Copilot surface. The canonical block is explicit that `AGENTS.md` is
authoritative and that each rule has exactly one canonical owner.

## Changes

- Replaced the 11-line restated non-negotiables list with a 3-line pointer to root `AGENTS.md`
  §"Product design constraints" and `DESIGN.md`.
- **Kept** the genuinely local, operationally useful content:
  - the `PRODUCT.md` / `DESIGN.md` / `.impeccable/design.json` document pointers — these are the
    "product context" step of the canonical read order and appear nowhere else in Copilot's
    default context;
  - the `impeccable` skill command guidance (`/impeccable critique|craft|live`, and re-running
    `/impeccable document` when the visual system drifts) — an exact local command sequence, not
    restated policy.

Net: 3 insertions, 11 deletions, one file.

## Managed-region safety

No byte between `<!-- studio:base:start -->` and `<!-- studio:base:end -->` was touched, so the file
will not be flagged as drift or skipped on the next sync. No changes to `AGENTS.md`, `agency.toml`,
`.github/agents/`, `.github/skills/`, `.github/prompts/`, or `.github/instructions/`.

## Issues

Closes #128

## Testing

- [x] `npm run check` — svelte-check 0 errors, 0 warnings; `tsc -p tsconfig.node.json` clean
- [x] `npm test` — 49 test files, 1302 tests passed
- [x] `npm run build` — built in 11.20s