### PR TITLE
Add Yahtzee game module

### DIFF
--- a/src/lib/games/yahtzee/YahtzeeEditor.svelte
+++ b/src/lib/games/yahtzee/YahtzeeEditor.svelte
@@ -1,0 +1,279 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { bumpOnChange } from '../../motion';
+  import { haptic } from '../../haptics';
+  import { yahtzee } from './index';
+  import {
+    CATEGORIES,
+    SIXES_INDEX,
+    UPPER_BONUS,
+    UPPER_BONUS_THRESHOLD,
+    YAHTZEE_BONUS,
+    allowsBonusYahtzees,
+    categoryForRound,
+    type YahtzeeInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: YahtzeeInput; ctx: RoundContext } = $props();
+
+  const cat = $derived(categoryForRound(ctx.roundIndex));
+  const isSixes = $derived(ctx.roundIndex === SIXES_INDEX);
+  const bonusRound = $derived(allowsBonusYahtzees(ctx.roundIndex));
+
+  let showHelp = $state(false);
+
+  function scoreFor(id: string): number {
+    return Number(input.scores[id]) || 0;
+  }
+
+  /** A player's upper subtotal *before* this round — used to preview the 63+ bonus live. */
+  function upperBefore(id: string): number {
+    return Number(ctx.totals[id]) || 0;
+  }
+
+  function upperBonusHits(id: string): boolean {
+    if (!isSixes) return false;
+    return upperBefore(id) + scoreFor(id) >= UPPER_BONUS_THRESHOLD;
+  }
+
+  function bonusYahtzeesFor(id: string): number {
+    return Math.max(0, Math.trunc(Number(input.bonusYahtzees?.[id]) || 0));
+  }
+
+  /** Preview of this round's total delta for a player (category score + any bonuses). */
+  function preview(id: string): number {
+    let pts = scoreFor(id);
+    if (upperBonusHits(id)) pts += UPPER_BONUS;
+    if (bonusRound) pts += bonusYahtzeesFor(id) * YAHTZEE_BONUS;
+    return pts;
+  }
+
+  function toggleFixed(id: string, hit: boolean) {
+    if (!cat?.fixedScore) return;
+    if ((scoreFor(id) >= cat.fixedScore) === hit) return;
+    input.scores[id] = hit ? cat.fixedScore : 0;
+    haptic(hit ? 'save' : 'tick');
+  }
+
+  const roundNum = $derived(ctx.roundIndex + 1);
+  const total = $derived(CATEGORIES.length);
+</script>
+
+{#if cat}
+  <div class="stack">
+    <div class="head">
+      <div class="row spread wrap">
+        <h3 class="ttl">
+          {cat.emoji} Round {roundNum}/{total} — {cat.label}
+        </h3>
+        <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+          Rules
+        </button>
+      </div>
+      <p class="hint">
+        {cat.hint}
+        {#if cat.fixedScore}· all-or-nothing: {cat.fixedScore} or 0{/if}
+      </p>
+      {#if isSixes}
+        <p class="callout">
+          ⬆️ Score {UPPER_BONUS_THRESHOLD}+ across Ones–Sixes and the +{UPPER_BONUS} bonus lands
+          automatically below.
+        </p>
+      {/if}
+      {#if bonusRound}
+        <p class="callout">
+          🎉 Rolled an extra Yahtzee after your box was already filled (Joker rule)? Add it here —
+          +{YAHTZEE_BONUS} each.
+        </p>
+      {/if}
+    </div>
+
+    {#if showHelp}
+      <pre class="help">{yahtzee.help}</pre>
+    {/if}
+
+    {#each ctx.players as p (p.id)}
+      {@const score = scoreFor(p.id)}
+      {@const hitBonus = upperBonusHits(p.id)}
+      {@const pts = preview(p.id)}
+      <div class="prow">
+        <div class="row spread" style="margin-bottom: 10px">
+          <span class="row" style="gap: 8px">
+            <Avatar name={p.name} color={p.color} />
+            <strong>{p.name}</strong>
+          </span>
+          <span class="preview" use:bumpOnChange={pts}>+{pts}</span>
+        </div>
+
+        {#if cat.fixedScore}
+          {@const hit = score >= cat.fixedScore}
+          <div class="fixed-toggle" role="radiogroup" aria-label={`${p.name} ${cat.label}`}>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={!hit}
+              class="fchoice"
+              class:on={!hit}
+              onclick={() => toggleFixed(p.id, false)}
+            >
+              ✗ 0
+            </button>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={hit}
+              class="fchoice"
+              class:on={hit}
+              onclick={() => toggleFixed(p.id, true)}
+            >
+              ✓ +{cat.fixedScore}
+            </button>
+          </div>
+        {:else if cat.face}
+          <div class="row spread wrap">
+            <span class="flabel">Dice showing {cat.face}</span>
+            <Stepper
+              bind:value={input.scores[p.id]}
+              step={cat.face}
+              min={0}
+              max={cat.max}
+              label={`${p.name} ${cat.label}`}
+            />
+          </div>
+        {:else}
+          <div class="row spread wrap">
+            <span class="flabel">Score</span>
+            <Stepper
+              bind:value={input.scores[p.id]}
+              min={0}
+              max={cat.max}
+              label={`${p.name} ${cat.label}`}
+            />
+          </div>
+        {/if}
+
+        {#if isSixes && hitBonus}
+          <p class="badge good">🎉 Upper bonus +{UPPER_BONUS}!</p>
+        {/if}
+
+        {#if bonusRound && input.bonusYahtzees}
+          <div class="row spread wrap bonus-row">
+            <span class="flabel">Extra Yahtzees (+{YAHTZEE_BONUS} ea)</span>
+            <Stepper
+              bind:value={input.bonusYahtzees[p.id]}
+              min={0}
+              max={5}
+              label={`${p.name} extra Yahtzees`}
+            />
+          </div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .head {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ttl {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+  }
+  .hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  .callout {
+    margin: 0;
+    padding: 9px 12px;
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--primary) 10%, var(--surface));
+    border: 1px dashed color-mix(in srgb, var(--primary) 45%, var(--border));
+    font-size: 0.85rem;
+  }
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .preview {
+    font-weight: 800;
+    font-size: 1.05rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .flabel {
+    font-size: 0.85rem;
+    color: var(--muted);
+    font-weight: 600;
+  }
+  .fixed-toggle {
+    display: flex;
+    gap: 4px;
+    padding: 4px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .fchoice {
+    flex: 1 1 0;
+    min-height: 46px;
+    padding: 0 10px;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--muted);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+    transition:
+      background var(--dur-base) var(--ease-standard),
+      color var(--dur-base) var(--ease-standard);
+  }
+  .fchoice.on {
+    background: var(--primary);
+    color: #fff;
+  }
+  .fchoice:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  /* Semantic tint co-signalled by emoji + words — never colour alone. */
+  .badge {
+    margin: 0;
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 4px 10px;
+    border-radius: 999px;
+    align-self: flex-start;
+  }
+  .badge.good {
+    background: color-mix(in srgb, var(--good) 16%, var(--surface));
+    color: var(--text);
+  }
+  .bonus-row {
+    padding-top: 6px;
+    border-top: 1px dashed var(--border);
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/yahtzee/index.ts
+++ b/src/lib/games/yahtzee/index.ts
@@ -1,0 +1,80 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { yahtzeeStats } from './stats';
+import {
+  CATEGORIES,
+  UPPER_BONUS,
+  UPPER_BONUS_THRESHOLD,
+  YAHTZEE_BONUS,
+  categoryForRound,
+  describeRound,
+  emptyInput,
+  maxRounds,
+  roundCellTone,
+  scoreRound,
+  validateYahtzee,
+  type Category,
+  type CategoryId,
+  type YahtzeeInput,
+} from './logic';
+
+// Re-exported so the editor and stats share a single entry point for the pure model.
+export {
+  CATEGORIES,
+  UPPER_BONUS,
+  UPPER_BONUS_THRESHOLD,
+  YAHTZEE_BONUS,
+  categoryForRound,
+  type Category,
+  type CategoryId,
+  type YahtzeeInput,
+};
+
+export const yahtzee: GameModule = {
+  id: 'yahtzee',
+  name: 'Yahtzee',
+  tagline: 'Roll five, fill the box, chase the bonus.',
+  emoji: '🎲',
+  keywords: ['dice', 'scorecard', 'upper section', 'full house', 'straight'],
+  minPlayers: 1,
+  maxPlayers: 10,
+
+  maxRounds,
+
+  createRoundInput: (ctx: RoundContext): YahtzeeInput =>
+    emptyInput(ctx.players.map((p) => p.id)),
+
+  validateRound: (input: YahtzeeInput, ctx: RoundContext): string | null =>
+    validateYahtzee(input, ctx),
+
+  scoreRound: (input: YahtzeeInput, ctx: RoundContext): Record<ID, number> =>
+    scoreRound(input, ctx),
+
+  describeRound: (round: Round, players): string => describeRound(round, players),
+
+  roundCellTone: (round: Round, playerId: ID) => roundCellTone(round, playerId),
+
+  help: [
+    '🎲 Yahtzee — 13 categories, one per round, same category for the whole table each turn.',
+    'Roll your own dice at the table as usual, then enter the score your category earned.',
+    '',
+    'Upper section (Ones–Sixes): sum of the matching dice.',
+    `Score 63+ across the upper section and everyone banks a +${UPPER_BONUS} bonus —`,
+    'awarded automatically the moment the Sixes round is scored.',
+    '',
+    'Lower section:',
+    '• 3 of a Kind / 4 of a Kind / Chance — enter the sum of all 5 dice.',
+    '• Full House (25) / Small Straight (30) / Large Straight (40) / Yahtzee (50) —',
+    '  all-or-nothing: hit it or score 0.',
+    '',
+    `Extra Yahtzees (rolling a 2nd, 3rd… Yahtzee) are worth +${YAHTZEE_BONUS} each under the`,
+    'Joker rule. Claim them in the final Chance round — the last stop in this fixed order.',
+    '',
+    'Highest total wins.',
+  ].join('\n'),
+
+  stats: yahtzeeStats,
+
+  RoundEditor,
+  editorLoader: () => import('./YahtzeeEditor.svelte'),
+};

--- a/src/lib/games/yahtzee/logic.ts
+++ b/src/lib/games/yahtzee/logic.ts
@@ -1,0 +1,276 @@
+import type { ID, Round, RoundContext } from '../../types';
+
+/**
+ * Yahtzee — the classic 13-category dice scorecard. Pure, Svelte-free logic so it can be
+ * unit-tested (see `yahtzee.test.ts`) without importing the editor.
+ *
+ * ## The round model
+ * A real scorecard lets each player fill its 13 boxes in whatever order their own rolls
+ * favour. Score King's engine scores the *whole table* once per round, so instead we fix
+ * the 13 categories to the 13 rounds, in the order they're printed on a physical
+ * scorecard (Ones…Sixes, then 3-of-a-Kind…Chance). Every player fills the SAME category
+ * each round — you still roll and choose for yourself at the table, just enter the
+ * resulting number into the box that's up when it's that category's turn. This keeps the
+ * whole table moving together and is the fastest fit for the generic per-round engine
+ * (one screen per category, `maxRounds = 13`, game auto-finishes).
+ *
+ * ## Known simplification — the Joker rule
+ * We don't model individual dice, so a category's score is whatever the player says it
+ * is (their own scorecard already told them that): a plain number for the upper section,
+ * 3-of-a-Kind/4-of-a-Kind/Chance, and a "hit or miss" toggle for the fixed-value
+ * categories (Full House/Small/Large Straight/Yahtzee) — which already accommodates the
+ * Joker rule letting a second Yahtzee claim a lower-section box at full value even
+ * without the natural combo. What we *can't* place mid-game is a Joker-earned bonus
+ * outside the categories that remain once Yahtzee is already filled — under this fixed
+ * order that's only the final Chance round, so extra-Yahtzee bonuses (+100 each) are
+ * entered there.
+ */
+
+export type CategoryId =
+  | 'ones'
+  | 'twos'
+  | 'threes'
+  | 'fours'
+  | 'fives'
+  | 'sixes'
+  | 'threeKind'
+  | 'fourKind'
+  | 'fullHouse'
+  | 'smallStraight'
+  | 'largeStraight'
+  | 'yahtzee'
+  | 'chance';
+
+export interface Category {
+  id: CategoryId;
+  label: string;
+  emoji: string;
+  section: 'upper' | 'lower';
+  /** Face value for an upper-section category (score is a multiple of this, 0–5×). */
+  face?: number;
+  /** Fixed all-or-nothing score for a lower-section category (Full House, straights, Yahtzee). */
+  fixedScore?: number;
+  /** Highest score this category can hold — bounds the entry widget. */
+  max: number;
+  hint: string;
+}
+
+/** The 13 categories, in classic scorecard order. Index === round index. */
+export const CATEGORIES: Category[] = [
+  { id: 'ones', label: 'Ones', emoji: '⚀', section: 'upper', face: 1, max: 5, hint: 'Sum of dice showing 1' },
+  { id: 'twos', label: 'Twos', emoji: '⚁', section: 'upper', face: 2, max: 10, hint: 'Sum of dice showing 2' },
+  { id: 'threes', label: 'Threes', emoji: '⚂', section: 'upper', face: 3, max: 15, hint: 'Sum of dice showing 3' },
+  { id: 'fours', label: 'Fours', emoji: '⚃', section: 'upper', face: 4, max: 20, hint: 'Sum of dice showing 4' },
+  { id: 'fives', label: 'Fives', emoji: '⚄', section: 'upper', face: 5, max: 25, hint: 'Sum of dice showing 5' },
+  { id: 'sixes', label: 'Sixes', emoji: '⚅', section: 'upper', face: 6, max: 30, hint: 'Sum of dice showing 6' },
+  {
+    id: 'threeKind',
+    label: '3 of a Kind',
+    emoji: '🎯',
+    section: 'lower',
+    max: 30,
+    hint: 'Sum of all 5 dice (needs 3+ matching)',
+  },
+  {
+    id: 'fourKind',
+    label: '4 of a Kind',
+    emoji: '🀄',
+    section: 'lower',
+    max: 30,
+    hint: 'Sum of all 5 dice (needs 4+ matching)',
+  },
+  {
+    id: 'fullHouse',
+    label: 'Full House',
+    emoji: '🏠',
+    section: 'lower',
+    fixedScore: 25,
+    max: 25,
+    hint: '3 of one + 2 of another',
+  },
+  {
+    id: 'smallStraight',
+    label: 'Small Straight',
+    emoji: '🔗',
+    section: 'lower',
+    fixedScore: 30,
+    max: 30,
+    hint: '4 in a row',
+  },
+  {
+    id: 'largeStraight',
+    label: 'Large Straight',
+    emoji: '➰',
+    section: 'lower',
+    fixedScore: 40,
+    max: 40,
+    hint: '5 in a row',
+  },
+  {
+    id: 'yahtzee',
+    label: 'Yahtzee',
+    emoji: '🎉',
+    section: 'lower',
+    fixedScore: 50,
+    max: 50,
+    hint: 'All 5 dice match',
+  },
+  {
+    id: 'chance',
+    label: 'Chance',
+    emoji: '🍀',
+    section: 'lower',
+    max: 30,
+    hint: 'Sum of all 5 dice, any combo',
+  },
+];
+
+export const UPPER_BONUS_THRESHOLD = 63;
+export const UPPER_BONUS = 35;
+export const YAHTZEE_BONUS = 100;
+
+export const SIXES_INDEX = CATEGORIES.findIndex((c) => c.id === 'sixes');
+export const YAHTZEE_INDEX = CATEGORIES.findIndex((c) => c.id === 'yahtzee');
+export const LAST_INDEX = CATEGORIES.length - 1;
+
+/** The category for a given (0-based) round index, or null once past the 13th round. */
+export function categoryForRound(roundIndex: number): Category | null {
+  return CATEGORIES[roundIndex] ?? null;
+}
+
+/** Only the final (Chance) round can carry an "extra Yahtzee" bonus claim — see file header. */
+export function allowsBonusYahtzees(roundIndex: number): boolean {
+  return roundIndex === LAST_INDEX;
+}
+
+export interface YahtzeeInput {
+  /** This round's raw category score per player (before upper/Yahtzee bonuses). */
+  scores: Record<ID, number>;
+  /** Extra Yahtzees claimed via the Joker rule (+100 each) — only used on the final round. */
+  bonusYahtzees?: Record<ID, number>;
+}
+
+/** A fresh, empty round input for every player. */
+export function emptyInput(playerIds: ID[]): YahtzeeInput {
+  return {
+    scores: Object.fromEntries(playerIds.map((id) => [id, 0])),
+    bonusYahtzees: Object.fromEntries(playerIds.map((id) => [id, 0])),
+  };
+}
+
+/** Clamp a raw entry into the range/step a category actually allows. */
+export function clampScore(cat: Category, raw: unknown): number {
+  const n = Math.trunc(Number(raw));
+  const value = Number.isFinite(n) ? n : 0;
+  if (cat.fixedScore != null) return value >= cat.fixedScore ? cat.fixedScore : 0;
+  if (cat.face != null) {
+    const clamped = Math.max(0, Math.min(cat.max, value));
+    return clamped - (clamped % cat.face);
+  }
+  return Math.max(0, Math.min(cat.max, value));
+}
+
+/** Null when a category's raw score entry is valid, otherwise a human-readable error. */
+export function validCategoryScore(cat: Category, raw: unknown): string | null {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return `${cat.label} needs a score of 0 or more.`;
+  if (cat.fixedScore != null && n !== 0 && n !== cat.fixedScore) {
+    return `${cat.label} is all-or-nothing — 0 or ${cat.fixedScore}.`;
+  }
+  if (n > cat.max) return `${cat.label} can't exceed ${cat.max}.`;
+  if (cat.face != null && n % cat.face !== 0) {
+    return `${cat.label} must be a multiple of ${cat.face}.`;
+  }
+  return null;
+}
+
+/** Read + coerce the game config (Yahtzee has no tunable rules today, but this keeps the shape). */
+export function readConfig(_config: Record<string, unknown>): Record<string, never> {
+  return {};
+}
+
+/** Null when the whole round is valid, otherwise the first human-readable error found. */
+export function validateYahtzee(input: YahtzeeInput, ctx: RoundContext): string | null {
+  const cat = categoryForRound(ctx.roundIndex);
+  if (!cat) return null;
+  for (const p of ctx.players) {
+    const err = validCategoryScore(cat, input.scores[p.id]);
+    if (err) return `${p.name}: ${err}`;
+  }
+  if (allowsBonusYahtzees(ctx.roundIndex)) {
+    for (const p of ctx.players) {
+      const b = Number(input.bonusYahtzees?.[p.id] ?? 0);
+      if (!Number.isFinite(b) || b < 0) return `${p.name}: extra Yahtzees can't be negative.`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Per-player point deltas for this round's category, folding in the upper-section bonus
+ * (awarded the moment Sixes is scored, when a player's six upper boxes total 63+) and any
+ * extra-Yahtzee Joker bonus claimed on the final Chance round.
+ */
+export function scoreRound(input: YahtzeeInput, ctx: RoundContext): Record<ID, number> {
+  const cat = categoryForRound(ctx.roundIndex);
+  const out: Record<ID, number> = {};
+  for (const p of ctx.players) {
+    if (!cat) {
+      out[p.id] = 0;
+      continue;
+    }
+    let pts = clampScore(cat, input.scores[p.id]);
+    if (ctx.roundIndex === SIXES_INDEX) {
+      const upperTotal = (Number(ctx.totals[p.id]) || 0) + pts;
+      if (upperTotal >= UPPER_BONUS_THRESHOLD) pts += UPPER_BONUS;
+    }
+    if (allowsBonusYahtzees(ctx.roundIndex)) {
+      const extra = Math.max(0, Math.trunc(Number(input.bonusYahtzees?.[p.id]) || 0));
+      pts += extra * YAHTZEE_BONUS;
+    }
+    out[p.id] = pts;
+  }
+  return out;
+}
+
+/** Fixed 13-round game — one category per round. */
+export function maxRounds(): number {
+  return CATEGORIES.length;
+}
+
+/** Whether a player's upper section (Ones…Sixes) has already earned the 63+ bonus. */
+export function upperBonusEarned(upperSubtotal: number): boolean {
+  return upperSubtotal >= UPPER_BONUS_THRESHOLD;
+}
+
+/** One-line summary of a recorded round for the history table. */
+export function describeRound(round: Round, players: { id: ID; name: string }[]): string {
+  const cat = categoryForRound(round.index);
+  const input = round.input as YahtzeeInput | undefined;
+  if (!cat || !input) return 'no change';
+  const parts = players
+    .map((p) => {
+      const score = input.scores?.[p.id];
+      if (score == null) return '';
+      const extra = Math.max(0, Math.trunc(Number(input.bonusYahtzees?.[p.id]) || 0));
+      const bonusTag = extra > 0 ? ` +${extra * YAHTZEE_BONUS}🎉` : '';
+      return `${p.name} ${score}${bonusTag}`;
+    })
+    .filter(Boolean);
+  return `${cat.emoji} ${cat.label}: ${parts.join(' · ')}`;
+}
+
+/** Per-cell emphasis for the round-by-round scorecard: a full hit or a scratched zero. */
+export function roundCellTone(
+  round: Round,
+  playerId: ID,
+): { tone: 'good' | 'bad' | 'warn'; label?: string } | null {
+  const cat = categoryForRound(round.index);
+  const input = round.input as YahtzeeInput | undefined;
+  if (!cat || !input) return null;
+  const score = Number(input.scores?.[playerId]);
+  if (!Number.isFinite(score)) return null;
+  if (score <= 0) return { tone: 'bad', label: 'Scratched' };
+  if (score >= cat.max) return { tone: 'good', label: 'Top score!' };
+  return null;
+}

--- a/src/lib/games/yahtzee/stats.ts
+++ b/src/lib/games/yahtzee/stats.ts
@@ -1,0 +1,136 @@
+import type { ID } from '../../types';
+import { CATEGORIES, UPPER_BONUS_THRESHOLD, YAHTZEE_BONUS, categoryForRound, type YahtzeeInput } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt, fmtPct } from '../../stats/format';
+
+interface YahtzeeAgg {
+  upperTotal: number;
+  upperGames: number;
+  upperBonuses: number;
+  yahtzees: number;
+  extraYahtzees: number;
+  fullHouses: number;
+  largeStraights: number;
+  bestChance: number;
+}
+
+/**
+ * Yahtzee stats, derived purely from each recorded category round. Pure — no Svelte —
+ * so it's independently unit-testable and safe for the stats engine to import.
+ */
+export function yahtzeeStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, YahtzeeAgg>();
+  const get = (id: ID): YahtzeeAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = {
+        upperTotal: 0,
+        upperGames: 0,
+        upperBonuses: 0,
+        yahtzees: 0,
+        extraYahtzees: 0,
+        fullHouses: 0,
+        largeStraights: 0,
+        bestChance: 0,
+      };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  // Track each player's running upper-section subtotal per game so we can tell whether the
+  // 63+ bonus landed once Sixes is scored.
+  const upperRunning = new Map<string, Map<ID, number>>();
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const cat = categoryForRound(r.index);
+    const input = r.input as YahtzeeInput | undefined;
+    if (!cat || !input?.scores) continue;
+
+    for (const [pid, rawScore] of Object.entries(input.scores)) {
+      const id = canonical(pid);
+      const a = get(id);
+      const score = Number(rawScore) || 0;
+
+      if (cat.section === 'upper') {
+        let byGame = upperRunning.get(r.gameId);
+        if (!byGame) {
+          byGame = new Map();
+          upperRunning.set(r.gameId, byGame);
+        }
+        const running = (byGame.get(id) ?? 0) + score;
+        byGame.set(id, running);
+        if (cat.id === 'sixes') {
+          a.upperTotal += running;
+          a.upperGames += 1;
+          if (running >= UPPER_BONUS_THRESHOLD) a.upperBonuses += 1;
+        }
+      }
+
+      if (cat.id === 'yahtzee' && score >= cat.fixedScore!) a.yahtzees += 1;
+      if (cat.id === 'fullHouse' && score >= cat.fixedScore!) a.fullHouses += 1;
+      if (cat.id === 'largeStraight' && score >= cat.fixedScore!) a.largeStraights += 1;
+      if (cat.id === 'chance' && score > a.bestChance) a.bestChance = score;
+    }
+
+    if (cat.id === 'chance') {
+      for (const [pid, extraRaw] of Object.entries(input.bonusYahtzees ?? {})) {
+        const extra = Math.max(0, Math.trunc(Number(extraRaw) || 0));
+        if (extra > 0) get(canonical(pid)).extraYahtzees += extra;
+      }
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.upperGames) {
+      metrics.push({
+        key: 'yz_bonus_rate',
+        label: 'Upper bonus rate',
+        value: fmtPct(a.upperBonuses / a.upperGames),
+        emoji: '⬆️',
+      });
+      metrics.push({
+        key: 'yz_upper_avg',
+        label: 'Avg upper total',
+        value: (a.upperTotal / a.upperGames).toFixed(1),
+        emoji: '🔢',
+      });
+    }
+    if (a.yahtzees) {
+      metrics.push({ key: 'yz_yahtzees', label: 'Yahtzees rolled', value: fmtInt(a.yahtzees), emoji: '🎉' });
+    }
+    if (a.extraYahtzees) {
+      metrics.push({
+        key: 'yz_extra',
+        label: 'Bonus Yahtzees',
+        value: fmtInt(a.extraYahtzees),
+        emoji: `+${YAHTZEE_BONUS}`,
+      });
+    }
+    if (a.fullHouses) {
+      metrics.push({ key: 'yz_fh', label: 'Full Houses', value: fmtInt(a.fullHouses), emoji: '🏠' });
+    }
+    if (a.largeStraights) {
+      metrics.push({ key: 'yz_ls', label: 'Large Straights', value: fmtInt(a.largeStraights), emoji: '➰' });
+    }
+    if (a.bestChance) {
+      metrics.push({ key: 'yz_chance', label: 'Best Chance roll', value: fmtInt(a.bestChance), emoji: '🍀' });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  const totalYahtzees = [...per.values()].reduce((sum, a) => sum + a.yahtzees, 0);
+  if (totalYahtzees) {
+    global.push({ key: 'yz_total', label: 'Yahtzees rolled', value: fmtInt(totalYahtzees), emoji: '🎉' });
+  }
+  return { perPlayer, global };
+}
+
+// Re-exported purely so CATEGORIES stays a single source of truth for anything importing
+// stats.ts directly (kept for symmetry with the other games' stats modules).
+export { CATEGORIES };

--- a/src/lib/games/yahtzee/yahtzee.test.ts
+++ b/src/lib/games/yahtzee/yahtzee.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from 'vitest';
+import type { ID, Player, Round, RoundContext } from '../../types';
+import { computeTotals } from '../../scoring';
+import { yahtzee } from './index';
+import {
+  CATEGORIES,
+  LAST_INDEX,
+  SIXES_INDEX,
+  UPPER_BONUS,
+  YAHTZEE_BONUS,
+  YAHTZEE_INDEX,
+  allowsBonusYahtzees,
+  categoryForRound,
+  clampScore,
+  describeRound,
+  emptyInput,
+  maxRounds,
+  roundCellTone,
+  scoreRound,
+  validCategoryScore,
+  validateYahtzee,
+  type YahtzeeInput,
+} from './logic';
+
+const NAMES = ['Alice', 'Bob', 'Carol'];
+
+function mkPlayers(n: number): Player[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `p${i + 1}`,
+    name: NAMES[i] ?? `P${i + 1}`,
+    color: '#7c5cff',
+    createdAt: 0,
+  }));
+}
+
+function ctx(
+  players: Player[],
+  totals: Record<ID, number>,
+  roundIndex: number,
+  rounds: Round[] = [],
+): RoundContext {
+  return { game: {} as never, players, config: {}, roundIndex, totals, rounds };
+}
+
+/** Play a full 13-round game from a sequence of per-round score maps. */
+function play(
+  players: Player[],
+  roundScores: Record<ID, number>[],
+  bonusYahtzees?: Record<ID, number>,
+): { rounds: Round[]; totals: Record<ID, number> } {
+  const ids = players.map((p) => p.id);
+  const rounds: Round[] = [];
+  let totals = computeTotals(rounds, ids);
+  roundScores.forEach((scores, i) => {
+    const input: YahtzeeInput = { scores, bonusYahtzees: i === LAST_INDEX ? bonusYahtzees : undefined };
+    const c = ctx(players, totals, i, rounds);
+    const deltas = scoreRound(input, c);
+    rounds.push({ id: `r${i}`, gameId: 'g1', index: i, input, deltas, createdAt: 0 });
+    totals = computeTotals(rounds, ids);
+  });
+  return { rounds, totals };
+}
+
+describe('yahtzee / categories', () => {
+  it('has exactly 13 categories in scorecard order', () => {
+    expect(CATEGORIES).toHaveLength(13);
+    expect(CATEGORIES[0].id).toBe('ones');
+    expect(CATEGORIES[5].id).toBe('sixes');
+    expect(CATEGORIES[11].id).toBe('yahtzee');
+    expect(CATEGORIES[12].id).toBe('chance');
+    expect(SIXES_INDEX).toBe(5);
+    expect(YAHTZEE_INDEX).toBe(11);
+    expect(LAST_INDEX).toBe(12);
+  });
+
+  it('maps round index to category and back out of range', () => {
+    expect(categoryForRound(0)?.id).toBe('ones');
+    expect(categoryForRound(12)?.id).toBe('chance');
+    expect(categoryForRound(13)).toBeNull();
+  });
+
+  it('only allows the extra-Yahtzee bonus on the final round', () => {
+    expect(allowsBonusYahtzees(11)).toBe(false);
+    expect(allowsBonusYahtzees(12)).toBe(true);
+  });
+
+  it('reports a fixed 13-round game', () => {
+    expect(maxRounds()).toBe(13);
+    expect(yahtzee.maxRounds!({}, 4)).toBe(13);
+  });
+});
+
+describe('yahtzee / clampScore', () => {
+  it('clamps an upper-section score to a multiple of its face, within range', () => {
+    const twos = CATEGORIES[1];
+    expect(clampScore(twos, 6)).toBe(6);
+    expect(clampScore(twos, 7)).toBe(6); // rounds down to the nearest multiple of 2
+    expect(clampScore(twos, -3)).toBe(0);
+    expect(clampScore(twos, 999)).toBe(10); // clamped to max (5 × 2)
+  });
+
+  it('collapses a fixed-score category to 0 or the fixed value', () => {
+    const fullHouse = CATEGORIES.find((c) => c.id === 'fullHouse')!;
+    expect(clampScore(fullHouse, 25)).toBe(25);
+    expect(clampScore(fullHouse, 10)).toBe(0);
+    expect(clampScore(fullHouse, 0)).toBe(0);
+  });
+
+  it('clamps a free-entry category (Chance) into range', () => {
+    const chance = CATEGORIES.find((c) => c.id === 'chance')!;
+    expect(clampScore(chance, 18)).toBe(18);
+    expect(clampScore(chance, -5)).toBe(0);
+    expect(clampScore(chance, 999)).toBe(30);
+  });
+});
+
+describe('yahtzee / validCategoryScore', () => {
+  it('rejects a non-multiple upper-section entry', () => {
+    const fives = CATEGORIES[4];
+    expect(validCategoryScore(fives, 12)).toMatch(/multiple of 5/);
+    expect(validCategoryScore(fives, 10)).toBeNull();
+  });
+
+  it('rejects an off-value fixed-score entry', () => {
+    const yahtzeeCategory = CATEGORIES.find((c) => c.id === 'yahtzee')!;
+    expect(validCategoryScore(yahtzeeCategory, 30)).toMatch(/all-or-nothing/);
+    expect(validCategoryScore(yahtzeeCategory, 50)).toBeNull();
+    expect(validCategoryScore(yahtzeeCategory, 0)).toBeNull();
+  });
+
+  it('rejects a negative or over-max score', () => {
+    const chance = CATEGORIES.find((c) => c.id === 'chance')!;
+    expect(validCategoryScore(chance, -1)).toMatch(/0 or more/);
+    expect(validCategoryScore(chance, 40)).toMatch(/exceed 30/);
+  });
+});
+
+describe('yahtzee / validateYahtzee', () => {
+  const players = mkPlayers(2);
+
+  it('flags the first invalid player with their name', () => {
+    const input: YahtzeeInput = { scores: { p1: 7, p2: 10 } };
+    expect(validateYahtzee(input, ctx(players, { p1: 0, p2: 0 }, 1))).toMatch(/Alice:.*multiple/);
+  });
+
+  it('passes a fully valid round', () => {
+    const input: YahtzeeInput = { scores: { p1: 6, p2: 10 } };
+    expect(validateYahtzee(input, ctx(players, { p1: 0, p2: 0 }, 1))).toBeNull();
+  });
+
+  it('rejects negative extra-Yahtzee claims on the final round', () => {
+    const input: YahtzeeInput = { scores: { p1: 20, p2: 15 }, bonusYahtzees: { p1: -1, p2: 0 } };
+    expect(validateYahtzee(input, ctx(players, { p1: 0, p2: 0 }, LAST_INDEX))).toMatch(
+      /can't be negative/,
+    );
+  });
+});
+
+describe('yahtzee / scoreRound — upper bonus', () => {
+  const players = mkPlayers(2);
+
+  it('awards +35 the moment Sixes pushes the upper total to 63+', () => {
+    // p1 already has 33 from Ones..Fives (3+6+9+12+... let's just use a round number),
+    // scoring 30 on Sixes brings them to 63 → bonus fires.
+    const input: YahtzeeInput = { scores: { p1: 30, p2: 30 } };
+    const totals = { p1: 33, p2: 32 };
+    const deltas = scoreRound(input, ctx(players, totals, SIXES_INDEX));
+    expect(deltas.p1).toBe(30 + UPPER_BONUS); // 33 + 30 = 63 → bonus
+    expect(deltas.p2).toBe(30); // 32 + 30 = 62 → no bonus
+  });
+
+  it('does not award the bonus outside the Sixes round', () => {
+    const input: YahtzeeInput = { scores: { p1: 12, p2: 0 } };
+    const totals = { p1: 60, p2: 0 };
+    const deltas = scoreRound(input, ctx(players, totals, 3)); // Fours round
+    expect(deltas.p1).toBe(12);
+  });
+});
+
+describe('yahtzee / scoreRound — extra Yahtzee bonus', () => {
+  const players = mkPlayers(2);
+
+  it('adds +100 per extra Yahtzee only on the final (Chance) round', () => {
+    const input: YahtzeeInput = { scores: { p1: 20, p2: 15 }, bonusYahtzees: { p1: 2, p2: 0 } };
+    const deltas = scoreRound(input, ctx(players, { p1: 0, p2: 0 }, LAST_INDEX));
+    expect(deltas.p1).toBe(20 + 2 * YAHTZEE_BONUS);
+    expect(deltas.p2).toBe(15);
+  });
+
+  it('ignores a bonus claim on a non-final round', () => {
+    const input: YahtzeeInput = { scores: { p1: 50 }, bonusYahtzees: { p1: 3 } };
+    const deltas = scoreRound(input, ctx([players[0]], { p1: 0 }, YAHTZEE_INDEX));
+    expect(deltas.p1).toBe(50);
+  });
+});
+
+describe('yahtzee / describeRound', () => {
+  const players = mkPlayers(2);
+
+  it('summarises a category round', () => {
+    const round: Round = {
+      id: 'r1',
+      gameId: 'g1',
+      index: 8,
+      input: { scores: { p1: 25, p2: 0 } },
+      deltas: { p1: 25, p2: 0 },
+      createdAt: 0,
+    };
+    expect(describeRound(round, players)).toBe('🏠 Full House: Alice 25 · Bob 0');
+  });
+
+  it('flags an extra-Yahtzee bonus in the summary', () => {
+    const round: Round = {
+      id: 'r2',
+      gameId: 'g1',
+      index: LAST_INDEX,
+      input: { scores: { p1: 20 }, bonusYahtzees: { p1: 1 } },
+      deltas: { p1: 120 },
+      createdAt: 0,
+    };
+    expect(describeRound(round, [players[0]])).toBe(`🍀 Chance: Alice 20 +${YAHTZEE_BONUS}🎉`);
+  });
+});
+
+describe('yahtzee / roundCellTone', () => {
+  const round = (index: number, score: number): Round => ({
+    id: 'r',
+    gameId: 'g1',
+    index,
+    input: { scores: { p1: score } } as YahtzeeInput,
+    deltas: { p1: score },
+    createdAt: 0,
+  });
+
+  it('flags a scratch (0) as bad', () => {
+    expect(roundCellTone(round(0, 0), 'p1')).toEqual({ tone: 'bad', label: 'Scratched' });
+  });
+
+  it('flags a top score as good', () => {
+    expect(roundCellTone(round(0, 5), 'p1')).toEqual({ tone: 'good', label: 'Top score!' });
+  });
+
+  it('is neutral for a middling score', () => {
+    expect(roundCellTone(round(0, 3), 'p1')).toBeNull();
+  });
+});
+
+describe('yahtzee / module wiring', () => {
+  it('exposes the expected identity and bounds', () => {
+    expect(yahtzee.id).toBe('yahtzee');
+    expect(yahtzee.minPlayers).toBe(1);
+    expect(yahtzee.maxPlayers).toBeGreaterThanOrEqual(10);
+    expect(typeof yahtzee.help).toBe('string');
+  });
+
+  it('creates a blank round input for every player', () => {
+    const players = mkPlayers(2);
+    const input = emptyInput(players.map((p) => p.id)) as YahtzeeInput;
+    expect(input.scores).toEqual({ p1: 0, p2: 0 });
+    expect(input.bonusYahtzees).toEqual({ p1: 0, p2: 0 });
+    expect(yahtzee.createRoundInput(ctx(players, { p1: 0, p2: 0 }, 0))).toEqual(input);
+  });
+});
+
+describe('yahtzee / full game simulation', () => {
+  it('crowns the highest total across all 13 rounds, including bonuses', () => {
+    const players = mkPlayers(2);
+    // p1: aces for the upper bonus path, strong lower section, one extra Yahtzee.
+    const roundScores: Record<ID, number>[] = [
+      { p1: 3, p2: 1 }, // ones
+      { p1: 6, p2: 2 }, // twos
+      { p1: 9, p2: 3 }, // threes
+      { p1: 12, p2: 4 }, // fours
+      { p1: 15, p2: 5 }, // fives
+      { p1: 18, p2: 6 }, // sixes → p1 upper = 63 → +35 bonus; p2 = 21 → no bonus
+      { p1: 20, p2: 0 }, // 3 of a kind
+      { p1: 24, p2: 0 }, // 4 of a kind
+      { p1: 25, p2: 0 }, // full house
+      { p1: 30, p2: 0 }, // small straight
+      { p1: 40, p2: 0 }, // large straight
+      { p1: 50, p2: 0 }, // yahtzee
+      { p1: 24, p2: 30 }, // chance
+    ];
+    const { totals } = play(players, roundScores, { p1: 1, p2: 0 });
+    // p1 upper: 3+6+9+12+15+18 = 63 (+35 bonus) = 98
+    // p1 lower: 20+24+25+30+40+50+24 = 213; plus extra Yahtzee 100 = 313
+    // p1 total: 98 + 313 = 411
+    expect(totals.p1).toBe(411);
+    // p2: upper 1+2+3+4+5+6 = 21 (no bonus) + chance 30 = 51
+    expect(totals.p2).toBe(51);
+    expect(totals.p1).toBeGreaterThan(totals.p2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new game module — Yahtzee 🎲 — following the auto-discovered `src/lib/games/<id>/index.ts` convention (no registry edits needed).

## Rules

Standard 13-category Yahtzee scorecard:
- **Upper section** (Ones–Sixes): sum of matching dice; +35 bonus once the upper subtotal reaches 63.
- **Lower section**: 3 of a Kind / 4 of a Kind (sum of all 5 dice), Full House (25), Small Straight (30), Large Straight (40), Yahtzee (50), Chance (sum of all 5 dice).
- Extra Yahtzee (Joker rule): +100 per additional Yahtzee.
- Highest total wins.

## Design choice

Modeled as **13 fixed rounds — one category per round for the whole table** — rather than one full-scorecard round per player. Score King's engine scores the whole table once per round, so fixing the 13 categories to the 13 rounds (in classic scorecard order) keeps everyone moving together and is the fastest fit for the generic round-editor shell. Players still roll and choose for themselves at the table; they just enter the resulting number into the box that's up.

Known simplification: since we don't model individual dice, extra-Yahtzee (Joker rule) bonuses can only be claimed on the final Chance round — the one category guaranteed to remain open after Yahtzee is scored under this fixed order. Documented in `logic.ts` and the in-game help text.

## Changes

- `src/lib/games/yahtzee/logic.ts` — pure scoring/validation logic (unit-tested)
- `src/lib/games/yahtzee/stats.ts` — game-specific stats hook
- `src/lib/games/yahtzee/index.ts` — GameModule wiring
- `src/lib/games/yahtzee/YahtzeeEditor.svelte` — round editor UI
- `src/lib/games/yahtzee/yahtzee.test.ts` — unit tests (25 tests)

## Issues

Closes #152

## Testing

- [x] `npm test` — new `yahtzee.test.ts` (25 tests passing)
- [x] `npm run check` — 0 errors, 0 warnings