### PR TITLE
feat(games): add Imploding Kittens game module

### DIFF
--- a/src/lib/games/implodingkittens/ImplodeBurst.svelte
+++ b/src/lib/games/implodingkittens/ImplodeBurst.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  import { prefersReducedMotion } from '../../motion';
+
+  /**
+   * A short 🕳️ collapse when a kitten implodes — the chaotic payoff Imploding
+   * Kittens begs for. Pure delight layered over an outcome already spelled out in
+   * words + chip ("🕳️ 1st out", struck-through name), so motion is never the only
+   * signal. The overlay is `pointer-events: none`, replays whenever `token` changes
+   * (a fresh implosion), and renders nothing at all under reduced motion. Modeled on
+   * the app's existing burst components (KaboomBurst / FeatherBurst / CoinBurst).
+   *
+   * A bigger `crown` blast is used for the last-kitten-standing moment: same engine,
+   * more pieces and a gold-and-sparkle glyph set for the win.
+   */
+  const { token = 0, crown = false }: { token?: number; crown?: boolean } = $props();
+
+  const reduced = prefersReducedMotion();
+
+  const pieces = $derived.by(() => {
+    const count = crown ? 14 : 10;
+    const glyphs = crown ? ['🎉', '✨', '🐱', '👑', '💫', '🎊'] : ['🕳️', '🕳️', '🙀', '💨', '⚫'];
+    return Array.from({ length: count }, (_, i) => {
+      const rand = (n: number) =>
+        (((Math.sin((token + i) * 12.9898 + n * 78.233) * 43758.5453) % 1) + 1) % 1;
+      // Radial scatter from the center of the row so an implosion actually bursts outward.
+      const angle = (i / count) * Math.PI * 2 + (rand(0) - 0.5) * 0.7;
+      const dist = (crown ? 46 : 34) + rand(1) * (crown ? 40 : 30);
+      return {
+        dx: Math.cos(angle) * dist,
+        dy: Math.sin(angle) * dist - (crown ? 16 : 8), // bias upward a touch
+        delay: rand(2) * 0.08,
+        duration: (crown ? 0.85 : 0.6) + rand(3) * 0.4,
+        spin: (rand(4) - 0.5) * 320,
+        size: (crown ? 1.0 : 0.85) + rand(5) * 0.6,
+        glyph: glyphs[Math.floor(rand(6) * glyphs.length)],
+      };
+    });
+  });
+</script>
+
+{#if !reduced && token > 0}
+  {#key token}
+    <div class="kaboom" class:crown aria-hidden="true">
+      {#each pieces as p, i (i)}
+        <span
+          class="bit"
+          style="
+            font-size: {p.size}rem;
+            animation-delay: {p.delay}s;
+            animation-duration: {p.duration}s;
+            --dx: {p.dx}px;
+            --dy: {p.dy}px;
+            --spin: {p.spin}deg;
+          ">{p.glyph}</span
+        >
+      {/each}
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .kaboom {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    overflow: visible;
+    z-index: 3;
+  }
+  .bit {
+    position: absolute;
+    line-height: 1;
+    opacity: 0;
+    will-change: transform, opacity;
+    animation-name: kaboom-fly;
+    animation-timing-function: cubic-bezier(0.16, 0.84, 0.44, 1);
+    animation-iteration-count: 1;
+    animation-fill-mode: both;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
+  }
+  @keyframes kaboom-fly {
+    0% {
+      opacity: 0;
+      transform: translate(0, 0) rotate(0deg) scale(0.3);
+    }
+    18% {
+      opacity: 1;
+      transform: translate(calc(var(--dx) * 0.5), calc(var(--dy) * 0.5))
+        rotate(calc(var(--spin) * 0.5)) scale(1.15);
+    }
+    100% {
+      opacity: 0;
+      transform: translate(var(--dx), var(--dy)) rotate(var(--spin)) scale(0.9);
+    }
+  }
+</style>

--- a/src/lib/games/implodingkittens/ImplodingKittensEditor.svelte
+++ b/src/lib/games/implodingkittens/ImplodingKittensEditor.svelte
@@ -1,0 +1,327 @@
+<script lang="ts">
+  import type { ID, RoundContext } from '../../types';
+  import { untrack } from 'svelte';
+  import Avatar from '../../components/Avatar.svelte';
+  import { ordinal } from '../../stats/format';
+  import { animateMotion, popIn } from '../../motion';
+  import { haptic } from '../../haptics';
+  import ImplosionField from './ImplosionField.svelte';
+  import ImplodeBurst from './ImplodeBurst.svelte';
+  import type { ImplodingKittensInput } from './logic';
+
+  let { input = $bindable(), ctx }: { input: ImplodingKittensInput; ctx: RoundContext } = $props();
+
+  const trackOrder = $derived(ctx.config.trackOrder !== false);
+
+  const outIndex = (id: ID): number => input.order.indexOf(id);
+  const isOut = (id: ID): boolean => outIndex(id) >= 0;
+
+  const alive = $derived(ctx.players.filter((p) => !input.order.includes(p.id)));
+  // In elimination-order mode the survivor is whoever's left once everyone else has
+  // imploded — crowned automatically so entry is a string of single taps.
+  const survivorId = $derived(
+    trackOrder ? (alive.length === 1 ? alive[0].id : null) : input.winner,
+  );
+
+  // Live ribbing: the first to cave (🕳️) and — once a match is decided — the runner-up
+  // who was one draw from surviving (😾). Personality that lands at the table, not just
+  // buried in Stats later.
+  const firstOutId = $derived(input.order[0] ?? null);
+  const runnerUpId = $derived(
+    survivorId && input.order.length ? input.order[input.order.length - 1] : null,
+  );
+
+  // Seats for the countdown costume: alive 🐱 / imploded 🕳️ / survivor 👑.
+  const seats = $derived(
+    ctx.players.map((p) => {
+      const oi = outIndex(p.id);
+      const state: 'alive' | 'out' | 'survivor' =
+        survivorId === p.id ? 'survivor' : oi >= 0 ? 'out' : 'alive';
+      return { id: p.id, name: p.name, color: p.color, state, outRank: oi >= 0 ? oi + 1 : 0 };
+    }),
+  );
+  const aliveCount = $derived(seats.filter((s) => s.state === 'alive').length);
+  const survivorName = $derived(
+    survivorId ? (ctx.players.find((p) => p.id === survivorId)?.name ?? null) : null,
+  );
+
+  // Per-row implosion tokens (bump → the 🕳️ burst replays on that row) and a single
+  // token for the last-kitten-standing win blast.
+  const boomToken = $state<Record<ID, number>>({});
+  let crownToken = $state(0);
+
+  // Don't fire the win beat for a survivor that was already crowned when this editor
+  // opened (e.g. editing a finished match) — only for a fresh crowning during entry.
+  let prevSurvivor: ID | null = untrack(() => survivorId);
+  $effect(() => {
+    const s = survivorId;
+    if (s && s !== prevSurvivor) {
+      crownToken += 1;
+      haptic('win');
+    }
+    prevSurvivor = s;
+  });
+
+  function syncWinner() {
+    input.winner = alive.length === 1 ? alive[0].id : null;
+  }
+
+  function eliminate(id: ID) {
+    if (!input.order.includes(id)) {
+      input.order = [...input.order, id];
+      boomToken[id] = (boomToken[id] ?? 0) + 1;
+      haptic('save');
+    }
+    syncWinner();
+  }
+  function revive(id: ID) {
+    input.order = input.order.filter((x) => x !== id);
+    syncWinner();
+  }
+  // trackOrder off: one tap picks the lone survivor (tap again to clear).
+  function crown(id: ID) {
+    input.winner = input.winner === id ? null : id;
+  }
+
+  // Svelte action: a quick shake when a row implodes (token bumps). Motion-only — the
+  // 🕳️ chip, struck name and rank already carry "out" — so it auto-skips under reduced
+  // motion via animateMotion.
+  function shakeOn(node: HTMLElement, token: number) {
+    let prev = token;
+    return {
+      update(next: number) {
+        if (next !== prev && next > 0) {
+          animateMotion(
+            node,
+            { x: [0, -5, 5, -3, 3, 0], rotate: [0, -1.5, 1.5, -1, 0.6, 0] },
+            { duration: 0.4, ease: 'easeOut' },
+          );
+        }
+        prev = next;
+      },
+    };
+  }
+</script>
+
+<div class="stack">
+  <ImplosionField {seats} {aliveCount} {survivorName} />
+
+  <div class="reminder menace">
+    ☠️ <span
+      ><strong>Imploding Kitten in play.</strong> No defuse for this one — flip it face up and you’re
+      gone.</span
+    >
+  </div>
+
+  <span class="prompt muted">
+    {#if survivorId}
+      🎉 Match over — the last kitten reigns. Save it to bank the win.
+    {:else if trackOrder}
+      Tap each kitten the instant it caves in 🕳️ — I’ll crown the survivor.
+    {:else}
+      Tap the last kitten standing 👑
+    {/if}
+  </span>
+
+  <div class="stack list">
+    {#each ctx.players as p (p.id)}
+      <div class="krow-wrap" use:shakeOn={boomToken[p.id] ?? 0}>
+        {#if survivorId === p.id}
+          <div class="krow survivor" aria-label="{p.name} is the last kitten standing">
+            <span class="who">
+              <Avatar name={p.name} color={p.color} />
+              <strong>{p.name}</strong>
+            </span>
+            <span class="badge crown" use:popIn>👑 Survivor</span>
+          </div>
+          <ImplodeBurst token={crownToken} crown />
+        {:else if trackOrder && isOut(p.id)}
+          <button
+            type="button"
+            class="krow out"
+            onclick={() => revive(p.id)}
+            aria-label="Bring {p.name} back in — they were the {ordinal(outIndex(p.id) + 1)} out"
+          >
+            <span class="who">
+              <Avatar name={p.name} color={p.color} />
+              <span class="name">{p.name}</span>
+              {#if firstOutId === p.id}
+                <span class="rib first">first to cave 🙀</span>
+              {:else if runnerUpId === p.id}
+                <span class="rib close">so close 😾</span>
+              {/if}
+            </span>
+            <span class="badge boom"
+              >🕳️ <span class="num">{ordinal(outIndex(p.id) + 1)}</span> out</span
+            >
+          </button>
+          <ImplodeBurst token={boomToken[p.id] ?? 0} />
+        {:else if trackOrder}
+          <button
+            type="button"
+            class="krow"
+            onclick={() => eliminate(p.id)}
+            aria-label="{p.name} imploded"
+          >
+            <span class="who">
+              <Avatar name={p.name} color={p.color} />
+              <strong>{p.name}</strong>
+            </span>
+            <span class="badge action">🕳️ Out</span>
+          </button>
+        {:else}
+          <button
+            type="button"
+            class="krow pick"
+            class:on={input.winner === p.id}
+            onclick={() => crown(p.id)}
+            aria-pressed={input.winner === p.id}
+          >
+            <span class="who">
+              <Avatar name={p.name} color={p.color} />
+              <strong>{p.name}</strong>
+            </span>
+            <span class="badge">{input.winner === p.id ? '👑 Survivor' : 'Tap to crown'}</span>
+          </button>
+        {/if}
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .list {
+    gap: 8px;
+  }
+  .prompt {
+    font-size: 0.88rem;
+  }
+  .krow-wrap {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    gap: 8px;
+    width: 100%;
+    will-change: transform;
+  }
+  .krow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 56px;
+    padding: 10px 12px;
+    text-align: left;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      border-color 0.15s ease;
+  }
+  button.krow:hover {
+    background: var(--surface-3);
+  }
+  button.krow:active {
+    transform: translateY(1px);
+  }
+  button.krow:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .who {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+  .who strong,
+  .who .name {
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .badge {
+    flex: none;
+    font-weight: 700;
+    font-size: 0.9rem;
+    color: var(--muted);
+  }
+  .badge.action {
+    color: var(--text);
+  }
+  .num {
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Live ribbing — a small playful tag next to the name. Text + emoji carry it; kept
+     muted so it's a wink, never a shout, and never colour alone. */
+  .rib {
+    flex: none;
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: var(--muted);
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    white-space: nowrap;
+  }
+
+  /* Imploded: dimmed and struck, carried by the 🕳️ chip + rank number, never
+     colour alone. Not coral — being out isn't an error, just out. */
+  .krow.out {
+    background: var(--surface);
+    opacity: 0.72;
+  }
+  .krow.out .name {
+    text-decoration: line-through;
+    color: var(--muted);
+  }
+  .badge.boom {
+    color: var(--muted);
+  }
+
+  /* Survivor: the restrained Crown Gold wash + underline the scoreboard uses for a
+     winner — the 👑 and the gold carry it, so gold stays a hint, never a block. */
+  .krow.survivor {
+    background: color-mix(in srgb, var(--accent) 13%, var(--surface-2));
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  }
+  .badge.crown {
+    color: var(--accent-ink);
+  }
+  .krow.pick.on {
+    background: color-mix(in srgb, var(--accent) 13%, var(--surface-2));
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  }
+  .krow.pick.on .badge {
+    color: var(--accent-ink);
+  }
+
+  .reminder {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 12px;
+    border-radius: 10px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+  /* Imploding gets a touch of menace — a loss-coral edge, co-signalled by the ☠️ and
+     the words, never colour alone. */
+  .reminder.menace {
+    border-color: color-mix(in srgb, var(--bad) 45%, var(--border));
+    background: color-mix(in srgb, var(--bad) 8%, var(--surface));
+  }
+  .reminder.menace strong {
+    color: var(--text);
+  }
+</style>

--- a/src/lib/games/implodingkittens/ImplosionField.svelte
+++ b/src/lib/games/implodingkittens/ImplosionField.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+  import type { ID } from '../../types';
+
+  /**
+   * Imploding Kittens' per-game costume: a compact strip of kitten faces, one per
+   * player, that visibly go 🐱 → 🕳️ as the deck thins toward a single survivor. It's
+   * the thematic "stage" the game was missing — the tension of the table shrinking to
+   * one, read at a glance. Lives entirely inside the game editor and never touches the
+   * shared chrome.
+   *
+   * Design guardrails: no Royal Violet (that stays on the shell's one Save action) and
+   * Crown Gold appears only on the lone survivor — the leader/winner rule. Depth comes
+   * from the surface ramp plus muted/semantic tints. Every state is co-signalled by a
+   * glyph + text (🕳️ / rank number / struck name / 👑), never colour alone, and the
+   * live caption spells out the count, so the strip is decoration that degrades
+   * gracefully and needs no motion to be understood.
+   */
+  type Seat = {
+    id: ID;
+    name: string;
+    color: string;
+    state: 'alive' | 'out' | 'survivor';
+    outRank: number; // 1-based implosion order, 0 for alive/survivor
+  };
+
+  const {
+    seats,
+    aliveCount,
+    survivorName = null,
+  }: {
+    seats: Seat[];
+    aliveCount: number;
+    survivorName?: string | null;
+  } = $props();
+</script>
+
+<div class="stage" class:won={!!survivorName}>
+  <div class="caption">
+    {#if survivorName}
+      <span class="win">🐱👑 {survivorName} — last kitten standing!</span>
+    {:else}
+      <span class="count"
+        ><span class="num">{aliveCount}</span>
+        {aliveCount === 1 ? 'kitten' : 'kittens'} still clawing</span
+      >
+      <span class="sub muted">☠️ one Imploding Kitten is hiding in the deck…</span>
+    {/if}
+  </div>
+
+  <div class="strip" aria-hidden="true">
+    {#each seats as s (s.id)}
+      <span
+        class="face"
+        class:out={s.state === 'out'}
+        class:survivor={s.state === 'survivor'}
+        style="--pc: {s.color}"
+        title={s.name}
+      >
+        <span class="glyph">{s.state === 'out' ? '🕳️' : s.state === 'survivor' ? '👑' : '🐱'}</span>
+        {#if s.state === 'out'}
+          <span class="rank num">{s.outRank}</span>
+        {/if}
+      </span>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .stage {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  /* The win beat borrows the scoreboard's restrained Crown Gold edge — the 👑 and the
+     gold caption carry it, so gold stays a hint, never a block. */
+  .stage.won {
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+    background: color-mix(in srgb, var(--accent) 10%, var(--surface-2));
+  }
+  .caption {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+  }
+  .count {
+    font-weight: 700;
+    font-size: 1rem;
+  }
+  .win {
+    font-weight: 800;
+    font-size: 1.02rem;
+    color: var(--accent-ink);
+  }
+  .sub {
+    font-size: 0.78rem;
+  }
+  .num {
+    font-variant-numeric: tabular-nums;
+  }
+  .strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .face {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 38px;
+    height: 38px;
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    /* A quiet tint of the player's palette colour so seats stay distinguishable,
+       reinforced by the title/name — never colour alone. */
+    border: 1px solid color-mix(in srgb, var(--pc) 45%, var(--border));
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--pc) 14%, transparent);
+    font-size: 1.15rem;
+    line-height: 1;
+  }
+  /* Imploded: dimmed and desaturated, carried by the 🕳️ glyph + rank number. Not
+     coral — being out isn't an error, just out. */
+  .face.out {
+    opacity: 0.5;
+    border-style: dashed;
+    filter: grayscale(0.4);
+  }
+  .face.survivor {
+    border-color: color-mix(in srgb, var(--accent) 60%, var(--border));
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--accent) 26%, transparent);
+    background: color-mix(in srgb, var(--accent) 12%, var(--surface));
+  }
+  .glyph {
+    display: block;
+  }
+  .rank {
+    position: absolute;
+    right: -3px;
+    bottom: -3px;
+    min-width: 15px;
+    height: 15px;
+    padding: 0 3px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 0.6rem;
+    font-weight: 800;
+  }
+</style>

--- a/src/lib/games/implodingkittens/implodingkittens.test.ts
+++ b/src/lib/games/implodingkittens/implodingkittens.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round, RoundContext } from '../../types';
+import {
+  emptyInput,
+  finishingPositions,
+  isFinished,
+  pickMatchLeaders,
+  scoreMatch,
+  targetWins,
+  validateMatch,
+  type ImplodingKittensInput,
+} from './logic';
+import { implodingkittens } from './index';
+import { implodingKittensStats } from './stats';
+
+const player = (id: string, name = id): Player => ({ id, name, color: '#7c5cff', createdAt: 0 });
+
+function ctxFor(playerIds: string[], config: Record<string, unknown> = {}): RoundContext {
+  return {
+    game: {
+      id: 'g',
+      type: 'implodingkittens',
+      config,
+      playerIds,
+      status: 'active',
+      createdAt: 0,
+      roundCount: 0,
+    } as Game,
+    players: playerIds.map((id) => player(id)),
+    config,
+    roundIndex: 0,
+    totals: Object.fromEntries(playerIds.map((id) => [id, 0])),
+    rounds: [],
+  };
+}
+
+function mkRound(gameId: string, index: number, input: ImplodingKittensInput, players: string[]): Round {
+  return {
+    id: `${gameId}-r${index}`,
+    gameId,
+    index,
+    input,
+    deltas: scoreMatch(input, players),
+    createdAt: 0,
+  };
+}
+
+describe('scoreMatch — a match win is +1 to the survivor', () => {
+  it('gives the survivor +1 and everyone else 0', () => {
+    expect(scoreMatch({ winner: 'A', order: ['C', 'B'] }, ['A', 'B', 'C'])).toEqual({
+      A: 1,
+      B: 0,
+      C: 0,
+    });
+  });
+
+  it('keys every seat so the whole table appears on the scorecard', () => {
+    const out = scoreMatch({ winner: 'B', order: ['A'] }, ['A', 'B']);
+    expect(Object.keys(out).sort()).toEqual(['A', 'B']);
+    expect(out).toEqual({ A: 0, B: 1 });
+  });
+
+  it('scores nobody when there is no survivor', () => {
+    expect(scoreMatch({ winner: null, order: [] }, ['A', 'B'])).toEqual({ A: 0, B: 0 });
+  });
+
+  it('ignores a winner who is not one of the players', () => {
+    expect(scoreMatch({ winner: 'Z', order: [] }, ['A', 'B'])).toEqual({ A: 0, B: 0 });
+  });
+});
+
+describe('validateMatch — survivor only (track order off)', () => {
+  it('requires a survivor', () => {
+    expect(validateMatch({ winner: null, order: [] }, ['A', 'B'], false)).toMatch(
+      /last player standing/i,
+    );
+  });
+
+  it('accepts a valid survivor', () => {
+    expect(validateMatch({ winner: 'A', order: [] }, ['A', 'B'], false)).toBeNull();
+  });
+
+  it('rejects a survivor who is not in the game', () => {
+    expect(validateMatch({ winner: 'Z', order: [] }, ['A', 'B'], false)).toMatch(
+      /one of the players/i,
+    );
+  });
+});
+
+describe('validateMatch — full elimination order (track order on)', () => {
+  it('accepts a complete order with the correct auto-survivor', () => {
+    expect(validateMatch({ winner: 'A', order: ['C', 'B'] }, ['A', 'B', 'C'], true)).toBeNull();
+  });
+
+  it('nudges while players are still in play', () => {
+    expect(validateMatch({ winner: null, order: ['B'] }, ['A', 'B', 'C'], true)).toMatch(
+      /2 still in play/,
+    );
+  });
+
+  it('requires the survivor to be crowned once one remains', () => {
+    expect(validateMatch({ winner: null, order: ['C', 'B'] }, ['A', 'B', 'C'], true)).toMatch(
+      /last kitten standing/i,
+    );
+  });
+
+  it('rejects a duplicate implosion', () => {
+    expect(validateMatch({ winner: null, order: ['B', 'B'] }, ['A', 'B', 'C'], true)).toMatch(
+      /only implode once/i,
+    );
+  });
+
+  it('rejects an unknown player in the order', () => {
+    expect(validateMatch({ winner: null, order: ['Z'] }, ['A', 'B', 'C'], true)).toMatch(
+      /isn’t in this game/i,
+    );
+  });
+
+  it('rejects a survivor who also appears in the elimination pile', () => {
+    expect(validateMatch({ winner: 'B', order: ['C', 'B'] }, ['A', 'B', 'C'], true)).toMatch(
+      /elimination pile/i,
+    );
+  });
+
+  it('rejects a match where everybody imploded', () => {
+    expect(validateMatch({ winner: null, order: ['A', 'B', 'C'] }, ['A', 'B', 'C'], true)).toMatch(
+      /has to survive/i,
+    );
+  });
+});
+
+describe('pickMatchLeaders — most match wins leads', () => {
+  it('returns the single leader', () => {
+    expect(pickMatchLeaders({ A: 2, B: 1, C: 0 })).toEqual(['A']);
+  });
+
+  it('returns everyone tied for the lead', () => {
+    expect(pickMatchLeaders({ A: 2, B: 2, C: 1 }).sort()).toEqual(['A', 'B']);
+  });
+
+  it('crowns nobody before a match has been won', () => {
+    expect(pickMatchLeaders({ A: 0, B: 0 })).toEqual([]);
+  });
+
+  it('handles an empty table', () => {
+    expect(pickMatchLeaders({})).toEqual([]);
+  });
+});
+
+describe('finishingPositions — 1 = survivor, first-out finishes last', () => {
+  it('orders a full 3-player match', () => {
+    expect(finishingPositions({ winner: 'A', order: ['C', 'B'] }, ['A', 'B', 'C'])).toEqual({
+      A: 1,
+      B: 2,
+      C: 3,
+    });
+  });
+
+  it('only positions the players it knows about', () => {
+    expect(finishingPositions({ winner: 'A', order: [] }, ['A', 'B'])).toEqual({ A: 1 });
+  });
+});
+
+describe('targetWins / isFinished — ends once a player reaches the target', () => {
+  it('is open-ended by default', () => {
+    expect(targetWins({})).toBe(0);
+    expect(targetWins({ targetWins: 0 })).toBe(0);
+    expect(isFinished({ A: 5, B: 2 }, {})).toBe(false);
+  });
+
+  it('caps to a positive target and coerces strings', () => {
+    expect(targetWins({ targetWins: 3 })).toBe(3);
+    expect(targetWins({ targetWins: '5' })).toBe(5);
+  });
+
+  it('finishes once any player reaches the target', () => {
+    expect(isFinished({ A: 2, B: 1 }, { targetWins: 3 })).toBe(false);
+    expect(isFinished({ A: 3, B: 1 }, { targetWins: 3 })).toBe(true);
+    expect(isFinished({ A: 1, B: 5 }, { targetWins: 3 })).toBe(true);
+  });
+
+  it('never finishes when open-ended, no matter the totals', () => {
+    expect(isFinished({ A: 99 }, { targetWins: 0 })).toBe(false);
+  });
+});
+
+describe('implodingkittens module', () => {
+  it('has the folder id and expansion-appropriate seat range', () => {
+    expect(implodingkittens.id).toBe('implodingkittens');
+    expect(implodingkittens.minPlayers).toBe(2);
+    expect(implodingkittens.maxPlayers).toBe(6);
+    expect(typeof implodingkittens.emoji).toBe('string');
+  });
+
+  it('creates a fresh, empty match', () => {
+    expect(implodingkittens.createRoundInput(ctxFor(['A', 'B']))).toEqual(emptyInput());
+    expect(emptyInput()).toEqual({ winner: null, order: [] });
+  });
+
+  it('finishes the game once the configured target win count is reached', () => {
+    expect(
+      implodingkittens.isFinished!({ A: 2, B: 1 }, { config: { targetWins: 3 }, roundCount: 3, playerCount: 2 }),
+    ).toBe(false);
+    expect(
+      implodingkittens.isFinished!({ A: 3, B: 1 }, { config: { targetWins: 3 }, roundCount: 4, playerCount: 2 }),
+    ).toBe(true);
+    expect(
+      implodingkittens.isFinished!({ A: 10, B: 1 }, { config: { targetWins: 0 }, roundCount: 11, playerCount: 2 }),
+    ).toBe(false);
+  });
+
+  it('validates & scores a round through the context (order tracked by default)', () => {
+    const ctx = ctxFor(['A', 'B', 'C']);
+    const input: ImplodingKittensInput = { winner: 'A', order: ['C', 'B'] };
+    expect(implodingkittens.validateRound(input, ctx)).toBeNull();
+    expect(implodingkittens.scoreRound(input, ctx)).toEqual({ A: 1, B: 0, C: 0 });
+  });
+
+  it('honors the track-order-off config', () => {
+    const ctx = ctxFor(['A', 'B', 'C'], { trackOrder: false });
+    expect(implodingkittens.validateRound({ winner: 'B', order: [] }, ctx)).toBeNull();
+  });
+
+  it('picks the leaderboard winner from totals', () => {
+    expect(implodingkittens.pickWinners!({ A: 3, B: 1 }, {})).toEqual(['A']);
+  });
+
+  it('describes a match with survivor and first-out', () => {
+    const players = [player('Ana'), player('Bo'), player('Cy')];
+    const round = mkRound('g', 0, { winner: 'Ana', order: ['Cy', 'Bo'] }, ['Ana', 'Bo', 'Cy']);
+    const desc = implodingkittens.describeRound!(round, players);
+    expect(desc).toContain('Ana');
+    expect(desc).toContain('👑');
+    expect(desc).toMatch(/Cy out first/);
+  });
+});
+
+describe('implodingKittensStats', () => {
+  const games: Game[] = [
+    {
+      id: 'g',
+      type: 'implodingkittens',
+      config: {},
+      playerIds: ['A', 'B', 'C'],
+      status: 'finished',
+      createdAt: 0,
+      roundCount: 2,
+    } as Game,
+  ];
+  const rounds: Round[] = [
+    mkRound('g', 0, { winner: 'A', order: ['C', 'B'] }, ['A', 'B', 'C']),
+    mkRound('g', 1, { winner: 'B', order: ['A', 'C'] }, ['A', 'B', 'C']),
+  ];
+  const out = implodingKittensStats({ games, rounds, players: [], canonical: (id: ID) => id });
+
+  it('counts first-to-implode per player', () => {
+    expect(out.perPlayer?.['C']?.find((m) => m.key === 'ik_first')?.value).toBe('1');
+    expect(out.perPlayer?.['A']?.find((m) => m.key === 'ik_first')?.value).toBe('1');
+  });
+
+  it('counts runner-up finishes', () => {
+    expect(out.perPlayer?.['B']?.find((m) => m.key === 'ik_runnerup')?.value).toBe('1');
+    expect(out.perPlayer?.['C']?.find((m) => m.key === 'ik_runnerup')?.value).toBe('1');
+  });
+
+  it('averages finishing position', () => {
+    // A finished 1st then 3rd -> avg 2; B finished 2nd then 1st -> avg 1.5
+    expect(out.perPlayer?.['A']?.find((m) => m.key === 'ik_finish')?.value).toBe('2');
+    expect(out.perPlayer?.['B']?.find((m) => m.key === 'ik_finish')?.value).toBe('1.5');
+  });
+
+  it('totals kittens imploded globally', () => {
+    expect(out.global?.find((m) => m.key === 'ik_boom')?.value).toBe('4');
+  });
+
+  it('maps merged players to their canonical id', () => {
+    const merged = implodingKittensStats({
+      games,
+      rounds: [mkRound('g', 0, { winner: 'A', order: ['C2', 'B'] }, ['A', 'B', 'C2'])],
+      players: [],
+      canonical: (id: ID) => (id === 'C2' ? 'C' : id),
+    });
+    expect(merged.perPlayer?.['C']?.find((m) => m.key === 'ik_first')?.value).toBe('1');
+  });
+
+  it('contributes nothing when elimination order is not tracked', () => {
+    const noOrder = implodingKittensStats({
+      games,
+      rounds: [mkRound('g', 0, { winner: 'A', order: [] }, ['A', 'B', 'C'])],
+      players: [],
+      canonical: (id: ID) => id,
+    });
+    expect(noOrder.perPlayer).toEqual({});
+    expect(noOrder.global).toEqual([]);
+  });
+
+  it('reports the longest run of back-to-back match wins', () => {
+    const streakRounds: Round[] = [
+      mkRound('g', 0, { winner: 'A', order: ['C', 'B'] }, ['A', 'B', 'C']),
+      mkRound('g', 1, { winner: 'A', order: ['B', 'C'] }, ['A', 'B', 'C']),
+      mkRound('g', 2, { winner: 'B', order: ['C', 'A'] }, ['A', 'B', 'C']),
+    ];
+    const streakOut = implodingKittensStats({
+      games,
+      rounds: streakRounds,
+      players: [],
+      canonical: (id: ID) => id,
+    });
+    expect(streakOut.perPlayer?.['A']?.find((m) => m.key === 'ik_streak')?.value).toBe('2');
+    // A single win isn't a streak, so B (one win) gets no streak metric.
+    expect(streakOut.perPlayer?.['B']?.find((m) => m.key === 'ik_streak')).toBeUndefined();
+  });
+});

--- a/src/lib/games/implodingkittens/index.ts
+++ b/src/lib/games/implodingkittens/index.ts
@@ -1,0 +1,103 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { implodingKittensStats } from './stats';
+import {
+  emptyInput,
+  isFinished as ikFinished,
+  pickMatchLeaders,
+  scoreMatch,
+  validateMatch,
+  type ImplodingKittensInput,
+} from './logic';
+
+export type { ImplodingKittensInput } from './logic';
+
+const trackOrderOn = (config: Record<string, unknown>): boolean => config.trackOrder !== false;
+
+export const implodingkittens: GameModule = {
+  id: 'implodingkittens',
+  name: 'Imploding Kittens',
+  tagline: 'Draw til you cave in — last kitten standing wins 🕳️🐱',
+  emoji: '🕳️',
+  keywords: ['exploding', 'imploding', 'kittens', 'party', 'elimination', 'cards', 'expansion'],
+  minPlayers: 2,
+  maxPlayers: 6,
+  configFields: [
+    {
+      key: 'targetWins',
+      label: 'End the game when a player reaches ___ match wins (0 = open-ended)',
+      type: 'number',
+      default: 3,
+      min: 0,
+      max: 50,
+      help: 'Play until someone banks this many match wins, then crown the leaderboard, or leave at 0 to keep dealing all night.',
+    },
+    {
+      key: 'trackOrder',
+      label: 'Track elimination order (who imploded when)',
+      type: 'boolean',
+      default: true,
+      help: 'On: tap each kitten as they implode and the survivor is crowned automatically — unlocks first-to-implode and finish stats. Off: just tap who survived.',
+    },
+  ],
+
+  // Higher match-win total leads (default win direction).
+
+  isFinished: (totals, { config }) => ikFinished(totals, config),
+
+  createRoundInput: (): ImplodingKittensInput => emptyInput(),
+
+  validateRound: (input: ImplodingKittensInput, ctx: RoundContext): string | null =>
+    validateMatch(
+      input,
+      ctx.players.map((p) => p.id),
+      trackOrderOn(ctx.config),
+    ),
+
+  scoreRound: (input: ImplodingKittensInput, ctx: RoundContext): Record<ID, number> =>
+    scoreMatch(
+      input,
+      ctx.players.map((p) => p.id),
+    ),
+
+  pickWinners: (totals): ID[] => pickMatchLeaders(totals),
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as ImplodingKittensInput;
+    const name = (id: ID | null | undefined) => players.find((p) => p.id === id)?.name ?? '?';
+    if (!input?.winner && (!input?.order || input.order.length === 0)) return 'no result';
+    const head = input.winner ? `👑 ${name(input.winner)} survived` : 'no survivor';
+    const parts = [head];
+    if (input.order && input.order.length) {
+      parts.push(`🕳️ ${name(input.order[0])} out first`);
+    }
+    return parts.join(' · ');
+  },
+
+  help: [
+    '🕳️🐱 Imploding Kittens — the Exploding Kittens expansion, played as a match tracker.',
+    '',
+    'Play a match: draw cards until someone flips an Imploding Kitten they can’t',
+    'Defuse — they’re OUT. Keep going until ONE player remains: the last kitten',
+    'standing wins the match and banks +1 on the leaderboard. Most match wins leads.',
+    '',
+    '☠️ The Imploding Kitten twist: when it’s drawn face down, its drawer looks at it,',
+    'then secretly slides it back into the draw pile face up, anywhere they like — no',
+    'Defuse card can stop it. The next player to draw it (now face up) is eliminated',
+    'on the spot; it can’t be Noped either.',
+    '',
+    'New cards in the expansion: Reverse (flips turn order — a Skip in 2-player),',
+    'Draw From the Bottom (end your turn from the bottom of the deck), Feral Cat',
+    '(a wild Cat Card for any combo), Alter the Future (peek & reorder the top 3',
+    'cards), and Targeted Attack (force any one player to take two turns).',
+    '',
+    'Each round here = one match. With “Track elimination order” on, tap each player',
+    'as they implode and the survivor is crowned for you; turn it off to just tap the',
+    'winner.',
+  ].join('\n'),
+
+  stats: implodingKittensStats,
+
+  RoundEditor,
+  editorLoader: () => import('./ImplodingKittensEditor.svelte'),
+};

--- a/src/lib/games/implodingkittens/logic.ts
+++ b/src/lib/games/implodingkittens/logic.ts
@@ -1,0 +1,136 @@
+import type { ID } from '../../types';
+
+/**
+ * Imploding Kittens is the Exploding Kittens expansion's *elimination* game, same
+ * shape as the base deck: players draw until only one is left standing. The twist
+ * is the Imploding Kitten — drawn face down it can't be Defused, so its drawer
+ * secretly slips it back into the draw pile face up; the next player to draw it is
+ * eliminated on the spot, no Nope, no defense. That changes *how* someone goes out,
+ * never *whether* a match has a single survivor, so it fits Score King's contract
+ * exactly like Exploding Kittens does: **one round = one match**, and a match win
+ * banks **+1** for the lone survivor (everyone else +0). Cumulative totals are each
+ * player's match-win tally, and the leaderboard is "most matches won". This file is
+ * pure (no Svelte, no I/O) so `implodingkittens.test.ts` can exercise the real rules.
+ */
+export interface ImplodingKittensInput {
+  /** The last player standing — the winner of this match. */
+  winner: ID | null;
+  /**
+   * Elimination order, earliest first: `order[0]` was the first to implode (🕳️),
+   * the final entry was the runner-up. Populated when "track elimination order"
+   * is on; left empty when the group only records who survived.
+   */
+  order: ID[];
+}
+
+/** A fresh, empty match: nobody eliminated, no survivor crowned yet. */
+export function emptyInput(): ImplodingKittensInput {
+  return { winner: null, order: [] };
+}
+
+/**
+ * Score one match: the survivor banks a match win (+1); everyone else scores 0 so
+ * they still appear on the scorecard. Keyed over the match's players, not just the
+ * winner, so `computeTotals` sees a delta for each seat.
+ */
+export function scoreMatch(input: ImplodingKittensInput, playerIds: ID[]): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) out[id] = 0;
+  if (input.winner && Object.prototype.hasOwnProperty.call(out, input.winner)) {
+    out[input.winner] = 1;
+  }
+  return out;
+}
+
+/**
+ * Validate a recorded match. When `trackOrder` is on we require a *complete*
+ * elimination order — everyone but the survivor imploded, exactly how a real match
+ * ends — which also gives clean finishing positions for stats. When it's off we
+ * only need the survivor. Returns `null` when valid, else a human-readable reason.
+ */
+export function validateMatch(
+  input: ImplodingKittensInput,
+  playerIds: ID[],
+  trackOrder: boolean,
+): string | null {
+  const known = new Set(playerIds);
+  const seen = new Set<ID>();
+  for (const id of input.order) {
+    if (!known.has(id)) return 'Elimination order lists a player who isn’t in this game.';
+    if (seen.has(id)) return 'A player can only implode once per match.';
+    seen.add(id);
+  }
+  if (input.winner && seen.has(input.winner)) {
+    return 'The survivor can’t also be in the elimination pile.';
+  }
+
+  if (trackOrder) {
+    const remaining = playerIds.filter((id) => !seen.has(id));
+    if (remaining.length > 1) {
+      const left = remaining.length;
+      return `Tap each kitten as they implode — ${left} still in play.`;
+    }
+    if (remaining.length === 0) {
+      return 'Someone has to survive — bring the last kitten back in.';
+    }
+    if (!input.winner || input.winner !== remaining[0]) {
+      return 'Crown the last kitten standing as the survivor.';
+    }
+    return null;
+  }
+
+  if (!input.winner) return 'Tap the last player standing to record the survivor.';
+  if (!known.has(input.winner)) return 'The survivor must be one of the players.';
+  return null;
+}
+
+/**
+ * Match leaders: the player(s) with the most match wins. Ties return everyone tied
+ * for the lead. Before anyone has won a match there is no leader, so return `[]`
+ * rather than crowning the whole table.
+ */
+export function pickMatchLeaders(totals: Record<ID, number>): ID[] {
+  const ids = Object.keys(totals);
+  if (ids.length === 0) return [];
+  const best = Math.max(...ids.map((id) => totals[id] ?? 0));
+  if (best <= 0) return [];
+  return ids.filter((id) => (totals[id] ?? 0) === best);
+}
+
+/**
+ * Finishing positions for a match (1 = survivor). With `n` players, the player who
+ * imploded first (`order[0]`) finishes last (`n`), the runner-up finishes 2nd, and
+ * the survivor finishes 1st. Players outside `order`/`winner` are omitted.
+ */
+export function finishingPositions(
+  input: ImplodingKittensInput,
+  playerIds: ID[],
+): Record<ID, number> {
+  const known = new Set(playerIds);
+  const pos: Record<ID, number> = {};
+  const order = input.order.filter((id) => known.has(id));
+  const n = playerIds.length;
+  order.forEach((id, i) => {
+    pos[id] = n - i;
+  });
+  if (input.winner && known.has(input.winner)) pos[input.winner] = 1;
+  return pos;
+}
+
+/**
+ * Read the target number of match wins that ends the game; 0 (or unset) means
+ * open-ended. Unlike a round cap, this is checked against cumulative totals via
+ * {@link isFinished} — the game ends the moment someone *reaches* the target, not
+ * after a fixed number of matches have been played.
+ */
+export function targetWins(config: Record<string, unknown>): number {
+  const t = Number(config.targetWins);
+  return Number.isFinite(t) && t > 0 ? Math.floor(t) : 0;
+}
+
+/** True once any player's match-win total has reached the configured target. */
+export function isFinished(totals: Record<ID, number>, config: Record<string, unknown>): boolean {
+  const target = targetWins(config);
+  if (target <= 0) return false;
+  return Object.values(totals).some((v) => (v ?? 0) >= target);
+}

--- a/src/lib/games/implodingkittens/stats.ts
+++ b/src/lib/games/implodingkittens/stats.ts
@@ -1,0 +1,143 @@
+import type { ID, Round } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg } from '../../stats/format';
+import { finishingPositions, type ImplodingKittensInput } from './logic';
+
+interface IKAgg {
+  firstOut: number;
+  runnerUp: number;
+  finishSum: number;
+  finishCount: number;
+  bestStreak: number;
+}
+
+/**
+ * Imploding Kittens flavour stats, derived from each match's recorded survivor and
+ * elimination order. The generic engine already carries match wins (the leaderboard
+ * is literally "most matches won"), so this hook adds only what it can't: who
+ * implodes first, who keeps reaching the final two, average finishing position, and
+ * the longest win streak. All pure; mirrors the module's own `finishingPositions`.
+ * With "track elimination order" off there's no order data, so this gracefully
+ * contributes nothing.
+ */
+export function implodingKittensStats({
+  games,
+  rounds,
+  canonical,
+}: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, IKAgg>();
+  const get = (id: ID): IKAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { firstOut: 0, runnerUp: 0, finishSum: 0, finishCount: 0, bestStreak: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let totalImploded = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const raw = r.input as ImplodingKittensInput | undefined;
+    if (!raw) continue;
+
+    const order = (raw.order ?? []).map(canonical);
+    const winner = raw.winner ? canonical(raw.winner) : null;
+    const players = [...new Set(Object.keys(r.deltas).map(canonical))];
+
+    totalImploded += order.length;
+    if (order.length) get(order[0]).firstOut += 1;
+
+    // Finishing positions only make sense for a completed match (everyone but the
+    // survivor imploded); guard so avg finish isn't skewed by a partial entry.
+    const complete = !!winner && order.length === players.length - 1 && order.length > 0;
+    if (complete) {
+      const pos = finishingPositions({ winner, order }, players);
+      for (const [id, p] of Object.entries(pos)) {
+        const a = get(id);
+        a.finishSum += p;
+        a.finishCount += 1;
+        if (p === 2) a.runnerUp += 1;
+      }
+    }
+  }
+
+  // Best win streak: the longest run of consecutive match wins within a single game.
+  // Matches are grouped by game and walked in play order; winning bumps a player's
+  // running streak, and any other outcome in a match they were part of resets it.
+  const byGame = new Map<ID, Round[]>();
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    let list = byGame.get(r.gameId);
+    if (!list) {
+      list = [];
+      byGame.set(r.gameId, list);
+    }
+    list.push(r);
+  }
+  for (const gameRounds of byGame.values()) {
+    gameRounds.sort((a, b) => a.index - b.index);
+    const streak = new Map<ID, number>();
+    for (const r of gameRounds) {
+      const raw = r.input as ImplodingKittensInput | undefined;
+      const winner = raw?.winner ? canonical(raw.winner) : null;
+      for (const id of new Set(Object.keys(r.deltas).map(canonical))) {
+        if (id === winner) {
+          const next = (streak.get(id) ?? 0) + 1;
+          streak.set(id, next);
+          const a = get(id);
+          if (next > a.bestStreak) a.bestStreak = next;
+        } else {
+          streak.set(id, 0);
+        }
+      }
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.firstOut) {
+      metrics.push({
+        key: 'ik_first',
+        label: 'First to implode',
+        value: `${a.firstOut}`,
+        emoji: '🕳️',
+      });
+    }
+    if (a.runnerUp) {
+      metrics.push({ key: 'ik_runnerup', label: 'Runner-up', value: `${a.runnerUp}`, emoji: '🥈' });
+    }
+    if (a.finishCount) {
+      metrics.push({
+        key: 'ik_finish',
+        label: 'Avg finish',
+        value: fmtAvg(a.finishSum / a.finishCount),
+        emoji: '🏁',
+      });
+    }
+    if (a.bestStreak >= 2) {
+      metrics.push({
+        key: 'ik_streak',
+        label: 'Best win streak',
+        value: `${a.bestStreak}`,
+        emoji: '🔥',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totalImploded) {
+    global.push({
+      key: 'ik_boom',
+      label: 'Kittens imploded',
+      value: `${totalImploded}`,
+      emoji: '🕳️',
+    });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Adds a new game module for **Imploding Kittens** 🕳️ — the Exploding Kittens expansion — modeled as a win/match tracker, mirroring the existing `explodingkittens` module's pattern.

## Changes

- `src/lib/games/implodingkittens/logic.ts` — pure scoring/validation logic: one round = one match, survivor banks +1, optional elimination order, `targetWins`/`isFinished` end condition (default 3 wins, 0 = open-ended).
- `src/lib/games/implodingkittens/stats.ts` — first-to-implode, runner-up, avg finish, best win streak.
- `src/lib/games/implodingkittens/index.ts` — the `GameModule` (auto-discovered by the registry, no other files touched).
- `ImplodingKittensEditor.svelte`, `ImplosionField.svelte`, `ImplodeBurst.svelte` — themed round editor (🕳️ costume distinct from Exploding Kittens' 💥).
- `implodingkittens.test.ts` — unit tests for scoring, validation, win-target/isFinished, stats.
- Help text covers the Imploding Kitten twist (can't be Defused; placed face-up when first drawn; explodes its drawer next time it's drawn) and the expansion's new cards (Reverse, Draw From the Bottom, Feral Cat, Alter the Future, Targeted Attack).

## Issues

Closes #154

## Testing

- [x] `npx vitest run implodingkittens` — 38 tests pass
- [x] `npx vitest run registry` — auto-discovery picks up the new module, 5 tests pass
- [x] `npm run check` (svelte-check + tsc) — 0 errors