### PR TITLE
chore(sync): update studio canon (2026-08-11)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,8 +49,7 @@ conflict, `AGENTS.md` wins.
 
 ## The installed AI layer
 
-Most of `.github/` is generated and distributed from the `jrmoulckers/.github` backbone. Treat it
-as read-only here:
+Much of `.github/` is generated and distributed from the `jrmoulckers/.github` backbone:
 
 | Path | What it is | How to use it |
 | --- | --- | --- |
@@ -60,7 +59,26 @@ as read-only here:
 | `.github/instructions/*.instructions.md` | Path-scoped rules | Applied automatically by glob; obey the most specific match |
 | `agency.toml` | Reviewed MCP servers and tool allowlists | Do not add servers or widen tool grants locally |
 
-**Never edit a generated file to change shared behaviour.** A local edit is detected as drift, is
+**Provenance is per file, not per directory — and in some files, per region.** Three shapes:
+
+- **Whole-file canon.** A `synced from jrmoulckers/.github` marker at the top and no region markers.
+  The entire file is generated. The comment syntax varies with the file type — HTML in Markdown, `#`
+  in `.toml`, `.yml`, `.gitattributes` and `.gitignore`, `/* */` in `.js`, `.ts`, `.css`, `.kt` and
+  `.swift`, and none at all in `.json`, which has no comment syntax.
+- **Managed-region files.** Root `AGENTS.md`, this file, and `.gitattributes` carry canon *between*
+  the `studio:base:start` and `studio:base:end` markers and are member-owned everywhere else. The
+  block is generated; the surrounding content is yours to write, trim, and maintain. Editing inside
+  the markers is drift; editing outside them is expected. `sync/lib/copier.mjs` is authoritative for
+  which files these are — the list above is illustrative and grows when a managed-merge kind is
+  added.
+- **Unmarked files.** Repository-owned and yours to edit normally. `.github/agents/` in particular
+  routinely holds both tiers side by side: canonical studio roles alongside locally authored agents
+  carrying authority specific to that repository.
+
+Check the marker — and, in a managed-region file, which side of it you are on — before assuming
+anything is off-limits.
+
+**Never edit generated content to change shared behaviour.** A local edit is detected as drift, is
 skipped on the next sync, and silently strands the repository on a stale copy. Change the canonical
 source in `jrmoulckers/.github` and let it sync. Genuinely repository-specific behaviour belongs in
 the local `AGENTS.md`, a locally authored agent, or a scoped instructions file.

--- a/.github/instructions/tokens.instructions.md
+++ b/.github/instructions/tokens.instructions.md
@@ -29,6 +29,31 @@ that owns them. A local product overlay wins when it identifies the actual sourc
 - Define light, dark, high-contrast, and reduced-motion behavior where the token category requires it.
 - Validate color choices against WCAG 2.2 AA contrast and avoid relying on color alone to communicate state.
 - Keep token names stable. Treat removals or renames as breaking changes and document migration paths.
+- **Treat a changed token *value* as an announced change, not a routine update.** A rename or removal
+  is the loud failure: consumers stop compiling and someone investigates. A value shift is the quiet
+  one — every consumer still builds, every test still passes, and the rendered result moves. The
+  ceremony belongs on the case that cannot announce itself.
+
+### Announcing a token value change
+
+The sync engine mirrors `dist/` verbatim and cannot tell a shifted value from an added file; both
+arrive in the member PR's **Updated** list as a path. So the announcement has to come from the
+owning repository, which is the only place that knows a value moved.
+
+When a value changes in `jrmoulckers/studio`:
+
+- State it in the change's own PR body and release notes as a **value shift**, with a before/after
+  table of the affected tokens. Naming the tier is not enough — `spacing.md: 12px → 16px` is the
+  reviewable unit.
+- Say explicitly whether names were preserved. "Names stable, values moved" is the sentence a member
+  needs, because it tells them the compile-clean path is the risky one.
+- Call out visual-regression surfaces the member should re-check: spacing and radius shifts move
+  layout, color shifts move contrast ratios and can break a WCAG 2.2 AA result that previously
+  passed.
+
+A member receiving a `chore(sync)` PR that touches `vendor/@jrm/tokens/**` should assume values may
+have moved and verify visually before merging. An entry in **Updated** means the bytes changed; it
+does not mean only additions arrived.
 
 ## Generated Output Rules
 

--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -92,6 +92,42 @@ must be a full 40-character SHA; branches and tags are rejected. Configure Depen
 equivalent automation to propose SHA update PRs, then review the exact upstream diff and release
 notes. Never resolve a mutable reference during a run.
 
+### Keep required checks terminal
+
+Never put `paths` or `paths-ignore` on the `pull_request` trigger of a workflow that supplies a
+required check. When the filter does not match, GitHub does not start the workflow or create its
+check run, so the required check remains pending and blocks the pull request indefinitely.
+
+Trigger the workflow for every pull request in its protected scope, detect applicability in a job,
+and gate the expensive job with `jobs.<job_id>.if`. A skipped job produces a terminal `skipped`
+conclusion that GitHub accepts as success for a required check:
+
+```yaml
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  packages: read
+  pull-requests: read
+
+jobs:
+  changes:
+    uses: jrmoulckers/.github/.github/workflows/reusable-change-detection.yml@<reviewed-commit-sha>
+    with:
+      path-groups-json: '{"web":["apps/web/","packages/ui/"]}'
+
+  lint:
+    needs: changes
+    if: contains(fromJSON(needs.changes.outputs.changed-groups-json), 'web')
+    uses: jrmoulckers/.github/.github/workflows/reusable-ci-lint.yml@<reviewed-commit-sha>
+```
+
+Event filtering is still appropriate for workflows that do not supply required checks. For a
+required check, however, no workflow run is categorically different from an intentionally skipped
+job: only the latter reports a terminal result. Keep the required job's name stable so the ruleset
+continues to require the intended check.
+
 **A caller `permissions:` block replaces the defaults — it does not add to them.** Every scope you
 omit is set to `none`, and a called workflow can never receive more than its caller holds. So a
 least-privilege `permissions: { contents: read }` in the caller silently strips the scopes the
@@ -131,10 +167,50 @@ Rules:
 - Omitting `permissions:` entirely inherits the repo default — safe, but less explicit.
 - If a scope truly cannot be granted, disable the job that needs it instead
   (e.g. `semantic-pr-title: false` for `reusable-ci-lint`).
-- Debug a `startup_failure` with no log by checking caller permissions first.
+- Debug a `startup_failure` with no log by checking caller permissions first — but confirm the
+  failure is scoped to the calling job before you do (see below).
 - Caller workflows own CI concurrency. Put the concurrency group on the caller workflow so matrix or
   multi-package reusable jobs do not cancel sibling calls. Canonical Pages deployment is the
   exception: it serializes repository deployments with `cancel-in-progress: false`.
+
+### A no-log failure is not always a permissions problem
+
+The permissions trap above is not the only way a run dies in seconds with an empty log. On a
+**private** repository, exhausting the Actions spending limit refuses the run before any job
+starts, with `recent account payments have failed or your spending limit needs to be increased`.
+Actions is free on public repositories for every runner type, so this cannot happen there.
+
+Discriminate before investigating, because the two look nearly identical and only one of them is
+a defect in this repository:
+
+| | Caller permissions | Spending limit |
+| --- | --- | --- |
+| What failed | Only the job that `uses:` the callee | **Every** job in the run, including untouched ones |
+| Triggered by | Adding or narrowing a `permissions:` block | Adding an expensive runner, or simply reaching the monthly cap |
+| Fixed in | The workflow file | Billing settings — nothing in the repository is wrong |
+
+**Check the run summary first: if jobs you did not touch failed alongside the one you did, stop
+reading YAML and check billing.** A green history proves nothing here, because the cap is reached
+by cumulative spend rather than by anything in the diff.
+
+That check is free but not always decisive — a single-job workflow presents identically under both
+causes. **`gh run view --log-failed` cannot separate them either; it returns `log not found` for
+both.** When the observation cannot decide, read the annotation, which survives even though the log
+does not:
+
+```bash
+gh run view <run-id> --json jobs --jq '.jobs[].databaseId'
+gh api repos/OWNER/REPO/check-runs/<check-run-id>/annotations
+```
+
+The billing refusal carries its `recent account payments have failed…` message there. A permissions
+failure does not. (Reported by `jrmoulckers/studio` from the live incident; the endpoint itself is
+verified, returning `[]` for a healthy run.)
+
+Non-Linux runners carry a minute multiplier — macOS bills at 10x and Windows at 2x — so adding a
+single macOS job can exhaust a budget that Linux jobs had comfortably fit inside. Budget for the
+multiplier when you add one, and prefer `ubuntu-latest` unless the job genuinely requires the
+platform (Swift and Xcode toolchains do; Node builds do not).
 
 ### Taking only part of `reusable-ci-lint`
 
@@ -269,9 +345,8 @@ jobs:
 ```
 
 `NODE_AUTH_TOKEN` resolves as `secrets.NODE_AUTH_TOKEN || github.token`, so the job's
-`GITHUB_TOKEN` is used unless the caller passes its own. Grant the consuming repository read access
-to each package under the package's **Manage Actions access** settings; GitHub recommends this over
-storing a PAT. Pass an explicit secret only for a registry `GITHUB_TOKEN` cannot reach:
+`GITHUB_TOKEN` is used unless the caller passes its own. Pass an explicit secret only for a registry
+`GITHUB_TOKEN` cannot reach:
 
 ```yaml
     secrets:
@@ -280,8 +355,23 @@ storing a PAT. Pass an explicit secret only for a registry `GITHUB_TOKEN` cannot
 
 Rules and interactions:
 
+- **Authentication and authorization are separate.** A token is always required: the registry
+  rejects an unauthenticated read with `401` even for a **public** package. Package visibility only
+  decides *who* is allowed, not *whether* credentials are needed. So `packages: read` and a token
+  stay mandatory regardless of visibility, and flipping a package to public is never a reason to
+  drop either.
+- Authorization depends on visibility. A **public** package needs no grant — `GITHUB_TOKEN` can read
+  it. A **private** package must additionally grant the consuming repository read access under the
+  package's **Manage Actions access** settings, which GitHub recommends over storing a PAT. A `403`
+  (`permission_denied: read_package`) means authentication succeeded and authorization failed, so it
+  points at the grant or the package, not at the token being absent.
 - `packages: read` is required for `GITHUB_TOKEN` to read a GitHub Packages package at all, and a
-  caller `permissions:` block must grant it or the run fails at startup.
+  caller `permissions:` block must grant it. **If the caller omits it the entire run fails at
+  startup**: no jobs are created, no check-run is produced, and there is no log to read — the only
+  surface text is a generic "workflow file issue". The failure is whole-run, not per-job, so
+  unrelated valid jobs in the same workflow file do not run either. Nothing inside a reusable
+  workflow can detect or report this, because the permission ceiling is enforced before any job
+  exists; it can only be caught by inspecting caller workflows before the run.
 - `registry-scope` requires `registry-url`. Setting `registry-url` without a scope replaces the
   **default** registry for every package and emits a warning.
 - `actions/setup-node` writes its `.npmrc` to `$RUNNER_TEMP/.npmrc` and exports

--- a/.studio-sync.lock.json
+++ b/.studio-sync.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "backbone": "jrmoulckers/.github",
-  "generatedAt": "2026-08-10T08:27:56.413Z",
+  "generatedAt": "2026-08-11T04:27:09.102Z",
   "entries": {
     ".gitattributes": {
       "sourceSha256": "4be6041de14159436002446da3193a178a4defa235fe71585c04002d070d80c7",
@@ -114,9 +114,9 @@
       "syncedAt": "2026-08-07T15:34:55.220Z"
     },
     ".github/copilot-instructions.md": {
-      "sourceSha256": "997b381ea68e9e081a6bb47b3f395c26d9a78b565c2c2974263b11b08703d932",
-      "targetSha256": "311544714e626b2377a1025ae1e3994cfaac00adff635ef7c5b9d35e33e360fa",
-      "syncedAt": "2026-08-10T08:27:56.409Z"
+      "sourceSha256": "f8f1ed9ad63ac948bf568540bfd3551d269af4d511112771d0818805f3c7e09d",
+      "targetSha256": "7c8a5883a4b81879ac7f0fafe2aeb40b6627387f5beb7934a1c31f2493ac4dd4",
+      "syncedAt": "2026-08-11T04:27:09.098Z"
     },
     ".github/instructions/agents.instructions.md": {
       "sourceSha256": "70f066ca74342a504f7411fbb21e62012b5b8ce05403ed32e93c3d39d145c8aa",
@@ -134,14 +134,14 @@
       "syncedAt": "2026-08-08T22:39:33.891Z"
     },
     ".github/instructions/tokens.instructions.md": {
-      "sourceSha256": "9f4057f4cb29336105e7fdcd01191302167cff4cc9c43553416b28910772b51a",
-      "targetSha256": "88b251762e6cb19d28ec0e5e672f8caf778ebfe58066558d0bb0507fe56f7dff",
-      "syncedAt": "2026-08-08T22:39:33.892Z"
+      "sourceSha256": "da5d995cceba6a3f72ed47b771b3ba81658132cdfe3f9a83e13fe7cc5635ee1b",
+      "targetSha256": "492b9cc97e2fe3e05b412ccc4bc72796e7a8f713319f49da1920b8db56f5fe71",
+      "syncedAt": "2026-08-11T04:27:09.102Z"
     },
     ".github/instructions/workflow.instructions.md": {
-      "sourceSha256": "5f9ac806833620e496f4a13c8efa0494b90a3a43a5ff887c3d6d9d75477626cd",
-      "targetSha256": "6cea1057721f85a69713c5bd0c99706418dfe549ae07a07bfabe7ac646da435f",
-      "syncedAt": "2026-08-10T08:27:56.412Z"
+      "sourceSha256": "f832c6dfa49f91055a8f5f4a91d0fccf88481fad9dc09dcde08381c67bed5c7c",
+      "targetSha256": "4206060d01da2c70515289c2750a497eff07c3f33c7a51c074b94234a09f279a",
+      "syncedAt": "2026-08-11T04:27:09.102Z"
     },
     ".github/prompts/backlog.prompt.md": {
       "sourceSha256": "662578e4e512ac591b86127f50c601283a27b6ce96c9e09b022b833f720fe750",


### PR DESCRIPTION
## Studio canon sync — 2026-08-11

Synced from [`jrmoulckers/.github`](https://github.com/jrmoulckers/.github) by the studio sync tool.

### Updated (3)

- `.github/copilot-instructions.md`
- `.github/instructions/tokens.instructions.md`
- `.github/instructions/workflow.instructions.md`

---
<sub>Native assets are not copied: community-health files are inherited from the backbone `.github` repo, and reusable workflows are called via `uses: jrmoulckers/.github/.github/workflows/*@<reviewed-commit-sha>`. Vendored `@jrm/tokens` files under `vendor/@jrm/tokens/` are generated in `jrmoulckers/studio` and carried here by the sync engine — do not hand-edit them.</sub>
