### PR TITLE
feat(wizard): add Wizard game module

### DIFF
--- a/src/lib/games/wizard/WizardEditor.svelte
+++ b/src/lib/games/wizard/WizardEditor.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { bumpOnChange } from '../../motion';
+  import { wizard } from './index';
+  import { cardsForRound, scoreRow, type WizardInput } from './logic';
+
+  let { input = $bindable(), ctx }: { input: WizardInput; ctx: RoundContext } = $props();
+
+  const n = $derived(cardsForRound(ctx.roundIndex));
+  const bidSum = $derived(
+    ctx.players.reduce((a, p) => a + (Number(input.rows[p.id]?.bid) || 0), 0),
+  );
+  const trickSum = $derived(
+    ctx.players.reduce((a, p) => a + (Number(input.rows[p.id]?.tricks) || 0), 0),
+  );
+  const tableRead = $derived(
+    bidSum === n ? '⚖️ dead even' : bidSum > n ? '🌊 over-bid table' : '🍃 bids to spare',
+  );
+  const left = $derived(n - trickSum);
+
+  // Who's leading right now — crowned so the table can see the race, never
+  // colour alone (the 👑 + "leading" label carry the state).
+  const leaderIds = $derived(computeLeaders(ctx.players, ctx.totals));
+  function computeLeaders(
+    players: RoundContext['players'],
+    totals: Record<string, number>,
+  ): Set<string> {
+    if (players.length < 2) return new Set();
+    const vals = players.map((p) => totals[p.id] ?? 0);
+    const max = Math.max(...vals);
+    const min = Math.min(...vals);
+    if (max === min) return new Set();
+    return new Set(players.filter((p) => (totals[p.id] ?? 0) === max).map((p) => p.id));
+  }
+
+  function preview(id: string): number {
+    return scoreRow(input.rows[id]);
+  }
+
+  let showHelp = $state(false);
+</script>
+
+<div class="stack">
+  <div class="row spread wrap">
+    <span class="pill" class:score-bad={trickSum > n}>
+      🃏 {trickSum} of {n} tricks{#if left > 0}
+        · {left} to go{:else if left === 0}
+        · hand complete ✓{:else}
+        · {-left} over!{/if}
+    </span>
+    <span class="row wrap" style="gap: 8px">
+      <span class="pill">Bids: {bidSum} · {tableRead}</span>
+      <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+        How to score
+      </button>
+    </span>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{wizard.help}</pre>
+  {/if}
+
+  {#each ctx.players as p (p.id)}
+    {@const row = input.rows[p.id]}
+    {#if row}
+      {@const delta = preview(p.id)}
+      {@const leading = leaderIds.has(p.id)}
+      <div class="prow">
+        <div class="phead row spread">
+          <span class="who row" style="gap: 8px">
+            <Avatar name={p.name} color={p.color} />
+            <strong>{p.name}</strong>
+            {#if leading}<span class="crown" title="Leading">👑</span>{/if}
+          </span>
+          <span
+            class="proj"
+            class:score-good={delta >= 0}
+            class:score-bad={delta < 0}
+            use:bumpOnChange={delta}
+          >
+            {delta >= 0 ? `+${delta}` : delta}
+          </span>
+        </div>
+
+        <div class="fields row">
+          <label class="f">
+            <span>Bid</span>
+            <Stepper bind:value={row.bid} min={0} max={n} label={`${p.name} bid`} />
+          </label>
+          <label class="f">
+            <span>Tricks</span>
+            <Stepper bind:value={row.tricks} min={0} max={n} label={`${p.name} tricks`} />
+          </label>
+        </div>
+      </div>
+    {/if}
+  {/each}
+</div>
+
+<style>
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .who strong {
+    font-weight: 700;
+  }
+  .crown {
+    font-size: 0.95rem;
+  }
+  .proj {
+    font-weight: 800;
+    font-size: 1.05rem;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    padding-left: 8px;
+  }
+  .fields {
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  .f {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/wizard/index.ts
+++ b/src/lib/games/wizard/index.ts
@@ -1,0 +1,59 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { wizardStats } from './stats';
+import {
+  describeRound as describeWizardRound,
+  emptyRow,
+  roundsForPlayerCount,
+  scoreRound as scoreWizard,
+  validateRound as validateWizard,
+  type WizardInput,
+} from './logic';
+
+export type { WizardInput, WizardRow } from './logic';
+
+export const wizard: GameModule = {
+  id: 'wizard',
+  name: 'Wizard',
+  tagline: 'Bid the exact tricks, or pay for the miss.',
+  emoji: '🧙',
+  keywords: ['trick taking', 'bidding', 'cards', 'trump'],
+  minPlayers: 3,
+  maxPlayers: 6,
+
+  createRoundInput: (ctx: RoundContext): WizardInput => ({
+    rows: Object.fromEntries(ctx.players.map((p) => [p.id, emptyRow()])),
+  }),
+
+  validateRound: (input: WizardInput, ctx: RoundContext): string | null =>
+    validateWizard(input, ctx.players, ctx.roundIndex),
+
+  scoreRound: (input: WizardInput, ctx: RoundContext): Record<ID, number> =>
+    scoreWizard(input, ctx.players),
+
+  maxRounds: (_config, playerCount) => roundsForPlayerCount(playerCount),
+
+  describeRound: (round: Round, players): string =>
+    describeWizardRound(round.input as WizardInput | undefined, players),
+
+  help: [
+    'A 60-card deck (the standard 52 plus 4 Wizards and 4 Jesters) deals 1 card',
+    'in round 1, growing by one card every round — 20 rounds at 3 players,',
+    '15 at 4, 12 at 5, 10 at 6.',
+    '',
+    'Every round, everyone bids the exact number of tricks they’ll take.',
+    '',
+    'Hit your bid exactly: 20 + 10 × bid.',
+    'Miss it: −10 for every trick over or under.',
+    '',
+    'Because every trick goes to exactly one player, the tricks recorded across',
+    'the table must add up to the round number — the editor checks this for you.',
+    '',
+    'Highest total after the last round wins.',
+  ].join('\n'),
+
+  stats: wizardStats,
+
+  RoundEditor,
+  editorLoader: () => import('./WizardEditor.svelte'),
+};

--- a/src/lib/games/wizard/logic.ts
+++ b/src/lib/games/wizard/logic.ts
@@ -1,0 +1,123 @@
+import type { ID, Player } from '../../types';
+
+/**
+ * Pure, Svelte-free Wizard scoring. No I/O, no DOM — independently unit-testable
+ * and safe for the stats engine to import.
+ *
+ * Wizard is played with a 60-card deck (the standard 52 plus 4 Wizards and 4
+ * Jesters). Round `n` (1-based) deals `n` cards to every player, so the game
+ * runs for as many rounds as the deck allows: 20 rounds at 3 players, 15 at 4,
+ * 12 at 5, 10 at 6 (`floor(60 / playerCount)`).
+ *
+ * Every round, every player bids the exact number of tricks they'll take, then
+ * the table plays the hand. Scoring rewards precision, not tricks:
+ * - Bid met exactly:   20 + 10 × bid
+ * - Bid missed:        −10 × |bid − tricks taken|
+ *
+ * Because a trick is won by exactly one player and round `n` deals out `n`
+ * tricks, the tricks recorded across the table must always sum to `n`.
+ */
+
+export interface WizardRow {
+  bid: number;
+  tricks: number;
+}
+
+export interface WizardInput {
+  rows: Record<ID, WizardRow>;
+}
+
+/** Points for landing exactly on a bid. */
+export const HIT_BASE = 20;
+/** Points per bid trick when the bid is hit. */
+export const HIT_PER_TRICK = 10;
+/** Points lost per trick over/under a missed bid. */
+export const MISS_PENALTY = 10;
+
+/** A fresh, unbid row. */
+export function emptyRow(): WizardRow {
+  return { bid: 0, tricks: 0 };
+}
+
+/** Cards dealt (and tricks available) in round `roundIndex` (0-based). */
+export function cardsForRound(roundIndex: number): number {
+  return roundIndex + 1;
+}
+
+/**
+ * Total rounds the 60-card deck supports for `playerCount` players — the deck
+ * is dealt out one more card per round until it can't deal a full round to
+ * everyone. `floor(60 / playerCount)`: 20 rounds at 3p, 15 at 4p, 12 at 5p,
+ * 10 at 6p.
+ */
+export function roundsForPlayerCount(playerCount: number): number {
+  if (playerCount <= 0) return 0;
+  return Math.floor(60 / playerCount);
+}
+
+function numOr(v: unknown, fallback: number): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/** Score a single player's row: hit the bid exactly, or pay per trick off. */
+export function scoreRow(row: WizardRow | undefined): number {
+  const bid = numOr(row?.bid, 0);
+  const tricks = numOr(row?.tricks, 0);
+  if (bid === tricks) return HIT_BASE + HIT_PER_TRICK * bid;
+  return -MISS_PENALTY * Math.abs(bid - tricks);
+}
+
+/** Per-player point deltas for one round. */
+export function scoreRound(
+  input: WizardInput,
+  players: readonly { id: ID }[],
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const p of players) out[p.id] = scoreRow(input?.rows?.[p.id]);
+  return out;
+}
+
+/**
+ * Validate one round. Bids and tricks must fall within the cards dealt this
+ * round, and — because every trick is won by exactly one player — the tricks
+ * recorded across the table must sum to exactly the cards dealt.
+ */
+export function validateRound(
+  input: WizardInput,
+  players: readonly { id: ID; name: string }[],
+  roundIndex: number,
+): string | null {
+  const n = cardsForRound(roundIndex);
+  let totalTricks = 0;
+
+  for (const p of players) {
+    const row = input?.rows?.[p.id] ?? emptyRow();
+    const bid = numOr(row.bid, 0);
+    if (!Number.isInteger(bid) || bid < 0 || bid > n) {
+      return `${p.name}: bid must be a whole number between 0 and ${n}.`;
+    }
+    const tricks = numOr(row.tricks, 0);
+    if (!Number.isInteger(tricks) || tricks < 0 || tricks > n) {
+      return `${p.name}: tricks must be a whole number between 0 and ${n}.`;
+    }
+    totalTricks += tricks;
+  }
+
+  if (totalTricks !== n) {
+    return `Tricks must total ${n} (currently ${totalTricks}).`;
+  }
+  return null;
+}
+
+/** Short per-player summary of a recorded round, e.g. "Ada 3/3 · Bo 1/0". */
+export function describeRound(input: WizardInput | undefined, players: Player[]): string {
+  return players
+    .map((p) => {
+      const row = input?.rows?.[p.id];
+      if (!row) return '';
+      return `${p.name} ${row.bid}/${row.tricks}`;
+    })
+    .filter(Boolean)
+    .join(' · ');
+}

--- a/src/lib/games/wizard/stats.ts
+++ b/src/lib/games/wizard/stats.ts
@@ -1,0 +1,109 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt, fmtPct } from '../../stats/format';
+import { scoreRow, type WizardInput } from './logic';
+
+interface WizardAgg {
+  bids: number;
+  hits: number;
+  zeroBids: number;
+  zeroHits: number;
+  bestRound: number;
+  worstRound: number;
+}
+
+/**
+ * Wizard stats, replayed purely from each round's recorded bids/tricks. A bid
+ * is "hit" when tricks === bid. Pure — no Svelte, no I/O — so it's independently
+ * unit-testable and safe for the stats engine to import.
+ */
+export function wizardStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, WizardAgg>();
+  const get = (id: ID): WizardAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { bids: 0, hits: 0, zeroBids: 0, zeroHits: 0, bestRound: -Infinity, worstRound: Infinity };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let totBids = 0;
+  let totHits = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as WizardInput | undefined;
+    if (!input?.rows) continue;
+    for (const [pid, row] of Object.entries(input.rows)) {
+      const a = get(canonical(pid));
+      const bid = Number(row.bid) || 0;
+      const tricks = Number(row.tricks) || 0;
+      const hit = bid === tricks;
+      a.bids += 1;
+      totBids += 1;
+      if (hit) {
+        a.hits += 1;
+        totHits += 1;
+      }
+      if (bid === 0) {
+        a.zeroBids += 1;
+        if (hit) a.zeroHits += 1;
+      }
+      const delta = scoreRow(row);
+      if (delta > a.bestRound) a.bestRound = delta;
+      if (delta < a.worstRound) a.worstRound = delta;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.bids) {
+      metrics.push({
+        key: 'wz_acc',
+        label: 'Bids nailed',
+        value: fmtPct(a.hits / a.bids),
+        emoji: '🎯',
+      });
+    }
+    if (a.zeroBids) {
+      metrics.push({
+        key: 'wz_zero',
+        label: 'Zero-bid success',
+        value: `${a.zeroHits}/${a.zeroBids}`,
+        emoji: '🫙',
+      });
+    }
+    if (a.bestRound > -Infinity) {
+      metrics.push({
+        key: 'wz_best',
+        label: 'Best round',
+        value: `+${fmtInt(a.bestRound)}`,
+        emoji: '✨',
+      });
+    }
+    if (a.worstRound < Infinity && a.worstRound < 0) {
+      metrics.push({
+        key: 'wz_worst',
+        label: 'Worst round',
+        value: fmtInt(a.worstRound),
+        emoji: '💥',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totBids) {
+    global.push({
+      key: 'wz_acc_all',
+      label: 'Bids nailed',
+      value: fmtPct(totHits / totBids),
+      emoji: '🎯',
+    });
+  }
+
+  return { perPlayer, global };
+}

--- a/src/lib/games/wizard/wizard.test.ts
+++ b/src/lib/games/wizard/wizard.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import type { Player, Round, RoundContext } from '../../types';
+import { wizard } from './index';
+import {
+  cardsForRound,
+  describeRound,
+  emptyRow,
+  roundsForPlayerCount,
+  scoreRound,
+  scoreRow,
+  validateRound,
+  type WizardInput,
+} from './logic';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+function row(bid: number, tricks: number) {
+  return { bid, tricks };
+}
+function hand(rows: Record<string, ReturnType<typeof row>>): WizardInput {
+  return { rows };
+}
+function player(id: string): Player {
+  return { id, name: id.toUpperCase(), color: '#7c5cff', createdAt: 0 };
+}
+const P3 = ['a', 'b', 'c'].map(player);
+const P4 = ['a', 'b', 'c', 'd'].map(player);
+const P5 = ['a', 'b', 'c', 'd', 'e'].map(player);
+const P6 = ['a', 'b', 'c', 'd', 'e', 'f'].map(player);
+
+// ── cards & rounds ───────────────────────────────────────────────────────────
+describe('cardsForRound', () => {
+  it('deals one more card each round, 1-based from a 0-based index', () => {
+    expect(cardsForRound(0)).toBe(1);
+    expect(cardsForRound(1)).toBe(2);
+    expect(cardsForRound(19)).toBe(20);
+  });
+});
+
+describe('roundsForPlayerCount', () => {
+  it('is floor(60 / playerCount) for the supported table sizes', () => {
+    expect(roundsForPlayerCount(3)).toBe(20);
+    expect(roundsForPlayerCount(4)).toBe(15);
+    expect(roundsForPlayerCount(5)).toBe(12);
+    expect(roundsForPlayerCount(6)).toBe(10);
+  });
+  it('is 0 for a non-positive player count', () => {
+    expect(roundsForPlayerCount(0)).toBe(0);
+    expect(roundsForPlayerCount(-1)).toBe(0);
+  });
+});
+
+// ── single-row scoring ───────────────────────────────────────────────────────
+describe('scoreRow', () => {
+  it('scores an exact hit: 20 + 10 x bid', () => {
+    expect(scoreRow(row(0, 0))).toBe(20);
+    expect(scoreRow(row(3, 3))).toBe(50);
+    expect(scoreRow(row(7, 7))).toBe(90);
+  });
+  it('scores a miss: -10 per trick over/under', () => {
+    expect(scoreRow(row(3, 1))).toBe(-20); // 2 short
+    expect(scoreRow(row(3, 5))).toBe(-20); // 2 over
+    expect(scoreRow(row(0, 1))).toBe(-10); // whiffed a zero bid
+  });
+  it('treats a missing row as an unbid, untaken 0/0 (a hit worth 20)', () => {
+    expect(scoreRow(undefined)).toBe(20);
+  });
+});
+
+describe('scoreRound', () => {
+  it('scores every player independently from their own row', () => {
+    const deltas = scoreRound(
+      hand({ a: row(2, 2), b: row(1, 0), c: row(0, 3) }),
+      P3,
+    );
+    expect(deltas).toEqual({ a: 40, b: -10, c: -30 });
+  });
+});
+
+// ── validation ──────────────────────────────────────────────────────────────
+describe('validateRound', () => {
+  it('accepts a round whose tricks total the cards dealt', () => {
+    const h = hand({ a: row(2, 1), b: row(0, 1), c: row(1, 1) });
+    expect(validateRound(h, P3, 2)).toBeNull(); // round index 2 -> 3 cards
+  });
+  it('rejects tricks that do not add up to the round number', () => {
+    const h = hand({ a: row(2, 1), b: row(0, 1), c: row(1, 0) });
+    expect(validateRound(h, P3, 2)).toMatch(/Tricks must total 3/);
+  });
+  it('rejects a bid above the cards dealt', () => {
+    const h = hand({ a: row(5, 0), b: row(0, 0), c: row(0, 0) });
+    expect(validateRound(h, P3, 0)).toMatch(/bid must be a whole number between 0 and 1/);
+  });
+  it('rejects tricks above the cards dealt', () => {
+    const h = hand({ a: row(0, 5), b: row(0, 0), c: row(0, 0) });
+    expect(validateRound(h, P3, 0)).toMatch(/tricks must be a whole number between 0 and 1/);
+  });
+  it('rejects a negative bid or trick count', () => {
+    const h = hand({ a: row(-1, 0), b: row(0, 0), c: row(0, 0) });
+    expect(validateRound(h, P3, 0)).toMatch(/bid must be a whole number/);
+  });
+  it('rejects a non-integer bid or trick count', () => {
+    const h = hand({ a: row(1.5, 0), b: row(0, 0), c: row(0, 0) });
+    expect(validateRound(h, P3, 0)).toMatch(/bid must be a whole number/);
+  });
+  it('scales the round total with the round number', () => {
+    const h5 = hand({ a: row(2, 2), b: row(1, 1), c: row(1, 1), d: row(1, 1), e: row(0, 0) });
+    expect(validateRound(h5, P5, 4)).toBeNull(); // round index 4 -> 5 cards, tricks sum to 5
+  });
+});
+
+// ── describeRound ───────────────────────────────────────────────────────────
+describe('describeRound', () => {
+  it('summarises bid/tricks per player', () => {
+    const input = hand({ a: row(2, 2), b: row(1, 0), c: row(0, 3) });
+    expect(describeRound(input, P3)).toBe('A 2/2 · B 1/0 · C 0/3');
+  });
+  it('skips players missing from the round', () => {
+    const input = hand({ a: row(2, 2) });
+    expect(describeRound(input, P3)).toBe('A 2/2');
+  });
+});
+
+// ── module wiring ───────────────────────────────────────────────────────────
+function ctxFor(
+  players: Player[],
+  config: Record<string, unknown>,
+  roundIndex: number,
+  rounds: Round[],
+): RoundContext {
+  return { game: { id: 'g' } as never, players, config, roundIndex, totals: {}, rounds };
+}
+
+describe('wizard module', () => {
+  it('has the expected identity and player bounds', () => {
+    expect(wizard.id).toBe('wizard');
+    expect(wizard.minPlayers).toBe(3);
+    expect(wizard.maxPlayers).toBe(6);
+    expect(wizard.teams).toBeFalsy();
+  });
+
+  it('creates a blank row for every player', () => {
+    const input = wizard.createRoundInput(ctxFor(P4, {}, 0, [])) as WizardInput;
+    expect(Object.keys(input.rows)).toEqual(['a', 'b', 'c', 'd']);
+    expect(input.rows.a).toEqual(emptyRow());
+  });
+
+  it('validateRound delegates to the round index for the card count', () => {
+    const good = hand({ a: row(1, 1), b: row(0, 0), c: row(0, 0), d: row(0, 0) });
+    expect(wizard.validateRound(good, ctxFor(P4, {}, 0, []))).toBeNull();
+    const bad = hand({ a: row(1, 1), b: row(0, 1), c: row(0, 0), d: row(0, 0) });
+    expect(wizard.validateRound(bad, ctxFor(P4, {}, 0, []))).toMatch(/Tricks must total 1/);
+  });
+
+  it('scoreRound matches the pure scoring function', () => {
+    const input = hand({ a: row(2, 2), b: row(1, 0), c: row(0, 3), d: row(0, 0) });
+    expect(wizard.scoreRound(input, ctxFor(P4, {}, 2, []))).toEqual({
+      a: 40,
+      b: -10,
+      c: -30,
+      d: 20,
+    });
+  });
+
+  it('maxRounds is the deck-derived round count for the table size', () => {
+    expect(wizard.maxRounds!({}, 3)).toBe(20);
+    expect(wizard.maxRounds!({}, 4)).toBe(15);
+    expect(wizard.maxRounds!({}, 5)).toBe(12);
+    expect(wizard.maxRounds!({}, 6)).toBe(10);
+  });
+
+  it('describeRound summarises the recorded bids/tricks', () => {
+    const r: Round = {
+      id: 'r0',
+      gameId: 'g',
+      index: 0,
+      input: hand({ a: row(1, 1), b: row(0, 0), c: row(0, 0) }),
+      deltas: {},
+      createdAt: 0,
+    };
+    expect(wizard.describeRound!(r, P3)).toBe('A 1/1 · B 0/0 · C 0/0');
+  });
+
+  it('has no config fields — Wizard needs none', () => {
+    expect(wizard.configFields ?? []).toEqual([]);
+  });
+});
+
+// ── full-length game sanity check ──────────────────────────────────────────
+describe('a full 6-player game', () => {
+  it('runs 10 rounds, each round n dealing n cards', () => {
+    const rounds = roundsForPlayerCount(6);
+    expect(rounds).toBe(10);
+    for (let i = 0; i < rounds; i++) {
+      expect(cardsForRound(i)).toBe(i + 1);
+    }
+  });
+
+  it('rejects a round beyond the deck once tricks cannot possibly total it', () => {
+    // Round 10 (index 9) deals 10 cards to 6 players — tricks must total 10.
+    const h = hand({
+      a: row(2, 2),
+      b: row(2, 2),
+      c: row(2, 2),
+      d: row(2, 2),
+      e: row(1, 1),
+      f: row(1, 0),
+    });
+    expect(validateRound(h, P6, 9)).toMatch(/Tricks must total 10/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the **Wizard** 🧙 game module, following current game-module conventions in this repo.

## Changes

- `src/lib/games/wizard/logic.ts` — pure scoring/validation core (bid/tricks rows, `20 + 10×bid` on an exact hit, `−10` per trick over/under on a miss, deck-derived round count).
- `src/lib/games/wizard/index.ts` — `GameModule` wiring, `editorLoader` lazy-chunk pattern, help text.
- `src/lib/games/wizard/WizardEditor.svelte` — round editor (bid/tricks steppers, live score preview, leader crown).
- `src/lib/games/wizard/stats.ts` — per-player bid-accuracy stats.
- `src/lib/games/wizard/wizard.test.ts` — 25 unit tests covering scoring, validation, and module wiring.

Rules confirmed against the published Wizard scoring: 60-card deck (52 + 4 Wizards + 4 Jesters), `floor(60/playerCount)` rounds, round `n` deals `n` cards, exact bid = `20 + 10×bid`, miss = `−10` per trick over/under, total tricks must equal the round number.

## Issues

Closes #149

## Testing

- [x] `npx vitest run src/lib/games/wizard` — 25/25 passed
- [x] `npm run check` (svelte-check + tsc) — 0 errors