### PR TITLE
feat(cribbage): add Cribbage game module (#141)

### DIFF
--- a/src/lib/games/cribbage/CountAssist.svelte
+++ b/src/lib/games/cribbage/CountAssist.svelte
@@ -1,0 +1,339 @@
+<script lang="ts">
+  import { haptic } from '../../haptics';
+  import {
+    RANKS,
+    SUITS,
+    breakdownTotal,
+    cardLabel,
+    cardName,
+    cardKey,
+    isHeels,
+    rankLabel,
+    sameCard,
+    scoreCards,
+    suitGlyph,
+    type Breakdown,
+    type Card,
+  } from './logic';
+
+  /**
+   * The tiebreaker. Cribbage's oldest argument is "that's only ten" — so this is
+   * an optional drawer that counts a hand *properly*: tap the cut, tap the four
+   * cards, and the rules engine ({@link scoreCards}) spells out every fifteen,
+   * pair, run, flush and nob it finds. Take the count and it fills the row above.
+   *
+   * Deliberately opt-in and collapsed by default: the fast path at the table is
+   * still tapping your own count into the steppers. This is here for the hand
+   * nobody can agree on, and for anyone still learning to count.
+   *
+   * No Royal Violet primary here — the shell's Save is the one primary action on
+   * the screen — and no colour-only signalling: every card carries its rank, its
+   * suit glyph and a spoken name, and the breakdown is written out in words.
+   */
+  const {
+    /** Whose count this is, for labels ("Ada's hand"). */
+    label,
+    /** The crib scores flushes differently, so it counts differently. */
+    isCrib = false,
+    /** Hand it back to the caller, which writes it into the counted row. */
+    onuse,
+    /** Told when the cut turns a jack, so the editor can offer his heels. */
+    onheels,
+  }: {
+    label: string;
+    isCrib?: boolean;
+    onuse: (b: Breakdown) => void;
+    onheels?: (heels: boolean) => void;
+  } = $props();
+
+  let starter = $state<Card | null>(null);
+  let picked = $state<Card[]>([]);
+
+  const used = $derived(new Set([...(starter ? [starter] : []), ...picked].map((c) => cardKey(c))));
+  const complete = $derived(picked.length === 4 && starter != null);
+  const result = $derived<Breakdown>(
+    complete
+      ? scoreCards(picked, starter, isCrib)
+      : { fifteens: 0, pairs: 0, runs: 0, flush: 0, nob: 0 },
+  );
+  const total = $derived(complete ? breakdownTotal(result) : 0);
+
+  /** Written-out count, so nothing depends on reading a colour or a chart. */
+  const lines = $derived(
+    complete
+      ? [
+          result.fifteens
+            ? `${result.fifteens} fifteen${result.fifteens === 1 ? '' : 's'} — ${result.fifteens * 2}`
+            : null,
+          result.pairs
+            ? `${result.pairs} pair${result.pairs === 1 ? '' : 's'} — ${result.pairs * 2}`
+            : null,
+          result.runs ? `runs — ${result.runs}` : null,
+          result.flush ? `flush — ${result.flush}` : null,
+          result.nob ? 'one for his nob — 1' : null,
+        ].filter((s): s is string => s != null)
+      : [],
+  );
+
+  function tap(card: Card) {
+    if (used.has(cardKey(card))) {
+      if (starter && sameCard(starter, card)) {
+        starter = null;
+        onheels?.(false);
+      } else {
+        picked = picked.filter((c) => !sameCard(c, card));
+      }
+      haptic('undo');
+      return;
+    }
+    if (!starter) {
+      starter = card;
+      if (isHeels(card)) onheels?.(true);
+    } else if (picked.length < 4) {
+      picked = [...picked, card];
+    } else {
+      return;
+    }
+    haptic('tick');
+  }
+
+  function clear() {
+    starter = null;
+    picked = [];
+    haptic('undo');
+  }
+
+  function use() {
+    if (!complete) return;
+    onuse({ ...result });
+    haptic('save');
+  }
+
+  const nextSlot = $derived(!starter ? 'the cut' : picked.length < 4 ? 'a card' : null);
+</script>
+
+<div class="assist">
+  <p class="lede">
+    Counting <strong>{label}</strong>{isCrib ? ' — crib rules: a flush needs all five.' : '.'}
+    {#if nextSlot}Tap {nextSlot}.{/if}
+  </p>
+
+  <div class="slots">
+    <div class="slot cut" class:filled={!!starter}>
+      <span class="cap">Cut</span>
+      {#if starter}
+        <button type="button" class="chip" onclick={() => tap(starter as Card)}>
+          <span aria-hidden="true">{cardLabel(starter)}</span>
+          <span class="sr-only">Remove {cardName(starter)} from the cut</span>
+        </button>
+      {:else}
+        <span class="empty" aria-hidden="true">—</span>
+      {/if}
+    </div>
+    <div class="slot hand">
+      <span class="cap">{isCrib ? 'Crib' : 'Hand'}</span>
+      <div class="chips">
+        {#each picked as card (cardKey(card))}
+          <button type="button" class="chip" onclick={() => tap(card)}>
+            <span aria-hidden="true">{cardLabel(card)}</span>
+            <span class="sr-only">Remove {cardName(card)}</span>
+          </button>
+        {/each}
+        {#each Array(Math.max(0, 4 - picked.length)) as _, i (i)}
+          <span class="empty" aria-hidden="true">—</span>
+        {/each}
+      </div>
+    </div>
+  </div>
+
+  <div class="deck" role="group" aria-label="Pick a card">
+    {#each RANKS as rank (rank)}
+      <span class="rank-head" aria-hidden="true">{rankLabel(rank)}</span>
+      {#each SUITS as suit (suit)}
+        {@const card = { rank, suit }}
+        {@const taken = used.has(cardKey(card))}
+        <button
+          type="button"
+          class="card"
+          class:taken
+          data-suit={suit}
+          aria-pressed={taken}
+          onclick={() => tap(card)}
+        >
+          <span aria-hidden="true">{suitGlyph(suit)}</span>
+          <span class="sr-only">{cardName(card)}</span>
+        </button>
+      {/each}
+    {/each}
+  </div>
+
+  <div class="outcome" role="status">
+    {#if complete}
+      <p class="total"><strong>{total}</strong> points</p>
+      <p class="lines">{lines.length ? lines.join(' · ') : 'nothing at all — a "nineteen".'}</p>
+    {:else}
+      <p class="lines">Pick a cut and four cards to count them.</p>
+    {/if}
+  </div>
+
+  <div class="acts row">
+    <button
+      type="button"
+      class="btn small ghost"
+      onclick={clear}
+      disabled={!starter && !picked.length}
+    >
+      Clear
+    </button>
+    <button type="button" class="btn small take" onclick={use} disabled={!complete}>
+      Take this count ({total})
+    </button>
+  </div>
+</div>
+
+<style>
+  .assist {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+  }
+  .lede {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--muted);
+  }
+  .lede strong {
+    color: var(--text);
+  }
+  .slots {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+  .slot {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .slot.hand {
+    flex: 1;
+  }
+  .cap {
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .chips {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .chip {
+    min-height: 46px;
+    min-width: 46px;
+    padding: 0 10px;
+    border-radius: var(--radius-chip);
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: var(--text);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+  }
+  .empty {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 46px;
+    min-width: 46px;
+    border-radius: var(--radius-chip);
+    border: 1px dashed var(--border);
+    color: var(--muted);
+  }
+  .deck {
+    display: grid;
+    grid-template-columns: 2rem repeat(4, 1fr);
+    gap: 4px;
+    align-items: center;
+    max-height: 240px;
+    overflow-y: auto;
+    padding: 4px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
+  .rank-head {
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--muted);
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+  .card {
+    min-height: 46px;
+    border-radius: var(--radius-chip);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background var(--dur-base) var(--ease-standard);
+  }
+  .card[data-suit='H'],
+  .card[data-suit='D'] {
+    color: var(--bad);
+  }
+  .card:hover:not(.taken) {
+    background: var(--surface-3);
+  }
+  /* Taken cards keep their glyph and gain a dashed, dimmed frame — the state is
+     never colour alone, and the button stays a live "remove" target. */
+  .card.taken {
+    border-style: dashed;
+    opacity: 0.45;
+  }
+  .card:focus-visible,
+  .chip:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .outcome {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .total {
+    margin: 0;
+    font-variant-numeric: tabular-nums;
+  }
+  .total strong {
+    font-size: 1.25rem;
+    font-weight: 800;
+  }
+  .lines {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--muted);
+  }
+  .acts {
+    gap: 8px;
+    justify-content: flex-end;
+  }
+  /* A quiet, confident confirm — deliberately not Royal Violet, which the shell's
+     Save button owns as the single primary action on this screen. */
+  .take {
+    font-weight: 700;
+    background: var(--surface-3);
+    border-color: color-mix(in srgb, var(--primary) 45%, var(--border));
+  }
+</style>

--- a/src/lib/games/cribbage/CribbageEditor.svelte
+++ b/src/lib/games/cribbage/CribbageEditor.svelte
@@ -1,0 +1,515 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { bumpOnChange } from '../../motion';
+  import { haptic } from '../../haptics';
+  import { cribbage } from './index';
+  import PegBoard from './PegBoard.svelte';
+  import CountAssist from './CountAssist.svelte';
+  import {
+    HEELS_POINTS,
+    breakdownTotal,
+    emptyEntry,
+    finishView,
+    leaders,
+    readConfig,
+    resolveMode,
+    scoreDeal,
+    skunkLabel,
+    unitFor,
+    unitTotals,
+    unitsFor,
+    type Breakdown,
+    type CribbageInput,
+    type Unit,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: CribbageInput; ctx: RoundContext } = $props();
+
+  const cfg = $derived(readConfig(ctx.config));
+  const mode = $derived(resolveMode(ctx.config, ctx.players.length));
+  const partners = $derived(mode === 'partners');
+  const units = $derived(unitsFor(ctx.players, mode));
+  const byId = $derived(new Map(ctx.players.map((p) => [p.id, p])));
+
+  const dealerUnit = $derived(unitFor(units, input.dealerId ?? null));
+  const dealerName = $derived(
+    input.dealerId ? (byId.get(input.dealerId)?.name ?? 'the dealer') : 'nobody yet',
+  );
+
+  const results = $derived(scoreDeal(input, ctx.players, ctx.config));
+  const before = $derived(unitTotals(units, ctx.totals));
+  const leaderKeys = $derived(leaders(before));
+  const projected = $derived(
+    Object.fromEntries(
+      units.map((u) => [u.key, (before[u.key] ?? 0) + (results[u.key]?.total ?? 0)]),
+    ),
+  );
+  /** The finish, if this deal ends it — the skunk moment lives here. */
+  const finish = $derived(cfg.skunks ? finishView(projected, cfg.target) : null);
+  const finishCopy = $derived(finish ? skunkLabel(finish.kind) : null);
+
+  const unitName = (u: Unit): string =>
+    u.memberIds
+      .map((id) => byId.get(id)?.name)
+      .filter(Boolean)
+      .join(' & ') || `Team ${u.index + 1}`;
+
+  let showHelp = $state(false);
+  /** Which unit (and which pile) has the counting drawer open — one at a time. */
+  let assist = $state<string | null>(null);
+
+  function setDealer(id: string) {
+    if (input.dealerId === id) return;
+    input.dealerId = id;
+    haptic('tick');
+  }
+
+  function toggleHeels() {
+    input.heels = !input.heels;
+    haptic('tick');
+  }
+
+  function entryFor(key: string) {
+    if (!input.entries[key]) input.entries[key] = emptyEntry();
+    return input.entries[key];
+  }
+
+  function applyCount(key: string, pile: 'hand' | 'crib', b: Breakdown) {
+    entryFor(key)[pile] = { ...b };
+    assist = null;
+  }
+
+  /** Everything the draft holds, so "Clear deal" only appears once it's worth it. */
+  const dirty = $derived(input.heels || units.some((u) => (results[u.key]?.total ?? 0) > 0));
+
+  function clearDeal() {
+    for (const u of units) input.entries[u.key] = emptyEntry();
+    input.heels = false;
+    assist = null;
+    haptic('undo');
+  }
+
+  const COUNTS = [
+    { key: 'fifteens' as const, label: 'Fifteens', hint: '×2', max: 8 },
+    { key: 'pairs' as const, label: 'Pairs', hint: '×2', max: 6 },
+    { key: 'runs' as const, label: 'Runs', hint: 'points', max: 15 },
+    { key: 'flush' as const, label: 'Flush', hint: 'points', max: 5 },
+    { key: 'nob' as const, label: 'Nob', hint: '🂻 suit', max: 1 },
+  ];
+</script>
+
+<div class="stack">
+  <!-- Whose deal it is, front and centre: the crib follows the dealer, and that's
+       the single most-argued thing at a cribbage table. -->
+  <section class="deal">
+    <div class="row spread wrap head">
+      <h3 class="ttl">🂠 Hand {ctx.roundIndex + 1} — whose deal?</h3>
+      <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+        How to count
+      </button>
+    </div>
+
+    <div class="dealers" role="radiogroup" aria-label="Whose deal it is">
+      {#each ctx.players as p (p.id)}
+        {@const on = input.dealerId === p.id}
+        <button
+          type="button"
+          role="radio"
+          aria-checked={on}
+          class="dealer"
+          class:on
+          onclick={() => setDealer(p.id)}
+        >
+          <Avatar name={p.name} color={p.color} />
+          <span class="dname">{p.name}</span>
+          {#if on}<span class="badge">deals</span>{/if}
+        </button>
+      {/each}
+    </div>
+
+    <p class="crib-note" use:bumpOnChange={input.dealerId}>
+      <span aria-hidden="true">🂠</span>
+      <strong>{dealerName}</strong> deals — the crib is
+      <strong>{dealerName}'s</strong>, and so is his heels.
+    </p>
+
+    <button type="button" class="heels" class:on={input.heels} onclick={toggleHeels}>
+      <span class="hmark" aria-hidden="true">{input.heels ? '✓' : '🂻'}</span>
+      <span class="htext">
+        <strong>His heels</strong>
+        <span class="hsub">The cut turned a jack — {dealerName} takes +{HEELS_POINTS}</span>
+      </span>
+    </button>
+
+    {#if showHelp}
+      <pre class="help">{cribbage.help}</pre>
+    {/if}
+  </section>
+
+  {#if finish && finishCopy && finish.kind !== 'none'}
+    <p class="skunk" class:double={finish.kind === 'double'} role="status">
+      <span class="sk-emoji" aria-hidden="true">{finishCopy.emoji}</span>
+      <span>
+        <strong>{finishCopy.headline}</strong>
+        {finishCopy.cheer} Loser finishes on {finish.loserScore}.
+      </span>
+    </p>
+  {/if}
+
+  {#each units as u (u.key)}
+    {@const res = results[u.key] ?? {
+      pegging: 0,
+      hand: 0,
+      crib: 0,
+      heels: 0,
+      isDealer: false,
+      total: 0,
+    }}
+    {@const entry = input.entries[u.key] ?? emptyEntry()}
+    {@const isDealer = dealerUnit?.key === u.key}
+    <section class="unit" class:dealing={isDealer}>
+      <div class="uhead row spread wrap">
+        <span class="who row wrap">
+          {#if partners}
+            <span class="team">Team {u.index + 1}</span>
+          {:else}
+            {@const p = byId.get(u.memberIds[0])}
+            {#if p}<Avatar name={p.name} color={p.color} />{/if}
+          {/if}
+          <strong class="uname">{unitName(u)}</strong>
+          {#if isDealer}<span class="crib-flag">🂠 dealer · holds the crib</span>{/if}
+        </span>
+        <span class="proj" use:bumpOnChange={res.total}>+{res.total}</span>
+      </div>
+
+      <PegBoard
+        before={before[u.key] ?? 0}
+        delta={res.total}
+        target={cfg.target}
+        leading={leaderKeys.has(u.key)}
+        showSkunkLine={cfg.skunks}
+      />
+
+      <div class="pile">
+        <div class="prow row spread wrap">
+          <span class="plabel">📌 Pegged in the play</span>
+          <Stepper
+            bind:value={entry.pegging}
+            min={0}
+            max={60}
+            label={`${unitName(u)} pegging points`}
+          />
+        </div>
+      </div>
+
+      {#snippet counter(key: string, pile: 'hand' | 'crib', title: string, b: Breakdown)}
+        <div class="pile">
+          <div class="prow row spread wrap">
+            <span class="plabel">{title}</span>
+            <span class="ptotal">{breakdownTotal(b)}</span>
+          </div>
+          <div class="counts">
+            {#each COUNTS as f (f.key)}
+              <label class="f">
+                <span class="flabel">{f.label} <span class="fhint">{f.hint}</span></span>
+                <Stepper
+                  bind:value={b[f.key]}
+                  min={0}
+                  max={f.max}
+                  label={`${unitName(u)} ${title} ${f.label}`}
+                />
+              </label>
+            {/each}
+          </div>
+          <div class="row assist-row">
+            <button
+              type="button"
+              class="btn small ghost"
+              aria-expanded={assist === `${key}:${pile}`}
+              onclick={() => (assist = assist === `${key}:${pile}` ? null : `${key}:${pile}`)}
+            >
+              {assist === `${key}:${pile}` ? 'Close the counter' : '🔍 Count it for me'}
+            </button>
+          </div>
+          {#if assist === `${key}:${pile}`}
+            <CountAssist
+              label={title}
+              isCrib={pile === 'crib'}
+              onuse={(next) => applyCount(key, pile, next)}
+              onheels={(h) => (input.heels = h)}
+            />
+          {/if}
+        </div>
+      {/snippet}
+
+      {@render counter(u.key, 'hand', `${unitName(u)}'s hand`, entry.hand)}
+
+      {#if isDealer}
+        {@render counter(u.key, 'crib', `${unitName(u)}'s crib`, entry.crib)}
+      {/if}
+
+      <p class="tally">
+        {res.pegging} pegged · {res.hand} in hand{#if isDealer}
+          · {res.crib} in the crib{#if res.heels}
+            · {res.heels} for his heels{/if}{/if}
+        — <strong>+{res.total}</strong>
+      </p>
+    </section>
+  {/each}
+
+  {#if dirty}
+    <div class="row foot">
+      <button type="button" class="btn small ghost" onclick={clearDeal}>Clear this deal</button>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .deal {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .head {
+    align-items: center;
+  }
+  .ttl {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+  }
+  .dealers {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .dealer {
+    flex: 1 1 140px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 8px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background var(--dur-base) var(--ease-standard);
+  }
+  .dealer:hover {
+    background: var(--surface-3);
+  }
+  /* The dealer chip is a selection, not the screen's primary action, so it reads
+     as a filled, bordered state carrying an explicit "deals" badge — never colour
+     on its own. */
+  .dealer.on {
+    background: var(--surface-3);
+    border-color: var(--primary);
+    box-shadow: inset 3px 0 0 var(--primary);
+  }
+  .dealer:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .dname {
+    flex: 1;
+    text-align: left;
+  }
+  .badge {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 3px 8px;
+    border-radius: 999px;
+    background: var(--primary);
+    color: #fff;
+  }
+  .crib-note {
+    margin: 0;
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
+    font-size: 0.9rem;
+    color: var(--muted);
+    padding: 9px 12px;
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    border: 1px dashed var(--border);
+  }
+  .crib-note strong {
+    color: var(--text);
+  }
+  .heels {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 46px;
+    padding: 8px 12px;
+    text-align: left;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+  }
+  .heels.on {
+    border-color: var(--good);
+    background: color-mix(in srgb, var(--good) 12%, var(--surface));
+  }
+  .heels:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .hmark {
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+  .htext {
+    display: flex;
+    flex-direction: column;
+  }
+  .hsub {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .skunk {
+    margin: 0;
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    padding: 11px 12px;
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--warn) 14%, var(--surface));
+    border: 1px solid color-mix(in srgb, var(--warn) 45%, var(--border));
+    font-size: 0.9rem;
+  }
+  .skunk.double {
+    background: color-mix(in srgb, var(--bad) 14%, var(--surface));
+    border-color: color-mix(in srgb, var(--bad) 45%, var(--border));
+  }
+  .sk-emoji {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+  .unit {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  /* The dealing side is framed, not merely tinted — the crib is the one thing a
+     scorekeeper must never get wrong. */
+  .unit.dealing {
+    border-color: color-mix(in srgb, var(--primary) 55%, var(--border));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary) 20%, transparent);
+  }
+  .uhead {
+    align-items: center;
+  }
+  .who {
+    gap: 8px;
+    align-items: center;
+  }
+  .team {
+    font-weight: 700;
+    padding: 3px 10px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    font-size: 0.8rem;
+  }
+  .uname {
+    font-weight: 700;
+  }
+  .crib-flag {
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--primary);
+    padding: 3px 8px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--primary) 45%, var(--border));
+  }
+  .proj {
+    font-weight: 800;
+    font-size: 1.25rem;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+  .pile {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .prow {
+    align-items: center;
+  }
+  .plabel {
+    font-weight: 700;
+  }
+  .ptotal {
+    font-weight: 800;
+    font-size: 1.25rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .counts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 10px;
+  }
+  .f {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .flabel {
+    font-size: 0.9rem;
+    color: var(--muted);
+  }
+  .fhint {
+    font-size: 0.8rem;
+  }
+  .assist-row {
+    justify-content: flex-end;
+  }
+  .tally {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .tally strong {
+    color: var(--text);
+  }
+  .foot {
+    justify-content: flex-end;
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+    font-size: 0.9rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/cribbage/PegBoard.svelte
+++ b/src/lib/games/cribbage/PegBoard.svelte
@@ -1,0 +1,228 @@
+<script lang="ts">
+  import { pegView, skunkLine, doubleSkunkLine } from './logic';
+
+  /**
+   * Cribbage's costume: a stylized pegging board lane for one side. Two pegs sit
+   * on a real board — the one you just moved and the one behind it — so that's
+   * exactly what this shows: a back peg where the side stood before this deal,
+   * and a front peg where this deal lands them.
+   *
+   * The lane is drawn in streets of five holes, the way a board is, but the
+   * numbers and words always carry the meaning: the score, the holes still to
+   * peg, and a named skunk marker. Colour is never the only signal. The fill uses
+   * the neutral/primary tokens; Crown Gold appears solely on the 👑 for the side
+   * actually leading, and on the finish flag once a side pegs out.
+   *
+   * Motion is a single eased slide of the front peg, already skipped wholesale by
+   * the reduced-motion media query below — the peg still lands in the right hole,
+   * it simply arrives instantly.
+   */
+  const {
+    /** Where the side stood before this deal. */
+    before,
+    /** Points this deal adds. */
+    delta,
+    /** Holes to peg out (121 or 61). */
+    target,
+    /** True when this side currently leads the table — the only 👑 on the lane. */
+    leading = false,
+    /** Highlight the skunk line (turned off when the group doesn't call skunks). */
+    showSkunkLine = true,
+  }: {
+    before: number;
+    delta: number;
+    target: number;
+    leading?: boolean;
+    showSkunkLine?: boolean;
+  } = $props();
+
+  const v = $derived(pegView(before, delta, target));
+  const pct = (n: number) => (target > 0 ? Math.max(0, Math.min(100, (n / target) * 100)) : 0);
+
+  const backPct = $derived(pct(v.before));
+  const frontPct = $derived(pct(v.projected));
+  const skunkPct = $derived(pct(skunkLine(target)));
+  const doublePct = $derived(pct(doubleSkunkLine(target)));
+
+  /** Street ticks, one per five holes — the board's own rhythm, capped for width. */
+  const streets = $derived(
+    target > 0 ? Array.from({ length: Math.min(Math.ceil(target / 5), 25) }, (_, i) => i) : [],
+  );
+
+  const signed = $derived(delta >= 0 ? `+${delta}` : `−${Math.abs(delta)}`);
+</script>
+
+{#if target > 0}
+  <div class="board" class:out={v.pegsOut}>
+    <div class="lane" aria-hidden="true">
+      <div class="holes">
+        {#each streets as s (s)}
+          <span class="street"></span>
+        {/each}
+      </div>
+      <span class="track back" style="transform: scaleX({backPct / 100})"></span>
+      <span class="track front" style="transform: scaleX({frontPct / 100})"></span>
+      {#if showSkunkLine && doublePct > 0 && doublePct < 100}
+        <span class="mark double" style="left: {doublePct}%"></span>
+      {/if}
+      {#if showSkunkLine && skunkPct > 0 && skunkPct < 100}
+        <span class="mark skunk" style="left: {skunkPct}%"></span>
+      {/if}
+      <span class="peg back-peg" style="left: {backPct}%"></span>
+      <span class="peg front-peg" style="left: {frontPct}%"></span>
+    </div>
+
+    <div class="read">
+      <span class="race">
+        <span class="n">{v.before}</span>
+        <span class="arrow" aria-hidden="true">→</span>
+        <span class="n now">{v.projected}</span>
+        <span class="of">/ {target}</span>
+      </span>
+      <span class="tag">
+        {#if v.pegsOut}
+          <span class="home">🏁 pegs out!</span>
+        {:else}
+          <span class="togo">{v.remaining} holes to go</span>
+        {/if}
+        <span class="swing">({signed})</span>
+        {#if leading && !v.pegsOut}<span class="lead" title="Leading">👑</span>{/if}
+      </span>
+    </div>
+
+    {#if showSkunkLine && !v.pegsOut && v.inSkunkRange}
+      <p class="warn-line">🦨 still short of the skunk line ({skunkLine(target)})</p>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .board {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .lane {
+    position: relative;
+    height: 16px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    overflow: hidden;
+  }
+  /* Streets of five holes — the board's own rhythm, purely decorative. */
+  .holes {
+    position: absolute;
+    inset: 0;
+    display: flex;
+  }
+  .street {
+    flex: 1;
+    border-right: 1px solid var(--border);
+    opacity: 0.7;
+  }
+  .street:last-child {
+    border-right: 0;
+  }
+  .track {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    transform-origin: left center;
+    border-radius: 999px;
+  }
+  /* The settled score sits under a lighter projection of this deal's swing. */
+  .track.front {
+    background: color-mix(in srgb, var(--primary) 35%, transparent);
+    transition: transform var(--dur-slow, 0.24s) var(--ease-out, ease);
+  }
+  .track.back {
+    background: color-mix(in srgb, var(--primary) 70%, transparent);
+  }
+  .mark {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    transform: translateX(-1px);
+  }
+  .mark.skunk {
+    background: var(--warn);
+  }
+  .mark.double {
+    background: var(--bad);
+  }
+  .peg {
+    position: absolute;
+    top: 50%;
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    transform: translate(-50%, -50%);
+    border: 1px solid var(--surface);
+  }
+  .peg.back-peg {
+    background: var(--muted);
+  }
+  .peg.front-peg {
+    background: var(--primary);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 30%, transparent);
+    transition: left var(--dur-slow, 0.24s) var(--ease-out, ease);
+  }
+  .board.out .peg.front-peg {
+    background: var(--accent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 35%, transparent);
+  }
+  .read {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    flex-wrap: wrap;
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .race {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    font-variant-numeric: tabular-nums;
+  }
+  .n {
+    font-weight: 700;
+    color: var(--text);
+  }
+  .n.now {
+    color: var(--primary);
+  }
+  .tag {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 5px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+  .home {
+    color: var(--accent-ink);
+    font-weight: 800;
+  }
+  .swing {
+    color: var(--muted);
+    font-weight: 500;
+  }
+  .warn-line {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--warn);
+    font-variant-numeric: tabular-nums;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .track.front,
+    .peg.front-peg {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/games/cribbage/cribbage.test.ts
+++ b/src/lib/games/cribbage/cribbage.test.ts
@@ -1,0 +1,811 @@
+import { describe, expect, it } from 'vitest';
+import type { ID, Game, Round, RoundContext } from '../../types';
+import { defaultWinners } from '../../types';
+import { cribbage } from './index';
+import { cribbageStats } from './stats';
+import {
+  HEELS_POINTS,
+  IMPOSSIBLE_HAND,
+  PERFECT_HAND,
+  breakdownTotal,
+  cardLabel,
+  cardValue,
+  countFifteens,
+  countPairs,
+  defaultDealer,
+  describeDeal,
+  doubleSkunkLine,
+  emptyBreakdown,
+  emptyEntry,
+  emptyInput,
+  finishView,
+  flushPoints,
+  isFinished,
+  isHeels,
+  leaders,
+  nobPoints,
+  pegView,
+  readConfig,
+  resolveMode,
+  runPoints,
+  scoreCards,
+  scoreDeal,
+  scoreRound,
+  skunkFor,
+  skunkLabel,
+  skunkLine,
+  unitFor,
+  unitTotals,
+  unitsFor,
+  validateRound,
+  type Card,
+  type CribbageInput,
+  type Suit,
+} from './logic';
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+/** Terse card literal: "5H", "10S", "JD", "AC". */
+function c(spec: string): Card {
+  const suit = spec.slice(-1) as Suit;
+  const face = spec.slice(0, -1);
+  const rank = face === 'A' ? 1 : face === 'J' ? 11 : face === 'Q' ? 12 : face === 'K' ? 13 : +face;
+  return { rank, suit };
+}
+
+const hand = (...specs: string[]): Card[] => specs.map(c);
+
+const players = [
+  { id: 'a', name: 'Ada', color: '#111', createdAt: 0 },
+  { id: 'b', name: 'Bo', color: '#222', createdAt: 0 },
+];
+
+const four = [
+  ...players,
+  { id: 'c', name: 'Cy', color: '#333', createdAt: 0 },
+  { id: 'd', name: 'Di', color: '#444', createdAt: 0 },
+];
+
+function ctx(partial: Partial<RoundContext> = {}): RoundContext {
+  return {
+    players,
+    config: {},
+    roundIndex: 0,
+    totals: { a: 0, b: 0 },
+    rounds: [],
+    game: {} as Game,
+    ...partial,
+  } as RoundContext;
+}
+
+function input(partial: Partial<CribbageInput> = {}): CribbageInput {
+  return {
+    dealerId: 'a',
+    heels: false,
+    entries: { a: emptyEntry(), b: emptyEntry() },
+    ...partial,
+  };
+}
+
+// ── card helpers ─────────────────────────────────────────────────────────────
+
+describe('card values', () => {
+  it('counts the ace as one and every face card as ten', () => {
+    expect(cardValue(c('AS'))).toBe(1);
+    expect(cardValue(c('9H'))).toBe(9);
+    expect(cardValue(c('10D'))).toBe(10);
+    expect(cardValue(c('JC'))).toBe(10);
+    expect(cardValue(c('QS'))).toBe(10);
+    expect(cardValue(c('KH'))).toBe(10);
+  });
+
+  it('labels cards the way a player reads them', () => {
+    expect(cardLabel(c('AS'))).toBe('A♠');
+    expect(cardLabel(c('10D'))).toBe('10♦');
+    expect(cardLabel(c('JH'))).toBe('J♥');
+  });
+});
+
+// ── fifteens ─────────────────────────────────────────────────────────────────
+
+describe('countFifteens', () => {
+  it('finds the plain two-card fifteen', () => {
+    expect(countFifteens(hand('9S', '6H', 'KC', 'QD', '8H'))).toBe(1);
+  });
+
+  it('finds three-card and four-card combinations', () => {
+    // 4+5+6 = 15, and 4+5+6 is the only one here besides 2+4+9 and 2+4+3+6.
+    expect(countFifteens(hand('4S', '5H', '6C', '2D', '9H'))).toBe(3);
+  });
+
+  it('counts every ten-card + five pairing separately', () => {
+    // Each of J/Q/K/10 makes fifteen with the five: four fifteens = 8.
+    expect(countFifteens(hand('JS', 'QH', 'KC', '10D', '5S'))).toBe(4);
+  });
+
+  it('counts eight fifteens in the perfect hand', () => {
+    // Four ten-cards? No — one jack plus four fives: J+5 ×4, and 5+5+5 ×4.
+    expect(countFifteens(hand('JS', '5H', '5C', '5D', '5S'))).toBe(8);
+  });
+
+  it('ignores single cards and the empty set', () => {
+    expect(countFifteens(hand())).toBe(0);
+    expect(countFifteens(hand('KS'))).toBe(0);
+  });
+});
+
+// ── pairs ────────────────────────────────────────────────────────────────────
+
+describe('countPairs', () => {
+  it('scores a plain pair once', () => {
+    expect(countPairs(hand('7S', '7H', '2C', '3D', '9S'))).toBe(1);
+  });
+
+  it('scores three of a kind as three pairs (pair royal)', () => {
+    expect(countPairs(hand('8S', '8H', '8C', '3D', '9S'))).toBe(3);
+  });
+
+  it('scores four of a kind as six pairs (double pair royal)', () => {
+    expect(countPairs(hand('8S', '8H', '8C', '8D', '9S'))).toBe(6);
+  });
+
+  it('does not pair unlike ten-cards', () => {
+    expect(countPairs(hand('10S', 'JH', 'QC', 'KD', '2S'))).toBe(0);
+  });
+});
+
+// ── runs ─────────────────────────────────────────────────────────────────────
+
+describe('runPoints', () => {
+  it('scores a run of three', () => {
+    expect(runPoints(hand('4S', '5H', '6C', 'KD', '9S'))).toBe(3);
+  });
+
+  it('scores a run of four and a run of five', () => {
+    expect(runPoints(hand('4S', '5H', '6C', '7D', 'KS'))).toBe(4);
+    expect(runPoints(hand('4S', '5H', '6C', '7D', '8S'))).toBe(5);
+  });
+
+  it('scores a double run of three as six', () => {
+    expect(runPoints(hand('4S', '4H', '5C', '6D', 'KS'))).toBe(6);
+  });
+
+  it('scores a triple run of three as nine', () => {
+    expect(runPoints(hand('4S', '4H', '4C', '5D', '6S'))).toBe(9);
+  });
+
+  it('scores a double-double run of three as twelve', () => {
+    expect(runPoints(hand('4S', '4H', '5C', '5D', '6S'))).toBe(12);
+  });
+
+  it('scores a double run of four as eight', () => {
+    expect(runPoints(hand('4S', '4H', '5C', '6D', '7S'))).toBe(8);
+  });
+
+  it('takes only the longest run when two are present', () => {
+    // A-2-3 and 6-7-8 both run; only the longest counts, and they tie at three,
+    // so the first found wins — never both.
+    expect(runPoints(hand('AS', '2H', '3C', '6D', '7S'))).toBe(3);
+  });
+
+  it('ignores runs shorter than three', () => {
+    expect(runPoints(hand('4S', '5H', 'KC', 'QD', '2S'))).toBe(0);
+  });
+
+  it('does not wrap king round to ace', () => {
+    expect(runPoints(hand('QS', 'KH', 'AC', '2D', '7S'))).toBe(0);
+  });
+
+  it('runs by rank, so J-Q-K counts even though all are worth ten', () => {
+    expect(runPoints(hand('JS', 'QH', 'KC', '2D', '7S'))).toBe(3);
+  });
+});
+
+// ── flush & nob ──────────────────────────────────────────────────────────────
+
+describe('flushPoints', () => {
+  it('scores four for a hand flush the starter misses', () => {
+    expect(flushPoints(hand('2S', '5S', '9S', 'KS'), c('7H'), false)).toBe(4);
+  });
+
+  it('scores five when the starter matches the hand flush', () => {
+    expect(flushPoints(hand('2S', '5S', '9S', 'KS'), c('7S'), false)).toBe(5);
+  });
+
+  it('gives the crib nothing for four of a suit', () => {
+    expect(flushPoints(hand('2S', '5S', '9S', 'KS'), c('7H'), true)).toBe(0);
+  });
+
+  it('gives the crib five only when all five share a suit', () => {
+    expect(flushPoints(hand('2S', '5S', '9S', 'KS'), c('7S'), true)).toBe(5);
+  });
+
+  it('scores nothing on a mixed hand', () => {
+    expect(flushPoints(hand('2S', '5S', '9S', 'KH'), c('7S'), false)).toBe(0);
+  });
+});
+
+describe('nobPoints', () => {
+  it('scores one for a jack matching the starter suit', () => {
+    expect(nobPoints(hand('JH', '2S', '5C', '9D'), c('7H'))).toBe(1);
+  });
+
+  it('scores nothing for a jack of the wrong suit', () => {
+    expect(nobPoints(hand('JH', '2S', '5C', '9D'), c('7S'))).toBe(0);
+  });
+
+  it('scores nothing when the jack IS the starter (that is heels, not nob)', () => {
+    expect(nobPoints(hand('2H', '3S', '5C', '9D'), c('JD'))).toBe(0);
+    expect(isHeels(c('JD'))).toBe(true);
+    expect(isHeels(c('10D'))).toBe(false);
+    expect(isHeels(null)).toBe(false);
+  });
+});
+
+// ── the whole hand ───────────────────────────────────────────────────────────
+
+describe('scoreCards', () => {
+  it('scores the perfect 29 hand', () => {
+    // J♠ + 5♥ 5♣ 5♦, cut 5♠: eight fifteens (16), six pairs (12), nob (1).
+    const b = scoreCards(hand('JS', '5H', '5C', '5D'), c('5S'));
+    expect(b).toEqual({ fifteens: 8, pairs: 6, runs: 0, flush: 0, nob: 1 });
+    expect(breakdownTotal(b)).toBe(PERFECT_HAND);
+  });
+
+  it('scores 28 when the jack does not match the cut', () => {
+    const b = scoreCards(hand('JS', '5H', '5C', '5D'), c('5C'));
+    expect(breakdownTotal(b)).toBe(28);
+  });
+
+  it('scores 24 for the double-double run with fifteens', () => {
+    // 4-4-5-5-6: twelve run points, four fifteens (8), two pairs (4).
+    const b = scoreCards(hand('4S', '4H', '5C', '5D'), c('6S'));
+    expect(b.runs).toBe(12);
+    expect(b.pairs).toBe(2);
+    expect(b.fifteens).toBe(4);
+    expect(breakdownTotal(b)).toBe(24);
+  });
+
+  it('scores 24 for the classic 7-7-8-8 with a cut nine', () => {
+    // 7-7-8-8-9: double-double run of three (7,8,9 four ways = 12),
+    // fifteens 7+8 ×4 = 8, two pairs = 4.
+    const b = scoreCards(hand('7S', '7H', '8C', '8D'), c('9S'));
+    expect(b.runs).toBe(12);
+    expect(b.fifteens).toBe(4);
+    expect(b.pairs).toBe(2);
+    expect(breakdownTotal(b)).toBe(24);
+  });
+
+  it('never produces nineteen — the "impossible hand"', () => {
+    // Exhaustive over a reasonable slice: no five cards can total 19.
+    const deck: Card[] = [];
+    for (const suit of ['S', 'H', 'D', 'C'] as Suit[]) {
+      for (let rank = 1; rank <= 13; rank += 1) deck.push({ rank, suit });
+    }
+    let checked = 0;
+    for (let i = 0; i < deck.length; i += 7) {
+      for (let j = i + 1; j < deck.length; j += 5) {
+        for (let k = j + 1; k < deck.length; k += 5) {
+          for (let l = k + 1; l < deck.length; l += 5) {
+            for (let m = l + 1; m < deck.length; m += 5) {
+              const total = breakdownTotal(
+                scoreCards([deck[i], deck[j], deck[k], deck[l]], deck[m]),
+              );
+              expect(total).not.toBe(IMPOSSIBLE_HAND);
+              checked += 1;
+            }
+          }
+        }
+      }
+    }
+    expect(checked).toBeGreaterThan(500);
+  });
+
+  it('scores a flush hand with a matching starter', () => {
+    // 2♥ 4♥ 6♥ 9♥ + cut 8♥: flush of five, plus 6+9 and 2+4+9 fifteens.
+    const b = scoreCards(hand('2H', '4H', '6H', '9H'), c('8H'));
+    expect(b.flush).toBe(5);
+    expect(b.fifteens).toBe(2);
+    expect(breakdownTotal(b)).toBe(9);
+  });
+
+  it('scores a crib flush only on all five', () => {
+    const four = hand('2H', '4H', '6H', '9H');
+    expect(scoreCards(four, c('8S'), true).flush).toBe(0);
+    expect(scoreCards(four, c('8H'), true).flush).toBe(5);
+  });
+
+  it('scores a bare hand with no starter', () => {
+    expect(breakdownTotal(scoreCards(hand('7S', '8H', '9C', 'KD')))).toBe(5);
+  });
+
+  it('scores zero for a genuinely worthless hand', () => {
+    expect(breakdownTotal(scoreCards(hand('2H', '4D', '8C', 'KS'), c('6S')))).toBe(0);
+  });
+});
+
+describe('breakdownTotal', () => {
+  it('doubles fifteens and pairs, and takes runs/flush/nob at face value', () => {
+    expect(breakdownTotal({ fifteens: 3, pairs: 2, runs: 5, flush: 4, nob: 1 })).toBe(20);
+  });
+
+  it('is zero for an empty or missing breakdown', () => {
+    expect(breakdownTotal(emptyBreakdown())).toBe(0);
+    expect(breakdownTotal(undefined)).toBe(0);
+  });
+
+  it('treats negative or non-numeric components as zero', () => {
+    expect(breakdownTotal({ fifteens: -3, pairs: 1, runs: NaN, flush: 4, nob: -1 })).toBe(6);
+  });
+});
+
+// ── scoring units & the deal ─────────────────────────────────────────────────
+
+describe('unitsFor / resolveMode', () => {
+  it('gives every seat its own unit in solo play', () => {
+    expect(unitsFor(players, 'solo').map((u) => u.memberIds)).toEqual([['a'], ['b']]);
+  });
+
+  it('pairs four seats by pick order into two partnerships', () => {
+    expect(unitsFor(four, 'partners').map((u) => u.memberIds)).toEqual([
+      ['a', 'b'],
+      ['c', 'd'],
+    ]);
+  });
+
+  it('falls back to solo when partnerships are asked for without four seats', () => {
+    expect(resolveMode({ mode: 'partners' }, 4)).toBe('partners');
+    expect(resolveMode({ mode: 'partners' }, 3)).toBe('solo');
+    expect(resolveMode({ mode: 'partners' }, 2)).toBe('solo');
+    expect(resolveMode({}, 4)).toBe('solo');
+  });
+
+  it('finds the unit holding a player', () => {
+    const units = unitsFor(four, 'partners');
+    expect(unitFor(units, 'd')?.key).toBe('team-2');
+    expect(unitFor(units, 'zz')).toBeNull();
+    expect(unitFor(units, null)).toBeNull();
+  });
+});
+
+describe('defaultDealer', () => {
+  it('rotates the deal one seat every hand', () => {
+    expect(defaultDealer(players, 0)).toBe('a');
+    expect(defaultDealer(players, 1)).toBe('b');
+    expect(defaultDealer(players, 2)).toBe('a');
+    expect(defaultDealer(four, 5)).toBe('b');
+  });
+
+  it('is null with nobody seated', () => {
+    expect(defaultDealer([], 3)).toBeNull();
+  });
+});
+
+describe('scoreDeal', () => {
+  it('gives the crib and his heels to the dealer alone', () => {
+    const i = input({
+      heels: true,
+      entries: {
+        a: {
+          pegging: 3,
+          hand: { ...emptyBreakdown(), fifteens: 2 },
+          crib: { ...emptyBreakdown(), runs: 3 },
+        },
+        b: {
+          pegging: 5,
+          hand: { ...emptyBreakdown(), pairs: 1 },
+          crib: { ...emptyBreakdown(), runs: 8 },
+        },
+      },
+    });
+    const res = scoreDeal(i, players);
+    // Dealer: 3 pegged + 4 hand + 3 crib + 2 heels.
+    expect(res.a).toMatchObject({
+      pegging: 3,
+      hand: 4,
+      crib: 3,
+      heels: 2,
+      isDealer: true,
+      total: 12,
+    });
+    // Non-dealer: crib and heels are ignored even though a stale count is stored.
+    expect(res.b).toMatchObject({
+      pegging: 5,
+      hand: 2,
+      crib: 0,
+      heels: 0,
+      isDealer: false,
+      total: 7,
+    });
+  });
+
+  it('withholds heels when the cut was not a jack', () => {
+    expect(scoreDeal(input({ heels: false }), players).a.heels).toBe(0);
+    expect(scoreDeal(input({ heels: true }), players).a.heels).toBe(HEELS_POINTS);
+  });
+
+  it('scores nothing for anyone when the dealer is unset', () => {
+    const res = scoreDeal(input({ dealerId: null, heels: true }), players);
+    expect(res.a.heels).toBe(0);
+    expect(res.b.heels).toBe(0);
+  });
+});
+
+describe('scoreRound', () => {
+  it('mirrors a partnership score onto both partners', () => {
+    const cfg = { mode: 'partners' };
+    const i: CribbageInput = {
+      dealerId: 'c',
+      heels: true,
+      entries: {
+        'team-1': {
+          pegging: 4,
+          hand: { ...emptyBreakdown(), fifteens: 1 },
+          crib: emptyBreakdown(),
+        },
+        'team-2': {
+          pegging: 1,
+          hand: { ...emptyBreakdown(), runs: 5 },
+          crib: { ...emptyBreakdown(), pairs: 1 },
+        },
+      },
+    };
+    const deltas = scoreRound(i, four, cfg);
+    expect(deltas).toEqual({ a: 6, b: 6, c: 10, d: 10 });
+  });
+
+  it('scores three-handed play as three independent seats', () => {
+    const three = four.slice(0, 3);
+    const i: CribbageInput = {
+      dealerId: 'b',
+      heels: false,
+      entries: {
+        a: { pegging: 2, hand: emptyBreakdown(), crib: emptyBreakdown() },
+        b: {
+          pegging: 0,
+          hand: { ...emptyBreakdown(), fifteens: 2 },
+          crib: { ...emptyBreakdown(), nob: 1 },
+        },
+        c: { pegging: 1, hand: emptyBreakdown(), crib: emptyBreakdown() },
+      },
+    };
+    expect(scoreRound(i, three, {})).toEqual({ a: 2, b: 5, c: 1 });
+  });
+});
+
+describe('validateRound', () => {
+  it('accepts a well-formed deal', () => {
+    expect(validateRound(input(), players)).toBeNull();
+  });
+
+  it('insists on a dealer', () => {
+    expect(validateRound(input({ dealerId: null }), players)).toMatch(/whose deal/i);
+  });
+
+  it('rejects a dealer who is not at the table', () => {
+    expect(validateRound(input({ dealerId: 'zz' }), players)).toMatch(/isn't in this game/i);
+  });
+
+  it('rejects negative pegging and negative counts', () => {
+    const bad = input({ entries: { a: { ...emptyEntry(), pegging: -1 }, b: emptyEntry() } });
+    expect(validateRound(bad, players)).toMatch(/negative/i);
+    const badHand = input({
+      entries: { a: { ...emptyEntry(), hand: { ...emptyBreakdown(), runs: -3 } }, b: emptyEntry() },
+    });
+    expect(validateRound(badHand, players)).toMatch(/negative/i);
+  });
+});
+
+// ── the board: target, skunks, pegging view ──────────────────────────────────
+
+describe('readConfig', () => {
+  it('defaults to the classic long game', () => {
+    expect(readConfig({})).toEqual({ target: 121, mode: 'solo', skunks: true });
+  });
+
+  it('reads the short 61-hole game and partnerships', () => {
+    expect(readConfig({ target: '61', mode: 'partners', skunks: false })).toEqual({
+      target: 61,
+      mode: 'partners',
+      skunks: false,
+    });
+  });
+
+  it('falls back to 121 on a garbage target', () => {
+    expect(readConfig({ target: 'nope' }).target).toBe(121);
+    expect(readConfig({ target: 0 }).target).toBe(121);
+  });
+});
+
+describe('the 121 win threshold', () => {
+  it('is not finished one hole short', () => {
+    expect(isFinished({ a: 120, b: 118 }, {})).toBe(false);
+  });
+
+  it('is finished exactly on 121', () => {
+    expect(isFinished({ a: 121, b: 118 }, {})).toBe(true);
+  });
+
+  it('is finished past 121', () => {
+    expect(isFinished({ a: 126, b: 90 }, {})).toBe(true);
+  });
+
+  it('honours a short 61-hole game', () => {
+    expect(isFinished({ a: 60, b: 40 }, { target: 61 })).toBe(false);
+    expect(isFinished({ a: 61, b: 40 }, { target: 61 })).toBe(true);
+  });
+
+  it('picks the highest total as the winner', () => {
+    expect(defaultWinners(cribbage, { a: 121, b: 90 }, {})).toEqual(['a']);
+  });
+});
+
+describe('skunk boundaries', () => {
+  it('puts the lines at 91 and 61 on a standard board', () => {
+    expect(skunkLine(121)).toBe(91);
+    expect(doubleSkunkLine(121)).toBe(61);
+  });
+
+  it('keeps the lines proportional on a short 61-hole game', () => {
+    expect(skunkLine(61)).toBe(46);
+    expect(doubleSkunkLine(61)).toBe(31);
+  });
+
+  it('is no skunk at exactly the skunk line', () => {
+    expect(skunkFor(91, 121)).toBe('none');
+  });
+
+  it('is a skunk one hole below the line', () => {
+    expect(skunkFor(90, 121)).toBe('skunk');
+  });
+
+  it('is still a skunk at exactly the double line', () => {
+    expect(skunkFor(61, 121)).toBe('skunk');
+  });
+
+  it('is a double skunk one hole below the double line', () => {
+    expect(skunkFor(60, 121)).toBe('double');
+    expect(skunkFor(0, 121)).toBe('double');
+  });
+
+  it('names the moment', () => {
+    expect(skunkLabel(skunkFor(60, 121)).headline).toMatch(/double skunk/i);
+    expect(skunkLabel(skunkFor(90, 121)).headline).toMatch(/^skunk/i);
+    expect(skunkLabel(skunkFor(100, 121)).headline).toMatch(/pegged out/i);
+  });
+});
+
+describe('finishView', () => {
+  it('stays null while nobody has pegged out', () => {
+    expect(finishView({ a: 118, b: 60 }, 121)).toBeNull();
+  });
+
+  it('reports the skunk once the winner is home', () => {
+    expect(finishView({ a: 121, b: 88 }, 121)).toEqual({
+      winnerScore: 121,
+      loserScore: 88,
+      kind: 'skunk',
+    });
+  });
+
+  it('reports a double skunk', () => {
+    expect(finishView({ a: 122, b: 44 }, 121)?.kind).toBe('double');
+  });
+
+  it('needs at least two sides', () => {
+    expect(finishView({ a: 130 }, 121)).toBeNull();
+  });
+});
+
+describe('pegView', () => {
+  it('projects this deal onto the board', () => {
+    const v = pegView(88, 12, 121);
+    expect(v).toMatchObject({ before: 88, projected: 100, remaining: 21, pegsOut: false });
+    expect(v.inSkunkRange).toBe(false);
+  });
+
+  it('flags the deal that pegs out', () => {
+    expect(pegView(115, 9, 121).pegsOut).toBe(true);
+    expect(pegView(115, 9, 121).remaining).toBe(0);
+  });
+
+  it('flags a projected score still short of the skunk line', () => {
+    expect(pegView(70, 6, 121).inSkunkRange).toBe(true);
+  });
+
+  it('never pegs backwards past the start', () => {
+    expect(pegView(3, -10, 121).projected).toBe(0);
+  });
+});
+
+describe('unitTotals / leaders', () => {
+  it('reads a partnership total off either partner', () => {
+    const units = unitsFor(four, 'partners');
+    expect(unitTotals(units, { a: 40, b: 40, c: 55, d: 55 })).toEqual({
+      'team-1': 40,
+      'team-2': 55,
+    });
+  });
+
+  it('names the side in front', () => {
+    expect([...leaders({ x: 40, y: 55 })]).toEqual(['y']);
+  });
+
+  it('names nobody on an all-square table', () => {
+    expect(leaders({ x: 40, y: 40 }).size).toBe(0);
+    expect(leaders({ x: 0, y: 0 }).size).toBe(0);
+    expect(leaders({ x: 10 }).size).toBe(0);
+  });
+});
+
+// ── module surface ───────────────────────────────────────────────────────────
+
+describe('the cribbage module', () => {
+  it('is shaped for two to four players', () => {
+    expect(cribbage.id).toBe('cribbage');
+    expect(cribbage.minPlayers).toBe(2);
+    expect(cribbage.maxPlayers).toBe(4);
+    expect(cribbage.lowerIsBetter).toBeFalsy();
+  });
+
+  it('seeds a fresh deal with the rotating dealer and empty counts', () => {
+    const i = cribbage.createRoundInput(ctx({ roundIndex: 3 })) as CribbageInput;
+    expect(i.dealerId).toBe('b');
+    expect(i.heels).toBe(false);
+    expect(Object.keys(i.entries).sort()).toEqual(['a', 'b']);
+    expect(breakdownTotal(i.entries.a.hand)).toBe(0);
+  });
+
+  it('seeds partnership entries when four play as teams', () => {
+    const i = emptyInput(four, 0, { mode: 'partners' });
+    expect(Object.keys(i.entries).sort()).toEqual(['team-1', 'team-2']);
+  });
+
+  it('scores a deal through the module', () => {
+    const i = input({
+      heels: true,
+      entries: {
+        a: {
+          pegging: 2,
+          hand: { ...emptyBreakdown(), fifteens: 4, pairs: 1 },
+          crib: { ...emptyBreakdown(), fifteens: 2 },
+        },
+        b: { pegging: 6, hand: { ...emptyBreakdown(), runs: 5, nob: 1 }, crib: emptyBreakdown() },
+      },
+    });
+    // Ada deals: 2 pegged + 10 hand + 4 crib + 2 heels = 18. Bo: 6 + 6 = 12.
+    expect(cribbage.scoreRound(i, ctx())).toEqual({ a: 18, b: 12 });
+  });
+
+  it('validates through the module', () => {
+    expect(cribbage.validateRound(input(), ctx())).toBeNull();
+    expect(cribbage.validateRound(input({ dealerId: null }), ctx())).toBeTruthy();
+  });
+
+  it('is open-ended — the board, not a hand count, ends it', () => {
+    expect(cribbage.maxRounds?.({}, 2) ?? null).toBeNull();
+  });
+});
+
+describe('describeRound', () => {
+  it('names the dealer whose crib it was, and the points', () => {
+    const round = {
+      input: input({ heels: true }),
+      deltas: { a: 18, b: 12 },
+    } as unknown as Round;
+    const text = cribbage.describeRound?.(round, players) ?? '';
+    expect(text).toContain("Ada's crib");
+    expect(text).toContain('heels');
+    expect(text).toContain('Ada +18');
+    expect(text).toContain('Bo +12');
+  });
+
+  it('degrades gracefully on an unrecorded deal', () => {
+    expect(describeDeal(undefined, players)).toMatch(/not recorded/i);
+  });
+});
+
+describe('roundCellTone', () => {
+  const round = (deltas: Record<ID, number>) => ({ deltas }) as unknown as Round;
+
+  it('marks a monster deal', () => {
+    expect(cribbage.roundCellTone?.(round({ a: 24 }), 'a')?.tone).toBe('good');
+  });
+
+  it('marks a shut-out deal', () => {
+    expect(cribbage.roundCellTone?.(round({ a: 0 }), 'a')?.tone).toBe('bad');
+  });
+
+  it('leaves an ordinary deal alone', () => {
+    expect(cribbage.roundCellTone?.(round({ a: 9 }), 'a')).toBeNull();
+  });
+});
+
+// ── stats ────────────────────────────────────────────────────────────────────
+
+describe('cribbageStats', () => {
+  const game: Game = {
+    id: 'g1',
+    type: 'cribbage',
+    config: { target: 121 },
+    playerIds: ['a', 'b'],
+    status: 'finished',
+    createdAt: 0,
+    roundCount: 2,
+  };
+
+  const rounds: Round[] = [
+    {
+      id: 'r1',
+      gameId: 'g1',
+      index: 0,
+      createdAt: 0,
+      deltas: { a: 100, b: 20 },
+      input: input({
+        heels: true,
+        entries: {
+          a: {
+            pegging: 5,
+            hand: { ...emptyBreakdown(), fifteens: 8, pairs: 6, nob: 1 },
+            crib: { ...emptyBreakdown(), runs: 6 },
+          },
+          b: { pegging: 2, hand: emptyBreakdown(), crib: emptyBreakdown() },
+        },
+      }),
+    },
+    {
+      id: 'r2',
+      gameId: 'g1',
+      index: 1,
+      createdAt: 1,
+      deltas: { a: 25, b: 20 },
+      input: input({
+        dealerId: 'b',
+        entries: {
+          a: { pegging: 1, hand: { ...emptyBreakdown(), fifteens: 2 }, crib: emptyBreakdown() },
+          b: {
+            pegging: 3,
+            hand: { ...emptyBreakdown(), runs: 4 },
+            crib: { ...emptyBreakdown(), fifteens: 1 },
+          },
+        },
+      }),
+    },
+  ];
+
+  const run = () =>
+    cribbageStats({ games: [game], rounds, players: players as never, canonical: (id) => id });
+
+  it('records the best hand a player counted', () => {
+    const best = run().perPlayer?.a?.find((m) => m.key === 'cb_best');
+    expect(best?.value).toBe('29');
+  });
+
+  it('counts hands that scored nothing', () => {
+    const zero = run().perPlayer?.b?.find((m) => m.key === 'cb_zero');
+    expect(zero?.value).toBe('1');
+  });
+
+  it('counts crib points taken as dealer', () => {
+    expect(run().perPlayer?.a?.find((m) => m.key === 'cb_crib')?.value).toBe('6');
+    expect(run().perPlayer?.b?.find((m) => m.key === 'cb_crib')?.value).toBe('2');
+  });
+
+  it('counts his heels', () => {
+    expect(run().perPlayer?.a?.find((m) => m.key === 'cb_heels')?.value).toBe('1');
+  });
+
+  it('credits the skunk to the winner and marks the victim', () => {
+    // Final totals: Ada 125, Bo 40 — under 61, so a double skunk.
+    expect(run().perPlayer?.a?.find((m) => m.key === 'cb_skunks')?.value).toBe('1');
+    expect(run().perPlayer?.b?.find((m) => m.key === 'cb_skunked')?.value).toBe('1');
+    expect(run().global?.find((m) => m.key === 'cb_skunks_all')?.value).toBe('1');
+  });
+
+  it('returns empty stats with nothing to chew on', () => {
+    expect(cribbageStats({ games: [], rounds: [], players: [], canonical: (id) => id })).toEqual({
+      perPlayer: {},
+      global: [],
+    });
+  });
+});

--- a/src/lib/games/cribbage/index.ts
+++ b/src/lib/games/cribbage/index.ts
@@ -1,0 +1,119 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { cribbageStats } from './stats';
+import {
+  describeDeal,
+  emptyInput,
+  isFinished as cribbageFinished,
+  scoreRound as scoreCribbage,
+  validateRound as validateCribbage,
+  type CribbageInput,
+} from './logic';
+
+export type { Card, CribbageInput, CribbageConfig, Breakdown, UnitEntry, SkunkKind } from './logic';
+
+/** A deal this big is worth a nudge in the scorecard. */
+const MONSTER_DEAL = 20;
+
+export const cribbage: GameModule = {
+  id: 'cribbage',
+  name: 'Cribbage',
+  tagline: 'Fifteen-two, fifteen-four — peg your way to 121.',
+  emoji: '🂠',
+  keywords: ['crib', 'pegging', 'board', 'fifteens', 'nob', 'skunk', 'cards', 'two player'],
+  minPlayers: 2,
+  maxPlayers: 4,
+  teams: true,
+  configFields: [
+    {
+      key: 'target',
+      label: 'Length of board',
+      type: 'select',
+      default: '121',
+      options: [
+        { value: '121', label: 'Long game — 121 (twice around)' },
+        { value: '61', label: 'Short game — 61 (once around)' },
+      ],
+      help: 'First side to peg out wins. 121 is the classic; 61 is the quick one when the night is nearly over.',
+    },
+    {
+      key: 'mode',
+      label: 'Four players',
+      type: 'select',
+      default: 'solo',
+      options: [
+        { value: 'solo', label: 'Everyone for themselves' },
+        { value: 'partners', label: 'Partnerships: 1 & 2  vs  3 & 4' },
+      ],
+      help: 'Four-handed cribbage is usually two partnerships pegging one score each. Ignored with two or three players.',
+    },
+    {
+      key: 'skunks',
+      label: 'Call out skunks at the finish',
+      type: 'boolean',
+      default: true,
+      help: 'A loser short of the skunk line (91 on a 121 board) is skunked; short of half the board, double skunked.',
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): CribbageInput =>
+    emptyInput(ctx.players, ctx.roundIndex, ctx.config),
+
+  validateRound: (input: CribbageInput, ctx: RoundContext): string | null =>
+    validateCribbage(input, ctx.players, ctx.config),
+
+  scoreRound: (input: CribbageInput, ctx: RoundContext): Record<ID, number> =>
+    scoreCribbage(input, ctx.players, ctx.config),
+
+  isFinished: (totals, { config }) => cribbageFinished(totals, config),
+
+  describeRound: (round: Round, players): string =>
+    describeDeal(round.input as CribbageInput | undefined, players, round.deltas ?? {}),
+
+  // Scorecard emphasis for the two deals worth a second look: a monster count,
+  // and the deal where a side took nothing at all. Both are co-signalled by the
+  // title/AT label, and only the per-round (delta) view asks for a tone.
+  roundCellTone: (round: Round, playerId: ID) => {
+    const delta = round.deltas?.[playerId];
+    if (delta == null) return null;
+    if (delta >= MONSTER_DEAL) return { tone: 'good', label: `Monster deal (+${delta})` };
+    if (delta === 0) return { tone: 'bad', label: 'Shut out — nothing pegged' };
+    return null;
+  },
+
+  help: [
+    'Cribbage is a race up a board: first side to peg out (121 holes, or 61 for a',
+    'short game) wins the moment they get there.',
+    '',
+    'Every deal has three scoring beats, and this editor records them in that order:',
+    '',
+    '1. The play ("pegging") — fifteens, pairs, runs, a go, and last card. Tap the',
+    '   total each side pegged during the play.',
+    '2. The hands — non-dealer counts first, then the dealer.',
+    '3. The crib — the dealer’s alone, counted last.',
+    '',
+    'Counting a hand (four cards plus the cut starter):',
+    '• Fifteens — every combination adding to 15 is worth 2.',
+    '• Pairs — every pair is 2, so three of a kind is 6 and four of a kind is 12.',
+    '• Runs — three or more in rank, worth their length, once for each way it can',
+    '  be made (a double run of three is 6).',
+    '• Flush — 4 for four cards of a suit, 5 if the starter matches. The crib only',
+    '  flushes on all five, for 5.',
+    '• Nob — 1 for a jack in hand matching the starter’s suit.',
+    '',
+    '🂻 His heels: if the cut turns a jack, the dealer takes 2 straight away.',
+    '',
+    'The deal rotates every hand, and the crib always belongs to whoever dealt.',
+    '',
+    '🦨 Skunk: the loser finishes short of the skunk line (91 on a 121 board).',
+    '🦨🦨 Double skunk: they finish short of half the board (61). Talked about for years.',
+    '',
+    'No hand of five cards can ever count 19 — which is why a worthless hand is',
+    'jokingly called "a nineteen".',
+  ].join('\n'),
+
+  stats: cribbageStats,
+
+  RoundEditor,
+  editorLoader: () => import('./CribbageEditor.svelte'),
+};

--- a/src/lib/games/cribbage/logic.ts
+++ b/src/lib/games/cribbage/logic.ts
@@ -1,0 +1,560 @@
+import type { ID } from '../../types';
+
+/**
+ * Pure Cribbage scoring — no Svelte, no I/O, so it's independently unit-testable
+ * and safe for the stats engine to import.
+ *
+ * Cribbage is a race up a pegging board (121 holes, or 61 for a short "once
+ * around" game). Every deal, each side counts its hand; the *dealer* also counts
+ * the crib, and takes two for "his heels" when the cut turns a jack. Points also
+ * come from the play itself ("pegging"), which the editor records as one number
+ * because nobody wants to log fifteen-two by fifteen-two.
+ *
+ * Two shapes of scoring live here and they are deliberately separate:
+ *
+ * 1. {@link scoreCards} — the authoritative rules engine. Give it four cards and
+ *    a starter and it returns the exact breakdown (fifteens, pairs, runs, flush,
+ *    nob). This is what settles arguments at the table and what the tests hammer.
+ * 2. {@link breakdownTotal} — the fast path. Players count their own hands the way
+ *    they always have and tap in the components; we just add them up.
+ *
+ * Both produce the same {@link Breakdown} shape, so the editor, the history text
+ * and the stats hook never care which route a hand arrived by.
+ */
+
+// ── cards ────────────────────────────────────────────────────────────────────
+
+export type Suit = 'S' | 'H' | 'D' | 'C';
+
+/** Ace = 1 … Jack = 11, Queen = 12, King = 13. */
+export type Rank = number;
+
+export interface Card {
+  rank: Rank;
+  suit: Suit;
+}
+
+export const SUITS: readonly Suit[] = ['S', 'H', 'D', 'C'];
+export const RANKS: readonly Rank[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+
+const RANK_LABELS: Record<number, string> = { 1: 'A', 11: 'J', 12: 'Q', 13: 'K' };
+const SUIT_GLYPHS: Record<Suit, string> = { S: '♠', H: '♥', D: '♦', C: '♣' };
+const SUIT_NAMES: Record<Suit, string> = {
+  S: 'spades',
+  H: 'hearts',
+  D: 'diamonds',
+  C: 'clubs',
+};
+const RANK_NAMES: Record<number, string> = { 1: 'Ace', 11: 'Jack', 12: 'Queen', 13: 'King' };
+
+export function rankLabel(rank: Rank): string {
+  return RANK_LABELS[rank] ?? String(rank);
+}
+
+export function suitGlyph(suit: Suit): string {
+  return SUIT_GLYPHS[suit];
+}
+
+export function cardLabel(card: Card): string {
+  return `${rankLabel(card.rank)}${suitGlyph(card.suit)}`;
+}
+
+/** Spoken name, for assistive tech ("Jack of spades"). */
+export function cardName(card: Card): string {
+  return `${RANK_NAMES[card.rank] ?? card.rank} of ${SUIT_NAMES[card.suit]}`;
+}
+
+export function cardKey(card: Card): string {
+  return `${card.rank}${card.suit}`;
+}
+
+export function sameCard(a: Card, b: Card): boolean {
+  return a.rank === b.rank && a.suit === b.suit;
+}
+
+/** Counting value: face cards are all worth ten, the ace is worth one. */
+export function cardValue(card: Card): number {
+  return Math.min(10, card.rank);
+}
+
+// ── the breakdown every hand reduces to ──────────────────────────────────────
+
+/**
+ * One counted hand. `fifteens` and `pairs` are *counts* (each worth two) because
+ * that's how they're called at the table — "fifteen-two, fifteen-four, and a pair
+ * is six". `runs`, `flush` and `nob` are already points, since a run is called by
+ * its length and a flush is simply four or five.
+ */
+export interface Breakdown {
+  fifteens: number;
+  pairs: number;
+  runs: number;
+  flush: number;
+  nob: number;
+}
+
+export function emptyBreakdown(): Breakdown {
+  return { fifteens: 0, pairs: 0, runs: 0, flush: 0, nob: 0 };
+}
+
+function whole(v: unknown): number {
+  const n = Math.round(Number(v));
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/** Points a counted hand is worth. Negative/garbage components read as zero. */
+export function breakdownTotal(b: Breakdown | undefined): number {
+  if (!b) return 0;
+  return whole(b.fifteens) * 2 + whole(b.pairs) * 2 + whole(b.runs) + whole(b.flush) + whole(b.nob);
+}
+
+/** True when nothing has been counted into this breakdown yet. */
+export function breakdownEmpty(b: Breakdown | undefined): boolean {
+  return breakdownTotal(b) === 0;
+}
+
+/** The famous impossible score: no five cards can ever count nineteen. */
+export const IMPOSSIBLE_HAND = 19;
+
+/** Highest hand in cribbage: J + three fives, with the matching five cut. */
+export const PERFECT_HAND = 29;
+
+// ── the rules engine ─────────────────────────────────────────────────────────
+
+function subsets<T>(items: readonly T[]): T[][] {
+  let out: T[][] = [[]];
+  for (const item of items) out = [...out, ...out.map((existing) => [...existing, item])];
+  return out;
+}
+
+/** Every combination summing to fifteen scores two. */
+export function countFifteens(cards: readonly Card[]): number {
+  let n = 0;
+  for (const combo of subsets(cards)) {
+    if (combo.length < 2) continue;
+    if (combo.reduce((a, c) => a + cardValue(c), 0) === 15) n += 1;
+  }
+  return n;
+}
+
+/** Every distinct pair of equal rank scores two (so a triple is three pairs). */
+export function countPairs(cards: readonly Card[]): number {
+  let n = 0;
+  for (let i = 0; i < cards.length; i += 1) {
+    for (let j = i + 1; j < cards.length; j += 1) {
+      if (cards[i].rank === cards[j].rank) n += 1;
+    }
+  }
+  return n;
+}
+
+/**
+ * Run points. Only the *longest* run counts, and it counts once for every way it
+ * can be made — so a double run of three is six, a triple run is nine, and a
+ * double-double run is twelve. Ranks run A-2-3…J-Q-K; there is no wrap-around.
+ */
+export function runPoints(cards: readonly Card[]): number {
+  const counts = new Map<number, number>();
+  for (const c of cards) counts.set(c.rank, (counts.get(c.rank) ?? 0) + 1);
+  const ranks = [...counts.keys()].sort((a, b) => a - b);
+
+  let best = 0;
+  let bestMultiplier = 0;
+  let i = 0;
+  while (i < ranks.length) {
+    let j = i;
+    while (j + 1 < ranks.length && ranks[j + 1] === ranks[j] + 1) j += 1;
+    const length = j - i + 1;
+    if (length >= 3 && length > best) {
+      let multiplier = 1;
+      for (let k = i; k <= j; k += 1) multiplier *= counts.get(ranks[k]) ?? 1;
+      best = length;
+      bestMultiplier = multiplier;
+    }
+    i = j + 1;
+  }
+  return best * bestMultiplier;
+}
+
+/**
+ * Flush points. Four hand cards of one suit are worth four, plus one more when
+ * the starter matches. The crib is stricter: it only flushes when all five cards
+ * share a suit, and then it's worth five.
+ */
+export function flushPoints(hand: readonly Card[], starter: Card | null, isCrib: boolean): number {
+  if (hand.length < 4) return 0;
+  const suit = hand[0].suit;
+  if (!hand.every((c) => c.suit === suit)) return 0;
+  const withStarter = starter != null && starter.suit === suit;
+  if (isCrib) return withStarter ? 5 : 0;
+  return withStarter ? 5 : 4;
+}
+
+/** One for his nob: a jack in hand matching the starter's suit. */
+export function nobPoints(hand: readonly Card[], starter: Card | null): number {
+  if (!starter) return 0;
+  return hand.some((c) => c.rank === 11 && c.suit === starter.suit) ? 1 : 0;
+}
+
+/**
+ * Score a hand (or crib) of four cards against the cut starter, returning the
+ * same {@link Breakdown} shape a hand counted by tapping produces.
+ *
+ * This is the *hand* count only. Two for his heels belongs to the dealer at the
+ * cut, not to any hand, so it's tracked separately on the round input.
+ */
+export function scoreCards(
+  hand: readonly Card[],
+  starter: Card | null = null,
+  isCrib = false,
+): Breakdown {
+  const all = starter ? [...hand, starter] : [...hand];
+  return {
+    fifteens: countFifteens(all),
+    pairs: countPairs(all),
+    runs: runPoints(all),
+    flush: flushPoints(hand, starter, isCrib),
+    nob: nobPoints(hand, starter),
+  };
+}
+
+/** True when the cut turns a jack — two for his heels, straight to the dealer. */
+export function isHeels(starter: Card | null): boolean {
+  return starter?.rank === 11;
+}
+
+export const HEELS_POINTS = 2;
+
+// ── scoring units (solo seats, or two partnerships) ──────────────────────────
+
+export type PlayStyle = 'solo' | 'partners';
+
+export interface Unit {
+  key: string;
+  /** 0-based order — a seat, or Team 1 / Team 2. */
+  index: number;
+  memberIds: ID[];
+}
+
+/**
+ * Effective play style. Partnerships need exactly four seats; any other count
+ * falls back to solo so a game is never wedged into an impossible shape. Mirrors
+ * the approach Spades and Euchre take, for the same reason: the shell has no
+ * partnership model, so a game keeps team play inside its own module.
+ */
+export function resolveMode(config: Record<string, unknown>, playerCount: number): PlayStyle {
+  return readConfig(config).mode === 'partners' && playerCount === 4 ? 'partners' : 'solo';
+}
+
+/** Group seats into scoring units. Partners pair by pick order: 1 & 2 vs 3 & 4. */
+export function unitsFor(players: readonly { id: ID }[], mode: PlayStyle): Unit[] {
+  if (mode === 'partners' && players.length === 4) {
+    return [
+      { key: 'team-1', index: 0, memberIds: [players[0].id, players[1].id] },
+      { key: 'team-2', index: 1, memberIds: [players[2].id, players[3].id] },
+    ];
+  }
+  return players.map((p, i) => ({ key: p.id, index: i, memberIds: [p.id] }));
+}
+
+/** The unit a player belongs to, or null when they aren't seated. */
+export function unitFor(units: readonly Unit[], playerId: ID | null): Unit | null {
+  if (!playerId) return null;
+  return units.find((u) => u.memberIds.includes(playerId)) ?? null;
+}
+
+// ── config ───────────────────────────────────────────────────────────────────
+
+export interface CribbageConfig {
+  /** Holes to peg out: 121 the classic long game, 61 the short one. */
+  target: number;
+  mode: PlayStyle;
+  /** Celebrate skunks at the finish. */
+  skunks: boolean;
+}
+
+export const DEFAULT_CONFIG: CribbageConfig = { target: 121, mode: 'solo', skunks: true };
+
+export function readConfig(config: Record<string, unknown> = {}): CribbageConfig {
+  const t = Math.round(Number(config.target));
+  return {
+    target: Number.isFinite(t) && t > 0 ? t : DEFAULT_CONFIG.target,
+    mode: config.mode === 'partners' ? 'partners' : 'solo',
+    skunks: config.skunks !== false,
+  };
+}
+
+// ── the round ────────────────────────────────────────────────────────────────
+
+export interface UnitEntry {
+  /** Points taken during the play — fifteens, pairs, runs, go, and last card. */
+  pegging: number;
+  hand: Breakdown;
+  /** Only counted for the dealer's unit; kept per-unit so a mis-set dealer is recoverable. */
+  crib: Breakdown;
+}
+
+export interface CribbageInput {
+  /** Whose deal it is — the crib and his heels belong to this player's unit. */
+  dealerId: ID | null;
+  /** The cut turned a jack: two for his heels, to the dealer. */
+  heels: boolean;
+  /** Counted results, keyed by scoring-unit key. */
+  entries: Record<string, UnitEntry>;
+}
+
+export function emptyEntry(): UnitEntry {
+  return { pegging: 0, hand: emptyBreakdown(), crib: emptyBreakdown() };
+}
+
+/**
+ * Whose deal it is by default. The deal rotates one seat every hand, so hand 1
+ * is dealt by the first seat, hand 2 by the second, and so on around the table.
+ * In partnerships it still rotates seat by seat, which alternates the crib
+ * between the two teams exactly as it should.
+ */
+export function defaultDealer(players: readonly { id: ID }[], roundIndex: number): ID | null {
+  if (!players.length) return null;
+  const i = ((Math.trunc(roundIndex) % players.length) + players.length) % players.length;
+  return players[i].id;
+}
+
+export function emptyInput(
+  players: readonly { id: ID }[],
+  roundIndex: number,
+  config: Record<string, unknown> = {},
+): CribbageInput {
+  const units = unitsFor(players, resolveMode(config, players.length));
+  const entries: Record<string, UnitEntry> = {};
+  for (const u of units) entries[u.key] = emptyEntry();
+  return { dealerId: defaultDealer(players, roundIndex), heels: false, entries };
+}
+
+/** Everything one unit takes this deal, split so the editor can show the parts. */
+export interface UnitResult {
+  pegging: number;
+  hand: number;
+  /** Crib points — zero unless this unit holds the deal. */
+  crib: number;
+  /** Two for his heels — zero unless this unit holds the deal. */
+  heels: number;
+  isDealer: boolean;
+  total: number;
+}
+
+export function scoreUnit(
+  entry: UnitEntry | undefined,
+  input: CribbageInput,
+  isDealer: boolean,
+): UnitResult {
+  const e = entry ?? emptyEntry();
+  const pegging = whole(e.pegging);
+  const hand = breakdownTotal(e.hand);
+  const crib = isDealer ? breakdownTotal(e.crib) : 0;
+  const heels = isDealer && input?.heels ? HEELS_POINTS : 0;
+  return { pegging, hand, crib, heels, isDealer, total: pegging + hand + crib + heels };
+}
+
+/** Per-unit results for a deal, keyed by unit key. */
+export function scoreDeal(
+  input: CribbageInput,
+  players: readonly { id: ID }[],
+  config: Record<string, unknown> = {},
+): Record<string, UnitResult> {
+  const units = unitsFor(players, resolveMode(config, players.length));
+  const dealerUnit = unitFor(units, input?.dealerId ?? null);
+  const out: Record<string, UnitResult> = {};
+  for (const u of units) {
+    out[u.key] = scoreUnit(input?.entries?.[u.key], input, dealerUnit?.key === u.key);
+  }
+  return out;
+}
+
+/** Per-player point deltas for a deal — partners each carry the team's score. */
+export function scoreRound(
+  input: CribbageInput,
+  players: readonly { id: ID }[],
+  config: Record<string, unknown> = {},
+): Record<ID, number> {
+  const units = unitsFor(players, resolveMode(config, players.length));
+  const results = scoreDeal(input, players, config);
+  const out: Record<ID, number> = {};
+  for (const u of units) {
+    for (const id of u.memberIds) out[id] = results[u.key]?.total ?? 0;
+  }
+  return out;
+}
+
+/** Null when the deal is good to record, otherwise a friendly reason. */
+export function validateRound(
+  input: CribbageInput,
+  players: readonly { id: ID; name: string }[],
+  config: Record<string, unknown> = {},
+): string | null {
+  const units = unitsFor(players, resolveMode(config, players.length));
+  if (!input?.dealerId) return 'Tap whose deal it is — the crib goes to the dealer.';
+  if (!unitFor(units, input.dealerId)) return "That dealer isn't in this game.";
+
+  for (const u of units) {
+    const e = input.entries?.[u.key] ?? emptyEntry();
+    const who =
+      u.memberIds
+        .map((id) => players.find((p) => p.id === id)?.name)
+        .filter(Boolean)
+        .join(' & ') || `Team ${u.index + 1}`;
+    if (!Number.isFinite(Number(e.pegging)) || Number(e.pegging) < 0) {
+      return `${who}: pegging points can't be negative.`;
+    }
+    for (const [label, b] of [
+      ['hand', e.hand],
+      ['crib', e.crib],
+    ] as const) {
+      for (const v of Object.values(b ?? {})) {
+        if (!Number.isFinite(Number(v)) || Number(v) < 0) {
+          return `${who}: ${label} counts can't be negative.`;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+// ── the board: pegging toward the finish, skunk lines and all ────────────────
+
+/**
+ * The skunk line, three-quarters of the way up the board — 91 on a standard 121
+ * board, exactly where tradition puts it. A loser short of this is skunked, and
+ * the proportion keeps the line sensible on a short 61-hole game too (46).
+ */
+export function skunkLine(target: number): number {
+  return Math.ceil(target * 0.75);
+}
+
+/** The double-skunk line, half the board — 61 on a 121 board. */
+export function doubleSkunkLine(target: number): number {
+  return Math.ceil(target * 0.5);
+}
+
+export type SkunkKind = 'none' | 'skunk' | 'double';
+
+/** How badly the trailing side was beaten, once someone has pegged out. */
+export function skunkFor(loserScore: number, target: number): SkunkKind {
+  if (loserScore < doubleSkunkLine(target)) return 'double';
+  if (loserScore < skunkLine(target)) return 'skunk';
+  return 'none';
+}
+
+export interface SkunkLabel {
+  kind: SkunkKind;
+  emoji: string;
+  headline: string;
+  cheer: string;
+}
+
+/** Copy for the end-of-game moment, so the editor and stats never re-invent it. */
+export function skunkLabel(kind: SkunkKind): SkunkLabel {
+  if (kind === 'double') {
+    return {
+      kind,
+      emoji: '🦨🦨',
+      headline: 'Double skunk!',
+      cheer: 'Not even halfway up the board. This one goes in the family history.',
+    };
+  }
+  if (kind === 'skunk') {
+    return {
+      kind,
+      emoji: '🦨',
+      headline: 'Skunk!',
+      cheer: 'Short of the skunk line — a proper drubbing.',
+    };
+  }
+  return { kind, emoji: '🏁', headline: 'Pegged out', cheer: 'A clean, honest finish.' };
+}
+
+/** A unit's position on the board, before and after this deal. */
+export interface PegView {
+  before: number;
+  projected: number;
+  target: number;
+  /** True when this deal takes the unit past the finish. */
+  pegsOut: boolean;
+  /** Holes still to peg after this deal (0 once out). */
+  remaining: number;
+  /** True when the projected score is still short of the skunk line. */
+  inSkunkRange: boolean;
+}
+
+export function pegView(before: number, delta: number, target: number): PegView {
+  const projected = Math.max(0, before + delta);
+  const pegsOut = target > 0 && projected >= target;
+  return {
+    before,
+    projected,
+    target,
+    pegsOut,
+    remaining: target > 0 ? Math.max(0, target - projected) : 0,
+    inSkunkRange: target > 0 && projected < skunkLine(target),
+  };
+}
+
+/** Unit totals going into this deal (both partners mirror the team score). */
+export function unitTotals(
+  units: readonly Unit[],
+  totals: Record<ID, number>,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const u of units) {
+    out[u.key] = u.memberIds.length ? Math.max(...u.memberIds.map((id) => totals[id] ?? 0)) : 0;
+  }
+  return out;
+}
+
+/** Unit keys currently in front. Empty on an all-square table (nobody leads yet). */
+export function leaders(unitScores: Record<string, number>): Set<string> {
+  const keys = Object.keys(unitScores);
+  if (keys.length < 2) return new Set();
+  const values = keys.map((k) => unitScores[k]);
+  const max = Math.max(...values);
+  if (max === Math.min(...values)) return new Set();
+  return new Set(keys.filter((k) => unitScores[k] === max));
+}
+
+export function isFinished(totals: Record<ID, number>, config: Record<string, unknown>): boolean {
+  const { target } = readConfig(config);
+  return Object.values(totals).some((t) => t >= target);
+}
+
+/**
+ * The finish, once someone has pegged out: the winning score, the best of the
+ * rest, and how badly they were beaten. Returns null while the game is live.
+ */
+export interface FinishView {
+  winnerScore: number;
+  loserScore: number;
+  kind: SkunkKind;
+}
+
+export function finishView(unitScores: Record<string, number>, target: number): FinishView | null {
+  const values = Object.values(unitScores);
+  if (values.length < 2) return null;
+  const winnerScore = Math.max(...values);
+  if (target <= 0 || winnerScore < target) return null;
+  const loserScore = Math.min(...values);
+  return { winnerScore, loserScore, kind: skunkFor(loserScore, target) };
+}
+
+// ── history text ─────────────────────────────────────────────────────────────
+
+/** Short, glanceable summary of a recorded deal for the history table. */
+export function describeDeal(
+  input: CribbageInput | undefined,
+  players: readonly { id: ID; name: string }[],
+  deltas: Record<ID, number> = {},
+): string {
+  if (!input?.dealerId) return 'Deal not recorded';
+  const dealer = players.find((p) => p.id === input.dealerId)?.name ?? '?';
+  const parts = players.map((p) => `${p.name} +${deltas[p.id] ?? 0}`);
+  const heels = input.heels ? ' · 🂻 heels +2' : '';
+  return `🂠 ${dealer}'s crib${heels} — ${parts.join(' · ')}`;
+}

--- a/src/lib/games/cribbage/stats.ts
+++ b/src/lib/games/cribbage/stats.ts
@@ -1,0 +1,243 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg, fmtInt } from '../../stats/format';
+import {
+  breakdownTotal,
+  readConfig,
+  resolveMode,
+  scoreDeal,
+  skunkFor,
+  unitFor,
+  unitsFor,
+  type CribbageInput,
+} from './logic';
+
+interface CribbageAgg {
+  /** Hands counted (one per deal the member sat for). */
+  hands: number;
+  handPoints: number;
+  bestHand: number;
+  /** Hands that counted nothing at all. */
+  zeroHands: number;
+  /** Deals held as dealer, and the crib points taken across them. */
+  deals: number;
+  cribPoints: number;
+  bestCrib: number;
+  peggingPoints: number;
+  heels: number;
+  skunksDealt: number;
+  skunked: number;
+}
+
+function blank(): CribbageAgg {
+  return {
+    hands: 0,
+    handPoints: 0,
+    bestHand: 0,
+    zeroHands: 0,
+    deals: 0,
+    cribPoints: 0,
+    bestCrib: 0,
+    peggingPoints: 0,
+    heels: 0,
+    skunksDealt: 0,
+    skunked: 0,
+  };
+}
+
+/**
+ * Cribbage stats, replayed purely from each game's recorded deals. Hand and crib
+ * counts are personal in solo play and shared by a partnership (both partners
+ * count the same unit result), exactly as the scoring does. Skunks are read from
+ * each game's final standing against that game's own board length, so a short
+ * 61-hole game is judged by its own skunk line. No Svelte, no I/O.
+ */
+export function cribbageStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const per = new Map<ID, CribbageAgg>();
+  const get = (id: ID): CribbageAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = blank();
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let totalSkunks = 0;
+  let totalDoubles = 0;
+  let bestHandAnywhere = 0;
+
+  for (const g of games) {
+    const seats = g.playerIds.map((id) => ({ id }));
+    if (!seats.length) continue;
+    const cfg = readConfig(g.config);
+    const units = unitsFor(seats, resolveMode(g.config, seats.length));
+    const gameRounds = rounds.filter((r) => r.gameId === g.id).sort((a, b) => a.index - b.index);
+    if (!gameRounds.length) continue;
+
+    const finalScores: Record<string, number> = {};
+    for (const u of units) finalScores[u.key] = 0;
+
+    for (const r of gameRounds) {
+      const input = r.input as CribbageInput | undefined;
+      if (!input?.entries) continue;
+      const results = scoreDeal(input, seats, g.config);
+      const dealerUnit = unitFor(units, input.dealerId ?? null);
+
+      for (const u of units) {
+        const res = results[u.key];
+        if (!res) continue;
+        // The recorded ledger is the score of record, so the finish is read from
+        // it rather than from the replay; a unit's members all carry its delta.
+        finalScores[u.key] += Number(r.deltas?.[u.memberIds[0]]) || 0;
+        const entry = input.entries[u.key];
+        const cribCount = res.isDealer ? breakdownTotal(entry?.crib) : 0;
+
+        for (const mid of u.memberIds) {
+          const a = get(canonical(mid));
+          a.hands += 1;
+          a.handPoints += res.hand;
+          a.peggingPoints += res.pegging;
+          if (res.hand === 0) a.zeroHands += 1;
+          if (res.hand > a.bestHand) a.bestHand = res.hand;
+          if (res.isDealer) {
+            a.deals += 1;
+            a.cribPoints += cribCount;
+            if (cribCount > a.bestCrib) a.bestCrib = cribCount;
+          }
+        }
+        if (res.hand > bestHandAnywhere) bestHandAnywhere = res.hand;
+      }
+
+      // His heels is the individual dealer's two, not the whole unit's.
+      if (input.heels && input.dealerId && dealerUnit) {
+        get(canonical(input.dealerId)).heels += 1;
+      }
+    }
+
+    // The finish: who got home, and how badly the trailing side was beaten.
+    const keys = Object.keys(finalScores);
+    if (keys.length < 2) continue;
+    const winnerScore = Math.max(...keys.map((k) => finalScores[k]));
+    if (winnerScore < cfg.target) continue;
+    const loserKey = keys.reduce((lo, k) => (finalScores[k] < finalScores[lo] ? k : lo), keys[0]);
+    const kind = skunkFor(finalScores[loserKey], cfg.target);
+    if (kind === 'none') continue;
+
+    totalSkunks += 1;
+    if (kind === 'double') totalDoubles += 1;
+    for (const u of units) {
+      const won = finalScores[u.key] === winnerScore;
+      for (const mid of u.memberIds) {
+        const a = get(canonical(mid));
+        if (won) a.skunksDealt += 1;
+        else if (u.key === loserKey) a.skunked += 1;
+      }
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let allHands = 0;
+  let allHandPoints = 0;
+  let allHeels = 0;
+
+  for (const [id, a] of per) {
+    allHands += a.hands;
+    allHandPoints += a.handPoints;
+    allHeels += a.heels;
+
+    const metrics: Metric[] = [];
+    if (a.hands) {
+      metrics.push({
+        key: 'cb_best',
+        label: 'Best hand',
+        value: fmtInt(a.bestHand),
+        sub: a.bestHand >= 24 ? 'a monster' : undefined,
+        emoji: '🃏',
+      });
+      metrics.push({
+        key: 'cb_avg',
+        label: 'Avg per hand',
+        value: fmtAvg(a.handPoints / a.hands),
+        emoji: '🔢',
+      });
+    }
+    if (a.zeroHands) {
+      metrics.push({
+        key: 'cb_zero',
+        label: 'Hands worth nothing',
+        value: fmtInt(a.zeroHands),
+        emoji: '🫥',
+      });
+    }
+    if (a.cribPoints) {
+      metrics.push({
+        key: 'cb_crib',
+        label: 'Crib points',
+        value: fmtInt(a.cribPoints),
+        sub: a.deals ? `over ${a.deals} deal${a.deals === 1 ? '' : 's'}` : undefined,
+        emoji: '🂠',
+      });
+    }
+    if (a.peggingPoints) {
+      metrics.push({
+        key: 'cb_peg',
+        label: 'Pegged in play',
+        value: fmtInt(a.peggingPoints),
+        emoji: '📌',
+      });
+    }
+    if (a.heels) {
+      metrics.push({ key: 'cb_heels', label: 'His heels', value: fmtInt(a.heels), emoji: '🂻' });
+    }
+    if (a.skunksDealt) {
+      metrics.push({
+        key: 'cb_skunks',
+        label: 'Skunks dealt out',
+        value: fmtInt(a.skunksDealt),
+        emoji: '🦨',
+      });
+    }
+    if (a.skunked) {
+      metrics.push({
+        key: 'cb_skunked',
+        label: 'Times skunked',
+        value: fmtInt(a.skunked),
+        emoji: '😬',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (bestHandAnywhere) {
+    global.push({
+      key: 'cb_best_all',
+      label: 'Best hand counted',
+      value: fmtInt(bestHandAnywhere),
+      emoji: '🃏',
+    });
+  }
+  if (allHands) {
+    global.push({
+      key: 'cb_avg_all',
+      label: 'Avg per hand',
+      value: fmtAvg(allHandPoints / allHands),
+      emoji: '🔢',
+    });
+  }
+  if (allHeels) {
+    global.push({ key: 'cb_heels_all', label: 'His heels', value: fmtInt(allHeels), emoji: '🂻' });
+  }
+  if (totalSkunks) {
+    global.push({
+      key: 'cb_skunks_all',
+      label: 'Skunks',
+      value: fmtInt(totalSkunks),
+      sub: totalDoubles ? `${totalDoubles} double` : undefined,
+      emoji: '🦨',
+    });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Adds Cribbage as a new game module in `src/lib/games/cribbage/`, built from scratch against the current `GameModule` contract and modelled on the hearts/euchre/spades structure. No registry change was needed — I verified the auto-discovery assumption in `src/lib/games/registry.ts` (`import.meta.glob('./*/index.ts')` plus a structural guard), and `registry.test.ts` has no hardcoded module count, so the module is picked up by its folder alone.

### Player-count scope (the decision you asked me to state)

- **2 players** — classic, fully supported.
- **3 players** — supported as three independent seats (each keeps their own crib deal; the dealer rotates one seat per hand).
- **4 players** — supported **either** as four independent seats **or** as two partnerships (seats 1&2 vs 3&4), chosen with the `mode` config field. Partnerships mirror the unit score onto both members, following the Euchre/Spades precedent: the shell has no partnership model, so team play lives inside the module.

I deliberately did **not** model the 5-card discard mechanics or per-card pegging play. Pegging is entered as a single per-deal number, which is how a table actually keeps score, and it keeps the editor honest about what it can verify.

### Skunk lines

`skunkLine = ceil(target × 0.75)` and `doubleSkunkLine = ceil(target × 0.5)`. On a 121 board that reproduces the traditional **91** and **61** exactly, and it degrades sensibly to 46/31 on the short 61-hole game. (The obvious alternative — fixed `target − 30` / `target − 60` offsets — produces a nonsensical double-skunk line of 1 at target 61.) Boundaries follow the table convention: exactly 91 is not a skunk, 90 is; exactly 61 is still a skunk, 60 is a double.

### Design

Game-Night LARPer, with the pegging board as the costume:

- `PegBoard.svelte` renders progress to 121 as a peg lane with a back peg, a front peg, street ticks, and marked skunk / double-skunk lines. Fills animate with `transform: scaleX()` (not `width`) and are disabled under `prefers-reduced-motion`.
- **Whose crib it is** is stated three ways — a dealer radiogroup with a "DEALS" badge, an explicit crib-ownership note, and the crib counter only being live for the dealer's unit. A stale non-dealer crib count is ignored rather than erased, so a mis-set dealer is recoverable.
- Exactly one Royal Violet primary action per screen: the shell's Save button keeps it, so nothing here competes. Crown Gold appears only on the leader crown and the winning front peg.
- All targets ≥46px, `tabular-nums` on every changing score, every color cue paired with text/icon/position.

### Changes

- `logic.ts` — pure scoring core: card model, `scoreCards` rules engine (fifteens, pairs, runs with multiplicity, hand/crib flush, nob), `Breakdown`/`breakdownTotal`, units and partnerships, round scoring and validation, board/skunk views, history text.
- `cribbage.test.ts` — 99 tests.
- `stats.ts` — best hand, average, blanks, crib points, pegging, his heels, skunks dealt and taken. The finish is read from the recorded deltas ledger (the score of record) and judged against that game's own target.
- `index.ts` — the module: 2–4 players, `target` (121/61), `mode` (seats/partnerships), `skunks` toggle.
- `CribbageEditor.svelte`, `PegBoard.svelte`, `CountAssist.svelte` — editor, costume, and an optional 52-card picker that counts a hand for you and flags heels on a cut jack.

### Testing

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm test` — 1498 passed (53 files); 99 of those are cribbage
- [x] `npm run build`
- [x] `npm run lint`, `prettier --check`
- Rebased onto `b24df1e` (post Secret Hitler #143 and Stardew #144) and re-ran the **full** suite, not just this module. `coop` is intentionally left unset — Cribbage is competitive.

Scoring coverage is where the effort went, since fifteens and runs are where cribbage bugs hide: the classic **29-point hand** as a fixture, the 7-7-8-8+9 double-double run, hand-vs-crib flush asymmetry, nob vs. heels, the "impossible 19", the 121 win threshold, and both skunk boundaries from either side.

## Issues

Closes #141