### PR TITLE
feat(secrethitler): add Secret Hitler game module

### DIFF
--- a/src/lib/games/secrethitler/SecretHitlerEditor.svelte
+++ b/src/lib/games/secrethitler/SecretHitlerEditor.svelte
@@ -1,0 +1,539 @@
+<script lang="ts">
+  import type { RoundContext, ID } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import { haptic } from '../../haptics';
+  import {
+    computeState,
+    previewAfter,
+    powerColumn,
+    powerAt,
+    roleSetup,
+    teamSize,
+    eventOf,
+    TRACKER_MAX,
+    KILL_POWER_MIN,
+    HITLER_CHANCELLOR_MIN,
+    VETO_MIN,
+    type SecretHitlerInput,
+    type SHEventKind,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: SecretHitlerInput; ctx: RoundContext } = $props();
+
+  const LIB = [0, 1, 2, 3, 4];
+  const FASC = [0, 1, 2, 3, 4, 5];
+  const TRK = [0, 1, 2];
+
+  const pc = $derived(ctx.players.length);
+  const setup = $derived(roleSetup(pc));
+  const powers = $derived(powerColumn(pc));
+
+  const reminders = $derived(ctx.config.reminders !== false);
+  const hitlerHintOn = $derived.by(() => {
+    const h = (ctx.config.hitlerHint as string) ?? 'auto';
+    if (h === 'on') return true;
+    if (h === 'off') return false;
+    return setup.hitlerKnowsFascists;
+  });
+
+  const prior = $derived(ctx.rounds.slice(0, ctx.roundIndex).map((r) => eventOf(r.input)));
+  const before = $derived(computeState(prior));
+  const after = $derived(
+    previewAfter(before, {
+      event: input.event,
+      hitlerKilled: input.hitlerKilled,
+      target: input.target,
+      winners: input.winners,
+    }),
+  );
+
+  const decidesNow = $derived(!!after.winner && !before.winner);
+  const winTeam = $derived(after.winner);
+  const teamName = $derived(
+    winTeam === 'liberal' ? 'Liberal' : winTeam === 'fascist' ? 'Fascist' : '',
+  );
+  const needTeam = $derived(decidesNow && winTeam ? teamSize(pc, winTeam) : 0);
+  const picked = $derived(
+    (input.winners ?? []).filter((id) => ctx.players.some((p) => p.id === id)),
+  );
+
+  const pendingLiberal = $derived(
+    input.event === 'liberal' && before.liberal < 5 ? before.liberal : -1,
+  );
+  const pendingFascist = $derived(
+    input.event === 'fascist' && before.fascist < 6 ? before.fascist : -1,
+  );
+  const unlockedPower = $derived(
+    input.event === 'fascist' && before.fascist < 6 ? powerAt(pc, before.fascist + 1) : null,
+  );
+  const vetoNow = $derived(input.event === 'fascist' && before.fascist + 1 === VETO_MIN);
+
+  const canElectionFail = $derived(before.tracker < TRACKER_MAX);
+  const canExecute = $derived(before.fascist >= KILL_POWER_MIN);
+  const canHitlerChancellor = $derived(before.fascist >= HITLER_CHANCELLOR_MIN);
+
+  function selectEvent(kind: SHEventKind) {
+    input.event = kind;
+    if (kind !== 'execution') {
+      input.target = null;
+      input.hitlerKilled = false;
+    }
+    input.winners = [];
+    haptic('tick');
+  }
+  function setTarget(id: ID) {
+    input.target = input.target === id ? null : id;
+    haptic('tick');
+  }
+  function toggleHitler() {
+    input.hitlerKilled = !input.hitlerKilled;
+    if (!input.hitlerKilled) input.winners = [];
+    haptic(input.hitlerKilled ? 'save' : 'tick');
+  }
+  function toggleWinner(id: ID) {
+    const cur = input.winners ?? [];
+    if (cur.includes(id)) input.winners = cur.filter((x) => x !== id);
+    else if (cur.length < needTeam) input.winners = [...cur, id];
+    haptic('tick');
+  }
+</script>
+
+<div class="stack sh">
+  {#if reminders && prior.length === 0}
+    <div class="setup">
+      <span class="row" style="gap: 8px">
+        <span aria-hidden="true">🎭</span>
+        <strong>{pc}-player setup</strong>
+      </span>
+      <span class="muted"
+        >{setup.liberals} Liberal{setup.liberals === 1 ? '' : 's'} · {setup.fascists} Fascist{setup.fascists ===
+        1
+          ? ''
+          : 's'} · 1 Hitler</span
+      >
+      {#if hitlerHintOn}
+        <span class="muted">🤫 Hitler knows who the Fascists are.</span>
+      {/if}
+    </div>
+  {/if}
+
+  <!-- Policy tracks -->
+  <div class="tracks">
+    <div class="track">
+      <div class="track-head">
+        <span>📘 Liberal</span>
+        <span class="count" class:done={before.liberal >= 5}>{before.liberal}/5</span>
+      </div>
+      <div class="slots">
+        {#each LIB as i (i)}
+          <span
+            class="slot lib"
+            class:filled={i < before.liberal}
+            class:pending={i === pendingLiberal}
+            aria-hidden="true">{i < before.liberal ? '📘' : ''}</span
+          >
+        {/each}
+      </div>
+    </div>
+
+    <div class="track">
+      <div class="track-head">
+        <span>📕 Fascist</span>
+        <span class="count" class:done={before.fascist >= 6}>{before.fascist}/6</span>
+      </div>
+      <div class="slots">
+        {#each FASC as i (i)}
+          <span
+            class="slot fasc"
+            class:filled={i < before.fascist}
+            class:pending={i === pendingFascist}
+            class:goal={i === 5}
+            aria-hidden="true">{i < before.fascist ? '📕' : i === 5 ? '🏁' : ''}</span
+          >
+        {/each}
+      </div>
+      {#if reminders}
+        <div class="powers">
+          <span class="sr-only"
+            >Fascist board powers, in order: {powers
+              .map((p, i) => `policy ${i + 1} ${p ? p.label : 'no power'}`)
+              .join(', ')}.</span
+          >
+          <span class="pwrow" aria-hidden="true">
+            {#each powers as p, i (i)}
+              <span class="pw" title={p ? p.label : 'No power'}>{p ? p.emoji : '·'}</span>
+            {/each}
+            <span class="pw" title="Fascists win">🏆</span>
+          </span>
+        </div>
+      {/if}
+    </div>
+  </div>
+
+  <!-- Election tracker -->
+  <div class="tracker">
+    <span class="muted">🗳️ Election tracker</span>
+    <div class="row" style="gap: 10px">
+      <div class="dots" aria-hidden="true">
+        {#each TRK as i (i)}
+          <span class="dot" class:on={i < before.tracker} class:hot={before.tracker >= 3}></span>
+        {/each}
+      </div>
+      <span class="count trk" class:full={before.tracker >= TRACKER_MAX}
+        >{before.tracker}/{TRACKER_MAX}</span
+      >
+    </div>
+  </div>
+
+  <!-- Event picker -->
+  <span class="fieldlabel">What happened this round?</span>
+  <div class="events">
+    <button
+      type="button"
+      class="ev"
+      class:on={input.event === 'liberal'}
+      aria-pressed={input.event === 'liberal'}
+      onclick={() => selectEvent('liberal')}>📘 Liberal policy</button
+    >
+    <button
+      type="button"
+      class="ev"
+      class:on={input.event === 'fascist'}
+      aria-pressed={input.event === 'fascist'}
+      onclick={() => selectEvent('fascist')}>📕 Fascist policy</button
+    >
+    <button
+      type="button"
+      class="ev"
+      class:on={input.event === 'electionFailed'}
+      aria-pressed={input.event === 'electionFailed'}
+      disabled={!canElectionFail}
+      title={canElectionFail ? '' : 'Tracker full — record the forced policy'}
+      onclick={() => selectEvent('electionFailed')}>🗳️ Election failed</button
+    >
+    <button
+      type="button"
+      class="ev"
+      class:on={input.event === 'execution'}
+      aria-pressed={input.event === 'execution'}
+      disabled={!canExecute}
+      title={canExecute ? '' : 'Unlocks after the 4th Fascist policy'}
+      onclick={() => selectEvent('execution')}>🔫 Execution</button
+    >
+    {#if canHitlerChancellor}
+      <button
+        type="button"
+        class="ev wide"
+        class:on={input.event === 'hitlerChancellor'}
+        aria-pressed={input.event === 'hitlerChancellor'}
+        onclick={() => selectEvent('hitlerChancellor')}>🎩 Hitler elected Chancellor</button
+      >
+    {/if}
+  </div>
+
+  <!-- Execution details -->
+  {#if input.event === 'execution'}
+    <div class="sub">
+      <span class="fieldlabel">Who was executed? <span class="muted">(optional)</span></span>
+      <div class="chips">
+        {#each ctx.players as p (p.id)}
+          <button
+            type="button"
+            class="chip"
+            class:on={input.target === p.id}
+            aria-pressed={input.target === p.id}
+            onclick={() => setTarget(p.id)}
+          >
+            <Avatar name={p.name} color={p.color} size={22} />
+            {p.name}
+          </button>
+        {/each}
+      </div>
+      <button
+        type="button"
+        class="ev hitler"
+        class:on={input.hitlerKilled}
+        aria-pressed={input.hitlerKilled}
+        onclick={toggleHitler}>🎩 The executed player was Hitler</button
+      >
+    </div>
+  {/if}
+
+  <!-- Fascist power reminder -->
+  {#if reminders && input.event === 'fascist' && (unlockedPower || vetoNow)}
+    <div class="hint">
+      {#if unlockedPower}<span
+          >President power: <strong>{unlockedPower.emoji} {unlockedPower.label}</strong></span
+        >{/if}
+      {#if vetoNow}<span>🛑 Veto power is now unlocked.</span>{/if}
+    </div>
+  {/if}
+
+  <!-- Winning-team recorder -->
+  {#if decidesNow}
+    <div class="decide" aria-live="polite">
+      <strong>🏁 {teamName}s win!</strong>
+      <span class="muted"
+        >{after.winReason}. Reveal roles, then tap the {needTeam}
+        {teamName} team member{needTeam === 1 ? '' : 's'}.</span
+      >
+      <div class="chips">
+        {#each ctx.players as p (p.id)}
+          {@const on = picked.includes(p.id)}
+          <button
+            type="button"
+            class="chip win"
+            class:on
+            aria-pressed={on}
+            disabled={!on && picked.length >= needTeam}
+            onclick={() => toggleWinner(p.id)}
+          >
+            <Avatar name={p.name} color={p.color} size={22} />
+            {p.name}
+            {#if on}<span class="ck" aria-hidden="true">✓</span>{/if}
+          </button>
+        {/each}
+      </div>
+      <span class="muted sm" class:ready={picked.length === needTeam}
+        >{picked.length === needTeam ? '✓ ' : ''}{picked.length}/{needTeam} selected</span
+      >
+    </div>
+  {/if}
+</div>
+
+<style>
+  .sh {
+    gap: 12px;
+  }
+  .setup {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 10px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-size: 0.9rem;
+  }
+
+  .tracks {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .track {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+  }
+  .track-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-weight: 700;
+    margin-bottom: 8px;
+  }
+  .count {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    color: var(--muted);
+  }
+  .count.done {
+    color: var(--text);
+  }
+  .count.trk.full {
+    color: var(--warn);
+  }
+  .slots {
+    display: flex;
+    gap: 6px;
+  }
+  .slot {
+    flex: 1 1 0;
+    height: 26px;
+    min-width: 0;
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8rem;
+    transition:
+      background 0.15s ease,
+      border-color 0.15s ease;
+  }
+  .slot.lib.filled {
+    background: color-mix(in srgb, var(--good) 78%, transparent);
+    border-color: var(--good);
+  }
+  .slot.fasc.filled {
+    background: color-mix(in srgb, var(--bad) 78%, transparent);
+    border-color: var(--bad);
+  }
+  .slot.lib.pending {
+    border: 2px dashed var(--good);
+  }
+  .slot.fasc.pending {
+    border: 2px dashed var(--bad);
+  }
+  .slot.goal {
+    background: var(--surface-3);
+  }
+  .powers {
+    margin-top: 6px;
+  }
+  .pwrow {
+    display: flex;
+    gap: 6px;
+  }
+  .pw {
+    flex: 1 1 0;
+    text-align: center;
+    font-size: 0.8rem;
+    color: var(--muted);
+    opacity: 0.85;
+  }
+
+  .tracker {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .dots {
+    display: flex;
+    gap: 8px;
+  }
+  .dot {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--surface);
+    border: 1px solid var(--border);
+  }
+  .dot.on {
+    background: var(--warn);
+    border-color: var(--warn);
+  }
+  .dot.hot {
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--warn) 30%, transparent);
+  }
+
+  .events {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+  .ev {
+    min-height: 46px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    font-weight: 700;
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      border-color 0.15s ease;
+  }
+  .ev:hover:not(:disabled) {
+    background: var(--surface-2);
+  }
+  .ev.wide {
+    grid-column: 1 / -1;
+  }
+  .ev.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .ev:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+  .ev.hitler {
+    width: 100%;
+    margin-top: 4px;
+  }
+
+  .sub {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 7px 14px 7px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 600;
+  }
+  .chip.on {
+    border-color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 18%, var(--surface));
+  }
+  .chip .ck {
+    font-weight: 900;
+    color: var(--primary);
+  }
+  .chip:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .hint {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+    padding: 9px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-size: 0.9rem;
+  }
+
+  .decide {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--primary);
+    border-radius: var(--radius-sm);
+  }
+  .decide .sm {
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .decide .ready {
+    color: var(--good);
+    font-weight: 700;
+  }
+
+  /* Motion is only ever a 150ms state transition here; under reduced motion the
+     same states land instantly rather than easing. */
+  @media (prefers-reduced-motion: reduce) {
+    .slot,
+    .ev {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/games/secrethitler/index.ts
+++ b/src/lib/games/secrethitler/index.ts
@@ -1,0 +1,132 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { secretHitlerStats } from './stats';
+import { computeState, eventOf, previewAfter, validate, type SecretHitlerInput } from './logic';
+
+export type { SecretHitlerInput } from './logic';
+
+/** The recorded events entering the round at `ctx.roundIndex` (excludes the draft). */
+function eventsBefore(ctx: RoundContext): SecretHitlerInput[] {
+  return ctx.rounds.slice(0, ctx.roundIndex).map((r) => eventOf(r.input));
+}
+
+export const secrethitler: GameModule = {
+  id: 'secrethitler',
+  name: 'Secret Hitler',
+  tagline: 'Liberals vs. Fascists — enact policies, hunt the truth',
+  emoji: '🎩',
+  keywords: [
+    'social deduction',
+    'hidden role',
+    'hidden identity',
+    'bluffing',
+    'party',
+    'liberals',
+    'fascists',
+    'policies',
+    'werewolf',
+    'mafia',
+  ],
+  minPlayers: 5,
+  maxPlayers: 10,
+  teams: true,
+
+  configFields: [
+    {
+      key: 'reminders',
+      label: 'Show board reminders (roles & Fascist powers)',
+      type: 'boolean',
+      default: true,
+      help: 'Surfaces the role split and each Fascist board power as you enact policies.',
+    },
+    {
+      key: 'hitlerHint',
+      label: 'Hitler knows the Fascists',
+      type: 'select',
+      default: 'auto',
+      options: [
+        { value: 'auto', label: 'Auto (5–6 players only)' },
+        { value: 'on', label: 'Always remind' },
+        { value: 'off', label: 'Never remind' },
+      ],
+      help: 'In official 5–6 player games Hitler knows the other Fascists.',
+    },
+  ],
+
+  createRoundInput: (): SecretHitlerInput => ({
+    event: 'liberal',
+    hitlerKilled: false,
+    target: null,
+    winners: [],
+  }),
+
+  validateRound: (input: SecretHitlerInput, ctx: RoundContext): string | null => {
+    const before = computeState(eventsBefore(ctx));
+    const valid = (id: ID) => ctx.players.some((p) => p.id === id);
+    return validate(before, eventOf(input), ctx.players.length, valid);
+  },
+
+  scoreRound: (input: SecretHitlerInput, ctx: RoundContext): Record<ID, number> => {
+    const before = computeState(eventsBefore(ctx));
+    const after = previewAfter(before, eventOf(input));
+    const out: Record<ID, number> = {};
+    for (const p of ctx.players) out[p.id] = 0;
+    // Only the round that clinches the game carries the victory: award each recorded
+    // winner a single point so `pickWinners`/`isFinished` can read the outcome.
+    if (after.winner && !before.winner) {
+      for (const id of input.winners ?? []) if (id in out) out[id] = 1;
+    }
+    return out;
+  },
+
+  // Scoreless: the game is over once a victory has been recorded (a winner has a point).
+  isFinished: (totals) => Object.values(totals).some((t) => (Number(t) || 0) > 0),
+
+  // The winning team = every member awarded a victory point on the deciding round.
+  pickWinners: (totals) => Object.keys(totals).filter((id) => (Number(totals[id]) || 0) > 0),
+
+  describeRound: (round: Round, players): string => {
+    const input = eventOf(round.input);
+    const nameOf = (id: ID | null | undefined) =>
+      players.find((p) => p.id === id)?.name ?? 'someone';
+    const decided = (input.winners?.length ?? 0) > 0;
+    switch (input.event) {
+      case 'liberal':
+        return decided ? '📘 Liberal policy — Liberals win! 🏁' : '📘 Liberal policy enacted';
+      case 'fascist':
+        return decided ? '📕 Fascist policy — Fascists win! 🏁' : '📕 Fascist policy enacted';
+      case 'electionFailed':
+        return '🗳️ Government rejected — election tracker +1';
+      case 'execution':
+        if (input.hitlerKilled)
+          return `🔫 ${nameOf(input.target)} executed — it was Hitler! Liberals win 🏁`;
+        return input.target ? `🔫 ${nameOf(input.target)} executed` : '🔫 Player executed';
+      case 'hitlerChancellor':
+        return '🎩 Hitler elected Chancellor — Fascists win! 🏁';
+      default:
+        return 'Round recorded';
+    }
+  },
+
+  help: [
+    'Secret Hitler is a hidden-role game of Liberals vs. Fascists — one Fascist is secretly Hitler.',
+    'This is a tracker: tap in each enacted policy and the board keeps score for you.',
+    '',
+    'Liberals win by:',
+    '• enacting 5 Liberal policies 📘, or',
+    '• assassinating Hitler 🔫 (a President’s execution power).',
+    '',
+    'Fascists win by:',
+    '• enacting 6 Fascist policies 📕, or',
+    '• electing Hitler Chancellor 🎩 once 3 Fascist policies are enacted.',
+    '',
+    'Each round, record what the government did: a Liberal or Fascist policy, a failed',
+    'election (tracker +1; at 3 the top policy is force-enacted), an execution, or Hitler',
+    'taking the Chancellorship. When a win triggers, reveal roles and tap the winning team.',
+  ].join('\n'),
+
+  stats: secretHitlerStats,
+
+  RoundEditor,
+  editorLoader: () => import('./SecretHitlerEditor.svelte'),
+};

--- a/src/lib/games/secrethitler/logic.ts
+++ b/src/lib/games/secrethitler/logic.ts
@@ -1,0 +1,242 @@
+import type { ID } from '../../types';
+
+/**
+ * Pure Secret Hitler engine — no Svelte, no I/O. The module (`index.ts`), the round
+ * editor and the tests all fold a list of recorded events into board state through
+ * {@link computeState}. Secret Hitler is scoreless, so the point-oriented GameModule
+ * contract is satisfied by encoding the *outcome* rather than a running score: the
+ * round that clinches the game records the revealed winning team, and each of those
+ * members is later awarded a single victory point (see `index.ts`).
+ */
+
+/** The two secret teams. Hitler counts as Fascist. */
+export type SHTeam = 'liberal' | 'fascist';
+
+/** Everything that can happen on a recorded round (one government / one enacted policy). */
+export type SHEventKind =
+  | 'liberal' // a Liberal policy was enacted
+  | 'fascist' // a Fascist policy was enacted
+  | 'electionFailed' // the government was voted down — election tracker +1
+  | 'execution' // a President used the execution power
+  | 'hitlerChancellor'; // Hitler was elected Chancellor
+
+/** The editable draft for a single round. */
+export interface SecretHitlerInput {
+  event: SHEventKind;
+  /** For `execution`: was the executed player Hitler? Liberals win if so. */
+  hitlerKilled?: boolean;
+  /** For `execution`: which seated player was executed (flavour + stats). */
+  target?: ID | null;
+  /** The revealed winning team's members, recorded on the deciding round. */
+  winners?: ID[];
+}
+
+export const LIBERAL_TARGET = 5;
+export const FASCIST_TARGET = 6;
+export const TRACKER_MAX = 3;
+/** The execution power is printed on the 4th and 5th Fascist slots for every count. */
+export const KILL_POWER_MIN = 4;
+/** Electing Hitler Chancellor only wins once this many Fascist policies are enacted. */
+export const HITLER_CHANCELLOR_MIN = 3;
+/** Veto power unlocks once this many Fascist policies are enacted (all counts). */
+export const VETO_MIN = 5;
+
+/** Running public state of a game, folded from its recorded events. */
+export interface SHState {
+  liberal: number;
+  fascist: number;
+  tracker: number;
+  winner: SHTeam | null;
+  winReason: string | null;
+  /** Index of the event that decided the game, or null while it is still live. */
+  decidedAt: number | null;
+}
+
+export function emptyState(): SHState {
+  return { liberal: 0, fascist: 0, tracker: 0, winner: null, winReason: null, decidedAt: null };
+}
+
+function decide(s: SHState, team: SHTeam, reason: string, index: number): void {
+  s.winner = team;
+  s.winReason = reason;
+  s.decidedAt = index;
+}
+
+/** Apply one event to a mutable state (no-op once the game is decided). */
+function applyEvent(s: SHState, e: SecretHitlerInput, index: number): void {
+  if (s.winner) return;
+  switch (e.event) {
+    case 'liberal':
+      s.liberal = Math.min(LIBERAL_TARGET, s.liberal + 1);
+      s.tracker = 0;
+      if (s.liberal >= LIBERAL_TARGET) decide(s, 'liberal', 'Five Liberal policies enacted', index);
+      break;
+    case 'fascist':
+      s.fascist = Math.min(FASCIST_TARGET, s.fascist + 1);
+      s.tracker = 0;
+      if (s.fascist >= FASCIST_TARGET) decide(s, 'fascist', 'Six Fascist policies enacted', index);
+      break;
+    case 'electionFailed':
+      s.tracker = Math.min(TRACKER_MAX, s.tracker + 1);
+      break;
+    case 'execution':
+      if (e.hitlerKilled) decide(s, 'liberal', 'Hitler was assassinated', index);
+      break;
+    case 'hitlerChancellor':
+      if (s.fascist >= HITLER_CHANCELLOR_MIN) {
+        decide(s, 'fascist', 'Hitler was elected Chancellor', index);
+      }
+      break;
+  }
+}
+
+/**
+ * Fold recorded events into board state. Once a win condition triggers, later
+ * events are ignored — the game is over the moment it is decided.
+ */
+export function computeState(events: SecretHitlerInput[]): SHState {
+  const s = emptyState();
+  events.forEach((e, i) => applyEvent(s, e, i));
+  return s;
+}
+
+/** Preview the state after applying one more event to an existing state. */
+export function previewAfter(before: SHState, input: SecretHitlerInput): SHState {
+  const s: SHState = { ...before };
+  applyEvent(s, input, (before.decidedAt ?? -1) + 1);
+  return s;
+}
+
+// ── Setup: role split & board powers per player count ──────────────────────
+
+const ROLE_TABLE: Record<number, { liberals: number; fascists: number }> = {
+  5: { liberals: 3, fascists: 1 },
+  6: { liberals: 4, fascists: 1 },
+  7: { liberals: 4, fascists: 2 },
+  8: { liberals: 5, fascists: 2 },
+  9: { liberals: 5, fascists: 3 },
+  10: { liberals: 6, fascists: 3 },
+};
+
+export interface RoleSetup {
+  /** Plain Liberals. */
+  liberals: number;
+  /** Plain Fascists — excludes Hitler. */
+  fascists: number;
+  /** In 5–6 player games Hitler knows who the Fascists are. */
+  hitlerKnowsFascists: boolean;
+  /** Size of the Liberal team ( = liberals ). */
+  liberalTeam: number;
+  /** Size of the Fascist team ( = fascists + Hitler ). */
+  fascistTeam: number;
+}
+
+export function roleSetup(playerCount: number): RoleSetup {
+  const base =
+    ROLE_TABLE[playerCount] ??
+    ({
+      liberals: Math.max(1, playerCount - Math.floor(playerCount / 3) - 1),
+      fascists: Math.max(1, Math.floor(playerCount / 3)),
+    } as { liberals: number; fascists: number });
+  return {
+    liberals: base.liberals,
+    fascists: base.fascists,
+    hitlerKnowsFascists: playerCount <= 6,
+    liberalTeam: base.liberals,
+    fascistTeam: base.fascists + 1,
+  };
+}
+
+/** Expected number of members on the winning team, given the seated player count. */
+export function teamSize(playerCount: number, team: SHTeam): number {
+  const r = roleSetup(playerCount);
+  return team === 'liberal' ? r.liberalTeam : r.fascistTeam;
+}
+
+export interface Power {
+  key: string;
+  label: string;
+  emoji: string;
+}
+
+const PEEK: Power = { key: 'peek', label: 'Policy Peek', emoji: '🔍' };
+const INVESTIGATE: Power = { key: 'investigate', label: 'Investigate Loyalty', emoji: '🔎' };
+const SPECIAL: Power = { key: 'special', label: 'Special Election', emoji: '🗳️' };
+const EXECUTION: Power = { key: 'execution', label: 'Execution', emoji: '🔫' };
+
+/**
+ * The executive power printed on the Fascist board for the nth Fascist policy
+ * (1–6), for the given player count. Matches the official board layouts.
+ */
+export function powerAt(playerCount: number, fascistPolicy: number): Power | null {
+  let layout: Record<number, Power>;
+  if (playerCount <= 6) {
+    layout = { 3: PEEK, 4: EXECUTION, 5: EXECUTION };
+  } else if (playerCount <= 8) {
+    layout = { 2: INVESTIGATE, 3: SPECIAL, 4: EXECUTION, 5: EXECUTION };
+  } else {
+    layout = { 1: INVESTIGATE, 2: INVESTIGATE, 3: SPECIAL, 4: EXECUTION, 5: EXECUTION };
+  }
+  return layout[fascistPolicy] ?? null;
+}
+
+/** The full 1–5 power column for a player count (index 0 = 1st Fascist policy). */
+export function powerColumn(playerCount: number): (Power | null)[] {
+  return [1, 2, 3, 4, 5].map((n) => powerAt(playerCount, n));
+}
+
+// ── Shared helpers, reused by index.ts and the editor ──────────────────────
+
+/** Normalise a stored/loaded round input into a well-formed event. */
+export function eventOf(input: unknown): SecretHitlerInput {
+  const e = (input ?? {}) as Partial<SecretHitlerInput>;
+  return {
+    event: (e.event ?? 'liberal') as SHEventKind,
+    hitlerKilled: !!e.hitlerKilled,
+    target: e.target ?? null,
+    winners: Array.isArray(e.winners) ? e.winners : [],
+  };
+}
+
+/**
+ * Validate a drafted round against the state entering it. Returns null when valid,
+ * otherwise a human-readable message. `winners` must exactly match the winning team
+ * size on the deciding round so `pickWinners` can record the whole team.
+ */
+export function validate(
+  before: SHState,
+  input: SecretHitlerInput,
+  playerCount: number,
+  validId: (id: ID) => boolean,
+): string | null {
+  if (before.winner) {
+    return 'This game is already decided — tap “Finish & record winner”.';
+  }
+  switch (input.event) {
+    case 'electionFailed':
+      if (before.tracker >= TRACKER_MAX) {
+        return 'The election tracker is full — the top policy is force-enacted. Record it as a Liberal or Fascist policy.';
+      }
+      break;
+    case 'execution':
+      if (before.fascist < KILL_POWER_MIN) {
+        return 'The execution power unlocks after the 4th Fascist policy.';
+      }
+      break;
+    case 'hitlerChancellor':
+      if (before.fascist < HITLER_CHANCELLOR_MIN) {
+        return 'Electing Hitler Chancellor only ends the game once 3 Fascist policies are enacted.';
+      }
+      break;
+  }
+  const after = previewAfter(before, input);
+  if (after.winner) {
+    const need = teamSize(playerCount, after.winner);
+    const picked = (input.winners ?? []).filter(validId);
+    const teamName = after.winner === 'liberal' ? 'Liberal' : 'Fascist';
+    if (picked.length !== need) {
+      return `${teamName}s win! Tap the ${need} ${teamName} team member${need === 1 ? '' : 's'}.`;
+    }
+  }
+  return null;
+}

--- a/src/lib/games/secrethitler/secrethitler.test.ts
+++ b/src/lib/games/secrethitler/secrethitler.test.ts
@@ -1,0 +1,443 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round, RoundContext } from '../../types';
+import { secrethitler } from './index';
+import {
+  FASCIST_TARGET,
+  HITLER_CHANCELLOR_MIN,
+  KILL_POWER_MIN,
+  LIBERAL_TARGET,
+  TRACKER_MAX,
+  computeState,
+  emptyState,
+  eventOf,
+  powerAt,
+  powerColumn,
+  previewAfter,
+  roleSetup,
+  teamSize,
+  validate,
+  type SHEventKind,
+  type SecretHitlerInput,
+} from './logic';
+
+// ---- helpers ---------------------------------------------------------------
+
+function player(id: string, name = id): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+
+/** Seven seats — enough for the 4-Fascist / 2-Fascist role table and executions. */
+const seats = ['a', 'b', 'c', 'd', 'e', 'f', 'g'].map((id) => player(id));
+
+function ev(event: SHEventKind, extra: Partial<SecretHitlerInput> = {}): SecretHitlerInput {
+  return { event, hitlerKilled: false, target: null, winners: [], ...extra };
+}
+
+/** `n` repetitions of one event — the quickest way to fill a policy track. */
+function times(n: number, event: SHEventKind): SecretHitlerInput[] {
+  return Array.from({ length: n }, () => ev(event));
+}
+
+function round(index: number, input: SecretHitlerInput): Round {
+  return { id: `r${index}`, gameId: 'g', index, input, deltas: {}, createdAt: 0 };
+}
+
+function ctx(prior: SecretHitlerInput[], players: Player[] = seats): RoundContext {
+  const rounds = prior.map((input, i) => round(i, input));
+  return {
+    game: {} as Game,
+    players,
+    config: {},
+    roundIndex: rounds.length,
+    totals: {} as Record<ID, number>,
+    rounds,
+  };
+}
+
+const allIds = seats.map((p) => p.id);
+const validId = (id: ID) => allIds.includes(id);
+
+// ---- eventOf ---------------------------------------------------------------
+
+describe('eventOf', () => {
+  it('normalizes a missing or junk input into a well-formed Liberal policy', () => {
+    expect(eventOf(undefined)).toEqual({
+      event: 'liberal',
+      hitlerKilled: false,
+      target: null,
+      winners: [],
+    });
+    expect(eventOf({})).toEqual({
+      event: 'liberal',
+      hitlerKilled: false,
+      target: null,
+      winners: [],
+    });
+  });
+
+  it('coerces a non-array winners field to an empty team', () => {
+    expect(eventOf({ event: 'fascist', winners: 'nope' }).winners).toEqual([]);
+  });
+
+  it('preserves a fully recorded event', () => {
+    const input = ev('execution', { hitlerKilled: true, target: 'c', winners: ['a', 'b'] });
+    expect(eventOf(input)).toEqual(input);
+  });
+});
+
+// ---- computeState ----------------------------------------------------------
+
+describe('computeState', () => {
+  it('starts empty and undecided', () => {
+    expect(computeState([])).toEqual(emptyState());
+  });
+
+  it('counts policies onto their own track', () => {
+    const s = computeState([ev('liberal'), ev('fascist'), ev('liberal')]);
+    expect(s).toMatchObject({ liberal: 2, fascist: 1, winner: null });
+  });
+
+  it('advances the election tracker on a failed government', () => {
+    expect(computeState(times(2, 'electionFailed')).tracker).toBe(2);
+  });
+
+  it('clamps the election tracker at its maximum', () => {
+    expect(computeState(times(9, 'electionFailed')).tracker).toBe(TRACKER_MAX);
+  });
+
+  it('resets the election tracker whenever a policy is enacted', () => {
+    expect(computeState([ev('electionFailed'), ev('electionFailed'), ev('liberal')]).tracker).toBe(
+      0,
+    );
+    expect(computeState([ev('electionFailed'), ev('fascist')]).tracker).toBe(0);
+  });
+
+  it('records which event decided the game', () => {
+    const s = computeState(times(LIBERAL_TARGET, 'liberal'));
+    expect(s.decidedAt).toBe(LIBERAL_TARGET - 1);
+  });
+
+  it('ignores everything recorded after the game is decided', () => {
+    const s = computeState([...times(LIBERAL_TARGET, 'liberal'), ...times(3, 'fascist')]);
+    expect(s).toMatchObject({ liberal: LIBERAL_TARGET, fascist: 0, winner: 'liberal' });
+  });
+});
+
+// ---- win conditions --------------------------------------------------------
+
+describe('win conditions', () => {
+  it('Liberals win on the fifth Liberal policy — not the fourth', () => {
+    expect(computeState(times(LIBERAL_TARGET - 1, 'liberal')).winner).toBeNull();
+    const s = computeState(times(LIBERAL_TARGET, 'liberal'));
+    expect(s.winner).toBe('liberal');
+    expect(s.winReason).toBe('Five Liberal policies enacted');
+  });
+
+  it('Fascists win on the sixth Fascist policy — not the fifth', () => {
+    expect(computeState(times(FASCIST_TARGET - 1, 'fascist')).winner).toBeNull();
+    const s = computeState(times(FASCIST_TARGET, 'fascist'));
+    expect(s.winner).toBe('fascist');
+    expect(s.winReason).toBe('Six Fascist policies enacted');
+  });
+
+  it('Liberals win the moment Hitler is assassinated', () => {
+    const s = computeState([
+      ...times(KILL_POWER_MIN, 'fascist'),
+      ev('execution', { hitlerKilled: true, target: 'c' }),
+    ]);
+    expect(s.winner).toBe('liberal');
+    expect(s.winReason).toBe('Hitler was assassinated');
+  });
+
+  it('an execution that misses Hitler decides nothing', () => {
+    const s = computeState([...times(KILL_POWER_MIN, 'fascist'), ev('execution', { target: 'c' })]);
+    expect(s.winner).toBeNull();
+    expect(s.fascist).toBe(KILL_POWER_MIN);
+  });
+
+  it('Hitler as Chancellor wins only once three Fascist policies are enacted', () => {
+    const tooEarly = computeState([
+      ...times(HITLER_CHANCELLOR_MIN - 1, 'fascist'),
+      ev('hitlerChancellor'),
+    ]);
+    expect(tooEarly.winner).toBeNull();
+
+    const s = computeState([...times(HITLER_CHANCELLOR_MIN, 'fascist'), ev('hitlerChancellor')]);
+    expect(s.winner).toBe('fascist');
+    expect(s.winReason).toBe('Hitler was elected Chancellor');
+  });
+});
+
+// ---- previewAfter ----------------------------------------------------------
+
+describe('previewAfter', () => {
+  it('does not mutate the state it previews from', () => {
+    const before = computeState(times(2, 'fascist'));
+    const after = previewAfter(before, ev('fascist'));
+    expect(before.fascist).toBe(2);
+    expect(after.fascist).toBe(3);
+  });
+
+  it('shows the clinch one policy ahead of time', () => {
+    const before = computeState(times(LIBERAL_TARGET - 1, 'liberal'));
+    expect(before.winner).toBeNull();
+    expect(previewAfter(before, ev('liberal')).winner).toBe('liberal');
+  });
+});
+
+// ---- setup tables ----------------------------------------------------------
+
+describe('roleSetup', () => {
+  it('matches the official role split for every supported player count', () => {
+    const expected: Record<number, [number, number]> = {
+      5: [3, 1],
+      6: [4, 1],
+      7: [4, 2],
+      8: [5, 2],
+      9: [5, 3],
+      10: [6, 3],
+    };
+    for (const [count, [liberals, fascists]] of Object.entries(expected)) {
+      const r = roleSetup(Number(count));
+      expect([r.liberals, r.fascists], `setup for ${count} players`).toEqual([liberals, fascists]);
+      // Liberals + Fascists + Hitler always seats the whole table.
+      expect(r.liberalTeam + r.fascistTeam).toBe(Number(count));
+    }
+  });
+
+  it('only tells Hitler who the Fascists are in 5–6 player games', () => {
+    expect(roleSetup(5).hitlerKnowsFascists).toBe(true);
+    expect(roleSetup(6).hitlerKnowsFascists).toBe(true);
+    expect(roleSetup(7).hitlerKnowsFascists).toBe(false);
+  });
+});
+
+describe('teamSize', () => {
+  it('counts Hitler on the Fascist team', () => {
+    expect(teamSize(7, 'liberal')).toBe(4);
+    expect(teamSize(7, 'fascist')).toBe(3);
+  });
+});
+
+describe('powerAt / powerColumn', () => {
+  it('places the execution power on the 4th and 5th Fascist policies at every count', () => {
+    for (const count of [5, 6, 7, 8, 9, 10]) {
+      expect(powerAt(count, 4)?.key, `${count} players`).toBe('execution');
+      expect(powerAt(count, 5)?.key, `${count} players`).toBe('execution');
+    }
+  });
+
+  it('matches the small-table board (5–6 players)', () => {
+    expect(powerColumn(5).map((p) => p?.key ?? null)).toEqual([
+      null,
+      null,
+      'peek',
+      'execution',
+      'execution',
+    ]);
+  });
+
+  it('matches the mid-table board (7–8 players)', () => {
+    expect(powerColumn(8).map((p) => p?.key ?? null)).toEqual([
+      null,
+      'investigate',
+      'special',
+      'execution',
+      'execution',
+    ]);
+  });
+
+  it('matches the large-table board (9–10 players)', () => {
+    expect(powerColumn(10).map((p) => p?.key ?? null)).toEqual([
+      'investigate',
+      'investigate',
+      'special',
+      'execution',
+      'execution',
+    ]);
+  });
+});
+
+// ---- validate --------------------------------------------------------------
+
+describe('validate', () => {
+  it('accepts an ordinary policy round', () => {
+    expect(validate(emptyState(), ev('liberal'), 7, validId)).toBeNull();
+  });
+
+  it('refuses to record anything once the game is decided', () => {
+    const before = computeState(times(LIBERAL_TARGET, 'liberal'));
+    expect(validate(before, ev('liberal'), 7, validId)).toMatch(/already decided/i);
+  });
+
+  it('refuses a failed election once the tracker is full', () => {
+    const before = computeState(times(TRACKER_MAX, 'electionFailed'));
+    expect(validate(before, ev('electionFailed'), 7, validId)).toMatch(/force-enacted/i);
+  });
+
+  it('refuses an execution before the power unlocks', () => {
+    const before = computeState(times(KILL_POWER_MIN - 1, 'fascist'));
+    expect(validate(before, ev('execution'), 7, validId)).toMatch(/4th Fascist policy/i);
+  });
+
+  it('allows an execution once the 4th Fascist policy is enacted', () => {
+    const before = computeState(times(KILL_POWER_MIN, 'fascist'));
+    expect(validate(before, ev('execution', { target: 'c' }), 7, validId)).toBeNull();
+  });
+
+  it('refuses a Hitler chancellorship before three Fascist policies', () => {
+    const before = computeState(times(HITLER_CHANCELLOR_MIN - 1, 'fascist'));
+    expect(validate(before, ev('hitlerChancellor'), 7, validId)).toMatch(/3 Fascist policies/i);
+  });
+
+  it('demands the whole winning team on the deciding round', () => {
+    const before = computeState(times(LIBERAL_TARGET - 1, 'liberal'));
+    expect(validate(before, ev('liberal'), 7, validId)).toMatch(/Tap the 4 Liberal team members/i);
+    expect(validate(before, ev('liberal', { winners: ['a', 'b'] }), 7, validId)).toMatch(
+      /Tap the 4/i,
+    );
+    expect(
+      validate(before, ev('liberal', { winners: ['a', 'b', 'c', 'd'] }), 7, validId),
+    ).toBeNull();
+  });
+
+  it('does not count winners who are not seated in this game', () => {
+    const before = computeState(times(FASCIST_TARGET - 1, 'fascist'));
+    const bogus = ev('fascist', { winners: ['a', 'b', 'zzz'] });
+    expect(validate(before, bogus, 7, validId)).toMatch(/Tap the 3 Fascist team members/i);
+  });
+
+  it('sizes the demanded team to the table', () => {
+    const before = computeState(times(FASCIST_TARGET - 1, 'fascist'));
+    expect(validate(before, ev('fascist'), 5, validId)).toMatch(/Tap the 2 Fascist team members/i);
+    expect(validate(before, ev('fascist'), 10, validId)).toMatch(/Tap the 4 Fascist team members/i);
+  });
+});
+
+// ---- module scoring --------------------------------------------------------
+
+describe('secrethitler module', () => {
+  it('is a scoreless tracker until a game is clinched', () => {
+    const out = secrethitler.scoreRound(ev('liberal'), ctx(times(2, 'liberal')));
+    expect(out).toEqual({ a: 0, b: 0, c: 0, d: 0, e: 0, f: 0, g: 0 });
+  });
+
+  it('awards one victory point to each recorded winner on the deciding round', () => {
+    const prior = times(LIBERAL_TARGET - 1, 'liberal');
+    const input = ev('liberal', { winners: ['a', 'b', 'c', 'd'] });
+    const out = secrethitler.scoreRound(input, ctx(prior));
+    expect(out).toEqual({ a: 1, b: 1, c: 1, d: 1, e: 0, f: 0, g: 0 });
+  });
+
+  it('awards nothing for a game that was already decided', () => {
+    const prior = times(LIBERAL_TARGET, 'liberal');
+    const input = ev('fascist', { winners: ['e', 'f', 'g'] });
+    expect(secrethitler.scoreRound(input, ctx(prior))).toEqual({
+      a: 0,
+      b: 0,
+      c: 0,
+      d: 0,
+      e: 0,
+      f: 0,
+      g: 0,
+    });
+  });
+
+  it('ignores recorded winners who are not seated', () => {
+    const prior = times(FASCIST_TARGET - 1, 'fascist');
+    const input = ev('fascist', { winners: ['a', 'b', 'c', 'zzz'] });
+    const out = secrethitler.scoreRound(input, ctx(prior));
+    expect(out.a).toBe(1);
+    expect(out).not.toHaveProperty('zzz');
+  });
+
+  it('scores an assassination as a Liberal victory', () => {
+    const prior = times(KILL_POWER_MIN, 'fascist');
+    const input = ev('execution', {
+      hitlerKilled: true,
+      target: 'g',
+      winners: ['a', 'b', 'c', 'd'],
+    });
+    const out = secrethitler.scoreRound(input, ctx(prior));
+    expect(Object.values(out).filter(Boolean)).toHaveLength(4);
+  });
+
+  it('reports the game finished only once a victory is recorded', () => {
+    const info = { config: {}, roundCount: 3, playerCount: 7 };
+    expect(secrethitler.isFinished?.({ a: 0, b: 0, c: 0 }, info)).toBe(false);
+    expect(secrethitler.isFinished?.({ a: 1, b: 0, c: 0 }, info)).toBe(true);
+  });
+
+  it('picks exactly the winning team from the totals', () => {
+    expect(secrethitler.pickWinners?.({ a: 0, b: 0, c: 0 }, {})).toEqual([]);
+    expect(secrethitler.pickWinners?.({ a: 1, b: 0, c: 1, d: 0 }, {})?.sort()).toEqual(['a', 'c']);
+  });
+
+  it('lines scoreRound and pickWinners up end to end', () => {
+    const prior = times(HITLER_CHANCELLOR_MIN, 'fascist');
+    const input = ev('hitlerChancellor', { winners: ['e', 'f', 'g'] });
+    const totals = secrethitler.scoreRound(input, ctx(prior));
+    expect(secrethitler.pickWinners?.(totals, {})?.sort()).toEqual(['e', 'f', 'g']);
+  });
+
+  it('validates a drafted round through the module', () => {
+    expect(secrethitler.validateRound(ev('execution'), ctx([]))).toMatch(/4th Fascist policy/i);
+    expect(secrethitler.validateRound(ev('liberal'), ctx([]))).toBeNull();
+  });
+
+  it('creates a fresh, empty round input', () => {
+    expect(secrethitler.createRoundInput(ctx([]))).toEqual({
+      event: 'liberal',
+      hitlerKilled: false,
+      target: null,
+      winners: [],
+    });
+  });
+
+  it('seats a legal Secret Hitler table', () => {
+    expect(secrethitler.minPlayers).toBe(5);
+    expect(secrethitler.maxPlayers).toBe(10);
+    expect(secrethitler.teams).toBe(true);
+  });
+
+  it('exposes a lazily loaded round editor', () => {
+    expect(secrethitler.RoundEditor).toBeTruthy();
+    expect(typeof secrethitler.editorLoader).toBe('function');
+  });
+});
+
+// ---- describeRound ---------------------------------------------------------
+
+describe('describeRound', () => {
+  const describe1 = (input: SecretHitlerInput) =>
+    secrethitler.describeRound?.(round(0, input), seats) ?? '';
+
+  it('summarizes an ordinary policy', () => {
+    expect(describe1(ev('liberal'))).toBe('📘 Liberal policy enacted');
+    expect(describe1(ev('fascist'))).toBe('📕 Fascist policy enacted');
+  });
+
+  it('flags the policy that won the game', () => {
+    expect(describe1(ev('liberal', { winners: ['a'] }))).toMatch(/Liberals win/);
+    expect(describe1(ev('fascist', { winners: ['a'] }))).toMatch(/Fascists win/);
+  });
+
+  it('summarizes a failed election', () => {
+    expect(describe1(ev('electionFailed'))).toMatch(/election tracker \+1/);
+  });
+
+  it('names the executed player, and calls out a dead Hitler', () => {
+    expect(describe1(ev('execution', { target: 'c' }))).toBe('🔫 c executed');
+    expect(describe1(ev('execution', { target: 'c', hitlerKilled: true }))).toMatch(
+      /it was Hitler! Liberals win/,
+    );
+  });
+
+  it('falls back gracefully when no target was recorded', () => {
+    expect(describe1(ev('execution'))).toBe('🔫 Player executed');
+  });
+
+  it('summarizes Hitler taking the Chancellery', () => {
+    expect(describe1(ev('hitlerChancellor'))).toMatch(/Fascists win/);
+  });
+});

--- a/src/lib/games/secrethitler/stats.ts
+++ b/src/lib/games/secrethitler/stats.ts
@@ -1,0 +1,99 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { computeState, eventOf } from './logic';
+
+/**
+ * Secret Hitler stats, derived by replaying each game's recorded events through the
+ * same pure engine the module scores with. Roles are secret, so player-level facts
+ * are limited to what the table saw — chiefly who caught a bullet.
+ */
+export function secretHitlerStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+
+  const byGame = new Map<ID, { input: unknown; index: number }[]>();
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const arr = byGame.get(r.gameId) ?? [];
+    arr.push({ input: r.input, index: r.index });
+    byGame.set(r.gameId, arr);
+  }
+
+  let liberalWins = 0;
+  let fascistWins = 0;
+  let byExecution = 0;
+  let byChancellor = 0;
+  let libPolicies = 0;
+  let fascPolicies = 0;
+  const executions = new Map<ID, number>();
+
+  for (const [, arr] of byGame) {
+    arr.sort((a, b) => a.index - b.index);
+    const events = arr.map((x) => eventOf(x.input));
+    const state = computeState(events);
+    libPolicies += state.liberal;
+    fascPolicies += state.fascist;
+
+    for (const e of events) {
+      if (e.event === 'execution' && e.target) {
+        const id = canonical(e.target);
+        executions.set(id, (executions.get(id) ?? 0) + 1);
+      }
+    }
+
+    if (state.winner === 'liberal') liberalWins += 1;
+    else if (state.winner === 'fascist') fascistWins += 1;
+    if (state.winReason === 'Hitler was assassinated') byExecution += 1;
+    if (state.winReason === 'Hitler was elected Chancellor') byChancellor += 1;
+  }
+
+  const global: Metric[] = [];
+  if (liberalWins) {
+    global.push({
+      key: 'sh_lib',
+      label: 'Liberal victories',
+      value: `${liberalWins}`,
+      emoji: '📘',
+    });
+  }
+  if (fascistWins) {
+    global.push({
+      key: 'sh_fasc',
+      label: 'Fascist victories',
+      value: `${fascistWins}`,
+      emoji: '📕',
+    });
+  }
+  if (byExecution) {
+    global.push({
+      key: 'sh_exec',
+      label: 'Hitler assassinated',
+      value: `${byExecution}`,
+      emoji: '🔫',
+    });
+  }
+  if (byChancellor) {
+    global.push({
+      key: 'sh_chan',
+      label: 'Hitler took the Chancellery',
+      value: `${byChancellor}`,
+      emoji: '🎩',
+    });
+  }
+  if (libPolicies || fascPolicies) {
+    global.push({
+      key: 'sh_policies',
+      label: 'Policies enacted (📘 / 📕)',
+      value: `${libPolicies} / ${fascPolicies}`,
+      emoji: '📜',
+    });
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, n] of executions) {
+    if (n > 0) {
+      perPlayer[id] = [{ key: 'sh_executed', label: 'Times executed', value: `${n}`, emoji: '🔫' }];
+    }
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Recovers the Secret Hitler tracker that was written but never committed, modernizes it against the current `GameModule` contract, and lands it as a real game.

Secret Hitler is scoreless, so the module encodes the *outcome* rather than a running score: the round that clinches the game records the revealed winning team, and each member is awarded a single victory point that `isFinished` / `pickWinners` read back.

## Changes

- **New module** `src/lib/games/secrethitler/` — `index.ts`, `logic.ts` (pure engine), `stats.ts`, `SecretHitlerEditor.svelte`.
- **Contract drift fixed.** The salvaged code statically imported its editor into the module. It now points `RoundEditor` at the shared lazy host (`../editor`) and ships an `editorLoader`, so the editor is code-split into its own chunk like every other game — and the auto-discovery guard in `registry.ts`, which requires `editorLoader`, accepts it.
- **No registry edit.** Verified rather than assumed: `registry.ts` discovers games via `import.meta.glob('./*/index.ts')`, and `registry.test.ts` passes unchanged with the new module included.
- **Design pass.** The salvaged editor predated the passes that hardened Avalon and Two Rooms, and it did violate the constraints:
  - Policy tracks signalled filled slots with **colour alone** — filled slots now carry 📘 / 📕 glyphs alongside the existing tabular count.
  - The election tracker was three coloured dots with only a `title` — now paired with a tabular `n/3` count, dots marked `aria-hidden`.
  - The Fascist power column was `aria-hidden` with `title`s that assistive tech never reads — now has a real screen-reader summary.
  - Winning-team chips relied on a violet tint alone — now carry a ✓ mark, and the clinch panel announces via `aria-live="polite"`.
  - No `prefers-reduced-motion` handling — the 150ms state transitions now settle instantly under reduced motion.
  - Radii and type were off the DESIGN.md scale (`6px`, `0.85rem`) — pulled back to `--radius-sm` and `0.8rem`.
  - Crown Gold is unused (correct: no leader/winner surface here); Royal Violet stays on selection state only, matching the Avalon convention; all interactive targets are ≥46px.
- **Tests** `secrethitler.test.ts` — 51 cases covering both win conditions per side (5 Liberal / 6 Fascist policies, Hitler assassinated, Hitler elected Chancellor), the power-unlock and tracker gates, the official role-split and board-power tables for every supported player count, and module-level scoring/`pickWinners` end to end.

## Issues

Closes #142

## Testing

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm test` — 1354 passed (50 files)
- [x] `npm run build` — clean
- [x] `prettier --check` + `eslint` on the new module