### PR TITLE
feat(findingfriends): add Finding Friends game module

### DIFF
--- a/src/lib/games/findingfriends/FindingFriendsEditor.svelte
+++ b/src/lib/games/findingfriends/FindingFriendsEditor.svelte
@@ -1,0 +1,335 @@
+<script lang="ts">
+  import type { Player, RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import { findingFriends } from './index';
+  import {
+    deckCountFromConfig,
+    levelJump,
+    levelLabel,
+    sideLevelIndex,
+    totalPoints,
+    validateFindingFriends,
+    type FindingFriendsInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: FindingFriendsInput; ctx: RoundContext } = $props();
+
+  let showRules = $state(false);
+
+  const byId = $derived(new Map(ctx.players.map((p) => [p.id, p])));
+  const deckCount = $derived(deckCountFromConfig(ctx.config));
+  const pool = $derived(totalPoints(deckCount));
+
+  function members(ids: string[]): Player[] {
+    return ids.map((id) => byId.get(id)).filter((p): p is Player => !!p);
+  }
+  const declarerMembers = $derived(members(input.declarers));
+  const challengerMembers = $derived(members(input.challengers));
+
+  const declarerLevel = $derived(sideLevelIndex(input.declarers, ctx.totals));
+  const challengerLevel = $derived(sideLevelIndex(input.challengers, ctx.totals));
+
+  /** Tap a chip to flip that player between the banking and attacking side. */
+  function toggleSide(id: string) {
+    if (input.declarers.includes(id)) {
+      input.declarers = input.declarers.filter((x) => x !== id);
+      input.challengers = [...input.challengers, id];
+    } else {
+      input.challengers = input.challengers.filter((x) => x !== id);
+      input.declarers = [...input.declarers, id];
+    }
+  }
+
+  // Quick-pick points at each threshold boundary, scaled to the pool in play.
+  const quickPoints = $derived(
+    [0, pool * 0.2, pool * 0.4, pool * 0.6, pool * 0.8, pool].map((n) => Math.round(n)),
+  );
+
+  function setPoints(n: number) {
+    input.pointsCaptured = Math.max(0, Math.min(pool, n));
+  }
+
+  const preview = $derived(
+    input.pointsCaptured == null ? null : levelJump(input.pointsCaptured, deckCount),
+  );
+  const error = $derived(validateFindingFriends(input));
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="muted hint">Tap a player to move them between sides, then log the points.</span>
+    <button type="button" class="btn small ghost" onclick={() => (showRules = !showRules)}>
+      Rules
+    </button>
+  </div>
+
+  {#if showRules}
+    <pre class="help">{findingFriends.help}</pre>
+  {/if}
+
+  <div class="race" aria-label="Level race">
+    <div class="racerow">
+      <div class="racetop">
+        <span class="racename">🛡️ Declarers (bank)</span>
+        <span class="racescore">{levelLabel(declarerLevel)}</span>
+      </div>
+      <span class="tobarn">{declarerMembers.map((p) => p.name).join(' & ') || 'nobody yet'}</span>
+    </div>
+    <div class="racerow">
+      <div class="racetop">
+        <span class="racename">⚔️ Challengers (attack)</span>
+        <span class="racescore">{levelLabel(challengerLevel)}</span>
+      </div>
+      <span class="tobarn">
+        {challengerMembers.map((p) => p.name).join(' & ') || 'nobody yet'}
+      </span>
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="qlabel">Who's banking this deal?</div>
+    <div class="chips">
+      {#each ctx.players as p (p.id)}
+        {@const onDeclarers = input.declarers.includes(p.id)}
+        <button
+          type="button"
+          class="chip"
+          class:on={onDeclarers}
+          aria-pressed={onDeclarers}
+          onclick={() => toggleSide(p.id)}
+        >
+          <Avatar name={p.name} color={p.color} size={26} />
+          <span class="chipname">{p.name}</span>
+          <span class="chiprole">{onDeclarers ? 'bank' : 'attack'}</span>
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="qlabel">Points the challengers captured (5s, 10s, Ks)</div>
+    <div class="quick">
+      {#each quickPoints as n (n)}
+        <button
+          type="button"
+          class="qbtn"
+          class:on={input.pointsCaptured === n}
+          onclick={() => setPoints(n)}
+        >
+          {n}
+        </button>
+      {/each}
+    </div>
+    <input
+      class="numinput"
+      type="number"
+      inputmode="numeric"
+      min="0"
+      max={pool}
+      step="5"
+      placeholder="Exact points"
+      value={input.pointsCaptured ?? ''}
+      oninput={(e) => {
+        const v = e.currentTarget.valueAsNumber;
+        input.pointsCaptured = Number.isFinite(v) ? Math.max(0, Math.min(pool, v)) : null;
+      }}
+    />
+    <span class="muted hint">Pool this deal: {pool} points ({deckCount} deck{deckCount === 1 ? '' : 's'}).</span>
+  </div>
+
+  <div class="preview" class:ready={!!preview}>
+    {#if preview}
+      {#if !preview.winner || preview.levels === 0}
+        <span class="cel-emoji" aria-hidden="true">🤝</span>
+        <span class="cel-copy">
+          <span class="cel-head">Hold</span>
+          <span class="cel-cheer">Nobody advances this deal.</span>
+        </span>
+      {:else}
+        {@const winnerLabel =
+          preview.winner === 'declarers'
+            ? declarerMembers.map((p) => p.name).join(' & ') || 'Declarers'
+            : challengerMembers.map((p) => p.name).join(' & ') || 'Challengers'}
+        <span class="cel-emoji" aria-hidden="true">
+          {preview.winner === 'declarers' ? '🛡️' : '⚔️'}
+        </span>
+        <span class="cel-copy">
+          <span class="cel-head">
+            {preview.winner === 'declarers' ? 'Bank holds' : 'Breakthrough'}
+          </span>
+          <span class="cel-cheer">{winnerLabel}</span>
+        </span>
+        <strong class="pts score-good">+{preview.levels}</strong>
+      {/if}
+    {:else}
+      <span class="muted">Enter points captured to see the level jump.</span>
+    {/if}
+  </div>
+
+  {#if error}
+    <div class="muted hint">{error}</div>
+  {/if}
+</div>
+
+<style>
+  .hint {
+    font-size: 0.85rem;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .qlabel {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+
+  .race {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+  }
+  .racerow {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .racetop {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .racename {
+    font-weight: 700;
+  }
+  .racescore {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .tobarn {
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 8px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill, 999px);
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 600;
+  }
+  .chip.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .chipname {
+    white-space: nowrap;
+  }
+  .chiprole {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    opacity: 0.75;
+  }
+
+  .quick {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .qbtn {
+    min-height: 46px;
+    min-width: 46px;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+  .qbtn.on {
+    background: var(--primary);
+    border-color: var(--primary-strong);
+    color: #fff;
+  }
+  .numinput {
+    min-height: 46px;
+    padding: 8px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .preview {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-height: 46px;
+    padding: 10px 14px;
+    border: 1px dashed var(--border);
+    border-radius: var(--radius);
+    background: var(--surface-2);
+  }
+  .preview.ready {
+    border-style: solid;
+  }
+  .cel-emoji {
+    flex: 0 0 auto;
+    font-size: 1.5rem;
+    line-height: 1;
+  }
+  .cel-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .cel-head {
+    font-weight: 800;
+  }
+  .cel-cheer {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .pts {
+    flex: 0 0 auto;
+    font-size: 1.2rem;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-chip);
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/findingfriends/findingfriends.test.ts
+++ b/src/lib/games/findingfriends/findingfriends.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, it } from 'vitest';
+import type { ID, RoundContext, Round, Game } from '../../types';
+import { findingFriends } from './index';
+import { findingFriendsStats } from './stats';
+import {
+  DEFAULT_OPTIONS,
+  WINNING_LEVEL_INDEX,
+  deckCountFromConfig,
+  describeDeal,
+  levelJump,
+  levelLabel,
+  optionsFromConfig,
+  scoreFindingFriends,
+  sideHasWon,
+  sideLevelIndex,
+  totalPoints,
+  validateFindingFriends,
+  type FindingFriendsInput,
+} from './logic';
+
+const players = [
+  { id: 'a', name: 'Ann', color: '#111', createdAt: 0 },
+  { id: 'b', name: 'Bo', color: '#222', createdAt: 0 },
+  { id: 'c', name: 'Cy', color: '#333', createdAt: 0 },
+  { id: 'd', name: 'Di', color: '#444', createdAt: 0 },
+  { id: 'e', name: 'Eve', color: '#555', createdAt: 0 },
+  { id: 'f', name: 'Fin', color: '#666', createdAt: 0 },
+];
+
+function mk(partial: Partial<FindingFriendsInput> = {}): FindingFriendsInput {
+  return {
+    declarers: ['a', 'b'],
+    challengers: ['c', 'd', 'e', 'f'],
+    pointsCaptured: 0,
+    ...partial,
+  };
+}
+
+function ctx(config: Record<string, unknown> = {}, rounds: Round[] = []): RoundContext {
+  return { players, config, rounds } as unknown as RoundContext;
+}
+
+describe('totalPoints', () => {
+  it('is 100 per deck (four 5s@5 + four 10s@10 + four Ks@10)', () => {
+    expect(totalPoints(2)).toBe(200);
+    expect(totalPoints(3)).toBe(300);
+    expect(totalPoints(0)).toBe(0);
+  });
+});
+
+describe('levelJump', () => {
+  it('shuts out declarers +3 on zero points', () => {
+    expect(levelJump(0, 2)).toEqual({ winner: 'declarers', levels: 3 });
+  });
+
+  it('gives declarers +2 under 20% of the pool', () => {
+    expect(levelJump(35, 2)).toEqual({ winner: 'declarers', levels: 2 });
+  });
+
+  it('gives declarers +1 from 20% up to 40%', () => {
+    expect(levelJump(40, 2)).toEqual({ winner: 'declarers', levels: 1 });
+    expect(levelJump(75, 2)).toEqual({ winner: 'declarers', levels: 1 });
+  });
+
+  it('is a hold from 40% up to 60%', () => {
+    expect(levelJump(80, 2)).toEqual({ winner: null, levels: 0 });
+    expect(levelJump(115, 2)).toEqual({ winner: null, levels: 0 });
+  });
+
+  it('gives challengers +1 from 60% up to 80%', () => {
+    expect(levelJump(120, 2)).toEqual({ winner: 'challengers', levels: 1 });
+    expect(levelJump(155, 2)).toEqual({ winner: 'challengers', levels: 1 });
+  });
+
+  it('gives challengers +2 from 80% up to 100%', () => {
+    expect(levelJump(160, 2)).toEqual({ winner: 'challengers', levels: 2 });
+    expect(levelJump(195, 2)).toEqual({ winner: 'challengers', levels: 2 });
+  });
+
+  it('gives challengers +3 on a full sweep (100%+)', () => {
+    expect(levelJump(200, 2)).toEqual({ winner: 'challengers', levels: 3 });
+    expect(levelJump(999, 2)).toEqual({ winner: 'challengers', levels: 3 });
+  });
+
+  it('scales the thresholds with deck count', () => {
+    // 150/300 = 50% -> hold for 3 decks, but 150/200 = 75% -> challengers +1 for 2 decks.
+    expect(levelJump(150, 3)).toEqual({ winner: null, levels: 0 });
+    expect(levelJump(150, 2)).toEqual({ winner: 'challengers', levels: 1 });
+  });
+});
+
+describe('scoreFindingFriends', () => {
+  it('awards the shutout to every named declarer', () => {
+    expect(scoreFindingFriends(mk({ pointsCaptured: 0 }))).toEqual({
+      a: 3,
+      b: 3,
+      c: 0,
+      d: 0,
+      e: 0,
+      f: 0,
+    });
+  });
+
+  it('awards a breakthrough to every named challenger, not the declarers', () => {
+    expect(scoreFindingFriends(mk({ pointsCaptured: 200 }))).toEqual({
+      a: 0,
+      b: 0,
+      c: 3,
+      d: 3,
+      e: 3,
+      f: 3,
+    });
+  });
+
+  it('awards nobody on a hold', () => {
+    expect(scoreFindingFriends(mk({ pointsCaptured: 100 }))).toEqual({
+      a: 0,
+      b: 0,
+      c: 0,
+      d: 0,
+      e: 0,
+      f: 0,
+    });
+  });
+
+  it('returns all-zero deltas when the deal is unrecorded', () => {
+    expect(scoreFindingFriends(mk({ pointsCaptured: null }))).toEqual({
+      a: 0,
+      b: 0,
+      c: 0,
+      d: 0,
+      e: 0,
+      f: 0,
+    });
+  });
+
+  it('honours a different deck count', () => {
+    // 150/300 = 50% -> declarers +1 (20-40% band would need <120; 150 is in 40-60% hold
+    // for 3 decks: 0.5 -> hold). Use a value clearly in the declarer +1 band instead.
+    expect(scoreFindingFriends(mk({ pointsCaptured: 90 }), { deckCount: 3 })).toEqual({
+      a: 1,
+      b: 1,
+      c: 0,
+      d: 0,
+      e: 0,
+      f: 0,
+    });
+  });
+
+  it('only ever moves one side per deal (zero-sum by side)', () => {
+    for (const pts of [0, 35, 75, 100, 150, 195, 250]) {
+      const out = scoreFindingFriends(mk({ pointsCaptured: pts }));
+      const declarerSide = out.a + out.b;
+      const challengerSide = out.c + out.d + out.e + out.f;
+      expect(declarerSide === 0 || challengerSide === 0).toBe(true);
+    }
+  });
+});
+
+describe('validateFindingFriends', () => {
+  it('accepts a complete deal', () => {
+    expect(validateFindingFriends(mk())).toBeNull();
+  });
+
+  it('requires a declaring side', () => {
+    expect(validateFindingFriends(mk({ declarers: [] }))).toMatch(/banking side/i);
+  });
+
+  it('requires a challenging side', () => {
+    expect(validateFindingFriends(mk({ challengers: [] }))).toMatch(/attacking side/i);
+  });
+
+  it('rejects a player on both sides', () => {
+    expect(validateFindingFriends(mk({ declarers: ['a', 'c'] }))).toMatch(/only be on one side/i);
+  });
+
+  it('requires points captured', () => {
+    expect(validateFindingFriends(mk({ pointsCaptured: null }))).toMatch(/how many points/i);
+  });
+
+  it('rejects negative points', () => {
+    expect(validateFindingFriends(mk({ pointsCaptured: -5 }))).toMatch(/negative/i);
+  });
+});
+
+describe('sideLevelIndex / levelLabel / sideHasWon', () => {
+  it('reads the max total among a side\u2019s members as its level', () => {
+    expect(sideLevelIndex(['a', 'b'], { a: 3, b: 3 })).toBe(3);
+    expect(sideLevelIndex(['a', 'b'], { a: 5, b: 2 })).toBe(5);
+  });
+
+  it('is robust to missing totals and clamps into range', () => {
+    expect(sideLevelIndex(['a'], {})).toBe(0);
+    expect(sideLevelIndex(['a'], { a: 99 })).toBe(WINNING_LEVEL_INDEX);
+    expect(sideLevelIndex([], { a: 5 })).toBe(0);
+  });
+
+  it('labels level indices as card ranks', () => {
+    expect(levelLabel(0)).toBe('2');
+    expect(levelLabel(8)).toBe('10');
+    expect(levelLabel(WINNING_LEVEL_INDEX)).toBe('A');
+    expect(levelLabel(999)).toBe('A');
+  });
+
+  it('flags a side that has reached or passed Ace', () => {
+    expect(sideHasWon(['a'], { a: WINNING_LEVEL_INDEX })).toBe(true);
+    expect(sideHasWon(['a'], { a: WINNING_LEVEL_INDEX - 1 })).toBe(false);
+  });
+});
+
+describe('describeDeal', () => {
+  it('summarises a shutout naming the declarers', () => {
+    const input = mk({ pointsCaptured: 0 });
+    const s = describeDeal(input, players, { a: 3, b: 3, c: 0, d: 0, e: 0, f: 0 });
+    expect(s).toContain('Ann & Bo');
+    expect(s).toContain('+3');
+  });
+
+  it('summarises a breakthrough naming the challengers', () => {
+    const input = mk({ pointsCaptured: 200 });
+    const s = describeDeal(input, players, { a: 0, b: 0, c: 3, d: 3, e: 3, f: 3 });
+    expect(s).toContain('Cy & Di & Eve & Fin');
+    expect(s).toMatch(/breaks through/i);
+  });
+
+  it('summarises a hold', () => {
+    const input = mk({ pointsCaptured: 100 });
+    const s = describeDeal(input, players, { a: 0, b: 0, c: 0, d: 0, e: 0, f: 0 });
+    expect(s).toMatch(/hold/i);
+  });
+
+  it('handles an unrecorded deal', () => {
+    expect(describeDeal(mk({ pointsCaptured: null }), players, {})).toBe('Deal not recorded');
+  });
+
+  it('derives deltas fresh when none are supplied', () => {
+    const input = mk({ pointsCaptured: 0 });
+    expect(describeDeal(input, players)).toContain('+3');
+  });
+});
+
+describe('config coercion', () => {
+  it('deck count defaults to 2 and ignores junk', () => {
+    expect(deckCountFromConfig({})).toBe(2);
+    expect(deckCountFromConfig({ deckCount: '3' })).toBe(3);
+    expect(deckCountFromConfig({ deckCount: 0 })).toBe(2);
+    expect(deckCountFromConfig({ deckCount: -1 })).toBe(2);
+  });
+
+  it('resolves full options from config', () => {
+    expect(optionsFromConfig({ deckCount: '4' })).toEqual({ deckCount: 4 });
+    expect(optionsFromConfig({})).toEqual(DEFAULT_OPTIONS);
+  });
+});
+
+describe('findingFriends module', () => {
+  it('declares itself a 4-8 player team game', () => {
+    expect(findingFriends.id).toBe('findingfriends');
+    expect(findingFriends.teams).toBe(true);
+    expect(findingFriends.minPlayers).toBe(4);
+    expect(findingFriends.maxPlayers).toBe(8);
+  });
+
+  it('creates a fresh round input seating the first pick as the opening banker', () => {
+    const input = findingFriends.createRoundInput(ctx()) as FindingFriendsInput;
+    expect(input.declarers).toEqual(['a']);
+    expect(input.challengers).toEqual(['b', 'c', 'd', 'e', 'f']);
+    expect(input.pointsCaptured).toBeNull();
+  });
+
+  it('carries the previous deal\u2019s bank forward as the next default', () => {
+    const prevRound = {
+      id: 'r0',
+      gameId: 'g',
+      index: 0,
+      input: mk({ declarers: ['c', 'd'], challengers: ['a', 'b', 'e', 'f'] }),
+      deltas: {},
+      createdAt: 0,
+    } as unknown as Round;
+    const input = findingFriends.createRoundInput(ctx({}, [prevRound])) as FindingFriendsInput;
+    expect(input.declarers).toEqual(['c', 'd']);
+    expect(input.challengers).toEqual(['a', 'b', 'e', 'f']);
+  });
+
+  it('drops a departed player from the carried-forward bank', () => {
+    const smallerPlayers = players.filter((p) => p.id !== 'c');
+    const prevRound = {
+      id: 'r0',
+      gameId: 'g',
+      index: 0,
+      input: mk({ declarers: ['c', 'd'], challengers: ['a', 'b', 'e', 'f'] }),
+      deltas: {},
+      createdAt: 0,
+    } as unknown as Round;
+    const c2 = { players: smallerPlayers, config: {}, rounds: [prevRound] } as unknown as RoundContext;
+    const input = findingFriends.createRoundInput(c2) as FindingFriendsInput;
+    expect(input.declarers).toEqual(['d']);
+  });
+
+  it('scores through the module honouring the configured deck count', () => {
+    const input = mk({ pointsCaptured: 90 });
+    expect(findingFriends.scoreRound(input, ctx({ deckCount: '3' }))).toEqual({
+      a: 1,
+      b: 1,
+      c: 0,
+      d: 0,
+      e: 0,
+      f: 0,
+    });
+  });
+
+  it('finishes once a side reaches Ace', () => {
+    expect(findingFriends.isFinished!({ a: WINNING_LEVEL_INDEX, b: 4 }, {} as never)).toBe(true);
+    expect(findingFriends.isFinished!({ a: WINNING_LEVEL_INDEX - 1, b: 4 }, {} as never)).toBe(
+      false,
+    );
+  });
+
+  it('describes a recorded round from its stored deltas', () => {
+    const round = {
+      input: mk({ pointsCaptured: 0 }),
+      deltas: { a: 3, b: 3, c: 0, d: 0, e: 0, f: 0 },
+    } as unknown as Round;
+    expect(findingFriends.describeRound!(round, players)).toContain('Ann & Bo');
+  });
+
+  it('plays a full game up to Ace, tracking level via cumulative deltas', () => {
+    const deals: FindingFriendsInput[] = [
+      mk({ declarers: ['a', 'b'], challengers: ['c', 'd', 'e', 'f'], pointsCaptured: 0 }), // +3 -> 3
+      mk({ declarers: ['a', 'b'], challengers: ['c', 'd', 'e', 'f'], pointsCaptured: 30 }), // +2 -> 5
+      mk({ declarers: ['a', 'b'], challengers: ['c', 'd', 'e', 'f'], pointsCaptured: 50 }), // +1 -> 6
+      mk({ declarers: ['a', 'b'], challengers: ['c', 'd', 'e', 'f'], pointsCaptured: 0 }), // +3 -> 9
+      mk({ declarers: ['a', 'b'], challengers: ['c', 'd', 'e', 'f'], pointsCaptured: 0 }), // +3 -> 12 (Ace)
+    ];
+    const totals: Record<ID, number> = { a: 0, b: 0, c: 0, d: 0, e: 0, f: 0 };
+    let finished = false;
+    for (const deal of deals) {
+      const d = findingFriends.scoreRound(deal, ctx());
+      for (const id of Object.keys(totals)) totals[id] += d[id] ?? 0;
+      finished = findingFriends.isFinished!(totals, {
+        config: {},
+        roundCount: 1,
+        playerCount: 6,
+      });
+      if (finished) break;
+    }
+    expect(totals.a).toBe(12);
+    expect(totals.b).toBe(12);
+    expect(finished).toBe(true);
+  });
+});
+
+describe('findingFriendsStats', () => {
+  const games: Game[] = [
+    {
+      id: 'g',
+      type: 'findingfriends',
+      config: {},
+      playerIds: ['a', 'b', 'c', 'd', 'e', 'f'],
+      status: 'finished',
+      createdAt: 0,
+      roundCount: 3,
+    } as Game,
+  ];
+  const mkRound = (index: number, input: FindingFriendsInput, deltas: Record<ID, number>): Round =>
+    ({ id: `r${index}`, gameId: 'g', index, input, deltas, createdAt: 0 }) as Round;
+  const rounds: Round[] = [
+    mkRound(0, mk({ pointsCaptured: 0 }), { a: 3, b: 3, c: 0, d: 0, e: 0, f: 0 }),
+    mkRound(1, mk({ pointsCaptured: 200 }), { a: 0, b: 0, c: 3, d: 3, e: 3, f: 3 }),
+    mkRound(2, mk({ pointsCaptured: 100 }), { a: 0, b: 0, c: 0, d: 0, e: 0, f: 0 }),
+  ];
+  const out = findingFriendsStats({ games, rounds, players: [], canonical: (id: ID) => id });
+
+  const metric = (id: ID, key: string) => out.perPlayer?.[id]?.find((m) => m.key === key);
+  const g = (key: string) => out.global?.find((m) => m.key === key);
+
+  it('tracks bank hold rate per declarer', () => {
+    expect(metric('a', 'ff_hold')?.value).toBe('33%'); // held 1 of 3 banked deals
+  });
+
+  it('tracks breakthrough rate per challenger', () => {
+    expect(metric('c', 'ff_break')?.value).toBe('33%'); // broke through 1 of 3 attacked deals
+  });
+
+  it('counts shutouts', () => {
+    expect(metric('a', 'ff_shutout')?.value).toBe('1');
+  });
+
+  it('reports global rates over all deals', () => {
+    expect(g('ff_hold_all')?.value).toBe('33%');
+    expect(g('ff_break_all')?.value).toBe('33%');
+  });
+});

--- a/src/lib/games/findingfriends/index.ts
+++ b/src/lib/games/findingfriends/index.ts
@@ -1,0 +1,115 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { findingFriendsStats } from './stats';
+import {
+  WINNING_LEVEL_INDEX,
+  describeDeal,
+  deckCountFromConfig,
+  optionsFromConfig,
+  scoreFindingFriends,
+  sideLevelIndex,
+  validateFindingFriends,
+  type FindingFriendsInput,
+} from './logic';
+
+export type { FindingFriendsInput } from './logic';
+
+/**
+ * Carries the previous deal's side assignment forward (the bank usually stays with mostly
+ * the same people), dropping anyone no longer in the lineup. With no usable history, seats
+ * the first pick alone as the opening banker — an arbitrary but harmless starting point the
+ * table immediately adjusts on the first deal via the editor's side toggles.
+ */
+function defaultSides(ctx: RoundContext): { declarers: ID[]; challengers: ID[] } {
+  const ids = ctx.players.map((p) => p.id);
+  const last = ctx.rounds[ctx.rounds.length - 1]?.input as FindingFriendsInput | undefined;
+  if (last?.declarers?.length) {
+    const stillDeclarers = last.declarers.filter((id) => ids.includes(id));
+    if (stillDeclarers.length) {
+      const rest = ids.filter((id) => !stillDeclarers.includes(id));
+      return { declarers: stillDeclarers, challengers: rest };
+    }
+  }
+  const [first, ...rest] = ids;
+  return { declarers: first ? [first] : [], challengers: rest };
+}
+
+export const findingFriends: GameModule = {
+  id: 'findingfriends',
+  name: 'Finding Friends',
+  tagline: 'Call a partner in secret, race the levels to Ace.',
+  emoji: '🃏',
+  keywords: ['zhao pengyou', 'tractor', 'sheng ji', 'tuo la ji', 'trick taking', 'levels'],
+  minPlayers: 4,
+  maxPlayers: 8,
+  teams: true,
+  configFields: [
+    {
+      key: 'deckCount',
+      label: 'Decks in play',
+      type: 'select',
+      default: '2',
+      options: [
+        { value: '2', label: '2 decks — 4–6 players' },
+        { value: '3', label: '3 decks — 7–8 players' },
+        { value: '4', label: '4 decks — house rule for a big table' },
+      ],
+      help: 'More decks add more point cards (100 pts each); the level-jump table scales with it.',
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): FindingFriendsInput => ({
+    ...defaultSides(ctx),
+    pointsCaptured: null,
+  }),
+
+  validateRound: (input: FindingFriendsInput): string | null => validateFindingFriends(input),
+
+  scoreRound: (input: FindingFriendsInput, ctx: RoundContext): Record<ID, number> =>
+    scoreFindingFriends(input, optionsFromConfig(ctx.config)),
+
+  isFinished: (totals) => {
+    return Object.values(totals).some((t) => t >= WINNING_LEVEL_INDEX);
+  },
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as FindingFriendsInput;
+    return describeDeal(input, players, round.deltas);
+  },
+
+  roundCellTone: (round: Round, playerId: ID) => {
+    const input = round.input as FindingFriendsInput;
+    const delta = round.deltas?.[playerId] ?? 0;
+    if (delta > 0) {
+      const onDeclarers = input.declarers?.includes(playerId);
+      return { tone: 'good', label: onDeclarers ? 'Held the bank' : 'Broke through' };
+    }
+    return null;
+  },
+
+  help: [
+    'Finding Friends (Zhǎo Péngyou) — 4–8 players, 2+ decks, trick-taking with a level race.',
+    '',
+    'Each deal, the current banker ("declarers") calls a card to secretly recruit a partner;',
+    'everyone else is that deal\u2019s "challengers". Point cards: 5s = 5, 10s = 10, Ks = 10.',
+    '',
+    'After the deal, tally points the challengers captured:',
+    '• 0 points — declarers hold strong, +3 levels.',
+    '• Under 20% of the pool — declarers +2.',
+    '• 20–40% — declarers +1.',
+    '• 40–60% — a wash, nobody advances.',
+    '• 60–80% — challengers break through, +1.',
+    '• 80–100% — challengers +2.',
+    '• 100%+ (a full sweep) — challengers +3.',
+    '',
+    'The side that just won keeps (or takes over) the bank for the next deal.',
+    'Levels run 2 → 3 → … → K → A. First side to reach Ace wins the game!',
+  ].join('\n'),
+
+  stats: findingFriendsStats,
+
+  RoundEditor,
+  editorLoader: () => import('./FindingFriendsEditor.svelte'),
+};
+
+export { deckCountFromConfig, optionsFromConfig, sideLevelIndex };

--- a/src/lib/games/findingfriends/logic.ts
+++ b/src/lib/games/findingfriends/logic.ts
@@ -1,0 +1,186 @@
+import type { ID } from '../../types';
+
+/**
+ * Pure Finding Friends (找朋友 Zhǎo Péngyou / Tuō Lā Jī, a Tractor/Sheng Ji "level" variant)
+ * scoring — no Svelte, no I/O, so it's independently unit-testable and safe for the stats
+ * engine to import.
+ *
+ * Finding Friends is a *shifting*-partnership game: at the start of a deal the current
+ * banker calls a card (or two) to recruit a hidden ally, and everyone else defaults to the
+ * challenging side — so who's on which side can change deal to deal (unlike Euchre's fixed
+ * partnerships). Score King has no built-in notion of a rotating team, so this module keeps
+ * that entirely inside `FindingFriendsInput`: each round records exactly who was banking
+ * ("declarers") and who was attacking ("challengers") *that deal*, and the level jump is
+ * mirrored onto every player named for the winning side (same trick Euchre uses for its
+ * fixed teams — see euchre/logic.ts — just re-applied to a side whose roster can move).
+ * Because the winning side usually keeps most of its members from one deal to the next
+ * (the bank only passes to the *whole* challenging side when they win it), a player's
+ * cumulative total closely tracks "their side's" level over the course of a game.
+ */
+
+/** The 13 rungs of the level ladder: 2 through Ace. Index 0 = level "2", index 12 = "A". */
+export const LEVELS = [
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  'J',
+  'Q',
+  'K',
+  'A',
+] as const;
+export type Level = (typeof LEVELS)[number];
+
+/** Reaching (or passing) this level index — Ace — wins the game. */
+export const WINNING_LEVEL_INDEX = LEVELS.length - 1; // 12
+
+export type Side = 'declarers' | 'challengers';
+
+export interface FindingFriendsInput {
+  /** This deal's banker/defending side — trying to stop the challengers capturing points. */
+  declarers: ID[];
+  /** Everyone else this deal — trying to capture point cards off the declarers. */
+  challengers: ID[];
+  /** Point cards (5s/10s/Ks) the challengers captured this deal. Null until recorded. */
+  pointsCaptured: number | null;
+}
+
+export interface FindingFriendsOptions {
+  /** Decks in play — scales the point-card pool and the level-jump thresholds below. */
+  deckCount: number;
+}
+
+export const DEFAULT_OPTIONS: FindingFriendsOptions = { deckCount: 2 };
+
+/**
+ * Total point-card value in play for `deckCount` decks: each deck holds four 5s (5 each =
+ * 20), four 10s (10 each = 40) and four Kings (10 each = 40) = 100 points per deck.
+ */
+export function totalPoints(deckCount: number): number {
+  return Math.max(0, deckCount) * 100;
+}
+
+export interface LevelJumpResult {
+  /** Side that advances, or null on a "hold" — a wash where neither side moves. */
+  winner: Side | null;
+  /** Levels the winning side advances (0 on a hold). */
+  levels: number;
+}
+
+/**
+ * The classic Finding Friends / Zhao Pengyou level-jump table, expressed as fractions of
+ * the deck's total point-card value so it scales cleanly with `deckCount` (100 pts/deck).
+ * For the standard 2-deck game (200 total points) this reproduces the widely-cited bands:
+ *   0 pts            → declarers +3 (a shutout)
+ *   1–39 (<20%)       → declarers +2
+ *   40–79 (20–40%)    → declarers +1
+ *   80–119 (40–60%)   → hold, nobody advances
+ *   120–159 (60–80%)  → challengers +1
+ *   160–199 (80–100%) → challengers +2
+ *   200+ (100%+)      → challengers +3
+ * House rules vary the exact cutoffs (some shift the hold band, some skip it); this is a
+ * faithful, documented default rather than the only correct table.
+ */
+export function levelJump(pointsCaptured: number, deckCount: number): LevelJumpResult {
+  const total = totalPoints(deckCount);
+  if (pointsCaptured <= 0) return { winner: 'declarers', levels: 3 };
+  if (total <= 0) return { winner: null, levels: 0 };
+  const frac = pointsCaptured / total;
+  if (frac < 0.2) return { winner: 'declarers', levels: 2 };
+  if (frac < 0.4) return { winner: 'declarers', levels: 1 };
+  if (frac < 0.6) return { winner: null, levels: 0 };
+  if (frac < 0.8) return { winner: 'challengers', levels: 1 };
+  if (frac < 1.0) return { winner: 'challengers', levels: 2 };
+  return { winner: 'challengers', levels: 3 };
+}
+
+/** Per-player point deltas for a deal: every member of the winning side shares the jump. */
+export function scoreFindingFriends(
+  input: FindingFriendsInput,
+  opts: FindingFriendsOptions = DEFAULT_OPTIONS,
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of [...input.declarers, ...input.challengers]) out[id] = 0;
+  if (input.pointsCaptured == null) return out;
+
+  const { winner, levels } = levelJump(input.pointsCaptured, opts.deckCount);
+  if (!winner || levels === 0) return out;
+
+  const side = winner === 'declarers' ? input.declarers : input.challengers;
+  for (const id of side) out[id] = levels;
+  return out;
+}
+
+/** Null when the deal is valid to record, otherwise a human-readable reason. */
+export function validateFindingFriends(input: FindingFriendsInput): string | null {
+  if (input.declarers.length === 0) return 'Pick who was on the banking side this deal.';
+  if (input.challengers.length === 0) return 'Pick who was on the attacking side this deal.';
+  const overlap = input.declarers.filter((id) => input.challengers.includes(id));
+  if (overlap.length) return 'A player can only be on one side this deal.';
+  if (input.pointsCaptured == null) return 'Enter how many points the attackers captured.';
+  if (input.pointsCaptured < 0) return 'Points captured can\u2019t be negative.';
+  return null;
+}
+
+/** A side's current level index, from the cumulative totals of its named members. */
+export function sideLevelIndex(ids: ID[], totals: Record<ID, number>): number {
+  if (!ids.length) return 0;
+  const raw = Math.max(...ids.map((id) => totals[id] ?? 0));
+  return Math.max(0, Math.min(WINNING_LEVEL_INDEX, Math.round(raw)));
+}
+
+/** Human label for a level index, clamped into range (e.g. 0 → "2", 12 → "A"). */
+export function levelLabel(index: number): Level {
+  return LEVELS[Math.max(0, Math.min(WINNING_LEVEL_INDEX, Math.round(index)))];
+}
+
+/** A side has reached (or passed) Ace — the game-winning level. */
+export function sideHasWon(ids: ID[], totals: Record<ID, number>): boolean {
+  return sideLevelIndex(ids, totals) >= WINNING_LEVEL_INDEX;
+}
+
+/**
+ * Short, glanceable summary of a recorded deal for the history table. Reads the winning
+ * side straight off the stored per-player `deltas` (so the text always matches what was
+ * actually recorded, even under a house-rule table) rather than re-deriving it from
+ * `pointsCaptured` — `describeRound` doesn't have the game's config on hand, and a round's
+ * `deltas` already settled the question at score time. Falls back to the default-deck
+ * table only when no deltas are supplied (e.g. previewing before a round is scored).
+ */
+export function describeDeal(
+  input: FindingFriendsInput,
+  players: { id: ID; name: string }[],
+  deltas?: Record<ID, number>,
+): string {
+  if (input.pointsCaptured == null) return 'Deal not recorded';
+  const name = (id: ID): string => players.find((p) => p.id === id)?.name || '?';
+  const d = deltas ?? scoreFindingFriends(input);
+
+  const declarerPts = Math.max(0, ...input.declarers.map((id) => d[id] ?? 0));
+  const challengerPts = Math.max(0, ...input.challengers.map((id) => d[id] ?? 0));
+  if (declarerPts === 0 && challengerPts === 0) {
+    return `🤝 Hold — ${input.pointsCaptured} pts captured, no one advances`;
+  }
+  const winner: Side = declarerPts > 0 ? 'declarers' : 'challengers';
+  const pts = winner === 'declarers' ? declarerPts : challengerPts;
+  const side = winner === 'declarers' ? input.declarers : input.challengers;
+  const label = side.map(name).join(' & ') || (winner === 'declarers' ? 'Declarers' : 'Challengers');
+  const verb = winner === 'declarers' ? 'holds the bank' : 'breaks through';
+  return `${winner === 'declarers' ? '🛡️' : '⚔️'} ${label} ${verb} — +${pts} level${pts === 1 ? '' : 's'}`;
+}
+
+// --- config coercion (config values arrive as `unknown` from stored game config) ---
+
+export function deckCountFromConfig(config: Record<string, unknown>): number {
+  const n = Number(config.deckCount);
+  return Number.isFinite(n) && n > 0 ? Math.round(n) : DEFAULT_OPTIONS.deckCount;
+}
+
+export function optionsFromConfig(config: Record<string, unknown>): FindingFriendsOptions {
+  return { deckCount: deckCountFromConfig(config) };
+}

--- a/src/lib/games/findingfriends/stats.ts
+++ b/src/lib/games/findingfriends/stats.ts
@@ -1,0 +1,121 @@
+import type { ID } from '../../types';
+import type { FindingFriendsInput } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt, fmtPct } from '../../stats/format';
+
+interface FfAgg {
+  /** Deals this player banked (was named a declarer). */
+  banked: number;
+  /** Banked deals that held (declarers gained levels). */
+  held: number;
+  /** Deals this player attacked (was named a challenger). */
+  attacked: number;
+  /** Attacking deals that broke through (challengers gained levels). */
+  brokeThrough: number;
+  /** Shutout deals (0 points captured) this player's declaring side pulled off. */
+  shutouts: number;
+}
+
+/**
+ * Finding Friends stats, derived purely from each deal's recorded sides + deltas. Pure — no
+ * Svelte — so it's unit-testable and safe for the stats engine to import. Every named player
+ * on a deal (whichever side) is credited for that deal, mirroring how the roster itself can
+ * shift from one deal to the next.
+ */
+export function findingFriendsStats({
+  games,
+  rounds,
+  canonical,
+}: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, FfAgg>();
+  const get = (id: ID): FfAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { banked: 0, held: 0, attacked: 0, brokeThrough: 0, shutouts: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let deals = 0;
+  let holds = 0;
+  let breakthroughs = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as FindingFriendsInput | undefined;
+    if (!input?.declarers || input.pointsCaptured == null) continue;
+
+    const declarerPts = Math.max(0, ...input.declarers.map((id) => r.deltas?.[id] ?? 0));
+    const challengerPts = Math.max(0, ...input.challengers.map((id) => r.deltas?.[id] ?? 0));
+    const declarersHeld = declarerPts > 0;
+    const challengersBroke = challengerPts > 0;
+
+    deals += 1;
+    if (declarersHeld) holds += 1;
+    if (challengersBroke) breakthroughs += 1;
+
+    for (const pid of input.declarers) {
+      const a = get(canonical(pid));
+      a.banked += 1;
+      if (declarersHeld) a.held += 1;
+      if (input.pointsCaptured === 0) a.shutouts += 1;
+    }
+    for (const pid of input.challengers) {
+      const a = get(canonical(pid));
+      a.attacked += 1;
+      if (challengersBroke) a.brokeThrough += 1;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.banked) {
+      metrics.push({
+        key: 'ff_hold',
+        label: 'Bank hold rate',
+        value: fmtPct(a.held / a.banked),
+        sub: `${a.held}/${a.banked}`,
+        emoji: '🛡️',
+      });
+    }
+    if (a.shutouts) {
+      metrics.push({
+        key: 'ff_shutout',
+        label: 'Shutouts',
+        value: fmtInt(a.shutouts),
+        emoji: '🧹',
+      });
+    }
+    if (a.attacked) {
+      metrics.push({
+        key: 'ff_break',
+        label: 'Breakthrough rate',
+        value: fmtPct(a.brokeThrough / a.attacked),
+        sub: `${a.brokeThrough}/${a.attacked}`,
+        emoji: '⚔️',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (deals) {
+    global.push({
+      key: 'ff_hold_all',
+      label: 'Bank hold rate',
+      value: fmtPct(holds / deals),
+      emoji: '🛡️',
+    });
+    global.push({
+      key: 'ff_break_all',
+      label: 'Breakthrough rate',
+      value: fmtPct(breakthroughs / deals),
+      emoji: '⚔️',
+    });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Adds a new game module for **Finding Friends** 🃏 (Zhǎo Péngyou / Tuō Lā Jī), a Tractor/Sheng Ji level-race variant, following the existing `euchre`/`cribbage` module conventions (auto-discovered, lazy-loaded editor chunk, pure logic module, unit tests, stats hook).

## Changes

- `src/lib/games/findingfriends/logic.ts` — pure scoring: level-jump table (documented default, scales with deck count via percentage-of-pool bands: 0→+3, <20%→+2, 20–40%→+1, 40–60%→hold, 60–80%→+1, 80–100%→+2, 100%+→+3), side validation, level labels/indices, deal descriptions.
- `src/lib/games/findingfriends/index.ts` — `GameModule` wiring: 4–8 players, configurable deck count, carries the previous deal's bank forward as the next default, finishes when a side reaches Ace.
- `src/lib/games/findingfriends/FindingFriendsEditor.svelte` — round editor: tap-to-toggle side assignment, quick-pick + numeric points entry, live level-jump preview.
- `src/lib/games/findingfriends/stats.ts` — bank hold rate, breakthrough rate, shutouts.
- `src/lib/games/findingfriends/findingfriends.test.ts` — unit tests for scoring, validation, level tracking, module wiring and stats.

## Issues

Closes #156

## Testing

- [x] `npx vitest run src/lib/games/findingfriends` — 44 passed
- [x] `npm run check` — 0 errors, 0 warnings