### PR TITLE
feat(stardew): add Stardew Valley co-op game module

### DIFF
--- a/src/lib/components/ReplicaBoard.svelte
+++ b/src/lib/components/ReplicaBoard.svelte
@@ -235,9 +235,16 @@
   />
 
   {#if replica.game.status === 'finished'}
+    {@const wins = replica.game.winnerIds?.length ?? 0}
     <div class="card center banner">
-      🏆 {winnerNames || 'Nobody'}
-      {(replica.game.winnerIds?.length ?? 0) > 1 ? 'tie!' : 'wins!'}
+      {#if wins === 0}
+        {gmodule?.coop ? '🌙 The game held this time — no win recorded.' : '🤝 No winner recorded.'}
+      {:else if gmodule?.coop}
+        🏆 You all win together!
+      {:else}
+        🏆 {winnerNames || 'Nobody'}
+        {wins > 1 ? 'tie!' : 'wins!'}
+      {/if}
     </div>
   {:else if canAdd && draft}
     {@const RoundEditor = gmodule.RoundEditor}

--- a/src/lib/components/ShareResultsSheet.svelte
+++ b/src/lib/components/ShareResultsSheet.svelte
@@ -28,6 +28,14 @@
   const winnerNames = $derived(
     view.winners.map((id) => view.players.find((p) => p.id === id)?.name ?? '?').join(' & '),
   );
+  /** The one-line result headline, shared by the preview hero and the native share text. */
+  const heroLine = $derived(
+    !view.winners.length
+      ? ''
+      : view.coop
+        ? '🏆 Won together!'
+        : `🏆 ${winnerNames} ${view.winners.length > 1 ? 'tie!' : 'wins!'}`,
+  );
 
   const canNativeShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
 
@@ -117,7 +125,7 @@
         try {
           await navigator.share({
             files: [file],
-            text: winnerNames ? `🏆 ${winnerNames}` : undefined,
+            text: heroLine || undefined,
           });
         } catch {
           /* dismissed */
@@ -173,8 +181,8 @@
     <span class="pill">{view.emoji} {view.title}</span>
   </div>
 
-  {#if winnerNames}
-    <div class="hero">🏆 {winnerNames} {view.winners.length > 1 ? 'tie!' : 'wins!'}</div>
+  {#if heroLine}
+    <div class="hero">{heroLine}</div>
   {/if}
 
   <div class="board">

--- a/src/lib/games/stardew/StardewEditor.svelte
+++ b/src/lib/games/stardew/StardewEditor.svelte
@@ -1,0 +1,336 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Stepper from '../../components/Stepper.svelte';
+  import { bumpOnChange, popIn } from '../../motion';
+  import {
+    EVAL_CATEGORIES,
+    MAX_CANDLES,
+    MAX_EVALUATION,
+    STARDEW_HELP,
+    candleTier,
+    candleVerdict,
+    evaluationScore,
+    maxSeasons,
+    priorCategoryTotals,
+    scoreForTier,
+    seasonLabel,
+    seasonPoints,
+    targetCandles,
+    type CategoryKey,
+    type StardewSeasonInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: StardewSeasonInput; ctx: RoundContext } = $props();
+
+  const prior = $derived(priorCategoryTotals(ctx.rounds, ctx.roundIndex));
+  // Every seat holds the identical total in this co-op game, so the group score is
+  // just "the" total — there is no leader to pick out and no gap to close.
+  const priorScore = $derived(evaluationScore(ctx.totals));
+  const thisSeason = $derived(seasonPoints(input));
+  const projected = $derived(priorScore + thisSeason);
+  const tier = $derived(candleTier(projected));
+  const target = $derived(targetCandles(ctx.config));
+  const won = $derived(tier >= target);
+  const label = $derived(seasonLabel(ctx.roundIndex));
+  const totalSeasons = $derived(maxSeasons(ctx.config));
+  const toTarget = $derived(Math.max(0, scoreForTier(target) - projected));
+  const candles = $derived(
+    Array.from({ length: MAX_CANDLES }, (_, i) => ({
+      lit: i < tier,
+      isTarget: i + 1 === target,
+    })),
+  );
+
+  let showHelp = $state(false);
+
+  function cumulative(key: CategoryKey): number {
+    return (prior[key] ?? 0) + (Number(input[key]) || 0);
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="pill">{label.emoji} {label.name} · Year {label.year}</span>
+    <span class="row" style="gap: 8px">
+      <span class="pill">Season {ctx.roundIndex + 1} of {totalSeasons}</span>
+      <button
+        type="button"
+        class="btn small ghost"
+        onclick={() => (showHelp = !showHelp)}
+        aria-expanded={showHelp}
+      >
+        Evaluation
+      </button>
+    </span>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{STARDEW_HELP}</pre>
+  {/if}
+
+  <!--
+    Grandpa's Evaluation meter. Progress is Win Green because it is *progress*, not
+    standing; Crown Gold appears only once the group has actually secured its target
+    tier — at that moment the whole table is the winner, which is precisely what gold
+    is reserved for. Every colour cue is co-signalled by the 🕯️/🏆 glyph, the lit/unlit
+    shape, and the "n of 4 lit" text.
+  -->
+  <div class="meter" class:won aria-live="polite">
+    <div class="row spread">
+      <span class="overline">Grandpa's Evaluation</span>
+      <span class="score" class:lead={won}>
+        <span use:bumpOnChange={projected}>{projected}</span><span class="max"
+          >/{MAX_EVALUATION}</span
+        >
+      </span>
+    </div>
+    <div class="candles" role="img" aria-label="{tier} of {MAX_CANDLES} candles lit">
+      {#each candles as c, i (i)}
+        <span class="candle" class:lit={c.lit} class:target={c.isTarget}>
+          <span class="flame" aria-hidden="true">🕯️</span>
+        </span>
+      {/each}
+    </div>
+    <div class="row spread verdict">
+      <span class="verdict-text">
+        {#if won}<span class="trophy" aria-hidden="true" use:popIn>🏆</span>{/if}
+        {candleVerdict(tier)}
+      </span>
+      <span class="muted goal">
+        {#if won}
+          Target met · {tier} of {MAX_CANDLES} lit
+        {:else}
+          <span class="num">{toTarget}</span> more for {target}
+          {target === 1 ? 'candle' : 'candles'}
+        {/if}
+      </span>
+    </div>
+  </div>
+
+  <p class="shared">
+    <span aria-hidden="true">🤝</span> One farm, one score — this season adds
+    <strong>+{thisSeason}</strong> for every seat at the table.
+  </p>
+
+  {#each EVAL_CATEGORIES as c (c.key)}
+    {@const done = cumulative(c.key)}
+    {@const maxed = done >= c.cap}
+    <div class="crow">
+      <div class="label">
+        <span class="emoji" aria-hidden="true">{c.emoji}</span>
+        <span class="stack tight">
+          <strong>{c.label}</strong>
+          <span class="muted hint">{c.hint}</span>
+        </span>
+      </div>
+      <div class="right">
+        <span class="tally" class:maxed>
+          {done}<span class="cap">/{c.cap}</span>
+          {#if maxed}<span class="sr-only">— complete</span><span class="check" aria-hidden="true"
+              >✓</span
+            >{/if}
+        </span>
+        <Stepper
+          bind:value={input[c.key]}
+          min={0}
+          max={c.cap - (prior[c.key] ?? 0)}
+          label={c.label}
+        />
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .meter {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    transition:
+      background 0.2s ease,
+      border-color 0.2s ease;
+  }
+  /* The group's victory moment — the one place Crown Gold appears in this game. */
+  .meter.won {
+    background: color-mix(in srgb, var(--accent) 10%, var(--surface-2));
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  }
+  .overline {
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .score {
+    font-weight: 800;
+    font-size: 1.5rem;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+  /* Gold only for the won state, per the Crown Gold rule. */
+  .score.lead {
+    color: var(--accent-ink);
+  }
+  .score .max {
+    color: var(--muted);
+    font-size: 0.85rem;
+    font-weight: 700;
+  }
+  .candles {
+    display: flex;
+    gap: 8px;
+  }
+  .candle {
+    flex: 1 1 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.35rem;
+    line-height: 1;
+    padding: 10px 0;
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    border: 1px solid var(--border);
+  }
+  /* Unlit candles are dimmed *and* shrunk, so the lit/unlit split survives greyscale. */
+  .candle .flame {
+    display: block;
+    filter: grayscale(1);
+    opacity: 0.35;
+    transform: scale(0.82);
+    transition:
+      filter 0.2s ease,
+      opacity 0.2s ease,
+      transform 0.2s ease;
+  }
+  .candle.lit .flame {
+    filter: none;
+    opacity: 1;
+    transform: none;
+  }
+  /* Progress is Win Green — it means "going well", not "winning". */
+  .candle.lit {
+    background: color-mix(in srgb, var(--good) 14%, var(--surface));
+    border-color: color-mix(in srgb, var(--good) 45%, var(--border));
+  }
+  .meter.won .candle.lit {
+    background: color-mix(in srgb, var(--accent) 16%, var(--surface));
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  }
+  /* Non-colour cue for the goal candle, so the target reads without relying on hue. */
+  .candle.target {
+    box-shadow: inset 0 -3px 0 0 var(--muted);
+  }
+  .verdict {
+    font-size: 0.9rem;
+    font-weight: 600;
+    gap: 10px;
+  }
+  .verdict-text {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+  .trophy {
+    flex: none;
+    line-height: 1;
+  }
+  .goal {
+    flex: none;
+    font-weight: 600;
+    font-size: 0.8rem;
+    text-align: right;
+  }
+  .goal .num {
+    font-variant-numeric: tabular-nums;
+    color: var(--text);
+    font-weight: 700;
+  }
+  .shared {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  .shared strong {
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+  }
+  .crow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+  }
+  .label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+  .label .emoji {
+    font-size: 1.4rem;
+    line-height: 1;
+    flex: none;
+  }
+  .stack.tight {
+    gap: 2px;
+  }
+  .hint {
+    font-size: 0.75rem;
+  }
+  .right {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex: none;
+  }
+  .tally {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+    min-width: 34px;
+    text-align: right;
+    white-space: nowrap;
+  }
+  /* A completed category is called out by the ✓ glyph as well as the colour. */
+  .tally.maxed {
+    color: var(--good);
+  }
+  .tally .cap {
+    color: var(--muted);
+    font-weight: 700;
+    font-size: 0.8rem;
+  }
+  .tally .check {
+    margin-left: 3px;
+    font-size: 0.8rem;
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+    line-height: 1.5;
+  }
+  /* Calm alternative: the state change still lands, it just arrives instantly. */
+  @media (prefers-reduced-motion: reduce) {
+    .meter,
+    .candle .flame {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/games/stardew/index.ts
+++ b/src/lib/games/stardew/index.ts
@@ -1,0 +1,112 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { stardewStats } from './stats';
+import {
+  MAX_CANDLES,
+  MAX_YEARS,
+  STARDEW_HELP,
+  describeSeason,
+  emptySeason,
+  evaluationScore,
+  groupWon,
+  maxSeasons,
+  priorCategoryTotals,
+  seasonPoints,
+  validateSeason,
+  type StardewSeasonInput,
+} from './logic';
+
+export type { StardewSeasonInput } from './logic';
+
+/**
+ * Stardew Valley: The Board Game — the app's first fully *cooperative* tracker.
+ *
+ * The table plays as one farm against the game: every season you log the
+ * evaluation points the group earned together (bundles restored, Grandpa's
+ * Goals, Legendary Fish, gold prosperity). `scoreRound` hands that season's
+ * points to *every* seat, so all totals move as one shared evaluation score —
+ * the scoreboard reads the same by everyone's name because you're all in it
+ * together. At the end, Grandpa lights candles for the final score; the group
+ * wins by reaching its target candle tier, and `pickWinners` crowns everyone
+ * (or no one) accordingly.
+ */
+export const stardew: GameModule = {
+  id: 'stardew',
+  name: 'Stardew Valley',
+  tagline: 'Restore the farm together. Make Grandpa proud.',
+  emoji: '🌾',
+  keywords: [
+    'stardew',
+    'cooperative',
+    'co-op',
+    'coop',
+    'farming',
+    'grandpa',
+    'community center',
+    'candles',
+    'board game',
+  ],
+  // Cooperative 1–4 player game — the whole table shares one farm.
+  minPlayers: 1,
+  maxPlayers: 4,
+  // Every seat carries the identical total by design, so the shell must not read
+  // that permanent all-tie as "nobody has pulled ahead yet" drama, nor narrate a
+  // shared victory as a tie. See GameModule.coop.
+  coop: true,
+  configFields: [
+    {
+      key: 'years',
+      label: 'Years to farm',
+      type: 'number',
+      default: 1,
+      min: 1,
+      max: MAX_YEARS,
+      help: 'Base game is one year (4 seasons). Add years for a longer harvest.',
+    },
+    {
+      key: 'targetCandles',
+      label: 'Candles to make Grandpa proud',
+      type: 'number',
+      default: MAX_CANDLES,
+      min: 1,
+      max: MAX_CANDLES,
+      help: 'The group wins by lighting at least this many candles (4 is the top result).',
+    },
+  ],
+
+  // Seasons are the rounds: 4 per year.
+  maxRounds: (config) => maxSeasons(config),
+
+  createRoundInput: (): StardewSeasonInput => emptySeason(),
+
+  validateRound: (input: StardewSeasonInput, ctx: RoundContext): string | null =>
+    validateSeason(input, priorCategoryTotals(ctx.rounds, ctx.roundIndex)),
+
+  // Co-op: the season's evaluation points are shared — every seat gets the same
+  // delta, so all totals stay equal and read as the farm's collective score.
+  scoreRound: (input: StardewSeasonInput, ctx: RoundContext): Record<ID, number> => {
+    const pts = seasonPoints(input);
+    const out: Record<ID, number> = {};
+    for (const p of ctx.players) out[p.id] = pts;
+    return out;
+  },
+
+  // Nudge "looks complete" the moment the group secures its target tier — a soft
+  // offer, never a forced finish, so a table can keep farming the calendar out.
+  isFinished: (totals, { config }) => groupWon(evaluationScore(totals), config),
+
+  // Everyone shares the win, or no one does.
+  pickWinners: (totals, config): ID[] => {
+    const ids = Object.keys(totals);
+    return groupWon(evaluationScore(totals), config) ? ids : [];
+  },
+
+  describeRound: (round: Round): string => describeSeason(round),
+
+  help: STARDEW_HELP,
+
+  stats: stardewStats,
+
+  RoundEditor,
+  editorLoader: () => import('./StardewEditor.svelte'),
+};

--- a/src/lib/games/stardew/logic.ts
+++ b/src/lib/games/stardew/logic.ts
@@ -1,0 +1,270 @@
+import type { ID, Round } from '../../types';
+
+/**
+ * Pure, Svelte-free evaluation core for Stardew Valley: The Board Game — a
+ * cooperative farm-restoration game for 1–4 players. Kept separate from
+ * `index.ts` (which carries the module wiring) so `stardew.test.ts` can exercise
+ * the real scoring without a DOM. No I/O, no randomness — just data in, points
+ * and candle tiers out.
+ *
+ * ## Co-op shape
+ * The GameModule contract is player/point oriented, but this game is one shared
+ * story: the whole table restores the Community Center and meets Grandpa's Goals
+ * together, then earns a single **Grandpa's Evaluation** score. So each season's
+ * points are handed to *every* seat equally (see `index.ts scoreRound`), keeping
+ * all totals identical = the farm's shared evaluation score. Winning is the group
+ * reaching a target candle tier — never player-vs-player. The module flags itself
+ * `coop: true` so the shell narrates a shared win instead of a tie, and never
+ * crowns an arbitrary "leader" at a table that is equal by design.
+ */
+
+/** The four in-game seasons, cycled across the year(s). */
+export const SEASONS = [
+  { name: 'Spring', emoji: '🌱' },
+  { name: 'Summer', emoji: '☀️' },
+  { name: 'Fall', emoji: '🍂' },
+  { name: 'Winter', emoji: '❄️' },
+] as const;
+
+export const SEASONS_PER_YEAR = SEASONS.length;
+
+/** Hard ceiling on game length, in in-game years. */
+export const MAX_YEARS = 4;
+
+export type CategoryKey = 'bundles' | 'goals' | 'fish' | 'gold';
+
+/** One season's contribution to Grandpa's Evaluation, per category. */
+export interface StardewSeasonInput {
+  /** Community Center bundles restored this season. */
+  bundles: number;
+  /** Grandpa's Goals met this season. */
+  goals: number;
+  /** Legendary Fish landed this season. */
+  fish: number;
+  /** Gold-prosperity milestones reached this season. */
+  gold: number;
+}
+
+export interface EvalCategory {
+  key: CategoryKey;
+  label: string;
+  emoji: string;
+  /** Most points this category can contribute across the whole game. */
+  cap: number;
+  hint: string;
+}
+
+/**
+ * Grandpa's Evaluation categories. Each unit is worth one evaluation point and
+ * the caps mirror the real game: 6 Community Center bundle rooms, 4 Grandpa's
+ * Goals revealed at setup, 5 Legendary Fish, and up to 3 points of gold
+ * prosperity — a top score of 18.
+ */
+export const EVAL_CATEGORIES: readonly EvalCategory[] = [
+  {
+    key: 'bundles',
+    label: 'Bundles restored',
+    emoji: '🎁',
+    cap: 6,
+    hint: 'Community Center rooms completed',
+  },
+  { key: 'goals', label: "Grandpa's Goals met", emoji: '📜', cap: 4, hint: 'Goal cards fulfilled' },
+  { key: 'fish', label: 'Legendary Fish', emoji: '🐟', cap: 5, hint: 'Legendary catches landed' },
+  {
+    key: 'gold',
+    label: 'Gold prosperity',
+    emoji: '💰',
+    cap: 3,
+    hint: 'Wealth milestones (0–3 pts)',
+  },
+] as const;
+
+/** Highest possible evaluation score (Σ caps). */
+export const MAX_EVALUATION = EVAL_CATEGORIES.reduce((s, c) => s + c.cap, 0);
+
+export const MAX_CANDLES = 4;
+
+/**
+ * Minimum evaluation score that lights each candle tier: ≥1 → 1, ≥6 → 2,
+ * ≥10 → 3, ≥14 → 4. A score of 0 lights none. Indexed by (tier − 1).
+ */
+export const CANDLE_THRESHOLDS = [1, 6, 10, 14] as const;
+
+/** Coerce any stray value to a safe, non-negative whole number of points. */
+export function clean(value: unknown): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/** A fresh, empty season entry. */
+export function emptySeason(): StardewSeasonInput {
+  return { bundles: 0, goals: 0, fish: 0, gold: 0 };
+}
+
+/** Evaluation points earned in a single season (Σ its categories). */
+export function seasonPoints(input: Partial<StardewSeasonInput> | undefined): number {
+  if (!input) return 0;
+  return EVAL_CATEGORIES.reduce((sum, c) => sum + clean(input[c.key]), 0);
+}
+
+/** Candles (0–4) Grandpa lights for a final evaluation score. */
+export function candleTier(score: number): number {
+  const s = Number(score) || 0;
+  let tier = 0;
+  for (let i = 0; i < CANDLE_THRESHOLDS.length; i++) {
+    if (s >= CANDLE_THRESHOLDS[i]) tier = i + 1;
+  }
+  return tier;
+}
+
+/** Lowest score that reaches a given candle tier (1–4); 0 for tier ≤ 0. */
+export function scoreForTier(tier: number): number {
+  const t = Math.max(0, Math.min(MAX_CANDLES, Math.round(tier)));
+  return t <= 0 ? 0 : CANDLE_THRESHOLDS[t - 1];
+}
+
+/** A short, warm word for how proud Grandpa is at each candle tier. */
+export function candleVerdict(tier: number): string {
+  switch (Math.max(0, Math.min(MAX_CANDLES, Math.round(tier)))) {
+    case 4:
+      return 'Grandpa is beaming';
+    case 3:
+      return 'Grandpa is proud';
+    case 2:
+      return 'A fine start';
+    case 1:
+      return "You've made a home";
+    default:
+      return 'The farm needs you';
+  }
+}
+
+/** Config reader: number of in-game years (game length), clamped to 1–4. */
+export function years(config: Record<string, unknown> | undefined): number {
+  const y = Math.round(Number(config?.years));
+  return Number.isFinite(y) ? Math.max(1, Math.min(MAX_YEARS, y)) : 1;
+}
+
+/** Config reader: candle tier the group is aiming for, clamped to 1–4. */
+export function targetCandles(config: Record<string, unknown> | undefined): number {
+  const t = Math.round(Number(config?.targetCandles));
+  return Number.isFinite(t) ? Math.max(1, Math.min(MAX_CANDLES, t)) : MAX_CANDLES;
+}
+
+/** Total seasons in a game = 4 × years. */
+export function maxSeasons(config: Record<string, unknown> | undefined): number {
+  return years(config) * SEASONS_PER_YEAR;
+}
+
+export interface SeasonLabel {
+  name: string;
+  emoji: string;
+  /** 1-based year. */
+  year: number;
+  /** 1-based season-of-year (1–4). */
+  ordinal: number;
+}
+
+/** Human label for the season at a 0-based round index (Spring Y1, Summer Y1, …). */
+export function seasonLabel(roundIndex: number): SeasonLabel {
+  const i = Math.max(0, Math.floor(Number(roundIndex) || 0));
+  const s = SEASONS[i % SEASONS_PER_YEAR];
+  return {
+    name: s.name,
+    emoji: s.emoji,
+    year: Math.floor(i / SEASONS_PER_YEAR) + 1,
+    ordinal: (i % SEASONS_PER_YEAR) + 1,
+  };
+}
+
+export type CategoryTotals = Record<CategoryKey, number>;
+
+/** Sum each category across the seasons recorded *before* `beforeIndex`. */
+export function priorCategoryTotals(
+  rounds: readonly Round[] | undefined,
+  beforeIndex: number,
+): CategoryTotals {
+  const totals: CategoryTotals = { bundles: 0, goals: 0, fish: 0, gold: 0 };
+  for (const r of rounds ?? []) {
+    if (r.index >= beforeIndex) continue;
+    const input = r.input as Partial<StardewSeasonInput> | undefined;
+    for (const c of EVAL_CATEGORIES) totals[c.key] += clean(input?.[c.key]);
+  }
+  return totals;
+}
+
+/** Points a category can still earn given what's already been logged. */
+export function remainingCap(key: CategoryKey, prior: CategoryTotals): number {
+  const cap = EVAL_CATEGORIES.find((c) => c.key === key)?.cap ?? 0;
+  return Math.max(0, cap - (prior[key] ?? 0));
+}
+
+/**
+ * Validate one season's entry against the running category totals. Returns a
+ * human-readable message, or null when the entry is legal. Guards non-negative
+ * whole numbers and the per-category caps (you can't restore a 7th bundle).
+ */
+export function validateSeason(
+  input: Partial<StardewSeasonInput> | undefined,
+  prior: CategoryTotals,
+): string | null {
+  for (const c of EVAL_CATEGORIES) {
+    const raw = Number(input?.[c.key]);
+    if (!Number.isFinite(raw) || raw < 0 || !Number.isInteger(raw)) {
+      return `${c.emoji} ${c.label}: enter a whole number of points (0 or more).`;
+    }
+    const after = (prior[c.key] ?? 0) + raw;
+    if (after > c.cap) {
+      const left = remainingCap(c.key, prior);
+      return `${c.emoji} ${c.label} tops out at ${c.cap} — only ${left} left to log.`;
+    }
+  }
+  return null;
+}
+
+/**
+ * The shared group evaluation score from per-player totals. Every seat carries
+ * the same running total in this co-op game, so any of them is the group score;
+ * `max` is used defensively against an empty or ragged map.
+ */
+export function evaluationScore(totals: Record<ID, number> | undefined): number {
+  const vals = Object.values(totals ?? {});
+  return vals.length ? Math.max(...vals) : 0;
+}
+
+/** Did the group light at least the target number of candles? */
+export function groupWon(score: number, config: Record<string, unknown> | undefined): boolean {
+  return candleTier(score) >= targetCandles(config);
+}
+
+/** One-line summary of a recorded season for the history table. */
+export function describeSeason(round: Round): string {
+  const input = round.input as Partial<StardewSeasonInput> | undefined;
+  const { emoji, name, year } = seasonLabel(round.index);
+  const parts = EVAL_CATEGORIES.map((c) => {
+    const v = clean(input?.[c.key]);
+    return v ? `${c.emoji}${v}` : '';
+  }).filter(Boolean);
+  const pts = seasonPoints(input);
+  const detail = parts.length ? parts.join(' ') : 'a quiet season';
+  return `${emoji} ${name} Y${year} · ${detail} · +${pts} for the farm`;
+}
+
+export const STARDEW_HELP = [
+  '🌾 A cozy co-op: the whole table shares one farm and plays against the game.',
+  'Work together over the seasons to restore the Community Center and meet',
+  "Grandpa's Goals, then earn Grandpa's Evaluation.",
+  '',
+  'Each season, log the evaluation points the group earned together — every',
+  'point counts once for the whole farm, not per player:',
+  '• 🎁 Bundles restored — up to 6 (one per Community Center room)',
+  "• 📜 Grandpa's Goals met — up to 4",
+  '• 🐟 Legendary Fish landed — up to 5',
+  '• 💰 Gold prosperity — up to 3 (wealth & friendships flourishing)',
+  '',
+  `Add it all up for the final evaluation (top score ${MAX_EVALUATION}). Grandpa lights candles:`,
+  '• 1–5 → 🕯️ · 6–9 → 🕯️🕯️ · 10–13 → 🕯️🕯️🕯️ · 14+ → 🕯️🕯️🕯️🕯️',
+  '',
+  'Reach your target candles and the whole table wins together — every seat',
+  'shows the same score on purpose. 4 candles means Grandpa is beaming.',
+].join('\n');

--- a/src/lib/games/stardew/stardew.test.ts
+++ b/src/lib/games/stardew/stardew.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round, RoundContext } from '../../types';
+import {
+  CANDLE_THRESHOLDS,
+  EVAL_CATEGORIES,
+  MAX_CANDLES,
+  MAX_EVALUATION,
+  MAX_YEARS,
+  SEASONS_PER_YEAR,
+  STARDEW_HELP,
+  candleTier,
+  candleVerdict,
+  clean,
+  describeSeason,
+  emptySeason,
+  evaluationScore,
+  groupWon,
+  maxSeasons,
+  priorCategoryTotals,
+  remainingCap,
+  scoreForTier,
+  seasonLabel,
+  seasonPoints,
+  targetCandles,
+  validateSeason,
+  years,
+  type CategoryTotals,
+  type StardewSeasonInput,
+} from './logic';
+import { stardew } from './index';
+import { MODULES, getModule } from '../registry';
+
+function player(id: string, name = id): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+const players = [player('a', 'Ada'), player('b', 'Bo'), player('c', 'Cy')];
+
+function ctxWith(
+  ps: Player[],
+  opts: {
+    config?: Record<string, unknown>;
+    roundIndex?: number;
+    rounds?: Round[];
+    totals?: Record<ID, number>;
+  } = {},
+): RoundContext {
+  const config = opts.config ?? {};
+  const game: Game = {
+    id: 'g',
+    type: 'stardew',
+    config,
+    playerIds: ps.map((p) => p.id),
+    status: 'active',
+    createdAt: 0,
+    roundCount: 0,
+  };
+  return {
+    game,
+    players: ps,
+    config,
+    roundIndex: opts.roundIndex ?? 0,
+    totals: opts.totals ?? Object.fromEntries(ps.map((p) => [p.id, 0])),
+    rounds: opts.rounds ?? [],
+  };
+}
+
+function season(overrides: Partial<StardewSeasonInput> = {}): StardewSeasonInput {
+  return { ...emptySeason(), ...overrides };
+}
+
+function round(index: number, input: Partial<StardewSeasonInput>): Round {
+  return { id: `r${index}`, gameId: 'g', index, input, deltas: {}, createdAt: 0 };
+}
+
+const noPrior: CategoryTotals = { bundles: 0, goals: 0, fish: 0, gold: 0 };
+
+describe('Stardew evaluation categories', () => {
+  it('has the four evaluation categories with unique keys and a top score of 18', () => {
+    expect(EVAL_CATEGORIES).toHaveLength(4);
+    const keys = EVAL_CATEGORIES.map((c) => c.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).toEqual(['bundles', 'goals', 'fish', 'gold']);
+    expect(EVAL_CATEGORIES.map((c) => c.cap)).toEqual([6, 4, 5, 3]);
+    expect(MAX_EVALUATION).toBe(18);
+  });
+
+  it('starts a season empty', () => {
+    expect(emptySeason()).toEqual({ bundles: 0, goals: 0, fish: 0, gold: 0 });
+  });
+});
+
+describe('season scoring', () => {
+  it('sums a season across its categories', () => {
+    expect(seasonPoints(season({ bundles: 2, goals: 1, fish: 1, gold: 1 }))).toBe(5);
+  });
+
+  it('is zero for an empty or missing season', () => {
+    expect(seasonPoints(emptySeason())).toBe(0);
+    expect(seasonPoints(undefined)).toBe(0);
+  });
+
+  it('coerces junk to a safe, non-negative whole number', () => {
+    expect(clean('3')).toBe(3);
+    expect(clean(2.9)).toBe(2);
+    expect(clean(-4)).toBe(0);
+    expect(clean(NaN)).toBe(0);
+    expect(clean(undefined)).toBe(0);
+    expect(seasonPoints({ bundles: -3, goals: 2.7, fish: NaN, gold: 1 })).toBe(3);
+  });
+
+  it('labels seasons as Spring→Winter, rolling into the next year', () => {
+    expect(seasonLabel(0)).toMatchObject({ name: 'Spring', year: 1, ordinal: 1 });
+    expect(seasonLabel(3)).toMatchObject({ name: 'Winter', year: 1, ordinal: 4 });
+    expect(seasonLabel(4)).toMatchObject({ name: 'Spring', year: 2, ordinal: 1 });
+    expect(seasonLabel(9)).toMatchObject({ name: 'Summer', year: 3, ordinal: 2 });
+  });
+
+  it('runs four seasons per configured year, clamped to 1–4 years', () => {
+    expect(maxSeasons({ years: 1 })).toBe(SEASONS_PER_YEAR);
+    expect(maxSeasons({ years: 3 })).toBe(12);
+    expect(maxSeasons({})).toBe(4);
+    expect(years({ years: 99 })).toBe(MAX_YEARS);
+    expect(years({ years: 0 })).toBe(1);
+    expect(years(undefined)).toBe(1);
+  });
+
+  it('sums prior seasons per category, ignoring the round being edited and later ones', () => {
+    const rounds = [
+      round(0, { bundles: 2, fish: 1 }),
+      round(1, { bundles: 1, goals: 2 }),
+      round(2, { gold: 3 }),
+    ];
+    expect(priorCategoryTotals(rounds, 2)).toEqual({ bundles: 3, goals: 2, fish: 1, gold: 0 });
+    expect(priorCategoryTotals(rounds, 0)).toEqual(noPrior);
+    expect(priorCategoryTotals(undefined, 4)).toEqual(noPrior);
+  });
+});
+
+describe('candle tiers', () => {
+  it('lights no candle at zero', () => {
+    expect(candleTier(0)).toBe(0);
+    expect(candleTier(-5)).toBe(0);
+  });
+
+  it('maps 1–5 → 1, 6–9 → 2, 10–13 → 3, 14+ → 4', () => {
+    for (const s of [1, 2, 3, 4, 5]) expect(candleTier(s)).toBe(1);
+    for (const s of [6, 7, 8, 9]) expect(candleTier(s)).toBe(2);
+    for (const s of [10, 11, 12, 13]) expect(candleTier(s)).toBe(3);
+    for (const s of [14, 17, MAX_EVALUATION, 99]) expect(candleTier(s)).toBe(4);
+  });
+
+  it('lights exactly one more candle at each threshold boundary', () => {
+    CANDLE_THRESHOLDS.forEach((threshold, i) => {
+      expect(candleTier(threshold)).toBe(i + 1);
+      expect(candleTier(threshold - 1)).toBe(i);
+    });
+  });
+
+  it('reports the lowest score that reaches each tier', () => {
+    expect(scoreForTier(0)).toBe(0);
+    expect(scoreForTier(1)).toBe(1);
+    expect(scoreForTier(2)).toBe(6);
+    expect(scoreForTier(3)).toBe(10);
+    expect(scoreForTier(4)).toBe(14);
+    // Clamped rather than throwing on out-of-range input.
+    expect(scoreForTier(-2)).toBe(0);
+    expect(scoreForTier(9)).toBe(14);
+  });
+
+  it('gives a warm verdict for every tier', () => {
+    const said = [0, 1, 2, 3, 4].map(candleVerdict);
+    expect(new Set(said).size).toBe(5);
+    expect(said[0]).toMatch(/needs you/i);
+    expect(said[4]).toMatch(/beaming/i);
+  });
+});
+
+describe('validation', () => {
+  it('accepts a legal season', () => {
+    expect(validateSeason(season({ bundles: 2, goals: 1 }), noPrior)).toBeNull();
+  });
+
+  it('rejects fractional and negative entries', () => {
+    expect(validateSeason({ ...emptySeason(), bundles: 1.5 }, noPrior)).toMatch(/whole number/i);
+    expect(validateSeason({ ...emptySeason(), goals: -1 }, noPrior)).toMatch(/whole number/i);
+  });
+
+  it('rejects a category pushed past its lifetime cap, naming what is left', () => {
+    const prior: CategoryTotals = { bundles: 5, goals: 0, fish: 0, gold: 0 };
+    const msg = validateSeason(season({ bundles: 2 }), prior);
+    expect(msg).toMatch(/tops out at 6/);
+    expect(msg).toMatch(/only 1 left/);
+    // Exactly reaching the cap is legal.
+    expect(validateSeason(season({ bundles: 1 }), prior)).toBeNull();
+  });
+
+  it('reports the remaining headroom per category', () => {
+    expect(remainingCap('fish', { ...noPrior, fish: 2 })).toBe(3);
+    expect(remainingCap('gold', { ...noPrior, gold: 9 })).toBe(0);
+  });
+
+  it('validates through the module against the rounds already recorded', () => {
+    const rounds = [round(0, { bundles: 4 }), round(1, { bundles: 2 })];
+    const ctx = ctxWith(players, { rounds, roundIndex: 2 });
+    expect(stardew.validateRound(season({ bundles: 1 }), ctx)).toMatch(/tops out at 6/);
+    expect(stardew.validateRound(season({ goals: 1 }), ctx)).toBeNull();
+  });
+});
+
+describe('cooperative scoring — one farm, one score', () => {
+  it('hands the identical season delta to every seat', () => {
+    const ctx = ctxWith(players);
+    const deltas = stardew.scoreRound(season({ bundles: 2, fish: 1 }), ctx);
+    expect(deltas).toEqual({ a: 3, b: 3, c: 3 });
+  });
+
+  it('keeps a solo farm working', () => {
+    const ctx = ctxWith([player('solo')]);
+    expect(stardew.scoreRound(season({ gold: 2 }), ctx)).toEqual({ solo: 2 });
+  });
+
+  it('gives every seat zero for a quiet season rather than skipping them', () => {
+    const ctx = ctxWith(players);
+    expect(stardew.scoreRound(emptySeason(), ctx)).toEqual({ a: 0, b: 0, c: 0 });
+  });
+
+  it('reads the shared evaluation score off the (identical) totals', () => {
+    expect(evaluationScore({ a: 11, b: 11, c: 11 })).toBe(11);
+    expect(evaluationScore({})).toBe(0);
+    expect(evaluationScore(undefined)).toBe(0);
+  });
+
+  it('declares itself cooperative so the shell narrates a shared outcome', () => {
+    expect(stardew.coop).toBe(true);
+  });
+});
+
+describe('shared win and shared loss', () => {
+  const target = (t: number) => ({ targetCandles: t });
+
+  it('crowns every seat when the group reaches its target tier', () => {
+    const totals = { a: 14, b: 14, c: 14 };
+    expect(groupWon(14, target(4))).toBe(true);
+    expect(stardew.pickWinners!(totals, target(4))).toEqual(['a', 'b', 'c']);
+  });
+
+  it('crowns nobody when the group falls short — never an arbitrary leader', () => {
+    const totals = { a: 13, b: 13, c: 13 };
+    expect(groupWon(13, target(4))).toBe(false);
+    expect(stardew.pickWinners!(totals, target(4))).toEqual([]);
+  });
+
+  it('overshooting the target still wins', () => {
+    expect(stardew.pickWinners!({ a: 18, b: 18 }, target(2))).toEqual(['a', 'b']);
+  });
+
+  it('honours a lowered target, so 2 candles can be a win', () => {
+    const totals = { a: 6, b: 6 };
+    expect(stardew.pickWinners!(totals, target(2))).toEqual(['a', 'b']);
+    expect(stardew.pickWinners!(totals, target(3))).toEqual([]);
+  });
+
+  it('a scoreless farm never wins, even at the gentlest target', () => {
+    expect(stardew.pickWinners!({ a: 0, b: 0 }, target(1))).toEqual([]);
+  });
+
+  it('clamps a nonsense target into 1–4 rather than making the game unwinnable', () => {
+    expect(targetCandles({ targetCandles: 99 })).toBe(MAX_CANDLES);
+    expect(targetCandles({ targetCandles: 0 })).toBe(1);
+    expect(targetCandles(undefined)).toBe(MAX_CANDLES);
+    expect(stardew.pickWinners!({ a: 18 }, { targetCandles: 99 })).toEqual(['a']);
+  });
+
+  it('offers "looks complete" only once the target is secured', () => {
+    const info = (config: Record<string, unknown>) => ({
+      config,
+      roundCount: 2,
+      playerCount: 3,
+    });
+    expect(stardew.isFinished!({ a: 9, b: 9, c: 9 }, info(target(3)))).toBe(false);
+    expect(stardew.isFinished!({ a: 10, b: 10, c: 10 }, info(target(3)))).toBe(true);
+  });
+});
+
+describe('module wiring', () => {
+  it('is actually discovered by the auto-discovery registry', () => {
+    // registry.ts duck-types discovered modules and requires `editorLoader` to be a
+    // function; a module that misses it is silently dropped with a green build. So
+    // assert real discovery, not just a well-formed export.
+    expect(MODULES.map((m) => m.id)).toContain('stardew');
+    expect(getModule('stardew')).toBe(stardew);
+  });
+
+  it('is a cooperative 1–4 player game with a lazily loaded editor', () => {
+    expect(stardew.id).toBe('stardew');
+    expect(stardew.minPlayers).toBe(1);
+    expect(stardew.maxPlayers).toBe(4);
+    expect(typeof stardew.editorLoader).toBe('function');
+    expect(stardew.RoundEditor).toBeTruthy();
+    expect(stardew.lowerIsBetter).toBeFalsy();
+  });
+
+  it('runs 4 seasons per configured year', () => {
+    expect(stardew.maxRounds!({ years: 2 }, 3)).toBe(8);
+  });
+
+  it('starts every season from a clean sheet', () => {
+    expect(stardew.createRoundInput(ctxWith(players))).toEqual(emptySeason());
+  });
+
+  it('offers year and candle-target config within legal bounds', () => {
+    const byKey = Object.fromEntries((stardew.configFields ?? []).map((f) => [f.key, f]));
+    expect(byKey.years).toMatchObject({ type: 'number', default: 1, min: 1, max: MAX_YEARS });
+    expect(byKey.targetCandles).toMatchObject({ type: 'number', default: 4, min: 1, max: 4 });
+  });
+
+  it('describes a season with its label, categories and shared points', () => {
+    const text = describeSeason(round(4, { bundles: 1, fish: 2 }));
+    expect(text).toContain('Spring');
+    expect(text).toContain('Y2');
+    expect(text).toContain('🎁1');
+    expect(text).toContain('🐟2');
+    expect(text).toContain('+3');
+  });
+
+  it('describes an empty season without pretending points were scored', () => {
+    const text = describeSeason(round(1, {}));
+    expect(text).toContain('quiet season');
+    expect(text).toContain('+0');
+  });
+
+  it('explains the co-op shape and the candle ladder in its help', () => {
+    expect(stardew.help).toBe(STARDEW_HELP);
+    expect(STARDEW_HELP).toMatch(/co-op/i);
+    expect(STARDEW_HELP).toMatch(/whole table wins together/i);
+    expect(STARDEW_HELP).toContain('14+');
+  });
+});
+
+describe('stats', () => {
+  const game = (id: string): Game => ({
+    id,
+    type: 'stardew',
+    config: {},
+    playerIds: ['a', 'b'],
+    status: 'finished',
+    createdAt: 0,
+    roundCount: 0,
+  });
+  const statRound = (gameId: string, index: number, input: Partial<StardewSeasonInput>): Round => ({
+    ...round(index, input),
+    id: `${gameId}-${index}`,
+    gameId,
+  });
+
+  function run(games: Game[], rounds: Round[]) {
+    return stardew.stats!({
+      games,
+      rounds,
+      players: players.slice(0, 2),
+      canonical: (id: ID) => id,
+    });
+  }
+
+  it('rolls each farm up into one shared evaluation, never a per-player split', () => {
+    const result = run(
+      [game('g1'), game('g2')],
+      [
+        statRound('g1', 0, { bundles: 6, goals: 4 }),
+        statRound('g1', 1, { fish: 5, gold: 3 }),
+        statRound('g2', 0, { bundles: 2 }),
+      ],
+    );
+    expect(result.perPlayer).toBeUndefined();
+    const byKey = Object.fromEntries((result.global ?? []).map((m) => [m.key, m]));
+    expect(byKey.sv_best.value).toBe('18');
+    expect(byKey.sv_best.sub).toContain('🕯️🕯️🕯️🕯️');
+    expect(byKey.sv_perfect.value).toBe('1');
+    expect(byKey.sv_seasons.value).toBe('3');
+    expect(byKey.sv_bundles.value).toBe('8');
+    expect(byKey.sv_goals.value).toBe('4');
+    expect(byKey.sv_fish.value).toBe('5');
+  });
+
+  it('ignores rounds belonging to other games', () => {
+    const result = run([game('g1')], [statRound('other', 0, { bundles: 6 })]);
+    expect(result.global ?? []).toEqual([]);
+  });
+
+  it('produces nothing from no games', () => {
+    expect(run([], []).global ?? []).toEqual([]);
+  });
+});

--- a/src/lib/games/stardew/stats.ts
+++ b/src/lib/games/stardew/stats.ts
@@ -1,0 +1,90 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt } from '../../stats/format';
+import {
+  EVAL_CATEGORIES,
+  MAX_CANDLES,
+  candleTier,
+  candleVerdict,
+  clean,
+  seasonPoints,
+  type CategoryKey,
+  type StardewSeasonInput,
+} from './logic';
+
+/**
+ * Stardew stats are **cooperative**, so they read as one shared farm rather than
+ * a per-player leaderboard: each game's seasons are summed into a single
+ * Grandpa's Evaluation score, and the group's proudest results roll up into
+ * global metrics. Deliberately contributes no `perPlayer` metrics — every seat
+ * holds the identical total by design, so a per-player split would invent a
+ * distinction the game does not have. Pure — mirrors the module's own
+ * `seasonPoints`, no Svelte.
+ */
+export function stardewStats({ games, rounds }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const scoreByGame = new Map<ID, number>();
+  const totals: Record<CategoryKey, number> = { bundles: 0, goals: 0, fish: 0, gold: 0 };
+  let seasons = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as Partial<StardewSeasonInput> | undefined;
+    scoreByGame.set(r.gameId, (scoreByGame.get(r.gameId) ?? 0) + seasonPoints(input));
+    for (const c of EVAL_CATEGORIES) totals[c.key] += clean(input?.[c.key]);
+    seasons += 1;
+  }
+
+  const global: Metric[] = [];
+  const scores = [...scoreByGame.values()];
+  if (scores.length) {
+    const best = Math.max(...scores);
+    const tier = candleTier(best);
+    global.push({
+      key: 'sv_best',
+      label: 'Best evaluation',
+      value: fmtInt(best),
+      sub: `${'🕯️'.repeat(tier) || '—'} ${candleVerdict(tier)}`,
+      emoji: '🕯️',
+    });
+    const perfect = scores.filter((s) => candleTier(s) >= MAX_CANDLES).length;
+    if (perfect) {
+      global.push({
+        key: 'sv_perfect',
+        label: 'Farms Grandpa beamed at',
+        value: fmtInt(perfect),
+        emoji: '🌟',
+      });
+    }
+  }
+  if (seasons)
+    global.push({
+      key: 'sv_seasons',
+      label: 'Seasons farmed',
+      value: fmtInt(seasons),
+      emoji: '🍂',
+    });
+  if (totals.bundles)
+    global.push({
+      key: 'sv_bundles',
+      label: 'Bundles restored',
+      value: fmtInt(totals.bundles),
+      emoji: '🎁',
+    });
+  if (totals.goals)
+    global.push({
+      key: 'sv_goals',
+      label: "Grandpa's Goals met",
+      value: fmtInt(totals.goals),
+      emoji: '📜',
+    });
+  if (totals.fish)
+    global.push({
+      key: 'sv_fish',
+      label: 'Legendary Fish',
+      value: fmtInt(totals.fish),
+      emoji: '🐟',
+    });
+
+  return { global };
+}

--- a/src/lib/share/card.ts
+++ b/src/lib/share/card.ts
@@ -96,10 +96,13 @@ export async function renderRecapCard(view: RecapView): Promise<Blob> {
   // Winner hero.
   const byId = new Map(view.players.map((p) => [p.id, p]));
   const winnerNames = view.winners.map((id) => byId.get(id)?.name ?? '?').join(' & ');
-  const heroText = winnerNames
-    ? `🏆 ${winnerNames} ${view.winners.length > 1 ? 'tie!' : 'wins!'}`
-    : '🏁 Final standings';
-  ctx.fillStyle = winnerNames ? C.accentInk : C.text;
+  const won = view.winners.length > 0;
+  const heroText = !won
+    ? '🏁 Final standings'
+    : view.coop
+      ? '🏆 Won together!'
+      : `🏆 ${winnerNames} ${view.winners.length > 1 ? 'tie!' : 'wins!'}`;
+  ctx.fillStyle = won ? C.accentInk : C.text;
   ctx.font = `700 56px ${FONT}`;
   fillCentered(ctx, heroText, W / 2, y + 44, W - PAD * 2);
   y += 96 + 28;

--- a/src/lib/share/recap.test.ts
+++ b/src/lib/share/recap.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, Player } from '../types';
+import { buildRecapPayload, recapText, recapView } from './recap';
+
+/**
+ * Guards the co-op contract at the *share* boundary: a recap must report the exact
+ * recorded outcome. An empty winner list is a real result (the group lost to the
+ * game), not a missing one, so it must never be back-filled with the rank-1
+ * finishers — which, at a table that is equal by design, would crown everybody.
+ */
+function player(id: string, name: string): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+const players = [player('a', 'Ada'), player('b', 'Bo')];
+
+function finished(winnerIds: string[], type = 'stardew'): Game {
+  return {
+    id: 'g',
+    type,
+    config: {},
+    playerIds: players.map((p) => p.id),
+    status: 'finished',
+    createdAt: 0,
+    finishedAt: 1_700_000_000_000,
+    winnerIds,
+    roundCount: 1,
+  };
+}
+
+const rounds = [{ index: 0, deltas: { a: 11, b: 11 } }];
+
+describe('recap of a cooperative game', () => {
+  it('marks the view as co-op from the module', () => {
+    const view = recapView(buildRecapPayload(finished(['a', 'b']), players, rounds));
+    expect(view.coop).toBe(true);
+    expect(view.winners).toEqual(['0', '1']);
+  });
+
+  it('narrates a shared win as won together, never as a tie', () => {
+    const view = recapView(buildRecapPayload(finished(['a', 'b']), players, rounds));
+    const text = recapText(view, 'https://example.test/recap');
+    expect(text).toContain('won together');
+    expect(text).not.toContain('tie!');
+  });
+
+  it('keeps a shared loss winner-less instead of crowning the tied table', () => {
+    const view = recapView(buildRecapPayload(finished([]), players, rounds));
+    expect(view.winners).toEqual([]);
+    const text = recapText(view, 'https://example.test/recap');
+    expect(text).not.toContain('🏆');
+  });
+
+  it('still says "tie!" for a genuinely competitive all-tie', () => {
+    const view = recapView(buildRecapPayload(finished(['a', 'b'], 'tally'), players, rounds));
+    expect(view.coop).toBe(false);
+    expect(recapText(view, 'https://example.test/recap')).toContain('tie!');
+  });
+});

--- a/src/lib/share/recap.ts
+++ b/src/lib/share/recap.ts
@@ -144,6 +144,12 @@ export interface RecapView {
   players: { id: string; name: string; color: string }[];
   totals: Record<string, number>;
   winners: string[];
+  /**
+   * The shared game was cooperative — every seat carries the same total and the
+   * outcome is collective, so the recap says "you all win together" instead of
+   * reading an equal table as a tie. False when the module is unknown locally.
+   */
+  coop: boolean;
   lowerIsBetter: boolean;
   standings: Standing[];
   /** Round-by-round per-player deltas, aligned to {@link players} order. */
@@ -152,8 +158,12 @@ export interface RecapView {
 
 /**
  * Expand a payload into a ready-to-render view: synthesized players (positional ids),
- * derived totals + standings, resolved win direction, and winner ids. Falls back to the
- * rank-1 finishers when a payload carries no explicit winners.
+ * derived totals + standings, resolved win direction, and winner ids.
+ *
+ * A payload's `w` is the *exact recorded outcome*, so an empty list means "nobody
+ * won" — a real result for a cooperative game the table lost — and is preserved as
+ * such. Only a malformed payload missing `w` altogether falls back to the rank-1
+ * finishers.
  */
 export function recapView(payload: RecapPayload): RecapView {
   const module = getModule(payload.t);
@@ -168,9 +178,8 @@ export function recapView(payload: RecapPayload): RecapView {
   }
   const lowerIsBetter = module ? resolveLower(module, payload.cfg ?? {}) : false;
   const ranked = standings(totals, lowerIsBetter);
-  const explicit = payload.w.map((i) => String(i)).filter((id) => id in totals);
-  const winners = explicit.length
-    ? explicit
+  const winners = payload.w
+    ? payload.w.map((i) => String(i)).filter((id) => id in totals)
     : ranked.filter((s) => s.rank === 1).map((s) => s.playerId);
   return {
     type: payload.t,
@@ -181,6 +190,7 @@ export function recapView(payload: RecapPayload): RecapView {
     players,
     totals,
     winners,
+    coop: !!module?.coop,
     lowerIsBetter,
     standings: ranked,
     rounds: payload.r,
@@ -202,9 +212,11 @@ export function recapText(view: RecapView, url: string): string {
   });
   const winnerNames = view.winners.map((id) => byId.get(id)?.name ?? '?').join(' & ');
   const header = `${view.emoji} ${view.title} — ${date}`;
-  const crownLine = winnerNames
-    ? `🏆 ${winnerNames} ${view.winners.length > 1 ? 'tie!' : 'wins!'}`
-    : '';
+  const crownLine = !view.winners.length
+    ? ''
+    : view.coop
+      ? '🏆 The whole table won together!'
+      : `🏆 ${winnerNames} ${view.winners.length > 1 ? 'tie!' : 'wins!'}`;
   return [header, crownLine, '', ...lines, '', `Scored with Score King 👑 ${url}`]
     .filter((l) => l !== null)
     .join('\n');

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -186,6 +186,15 @@ export interface GameModule {
   resolveLowerIsBetter?(config: Record<string, unknown>): boolean;
   /** Whether this game uses fixed teams/partnerships. */
   teams?: boolean;
+  /**
+   * True when the whole table plays as one side against the game, so every seat
+   * carries the *same* total by design and the outcome is shared: everybody wins
+   * or nobody does. The shell uses this to narrate a shared victory ("you all win
+   * together") rather than a tie, and to keep the permanent all-seats equality
+   * from reading as a competitive deadlock. It never changes scoring — a co-op
+   * module still hands each player their delta through {@link scoreRound}.
+   */
+  coop?: boolean;
   configFields?: ConfigField[];
 
   /** Build a fresh, editable input object for the next round. */

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -300,11 +300,21 @@
     const names = (game?.winnerIds ?? [])
       .map((wid) => plist.find((p) => p.id === wid)?.name ?? '?')
       .join(' and ');
-    if (names) {
-      haptic('win');
+    const count = game?.winnerIds?.length ?? 0;
+    if (module?.coop) {
+      // A co-op table shares one outcome: everybody won, or the game beat you.
+      // Never announce a "tie" — nobody was playing against anybody.
+      haptic(count ? 'win' : 'tick');
       announce(
-        `Game finished. ${names} ${(game?.winnerIds?.length ?? 0) > 1 ? 'tie for the win' : 'wins'}.`,
+        count
+          ? 'Game finished. You all win together.'
+          : 'Game finished. The farm holds — no win this time.',
       );
+    } else if (names) {
+      haptic('win');
+      announce(`Game finished. ${names} ${count > 1 ? 'tie for the win' : 'wins'}.`);
+    } else {
+      announce('Game finished. No winner recorded.');
     }
   }
   async function doReopen() {
@@ -553,12 +563,25 @@
   />
 
   {#if game.status === 'finished'}
-    <div class="card center banner winner-banner">
-      <WinnerCelebration />
-      <span class="banner-text"
-        >🏆 {winnerNames || 'Nobody'} {(game.winnerIds?.length ?? 0) > 1 ? 'tie!' : 'wins!'}</span
-      >
-    </div>
+    {#if (game.winnerIds?.length ?? 0) === 0}
+      <!-- Finished with no winner: a co-op table the game beat, or any module that
+           records "nobody won". No confetti and no 🏆 — the result is real either
+           way, but celebrating a loss reads as a bug. -->
+      <div class="card center banner">
+        {module?.coop ? '🌙 The game held this time — no win recorded.' : '🤝 No winner recorded.'}
+      </div>
+    {:else}
+      <div class="card center banner winner-banner">
+        <WinnerCelebration />
+        <span class="banner-text">
+          {#if module?.coop}
+            🏆 You all win together!
+          {:else}
+            🏆 {winnerNames || 'Nobody'} {(game.winnerIds?.length ?? 0) > 1 ? 'tie!' : 'wins!'}
+          {/if}
+        </span>
+      </div>
+    {/if}
     <button class="btn block" style="margin-top: 12px" onclick={() => (shareOpen = true)}>
       📤 Share results
     </button>

--- a/src/pages/Recap.svelte
+++ b/src/pages/Recap.svelte
@@ -79,10 +79,14 @@
     </span>
   </div>
 
-  {#if winnerNames}
+  {#if view.winners.length}
     <div class="card center banner">
-      🏆 {winnerNames}
-      {view.winners.length > 1 ? 'tie!' : 'wins!'}
+      {#if view.coop}
+        🏆 The whole table won together!
+      {:else}
+        🏆 {winnerNames}
+        {view.winners.length > 1 ? 'tie!' : 'wins!'}
+      {/if}
     </div>
   {/if}
 


### PR DESCRIPTION
## Summary

Recovers the Stardew Valley: The Board Game tracker (written 2026-07-07, never committed) and lands it on the **current** `GameModule` contract. It is the app's first fully cooperative game: the whole table shares one farm, seasons are rounds, and the group wins or loses together.

## Changes

**New module — `src/lib/games/stardew/`**

- `logic.ts` — pure, Svelte-free core: four evaluation categories (🎁 bundles ×6, 📜 Grandpa's Goals ×4, 🐟 Legendary Fish ×5, 💰 gold ×3 → top score 18), candle tiers (1–5 → 🕯️, 6–9 → 🕯️🕯️, 10–13 → 🕯️🕯️🕯️, 14+ → 🕯️🕯️🕯️🕯️), season labels, per-category lifetime caps and validation.
- `index.ts` — `scoreRound` hands the season's points to **every** seat so all totals move as one; `pickWinners` crowns everyone or no one on the target candle tier; `isFinished` is a soft "looks complete" nudge once the target is secured.
- `StardewEditor.svelte` — shared evaluation meter, candle ladder, per-category steppers.
- `stats.ts` — deliberately global-only (no `perPlayer`): every seat holds the identical total, so a per-player split would invent a distinction the game doesn't have.
- `stardew.test.ts` — 41 tests covering season scoring, every candle-tier boundary, validation caps, shared-win/shared-loss paths, and **live registry discovery**.

**Contract drift fixed (the silent one).** The salvaged `index.ts` statically imported its editor. The current contract needs the shared `LazyEditor` host plus an `editorLoader`, and `registry.ts` duck-types on `typeof m.editorLoader === 'function'` — so the old shape would have been *silently dropped from auto-discovery* with a green build. `stardew.test.ts` now asserts `MODULES` contains `stardew` and `getModule('stardew') === stardew` rather than trusting the build. No registry edit was needed (confirmed: `import.meta.glob('./*/index.ts')`).

**Co-op handling in the shell.** A permanent all-seats tie is new here, so `GameModule` gains an opt-in `coop?: boolean` (scoring is untouched) and the outcome surfaces stop mis-narrating it:

- `leaders()` already returns empty on an all-tie, so no 👑 and no gold number is ever awarded to an arbitrary "leader" — verified, no change needed.
- Finished with **no winner** (a co-op table the game beat) no longer renders 🏆 + confetti + "Nobody wins!". It gets a calm, honest banner in both `GamePlay` and the guest `ReplicaBoard`, and an accurate screen-reader announcement.
- A **shared win** reads "🏆 You all win together!" instead of "Ada & Bo & Cy tie!" — nobody was playing against anybody. Competitive all-ties still say "tie!".
- `recapView` was back-filling winners with the rank-1 finishers whenever the payload's winner list was empty. At a table that is equal by design that crowned *everyone* on a loss. `w` is validated as present at v1, so an empty list is now honoured as the real recorded outcome; only a malformed payload missing `w` falls back. Covered by a new `recap.test.ts`. Same fix flows through the share sheet and the share card.

**Design review.** The salvaged editor used Crown Gold for the meter and every lit candle — a Crown Gold Rule violation, since gold belongs to the leader and winner alone. Progress is now Win Green (it means "going well", not "winning"); gold appears only once the group has actually secured its target tier, which is exactly the winner moment. Every colour cue is co-signalled (lit/unlit candles differ in scale *and* saturation so the split survives greyscale; the target candle carries a non-colour inset marker; a maxed category shows a ✓ and screen-reader text). Tabular numerals throughout, steppers carry the 46px targets, and both transitions are dropped under `prefers-reduced-motion` while the state change still lands.

The `design-system-font-size` hook flagged literal sizes in the editor; those exact values are the established ramp in all 26 shipped editors, so they were left to match siblings rather than forking the type scale in one new game. The other flagged lines are pre-existing and untouched.

## Issues

Closes #140

## Testing

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm test` — 51 files, 1348 tests passing (45 new)
- [x] `npm run build`
- [x] `npm run lint` + `prettier --write` on changed files