### PR TITLE
chore(tooling): pin ESLint config minor (#135)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "qrcode": "^1.5.4"
       },
       "devDependencies": {
-        "@jrmoulckers/eslint-config": ">=0.12.0 <1.0.0",
+        "@jrmoulckers/eslint-config": "^0.17.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@types/node": "^24.13.2",
         "@types/qrcode": "^1.5.6",
@@ -2249,8 +2249,8 @@
       }
     },
     "node_modules/@jrmoulckers/eslint-config": {
-      "version": "0.12.0",
-      "integrity": "sha512-xFCcq3VaOmVwB2yNdozUBY7dAndT0KicQjyIlEw4Hfh8Gryz7CJaiYn0tomAzHEIroTLYBzcPuwfYgop1q82Wg==",
+      "version": "0.17.0",
+      "integrity": "sha512-8YFove8TpwX92HkZEiO+W5FCCugoBPKgbZehCTIEHld8lBjPqH8NVlaNMBLseXYMmaTE/En7mR0jannvc4+X9g==",
       "dev": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
-    "@jrmoulckers/eslint-config": ">=0.12.0 <1.0.0",
+    "@jrmoulckers/eslint-config": "^0.17.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@types/node": "^24.13.2",
     "@types/qrcode": "^1.5.6",


### PR DESCRIPTION
## Summary

Pin the shared ESLint preset to the reviewed `0.17` minor and update only its lock entry.

## Changes

- change `@jrmoulckers/eslint-config` from `>=0.12.0 <1.0.0` to `^0.17.0`
- lock `@jrmoulckers/eslint-config@0.17.0` with the exact package artifact integrity
- preserve direct `eslint-plugin-svelte@2.46.1`; optional React, Next, JSX a11y, and React Hooks peers remain absent from both `npm ls` and `package-lock.json`

## Empirical ESLint comparison

Compared resolved flat configs from the exact `0.12.0` and `0.17.0` package artifacts for:

- JS: `eslint.config.js`
- tooling MJS: `scripts/vendor-configs.mjs`
- TS: `src/lib/config.ts`
- test TS: `src/lib/a11y.test.ts`
- Svelte: `src/App.svelte`

Active-rule delta: `@typescript-eslint/no-require-imports` becomes inactive for the JS config, tooling MJS, and test TS representatives. The ordinary TS and Svelte representatives have no added, removed, or changed active rules or options; plugin, parser, processor, and language-option selections are unchanged for all five representatives.

The linted file set is unchanged from the landed baseline: 312 total (5 JS, 1 MJS, 113 Svelte, 193 TS), with zero paths added and zero removed.

The exported `0.17.0` package manifest declares compatible peers for ESLint, Svelte, and TypeScript, with Next/React/JSX a11y/React Hooks/Svelte/TypeScript marked optional. No local ambient declaration shadows the package's shipped types.

## Issues

Closes #135

## Testing

- [x] Node 22.22.0 / npm 10.9.8 artifact and lock validation
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm test` (1,303 tests)
- [x] `npm run build`
- [x] `npm audit --omit=dev --audit-level=high`
- [x] `npm --prefix relay run typecheck`
- [x] `npm run configs:check`
- [x] CI real-registry clean install and validation on Node 22.23.1 / npm 10.9.8