### PR TITLE
feat(games): add Presidents game module

### DIFF
--- a/src/lib/games/presidents/PresidentsEditor.svelte
+++ b/src/lib/games/presidents/PresidentsEditor.svelte
@@ -1,0 +1,289 @@
+<script lang="ts">
+  import { flip } from 'svelte/animate';
+  import { SvelteMap } from 'svelte/reactivity';
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { prefersReducedMotion } from '../../motion';
+  import { haptic } from '../../haptics';
+  import {
+    SCHEME_META,
+    normalizeScheme,
+    pointsForPosition,
+    roundComplete,
+    titleFor,
+    type PresidentsInput,
+  } from './logic';
+  import { presidents } from './index';
+
+  let { input = $bindable(), ctx }: { input: PresidentsInput; ctx: RoundContext } = $props();
+
+  const scheme = $derived(normalizeScheme(ctx.config.scheme));
+  const meta = $derived(SCHEME_META[scheme]);
+  const n = $derived(ctx.players.length);
+
+  // Motion preference is read once (matches the rest of the app) so the
+  // ranking reorder gets a calm, instant alternative.
+  const reduced = prefersReducedMotion();
+  const flipDur = $derived(reduced ? 0 : 220);
+
+  let showHelp = $state(false);
+  let showPoints = $state(false);
+
+  function pos(id: string): number {
+    return Math.floor(Number(input.positions[id]) || 0);
+  }
+  function pts(id: string): number {
+    return pointsForPosition(scheme, pos(id), n);
+  }
+
+  // Ranking rows always read top→bottom as the current finishing order: the
+  // President on top, unranked players sink to the back. Steps are ±1 so a
+  // change is a gentle neighbour swap, animated via flip (snap under reduced
+  // motion).
+  const sortedPlayers = $derived.by(() => {
+    const order = new Map(ctx.players.map((p, i) => [p.id, i]));
+    return [...ctx.players].sort((a, b) => {
+      const pa = pos(a.id) || Number.POSITIVE_INFINITY;
+      const pb = pos(b.id) || Number.POSITIVE_INFINITY;
+      return pa - pb || (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0);
+    });
+  });
+
+  const complete = $derived(roundComplete(input, ctx.players));
+
+  // Two players can't share a finishing spot — flag any clash so it's fixable
+  // at a glance.
+  const clashes = $derived.by(() => {
+    const seen = new SvelteMap<number, number>();
+    for (const p of ctx.players) {
+      const v = pos(p.id);
+      if (v > 0) seen.set(v, (seen.get(v) ?? 0) + 1);
+    }
+    return seen;
+  });
+  function isClash(id: string): boolean {
+    const v = pos(id);
+    return v > 0 && (clashes.get(v) ?? 0) > 1;
+  }
+
+  function crownPresident(id: string) {
+    if (pos(id) === 1) return;
+    input.positions[id] = 1;
+    haptic('win');
+  }
+
+  // Reference payout table for the active scheme, 1st → last.
+  const payout = $derived.by(() => {
+    const rows: { pos: number; title: ReturnType<typeof titleFor>; pts: number }[] = [];
+    for (let i = 1; i <= n; i++) {
+      rows.push({ pos: i, title: titleFor(i, n), pts: pointsForPosition(scheme, i, n) });
+    }
+    return rows;
+  });
+</script>
+
+<div class="stack">
+  <div class="row spread wrap">
+    <span class="muted hint">Enter who finished where — first out is President.</span>
+    <span class="row" style="gap: 8px">
+      <button
+        type="button"
+        class="btn small ghost"
+        aria-pressed={showPoints}
+        onclick={() => (showPoints = !showPoints)}
+      >
+        {showPoints ? 'Hide points' : 'Points'}
+      </button>
+      <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+        {showHelp ? 'Hide rules' : 'How to play'}
+      </button>
+    </span>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{presidents.help}</pre>
+  {/if}
+
+  {#if showPoints}
+    <div class="points" role="note">
+      <p class="blurb">{meta.blurb}</p>
+      <div class="chips">
+        {#each payout as row (row.pos)}
+          <span class="chip">
+            <span class="p">{row.title.emoji} {row.title.label}</span>
+            <span class="v tnum">{row.pts > 0 ? '+' : ''}{row.pts}</span>
+          </span>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  <!-- Finishing-order entry: the table sorts itself as you assign each spot. -->
+  {#each sortedPlayers as p (p.id)}
+    {@const finish = pos(p.id)}
+    {@const clash = isClash(p.id)}
+    {@const title = titleFor(finish || 1, n)}
+    <div
+      class="prow"
+      class:clash
+      class:president={finish === 1 && !clash}
+      animate:flip={{ duration: flipDur }}
+    >
+      <div class="row spread head">
+        <span class="who">
+          <Avatar name={p.name} color={p.color} />
+          <strong>{p.name}</strong>
+        </span>
+        <span class="pts tnum" class:score-good={pts(p.id) > 0} class:score-bad={pts(p.id) < 0}>
+          {pts(p.id) > 0 ? '+' : ''}{pts(p.id)}
+        </span>
+      </div>
+      <div class="entry">
+        <span class="rank tnum" aria-label={`Finished ${finish || '—'}: ${title.label}`}>
+          <span class="badge" aria-hidden="true">{title.emoji}</span>
+          {title.label}
+        </span>
+        <Stepper bind:value={input.positions[p.id]} min={1} max={n} label={p.name} />
+        <button
+          type="button"
+          class="btn small ghost"
+          disabled={finish === 1}
+          onclick={() => crownPresident(p.id)}
+          title="{p.name} was first out — crown them President"
+        >
+          👑 Crown
+        </button>
+        {#if clash}
+          <span class="clash-tag" role="status">⚠ tied for {finish}</span>
+        {/if}
+      </div>
+    </div>
+  {/each}
+
+  {#if complete}
+    <div class="wrap-banner" role="status">
+      <span class="ic" aria-hidden="true">🏁</span>
+      <span>Round ready — every seat has a distinct finish.</span>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .hint {
+    font-size: 0.85rem;
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+  .points {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+  }
+  .blurb {
+    margin: 0 0 10px;
+    font-size: 0.85rem;
+    color: var(--muted);
+    line-height: 1.45;
+  }
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 9px;
+    border-radius: 999px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    font-size: 0.82rem;
+  }
+  .chip .v {
+    font-weight: 800;
+  }
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-chip);
+    padding: 12px;
+  }
+  .prow.clash {
+    border-color: color-mix(in srgb, var(--bad) 60%, var(--border));
+  }
+  /* The President's row gets a restrained crown-gold wash — leader treatment,
+     never used for ordinary buttons or decoration. */
+  .prow.president {
+    border-color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 12%, var(--surface-2));
+  }
+  .head {
+    margin-bottom: 10px;
+  }
+  .who {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .who strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .pts {
+    font-weight: 800;
+    font-size: 1.05rem;
+  }
+  .entry {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .rank {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 52px;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .badge {
+    font-size: 1.1rem;
+  }
+  .clash-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--bad);
+  }
+  .wrap-banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    border-radius: 10px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    font-weight: 700;
+    font-size: 0.9rem;
+  }
+  .tnum {
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/src/lib/games/presidents/index.ts
+++ b/src/lib/games/presidents/index.ts
@@ -1,0 +1,97 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { presidentsStats } from './stats';
+import {
+  describeRound as describePresidentsRound,
+  freshPositions,
+  isFinished as presidentsFinished,
+  maxRounds as presidentsMaxRounds,
+  scoreRound as scorePresidents,
+  validateRound as validatePresidents,
+  type PresidentsInput,
+} from './logic';
+
+export type { PresidentsInput, PresidentsConfig, SchemeId, TitleInfo, TitleTier } from './logic';
+export { pointsForPosition, titleFor, SCHEME_META } from './logic';
+
+export const presidents: GameModule = {
+  id: 'presidents',
+  name: 'Presidents',
+  tagline: 'Climb the ranks — crown a President, crown a Scum 👑',
+  emoji: '👑',
+  keywords: ['president', 'scum', 'asshole', 'landlord', 'cards', 'climbing', 'party'],
+  minPlayers: 3,
+  maxPlayers: 8,
+  configFields: [
+    {
+      key: 'scheme',
+      label: 'Scoring scheme',
+      type: 'select',
+      default: 'rankPoints',
+      options: [
+        { value: 'rankPoints', label: 'Rank points (default)' },
+        { value: 'tieredTitles', label: 'Tiered titles (+3 / +1 / 0 / −1 / −3)' },
+        { value: 'winsOnly', label: 'Presidencies only (+1 for President)' },
+      ],
+      help: 'How a finishing spot converts to points. Rank points scale with the table; tiered titles are fixed regardless of table size; presidencies-only just counts wins.',
+    },
+    {
+      key: 'targetScore',
+      label: 'End the game when a player reaches',
+      type: 'number',
+      default: 15,
+      min: 0,
+      help: 'First to this total wins outright. Set to 0 to disable and rely on a fixed round count instead.',
+    },
+    {
+      key: 'roundCount',
+      label: 'Play a fixed number of rounds',
+      type: 'number',
+      default: 0,
+      min: 0,
+      max: 500,
+      help: '0 = keep dealing until someone reaches the target score above. Set both for whichever comes first.',
+    },
+  ],
+
+  maxRounds: (config) => presidentsMaxRounds(config),
+
+  createRoundInput: (ctx: RoundContext): PresidentsInput => freshPositions(ctx.players),
+
+  validateRound: (input: PresidentsInput, ctx: RoundContext): string | null =>
+    validatePresidents(input, ctx.players, ctx.config),
+
+  scoreRound: (input: PresidentsInput, ctx: RoundContext): Record<ID, number> =>
+    scorePresidents(input, ctx.config),
+
+  isFinished: (totals, { config }) => presidentsFinished(totals, config),
+
+  describeRound: (round: Round, players): string =>
+    describePresidentsRound(round.input as PresidentsInput, players),
+
+  help: [
+    '👑 Presidents (a.k.a. President, Scum, Asshole, Landlord) — climb the ranks!',
+    '',
+    'Deal out the whole deck. Players take turns playing a single card or a set of',
+    'equal-rank cards that beats the last play (higher rank, same count), or pass.',
+    'When everyone passes, the pile clears and whoever played last leads again.',
+    '',
+    'The moment you play your last card, you\'re OUT for the round and lock in your',
+    'finishing spot: first out is President, last one holding cards is Scum.',
+    'Everyone else lands somewhere in between (Vice President / Citizen / Vice Scum',
+    'once the table is big enough to tell them apart).',
+    '',
+    'Enter each player\'s finishing spot below — the module maps it to points using',
+    'whichever scoring scheme you picked in setup. Highest total wins the game.',
+    '',
+    '🃏 Card passing (physical rule, not scored here): before the next deal, Scum',
+    'hands their best 1–2 cards to the President, who hands back any 1–2 cards in',
+    'return. Vice Scum/Vice President swap one card the same way at bigger tables.',
+    'Play this at the table — this app only tracks the score.',
+  ].join('\n'),
+
+  stats: presidentsStats,
+
+  RoundEditor,
+  editorLoader: () => import('./PresidentsEditor.svelte'),
+};

--- a/src/lib/games/presidents/logic.ts
+++ b/src/lib/games/presidents/logic.ts
@@ -1,0 +1,252 @@
+import type { ID, Player } from '../../types';
+
+/**
+ * Presidents (a.k.a. President / Scum / Asshole) — pure scoring. Svelte-free on
+ * purpose so the round editor, the module, and the tests all share one source of
+ * truth for position → title → points.
+ *
+ * Each round every player finishes in a strict order (no ties): the first player
+ * out is crowned President, the last player holding cards is stuck as Scum, and
+ * everyone between takes a title based on the table size:
+ *
+ *   3 players:      President · Citizen · Scum
+ *   4 players:       President · Vice President · Vice Scum · Scum
+ *   5+ players:      President · Vice President · Citizen(s) · Vice Scum · Scum
+ *
+ * The exact point value assigned per finish varies a lot between groups, so this
+ * module ships a well-documented default (`rankPoints`) plus two common house-rule
+ * alternates (`tieredTitles`, `winsOnly`), selectable in config.
+ *
+ * Card-passing (Scum hands their best 1–2 cards to the President, who hands back
+ * their worst) is a physical table ritual, not something this module scores — see
+ * the module's `help` text.
+ */
+
+export type SchemeId = 'rankPoints' | 'tieredTitles' | 'winsOnly';
+
+/** A single round: each player's finishing position (1 = President ... n = Scum). */
+export interface PresidentsInput {
+  positions: Record<ID, number>;
+}
+
+export interface PresidentsConfig {
+  scheme: SchemeId;
+  /** End the game once any player reaches this total. 0 disables the threshold. */
+  targetScore: number;
+  /** Play a fixed number of rounds instead (or in addition). 0 = open-ended. */
+  roundCount: number;
+}
+
+const DEFAULTS: PresidentsConfig = { scheme: 'rankPoints', targetScore: 15, roundCount: 0 };
+
+export function normalizeScheme(value: unknown): SchemeId {
+  return value === 'tieredTitles' || value === 'winsOnly' || value === 'rankPoints'
+    ? value
+    : DEFAULTS.scheme;
+}
+
+/** Coerce the target score (>= 0; 0 disables the threshold end condition). */
+export function normalizeTargetScore(value: unknown): number {
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n) || n < 0) return DEFAULTS.targetScore;
+  return n;
+}
+
+/** Coerce rounds-per-game (>= 0; 0 means open-ended / target-only). */
+export function normalizeRoundCount(value: unknown): number {
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n) || n < 0) return DEFAULTS.roundCount;
+  return Math.min(500, n);
+}
+
+export function readConfig(config: Record<string, unknown> = {}): PresidentsConfig {
+  return {
+    scheme: normalizeScheme(config.scheme),
+    targetScore: normalizeTargetScore(config.targetScore),
+    roundCount: normalizeRoundCount(config.roundCount),
+  };
+}
+
+// ── Titles ───────────────────────────────────────────────────────────────────
+
+export type TitleTier = 'president' | 'vp' | 'neutral' | 'vs' | 'scum';
+
+export interface TitleInfo {
+  tier: TitleTier;
+  label: string;
+  emoji: string;
+}
+
+const TITLES: Record<TitleTier, Omit<TitleInfo, 'tier'>> = {
+  president: { label: 'President', emoji: '👑' },
+  vp: { label: 'Vice President', emoji: '🎖️' },
+  neutral: { label: 'Citizen', emoji: '🙂' },
+  vs: { label: 'Vice Scum', emoji: '🥴' },
+  scum: { label: 'Scum', emoji: '💩' },
+};
+
+/**
+ * The title a finishing position earns at a given table size. Matches the
+ * standard convention: President/Scum always exist; Vice President/Vice Scum
+ * only appear once the table is big enough (4+) to have a distinct second-best
+ * and second-worst seat; everyone else in the middle is a Citizen.
+ */
+export function titleFor(position: number, playerCount: number): TitleInfo {
+  const n = Math.max(1, Math.floor(playerCount));
+  const pos = Math.min(n, Math.max(1, Math.floor(position)));
+  let tier: TitleTier;
+  if (pos === 1) tier = 'president';
+  else if (pos === n) tier = 'scum';
+  else if (n >= 4 && pos === 2) tier = 'vp';
+  else if (n >= 4 && pos === n - 1) tier = 'vs';
+  else tier = 'neutral';
+  return { tier, ...TITLES[tier] };
+}
+
+export interface SchemeMeta {
+  id: SchemeId;
+  label: string;
+  blurb: string;
+}
+
+export const SCHEME_META: Record<SchemeId, SchemeMeta> = {
+  rankPoints: {
+    id: 'rankPoints',
+    label: 'Rank points (default)',
+    blurb:
+      'Scales with the table: 1st scores playerCount−1, each spot down scores one less, last scores 0.',
+  },
+  tieredTitles: {
+    id: 'tieredTitles',
+    label: 'Tiered titles',
+    blurb:
+      'Fixed per title regardless of table size: President +3 · Vice President +1 · Citizen 0 · Vice Scum −1 · Scum −3.',
+  },
+  winsOnly: {
+    id: 'winsOnly',
+    label: 'Presidencies only',
+    blurb: 'Only the President scores: +1 per round won, everyone else 0. Tracks who rules the table most.',
+  },
+};
+
+const TIERED_POINTS: Record<TitleTier, number> = {
+  president: 3,
+  vp: 1,
+  neutral: 0,
+  vs: -1,
+  scum: -3,
+};
+
+/**
+ * Points a finishing position earns under a scheme. `playerCount` matters for
+ * `rankPoints` (which scales with the table) and for resolving the title used by
+ * `tieredTitles`.
+ */
+export function pointsForPosition(
+  scheme: SchemeId,
+  position: number,
+  playerCount: number,
+): number {
+  const n = Math.max(1, Math.floor(playerCount));
+  const pos = Math.floor(Number(position));
+  if (!Number.isFinite(pos) || pos < 1 || pos > n) return 0;
+
+  if (scheme === 'winsOnly') return pos === 1 ? 1 : 0;
+  if (scheme === 'tieredTitles') return TIERED_POINTS[titleFor(pos, n).tier];
+  // rankPoints: 1st scores n-1 down to 0 for last.
+  return n - pos;
+}
+
+/** Score one round: every player's finishing position mapped to points. */
+export function scoreRound(
+  input: PresidentsInput,
+  config: Partial<PresidentsConfig> | Record<string, unknown> = {},
+): Record<ID, number> {
+  const scheme = normalizeScheme((config as Record<string, unknown>).scheme);
+  const positions = input?.positions ?? {};
+  const playerCount = Object.keys(positions).length;
+  const out: Record<ID, number> = {};
+  for (const [id, pos] of Object.entries(positions)) {
+    out[id] = pointsForPosition(scheme, Number(pos) || 0, playerCount);
+  }
+  return out;
+}
+
+/**
+ * Validate a round: every player needs a distinct finishing spot from 1..n (no
+ * ties — someone is always literally the next to run out of cards, and someone
+ * is always literally last).
+ */
+export function validateRound(
+  input: PresidentsInput,
+  players: Pick<Player, 'id' | 'name'>[],
+  _config: Record<string, unknown> = {},
+): string | null {
+  const n = players.length;
+  const positions = input?.positions ?? {};
+  const takenBy = new Map<number, string>();
+  for (const p of players) {
+    const pos = Math.floor(Number(positions[p.id]) || 0);
+    if (pos < 1) return `Where did ${p.name} finish? 🏁`;
+    if (pos > n) return `${p.name}: only ${n} players are seated, so there's no spot ${pos}.`;
+    const clash = takenBy.get(pos);
+    if (clash) return `${clash} and ${p.name} can't both finish in the same spot.`;
+    takenBy.set(pos, p.name);
+  }
+  return null;
+}
+
+/** Fresh round draft: seed each player into a distinct spot, seating order = finish order. */
+export function freshPositions(players: Pick<Player, 'id'>[]): PresidentsInput {
+  return {
+    positions: Object.fromEntries(players.map((p, i) => [p.id, i + 1])),
+  };
+}
+
+/** Is this round complete: every player holds a distinct in-range finishing spot? */
+export function roundComplete(input: PresidentsInput, players: Pick<Player, 'id'>[]): boolean {
+  const n = players.length;
+  if (n === 0) return false;
+  const positions = input?.positions ?? {};
+  const seen = new Set<number>();
+  for (const p of players) {
+    const pos = Math.floor(Number(positions[p.id]) || 0);
+    if (pos < 1 || pos > n || seen.has(pos)) return false;
+    seen.add(pos);
+  }
+  return true;
+}
+
+/** A compact one-liner for a saved round: the President and the Scum, always. */
+export function describeRound(
+  input: PresidentsInput,
+  players: readonly { id: ID; name: string }[],
+): string {
+  const positions = input?.positions ?? {};
+  const n = Object.keys(positions).length;
+  if (!n) return 'no results yet';
+  const ranked = players
+    .map((p) => ({ name: p.name, pos: Math.floor(Number(positions[p.id]) || 0) }))
+    .filter((r) => r.pos >= 1 && r.pos <= n)
+    .sort((a, b) => a.pos - b.pos);
+  if (!ranked.length) return 'no results yet';
+  const first = ranked[0];
+  const last = ranked[ranked.length - 1];
+  const firstTitle = titleFor(first.pos, n);
+  if (ranked.length === 1) return `${firstTitle.emoji} ${first.name}`;
+  const lastTitle = titleFor(last.pos, n);
+  return `${firstTitle.emoji} ${first.name} · ${lastTitle.emoji} ${last.name}`;
+}
+
+/** True once any player has reached the configured target score. */
+export function isFinished(totals: Record<ID, number>, config: Record<string, unknown>): boolean {
+  const target = readConfig(config).targetScore;
+  if (target <= 0) return false;
+  return Object.values(totals).some((t) => t >= target);
+}
+
+/** Fixed round count from config, or null for an open-ended (target-only) game. */
+export function maxRounds(config: Record<string, unknown>): number | null {
+  const n = readConfig(config).roundCount;
+  return n > 0 ? n : null;
+}

--- a/src/lib/games/presidents/presidents.test.ts
+++ b/src/lib/games/presidents/presidents.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, Player, Round, RoundContext } from '../../types';
+import type { GameStatsInput } from '../../stats/types';
+import { presidents } from './index';
+import { presidentsStats } from './stats';
+import {
+  SCHEME_META,
+  freshPositions,
+  isFinished,
+  maxRounds,
+  normalizeRoundCount,
+  normalizeScheme,
+  normalizeTargetScore,
+  pointsForPosition,
+  readConfig,
+  roundComplete,
+  scoreRound,
+  titleFor,
+  validateRound,
+  type PresidentsInput,
+  type SchemeId,
+} from './logic';
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+function player(id: string, name = id): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+function ctxOf(players: Player[], config: Record<string, unknown>): RoundContext {
+  return {
+    game: { id: 'g', config } as unknown as Game,
+    players,
+    config,
+    roundIndex: 0,
+    totals: {},
+    rounds: [],
+  };
+}
+const P4 = [player('a', 'Alice'), player('b', 'Bob'), player('c', 'Carol'), player('d', 'Dan')];
+const P3 = [player('a', 'Alice'), player('b', 'Bob'), player('c', 'Carol')];
+
+// ── titles ─────────────────────────────────────────────────────────────────
+describe('titleFor', () => {
+  it('is just President/Scum with 2 players', () => {
+    expect(titleFor(1, 2).tier).toBe('president');
+    expect(titleFor(2, 2).tier).toBe('scum');
+  });
+
+  it('has no VP/Vice Scum at 3 players — the middle seat is a Citizen', () => {
+    expect(titleFor(1, 3).tier).toBe('president');
+    expect(titleFor(2, 3).tier).toBe('neutral');
+    expect(titleFor(3, 3).tier).toBe('scum');
+  });
+
+  it('introduces Vice President and Vice Scum at 4 players (no Citizen)', () => {
+    expect([1, 2, 3, 4].map((p) => titleFor(p, 4).tier)).toEqual([
+      'president',
+      'vp',
+      'vs',
+      'scum',
+    ]);
+  });
+
+  it('fills the middle with Citizens at 5+ players', () => {
+    expect([1, 2, 3, 4, 5].map((p) => titleFor(p, 5).tier)).toEqual([
+      'president',
+      'vp',
+      'neutral',
+      'vs',
+      'scum',
+    ]);
+    expect([1, 2, 3, 4, 5, 6, 7, 8].map((p) => titleFor(p, 8).tier)).toEqual([
+      'president',
+      'vp',
+      'neutral',
+      'neutral',
+      'neutral',
+      'neutral',
+      'vs',
+      'scum',
+    ]);
+  });
+
+  it('clamps out-of-range positions into the field', () => {
+    expect(titleFor(0, 4).tier).toBe('president');
+    expect(titleFor(99, 4).tier).toBe('scum');
+  });
+});
+
+// ── scoring ──────────────────────────────────────────────────────────────
+describe('pointsForPosition', () => {
+  it('rankPoints scales with the table: 1st = n-1 down to 0 for last', () => {
+    expect([1, 2, 3, 4, 5].map((p) => pointsForPosition('rankPoints', p, 5))).toEqual([
+      4, 3, 2, 1, 0,
+    ]);
+  });
+
+  it('tieredTitles is fixed regardless of table size', () => {
+    expect(pointsForPosition('tieredTitles', 1, 5)).toBe(3); // President
+    expect(pointsForPosition('tieredTitles', 2, 5)).toBe(1); // VP
+    expect(pointsForPosition('tieredTitles', 3, 5)).toBe(0); // Citizen
+    expect(pointsForPosition('tieredTitles', 4, 5)).toBe(-1); // Vice Scum
+    expect(pointsForPosition('tieredTitles', 5, 5)).toBe(-3); // Scum
+    // Same tiers, different table size — the values don't change.
+    expect(pointsForPosition('tieredTitles', 1, 8)).toBe(3);
+    expect(pointsForPosition('tieredTitles', 8, 8)).toBe(-3);
+  });
+
+  it('winsOnly only rewards the President', () => {
+    expect(pointsForPosition('winsOnly', 1, 4)).toBe(1);
+    expect([2, 3, 4].map((p) => pointsForPosition('winsOnly', p, 4))).toEqual([0, 0, 0]);
+  });
+
+  it('scores 0 for invalid or out-of-field positions', () => {
+    for (const scheme of ['rankPoints', 'tieredTitles', 'winsOnly'] as SchemeId[]) {
+      expect(pointsForPosition(scheme, 0, 4)).toBe(0);
+      expect(pointsForPosition(scheme, -1, 4)).toBe(0);
+      expect(pointsForPosition(scheme, 5, 4)).toBe(0);
+      expect(pointsForPosition(scheme, Number.NaN, 4)).toBe(0);
+    }
+  });
+});
+
+describe('scoreRound', () => {
+  it('maps a full round under rankPoints (default)', () => {
+    const input: PresidentsInput = { positions: { a: 1, b: 2, c: 3, d: 4 } };
+    expect(scoreRound(input, {})).toEqual({ a: 3, b: 2, c: 1, d: 0 });
+  });
+
+  it('honors the tieredTitles scheme', () => {
+    const input: PresidentsInput = { positions: { a: 1, b: 2, c: 3, d: 4, e: 5 } };
+    expect(scoreRound(input, { scheme: 'tieredTitles' })).toEqual({
+      a: 3,
+      b: 1,
+      c: 0,
+      d: -1,
+      e: -3,
+    });
+  });
+
+  it('honors the winsOnly scheme', () => {
+    const input: PresidentsInput = { positions: { a: 2, b: 1, c: 3, d: 4 } };
+    expect(scoreRound(input, { scheme: 'winsOnly' })).toEqual({ a: 0, b: 1, c: 0, d: 0 });
+  });
+
+  it('accumulates across rounds (highest total wins)', () => {
+    const rounds: PresidentsInput[] = [
+      { positions: { a: 1, b: 2 } },
+      { positions: { a: 2, b: 1 } },
+      { positions: { a: 1, b: 2 } },
+    ];
+    const totals: Record<string, number> = { a: 0, b: 0 };
+    for (const r of rounds) {
+      const d = scoreRound(r, {});
+      for (const id of Object.keys(d)) totals[id] += d[id];
+    }
+    // rankPoints for 2 players: 1st=1, 2nd=0. a: 1+0+1=2, b: 0+1+0=1.
+    expect(totals).toEqual({ a: 2, b: 1 });
+  });
+});
+
+// ── validation ─────────────────────────────────────────────────────────────
+describe('validateRound', () => {
+  it('passes when every player has a distinct finishing spot', () => {
+    expect(validateRound({ positions: { a: 1, b: 2, c: 3, d: 4 } }, P4)).toBeNull();
+  });
+
+  it('flags a player with no finishing spot', () => {
+    const err = validateRound({ positions: { a: 1, b: 0, c: 3, d: 4 } }, P4);
+    expect(err).toMatch(/Bob/);
+  });
+
+  it('flags two players sharing a spot', () => {
+    const err = validateRound({ positions: { a: 1, b: 1, c: 3, d: 4 } }, P4);
+    expect(err).toMatch(/can't both finish/);
+  });
+
+  it('flags a spot beyond the seated table', () => {
+    const err = validateRound({ positions: { a: 1, b: 2, c: 3, d: 5 } }, P4);
+    expect(err).toMatch(/only 4 players/);
+  });
+});
+
+describe('freshPositions / roundComplete', () => {
+  it('seeds every player into a distinct, valid spot', () => {
+    const input = freshPositions(P4);
+    expect(input.positions).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+    expect(validateRound(input, P4)).toBeNull();
+    expect(roundComplete(input, P4)).toBe(true);
+  });
+
+  it('is incomplete when a spot is missing or clashing', () => {
+    expect(roundComplete({ positions: { a: 1, b: 0, c: 3, d: 4 } }, P4)).toBe(false);
+    expect(roundComplete({ positions: { a: 1, b: 1, c: 3, d: 4 } }, P4)).toBe(false);
+  });
+});
+
+// ── config ───────────────────────────────────────────────────────────────
+describe('config normalizers', () => {
+  it('normalizeScheme falls back to rankPoints', () => {
+    expect(normalizeScheme('tieredTitles')).toBe('tieredTitles');
+    expect(normalizeScheme('winsOnly')).toBe('winsOnly');
+    expect(normalizeScheme(undefined)).toBe('rankPoints');
+    expect(normalizeScheme('???')).toBe('rankPoints');
+  });
+
+  it('normalizeTargetScore keeps >= 0 and defaults invalid to 15', () => {
+    expect(normalizeTargetScore(20)).toBe(20);
+    expect(normalizeTargetScore(0)).toBe(0);
+    expect(normalizeTargetScore(-5)).toBe(15);
+    expect(normalizeTargetScore(undefined)).toBe(15);
+  });
+
+  it('normalizeRoundCount keeps >= 0, caps at 500, defaults invalid to 0', () => {
+    expect(normalizeRoundCount(10)).toBe(10);
+    expect(normalizeRoundCount(0)).toBe(0);
+    expect(normalizeRoundCount(-5)).toBe(0);
+    expect(normalizeRoundCount(9999)).toBe(500);
+  });
+
+  it('readConfig applies all defaults together', () => {
+    expect(readConfig({})).toEqual({ scheme: 'rankPoints', targetScore: 15, roundCount: 0 });
+  });
+});
+
+describe('isFinished / maxRounds', () => {
+  it('ends when a player reaches the target score', () => {
+    expect(isFinished({ a: 15, b: 3 }, {})).toBe(true);
+    expect(isFinished({ a: 14, b: 3 }, {})).toBe(false);
+    expect(isFinished({ a: 10, b: 3 }, { targetScore: 10 })).toBe(true);
+  });
+
+  it('never finishes on target when the target is disabled (0)', () => {
+    expect(isFinished({ a: 999 }, { targetScore: 0 })).toBe(false);
+  });
+
+  it('maxRounds is the configured round count, or open-ended at 0', () => {
+    expect(maxRounds({ roundCount: 8 })).toBe(8);
+    expect(maxRounds({ roundCount: 0 })).toBeNull();
+    expect(maxRounds({})).toBeNull(); // default is open-ended (target-only)
+  });
+});
+
+// ── module wiring ──────────────────────────────────────────────────────────
+describe('presidents module', () => {
+  it('exposes the folder id and sane bounds', () => {
+    expect(presidents.id).toBe('presidents');
+    expect(presidents.minPlayers).toBe(3);
+    expect(presidents.maxPlayers).toBe(8);
+    expect(presidents.minPlayers).toBeLessThanOrEqual(presidents.maxPlayers);
+    expect(presidents.emoji).toBeTruthy();
+    expect(presidents.tagline).toBeTruthy();
+    expect(presidents.lowerIsBetter).toBeFalsy(); // highest total wins
+  });
+
+  it('offers all three scoring schemes in config', () => {
+    const field = presidents.configFields?.find((f) => f.key === 'scheme');
+    expect(field?.type).toBe('select');
+    const values = (field as { options: { value: string }[] }).options.map((o) => o.value);
+    expect(values.sort()).toEqual(['rankPoints', 'tieredTitles', 'winsOnly']);
+    expect(Object.keys(SCHEME_META).sort()).toEqual(values.sort());
+  });
+
+  it('createRoundInput seeds distinct spots that validate', () => {
+    const ctx = ctxOf(P4, {});
+    const input = presidents.createRoundInput(ctx) as PresidentsInput;
+    expect(presidents.validateRound(input, ctx)).toBeNull();
+  });
+
+  it('scoreRound routes through the configured scheme', () => {
+    const ctx = ctxOf(P3, { scheme: 'tieredTitles' });
+    const input: PresidentsInput = { positions: { a: 2, b: 1, c: 3 } };
+    expect(presidents.scoreRound(input, ctx)).toEqual({ a: 0, b: 3, c: -3 });
+  });
+
+  it('validateRound surfaces entry problems', () => {
+    const ctx = ctxOf(P4, {});
+    expect(presidents.validateRound({ positions: { a: 1, b: 1, c: 3, d: 4 } }, ctx)).toMatch(
+      /can't both finish/,
+    );
+  });
+
+  it('isFinished delegates to the shared logic with config', () => {
+    expect(presidents.isFinished!({ a: 15 }, { config: {}, roundCount: 1, playerCount: 4 })).toBe(
+      true,
+    );
+  });
+
+  it('maxRounds delegates to the shared logic with config', () => {
+    expect(presidents.maxRounds!({ roundCount: 5 }, 4)).toBe(5);
+    expect(presidents.maxRounds!({}, 4)).toBeNull();
+  });
+
+  it('describeRound names the President and the Scum', () => {
+    const input: PresidentsInput = { positions: { a: 2, b: 1, c: 4, d: 3 } };
+    const round = { input } as unknown as Round;
+    const desc = presidents.describeRound?.(round, P4) ?? '';
+    expect(desc).toContain('👑 Bob');
+    expect(desc).toContain('💩 Carol');
+  });
+
+  it('help mentions card passing as a physical, unscored ritual', () => {
+    expect(presidents.help).toMatch(/President/);
+    expect(presidents.help).toMatch(/Scum/);
+    expect(presidents.help).toMatch(/not scored/i);
+  });
+});
+
+// ── stats ────────────────────────────────────────────────────────────────
+describe('presidents stats', () => {
+  function statsInput(rounds: PresidentsInput[]): GameStatsInput {
+    const games = [{ id: 'g1' } as unknown as Game];
+    const roundRecords = rounds.map(
+      (input, i) => ({ id: `r${i}`, gameId: 'g1', index: i, input }) as unknown as Round,
+    );
+    return { games, rounds: roundRecords, players: P4, canonical: (id) => id };
+  }
+
+  it('derives presidencies, scum counts, and average finish per player', () => {
+    // Alice: 1st, 1st, 2nd → 2 presidencies, avg (1+1+2)/3 = 1.3
+    // Bob: 2nd, 4th, 1st → 1 presidency, 1 scum stretch
+    const res = presidentsStats(
+      statsInput([
+        { positions: { a: 1, b: 2, c: 3, d: 4 } },
+        { positions: { a: 1, b: 4, c: 2, d: 3 } },
+        { positions: { a: 2, b: 1, c: 4, d: 3 } },
+      ]),
+    );
+    const alice = res.perPlayer?.a ?? [];
+    expect(alice.find((m) => m.key === 'p_pres')?.value).toBe('2');
+    expect(alice.find((m) => m.key === 'p_avg')?.value).toBe('1.3');
+    const bob = res.perPlayer?.b ?? [];
+    expect(bob.find((m) => m.key === 'p_pres')?.value).toBe('1');
+    expect(bob.find((m) => m.key === 'p_scum')?.value).toBe('1');
+    expect(res.global?.find((m) => m.key === 'p_rounds')?.value).toBe('3');
+  });
+
+  it('ignores rounds from other games', () => {
+    const input = statsInput([{ positions: { a: 1, b: 2, c: 3, d: 4 } }]);
+    input.rounds = input.rounds.map((r) => ({ ...r, gameId: 'other' }) as Round);
+    const res = presidentsStats(input);
+    expect(res.perPlayer?.a).toBeUndefined();
+    expect(res.global?.length ?? 0).toBe(0);
+  });
+});

--- a/src/lib/games/presidents/stats.ts
+++ b/src/lib/games/presidents/stats.ts
@@ -1,0 +1,94 @@
+import type { ID } from '../../types';
+import { titleFor, type PresidentsInput } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg, fmtInt, fmtPct } from '../../stats/format';
+
+interface PresidentsAgg {
+  rounds: number;
+  posSum: number;
+  presidencies: number;
+  scums: number;
+  best: number;
+}
+
+/**
+ * Presidents stats, derived purely from each round's recorded finishing
+ * positions. A presidency is finishing 1st; a scum stretch is finishing last.
+ * Average finish is the mean spot across every round a player was ranked in.
+ * Pure — no Svelte — so it's unit-testable and safe for the stats engine to
+ * import.
+ */
+export function presidentsStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, PresidentsAgg>();
+  const get = (id: ID): PresidentsAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { rounds: 0, posSum: 0, presidencies: 0, scums: 0, best: Infinity };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let roundsPlayed = 0;
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as PresidentsInput | undefined;
+    if (!input?.positions) continue;
+    const n = Object.keys(input.positions).length;
+    if (!n) continue;
+    roundsPlayed += 1;
+    for (const [pid, raw] of Object.entries(input.positions)) {
+      const pos = Math.floor(Number(raw) || 0);
+      if (pos < 1 || pos > n) continue;
+      const a = get(canonical(pid));
+      a.rounds += 1;
+      a.posSum += pos;
+      if (titleFor(pos, n).tier === 'president') a.presidencies += 1;
+      if (titleFor(pos, n).tier === 'scum') a.scums += 1;
+      if (pos < a.best) a.best = pos;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let totPresidencies = 0;
+  for (const [id, a] of per) {
+    totPresidencies += a.presidencies;
+    if (!a.rounds) continue;
+    const metrics: Metric[] = [
+      { key: 'p_avg', label: 'Avg finish', value: fmtAvg(a.posSum / a.rounds), emoji: '📊' },
+    ];
+    if (a.presidencies) {
+      metrics.push({
+        key: 'p_pres',
+        label: 'Presidencies',
+        value: fmtInt(a.presidencies),
+        emoji: '👑',
+      });
+    }
+    metrics.push({
+      key: 'p_pres_rate',
+      label: 'President rate',
+      value: fmtPct(a.presidencies / a.rounds),
+      emoji: '🎖️',
+    });
+    if (a.scums) {
+      metrics.push({ key: 'p_scum', label: 'Times Scum', value: fmtInt(a.scums), emoji: '💩' });
+    }
+    perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (roundsPlayed) {
+    global.push({ key: 'p_rounds', label: 'Rounds played', value: fmtInt(roundsPlayed), emoji: '🃏' });
+  }
+  if (totPresidencies) {
+    global.push({
+      key: 'p_pres_all',
+      label: 'Presidencies handed out',
+      value: fmtInt(totPresidencies),
+      emoji: '👑',
+    });
+  }
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Adds a new game module — **Presidents** 👑 (a.k.a. President / Scum) — following the existing per-game convention (auto-discovered via `registry.ts`, lazy-loaded editor chunk).

## Changes

- `src/lib/games/presidents/logic.ts` — pure scoring: position → title mapping (President/VP/Citizen/Vice Scum/Scum, scaling with table size 3–8), three configurable scoring schemes (rank points default, tiered titles, presidencies-only), validation, target-score/round-count end conditions.
- `src/lib/games/presidents/index.ts` — `GameModule` wiring, config fields, help text (documents card-passing as a physical-only, unscored house ritual).
- `src/lib/games/presidents/PresidentsEditor.svelte` — round editor: rank each player via steppers, live points preview, points reference, help panel.
- `src/lib/games/presidents/stats.ts` — presidencies/scum counts and average finish per player.
- `src/lib/games/presidents/presidents.test.ts` — unit tests for titles, scoring schemes, validation, config normalizers, module wiring, and stats.

## Issues

Closes #150

## Testing

- [x] `npm test` — new `presidents.test.ts` (37 tests) + `registry.test.ts` pass
- [x] `npm run check` — svelte-check + tsc, 0 errors