### PR TITLE
chore(ci): refresh reusable-workflow pins to reviewed backbone commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       packages: read
       pull-requests: read
-    uses: jrmoulckers/.github/.github/workflows/reusable-ci-lint.yml@4162bad33b949a7cf5f2d0b1b88b33fd71324128
+    uses: jrmoulckers/.github/.github/workflows/reusable-ci-lint.yml@5f6ff9e22d82be576e01d0b094315a202ccbd186
     with:
       node-version: '22'
       package-manager: npm
@@ -54,7 +54,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: jrmoulckers/.github/.github/workflows/reusable-ci-web.yml@4162bad33b949a7cf5f2d0b1b88b33fd71324128
+    uses: jrmoulckers/.github/.github/workflows/reusable-ci-web.yml@5f6ff9e22d82be576e01d0b094315a202ccbd186
     with:
       node-version: '22'
       package-manager: npm
@@ -96,7 +96,7 @@ jobs:
     name: Security
     permissions:
       contents: read
-    uses: jrmoulckers/.github/.github/workflows/reusable-security-ci.yml@4162bad33b949a7cf5f2d0b1b88b33fd71324128
+    uses: jrmoulckers/.github/.github/workflows/reusable-security-ci.yml@5f6ff9e22d82be576e01d0b094315a202ccbd186
     with:
       node-version: '22'
       package-manager: npm
@@ -109,7 +109,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: jrmoulckers/.github/.github/workflows/reusable-perf-budget.yml@4162bad33b949a7cf5f2d0b1b88b33fd71324128
+    uses: jrmoulckers/.github/.github/workflows/reusable-perf-budget.yml@5f6ff9e22d82be576e01d0b094315a202ccbd186
     with:
       artifact-name: score-king-web
       output-dir: dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       packages: read
       pages: write
       id-token: write
-    uses: jrmoulckers/.github/.github/workflows/reusable-deploy-pages.yml@4162bad33b949a7cf5f2d0b1b88b33fd71324128
+    uses: jrmoulckers/.github/.github/workflows/reusable-deploy-pages.yml@5f6ff9e22d82be576e01d0b094315a202ccbd186
     with:
       node-version: '22'
       package-manager: npm


### PR DESCRIPTION
## Summary

Moves every backbone reusable-workflow reference in `ci.yml` and `deploy.yml` from
`4162bad3` (2026-08-10) to the reviewed backbone commit `5f6ff9e2` (2026-08-14).

Of the five reusable workflows this repository calls, only `reusable-perf-budget` changed in that
range. Its change adds an optional `exclude-glob` input so a bundle budget can measure shipped
bytes rather than the whole output directory. It is additive and backward compatible:
`exclude-glob` defaults to `''`, and the empty value takes the original
`du -sk "$OUTPUT_DIR"` path and the original single-row summary. No measured value changes here.

`exclude-glob` is deliberately **not** adopted. `vite.config.ts` sets no `build.sourcemap`, so
Vite's default (`false`) applies and `dist/` contains no `.map` files for a glob to exclude.

The other four callees — `reusable-ci-lint`, `reusable-ci-web`, `reusable-security-ci`, and
`reusable-deploy-pages` — are byte-identical at both commits, so moving them is a no-op that
keeps a single consistent pin across both workflow files.

The backbone landed release-tag publishing in `8aae3aac` (`feat(ci): publish release tags so
members' reusable-workflow pins can be updated`), but no tag exists on the repository yet, so a
reviewed 40-character commit SHA remains the only available immutable reference.

## Changes

- `.github/workflows/ci.yml` — repin `reusable-ci-lint`, `reusable-ci-web`,
  `reusable-security-ci`, and `reusable-perf-budget`.
- `.github/workflows/deploy.yml` — repin `reusable-deploy-pages`.

No caller `permissions:` block, input, or job name changed. Each callee's declared scopes at the
new SHA were re-read and are still satisfied by the existing caller grants:

| Callee | Scopes it declares | Caller grants |
| --- | --- | --- |
| `reusable-ci-lint` | `contents: read`, `packages: read`, `pull-requests: read` | all three |
| `reusable-ci-web` | `contents: read`, `packages: read` | both |
| `reusable-security-ci` | `contents: read` | yes |
| `reusable-perf-budget` | `contents: read`, `packages: read` | both |
| `reusable-deploy-pages` | `contents: read`, `packages: read`, `pages: write`, `id-token: write` | all four |

## Issues

Closes #137

## Testing

- [ ] CI green on this PR (authoritative gate for a workflow-reference change)

Local `npm ci` could not complete in this environment: the available token is authenticated
against GitHub Packages but returns `403 permission_denied: read_package` for
`@jrmoulckers/eslint-config`, so no local lint/format/typecheck/test/build run was possible.
Credential scopes were deliberately not widened. The change is a same-length hex SHA substitution
in YAML, so Prettier's output cannot differ from `main`; CI validates the rest.