### PR TITLE
feat(catan): add Catan game module

### DIFF
--- a/src/lib/games/catan/CatanEditor.svelte
+++ b/src/lib/games/catan/CatanEditor.svelte
@@ -1,0 +1,332 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { bumpOnChange } from '../../motion';
+  import { haptic } from '../../haptics';
+  import { catan } from './index';
+  import {
+    AWARD_POINTS,
+    MAX_CITIES,
+    MAX_DEV_VP,
+    MAX_SETTLEMENTS,
+    readConfig,
+    vpFor,
+    type CatanInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: CatanInput; ctx: RoundContext } = $props();
+
+  const cfg = $derived(readConfig(ctx.config));
+
+  function before(id: string): number {
+    return Number(ctx.totals[id]) || 0;
+  }
+  function projected(id: string): number {
+    return vpFor(input, id);
+  }
+  function delta(id: string): number {
+    return projected(id) - before(id);
+  }
+  function signed(n: number): string {
+    return n > 0 ? `+${n}` : `${n}`;
+  }
+  function reached(id: string): boolean {
+    return projected(id) >= cfg.targetVP;
+  }
+
+  function setAward(kind: 'longestRoad' | 'largestArmy', id: string) {
+    input[kind] = input[kind] === id ? null : id;
+    haptic('tick');
+  }
+
+  let showHelp = $state(false);
+</script>
+
+<div class="stack">
+  <div class="row spread wrap head">
+    <span class="pill">🎯 First to {cfg.targetVP} VP</span>
+    <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+      How VP work
+    </button>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{catan.help}</pre>
+  {/if}
+
+  {#snippet awardPicker(
+    kind: 'longestRoad' | 'largestArmy',
+    title: string,
+    emoji: string,
+    hint: string,
+  )}
+    <section class="award">
+      <div class="row spread wrap">
+        <h3 class="ttl">{emoji} {title}</h3>
+        <span class="pts">+{AWARD_POINTS} VP</span>
+      </div>
+      <p class="hint">{hint}</p>
+      <div class="chips" role="radiogroup" aria-label={title}>
+        {#each ctx.players as p (p.id)}
+          {@const on = input[kind] === p.id}
+          <button
+            type="button"
+            role="radio"
+            aria-checked={on}
+            class="chip"
+            class:on
+            onclick={() => setAward(kind, p.id)}
+          >
+            <Avatar name={p.name} color={p.color} size={22} />
+            <span class="cname">{p.name}</span>
+          </button>
+        {/each}
+      </div>
+    </section>
+  {/snippet}
+
+  {@render awardPicker(
+    'longestRoad',
+    'Longest Road',
+    '🛣️',
+    'Whoever holds the longest continuous road (5+ segments). Tap a chip again to clear it.',
+  )}
+  {@render awardPicker(
+    'largestArmy',
+    'Largest Army',
+    '⚔️',
+    'Whoever has played the most Knight cards (3+ minimum). Tap a chip again to clear it.',
+  )}
+
+  <section class="board">
+    <h3 class="ttl">🏠🏰 Settlements & cities</h3>
+    {#each ctx.players as p (p.id)}
+      <div class="prow" class:won={reached(p.id)}>
+        <div class="row spread top">
+          <span class="row who">
+            <Avatar name={p.name} color={p.color} />
+            <strong class="ellipsis">{p.name}</strong>
+          </span>
+          <span class="tally">
+            <span class="cur">{before(p.id)}</span>
+            <span class="arrow" aria-hidden="true">→</span>
+            <span class="proj" use:bumpOnChange={projected(p.id)}>{projected(p.id)}</span>
+            {#if delta(p.id) !== 0}
+              <span class="dchip" class:good={delta(p.id) > 0} class:bad={delta(p.id) < 0}>
+                {signed(delta(p.id))}
+              </span>
+            {/if}
+            {#if reached(p.id)}
+              <span class="crown" aria-hidden="true">👑</span>
+            {/if}
+          </span>
+        </div>
+
+        <div class="fields">
+          <label class="f">
+            <span class="flabel">🏠 Settlements</span>
+            <Stepper
+              bind:value={input.settlements[p.id]}
+              min={0}
+              max={MAX_SETTLEMENTS}
+              label={`${p.name} settlements`}
+            />
+          </label>
+          <label class="f">
+            <span class="flabel">🏰 Cities</span>
+            <Stepper
+              bind:value={input.cities[p.id]}
+              min={0}
+              max={MAX_CITIES}
+              label={`${p.name} cities`}
+            />
+          </label>
+          <label class="f">
+            <span class="flabel">🃏 VP cards</span>
+            <Stepper
+              bind:value={input.devVP[p.id]}
+              min={0}
+              max={MAX_DEV_VP}
+              label={`${p.name} victory point cards`}
+            />
+          </label>
+        </div>
+        {#if reached(p.id)}
+          <p class="win-note">👑 {p.name} has reached {cfg.targetVP} VP — the game ends here.</p>
+        {/if}
+      </div>
+    {/each}
+  </section>
+</div>
+
+<style>
+  .head {
+    align-items: center;
+  }
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    font-size: 0.85rem;
+    font-weight: 700;
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+    font-size: 0.9rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+  .award,
+  .board {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .ttl {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+  }
+  .pts {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+    color: var(--muted);
+  }
+  .hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  .chips {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .chip {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 6px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background var(--dur-base) var(--ease-standard);
+  }
+  .chip:hover {
+    background: var(--surface-3);
+  }
+  /* A claimed award reads as a selection, not the screen's primary action: a
+     filled/bordered state plus the explicit "holds it" glyph, never colour alone. */
+  .chip.on {
+    background: var(--surface-3);
+    border-color: var(--primary);
+    box-shadow: inset 3px 0 0 var(--primary);
+  }
+  .chip:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .cname {
+    white-space: nowrap;
+  }
+  .prow {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  /* The winning seat is framed in Crown Gold — the one moment gold marks a
+     player rather than a plain leader tint. */
+  .prow.won {
+    border-color: color-mix(in srgb, var(--accent) 60%, var(--border));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 25%, transparent);
+  }
+  .who {
+    gap: 8px;
+    align-items: center;
+    min-width: 0;
+  }
+  .ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .tally {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    flex: none;
+  }
+  .tally .cur,
+  .tally .arrow {
+    color: var(--muted);
+  }
+  .tally .proj {
+    font-weight: 800;
+    font-size: 1.2rem;
+  }
+  .dchip {
+    font-size: 0.78rem;
+    font-weight: 700;
+    padding: 1px 7px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    color: var(--muted);
+  }
+  .dchip.good {
+    color: var(--good);
+    background: color-mix(in srgb, var(--good) 18%, var(--surface-3));
+  }
+  .dchip.bad {
+    color: var(--bad);
+    background: color-mix(in srgb, var(--bad) 18%, var(--surface-3));
+  }
+  .crown {
+    font-size: 1.1rem;
+    line-height: 1;
+  }
+  .fields {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 10px;
+  }
+  .f {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .flabel {
+    font-size: 0.9rem;
+    color: var(--muted);
+  }
+  .win-note {
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--accent-ink);
+  }
+</style>

--- a/src/lib/games/catan/catan.test.ts
+++ b/src/lib/games/catan/catan.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest';
+import type { Player } from '../../types';
+import { catan } from './index';
+import {
+  AWARD_POINTS,
+  CITY_POINTS,
+  DEFAULT_TARGET_VP,
+  DEV_VP_POINTS,
+  MAX_CITIES,
+  MAX_DEV_VP,
+  MAX_SETTLEMENTS,
+  SETTLEMENT_POINTS,
+  carryForward,
+  describeRound,
+  emptyInput,
+  isFinished,
+  readConfig,
+  scoreRound,
+  totalsFor,
+  validateRound,
+  vpFor,
+  type CatanInput,
+} from './logic';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+function player(id: string): Player {
+  return { id, name: id.toUpperCase(), color: '#7c5cff', createdAt: 0 };
+}
+const P4 = ['a', 'b', 'c', 'd'].map(player);
+const IDS = P4.map((p) => p.id);
+
+// ── config ───────────────────────────────────────────────────────────────
+describe('readConfig', () => {
+  it('applies the standard 10 VP default', () => {
+    expect(readConfig({})).toEqual({ targetVP: DEFAULT_TARGET_VP });
+  });
+  it('reads an override (e.g. 13 for the 5–6 player expansion)', () => {
+    expect(readConfig({ targetVP: 13 })).toEqual({ targetVP: 13 });
+  });
+  it('floors an absurdly low target at 3', () => {
+    expect(readConfig({ targetVP: 1 }).targetVP).toBe(3);
+  });
+});
+
+// ── input shaping ────────────────────────────────────────────────────────
+describe('emptyInput / carryForward', () => {
+  it('starts every player at zero with no awards claimed', () => {
+    const input = emptyInput(IDS);
+    expect(input.settlements).toEqual({ a: 0, b: 0, c: 0, d: 0 });
+    expect(input.cities).toEqual({ a: 0, b: 0, c: 0, d: 0 });
+    expect(input.devVP).toEqual({ a: 0, b: 0, c: 0, d: 0 });
+    expect(input.longestRoad).toBeNull();
+    expect(input.largestArmy).toBeNull();
+  });
+
+  it('carries the previous checkpoint forward untouched', () => {
+    const prev: CatanInput = {
+      settlements: { a: 2, b: 1, c: 0, d: 0 },
+      cities: { a: 1, b: 0, c: 0, d: 0 },
+      devVP: { a: 0, b: 0, c: 0, d: 0 },
+      longestRoad: 'b',
+      largestArmy: null,
+    };
+    const next = carryForward(IDS, prev);
+    expect(next.settlements.a).toBe(2);
+    expect(next.cities.a).toBe(1);
+    expect(next.longestRoad).toBe('b');
+  });
+
+  it('falls back to an empty checkpoint with no previous round', () => {
+    expect(carryForward(IDS, undefined)).toEqual(emptyInput(IDS));
+  });
+
+  it('drops an award held by a player no longer in the roster', () => {
+    const prev: CatanInput = {
+      settlements: { a: 0 },
+      cities: { a: 0 },
+      devVP: { a: 0 },
+      longestRoad: 'ghost',
+      largestArmy: null,
+    };
+    expect(carryForward(['a'], prev).longestRoad).toBeNull();
+  });
+});
+
+// ── scoring ──────────────────────────────────────────────────────────────
+describe('vpFor / totalsFor', () => {
+  it('sums settlements, cities, VP cards and awards', () => {
+    const input: CatanInput = {
+      settlements: { a: 3 },
+      cities: { a: 1 },
+      devVP: { a: 1 },
+      longestRoad: 'a',
+      largestArmy: null,
+    };
+    // 3 settlements + 1 city*2 + 1 devVP + longest road (2) = 3+2+1+2 = 8
+    expect(vpFor(input, 'a')).toBe(
+      3 * SETTLEMENT_POINTS + 1 * CITY_POINTS + 1 * DEV_VP_POINTS + AWARD_POINTS,
+    );
+    expect(vpFor(input, 'a')).toBe(8);
+  });
+
+  it('awards both Longest Road and Largest Army to the same player when held', () => {
+    const input: CatanInput = {
+      settlements: { a: 0 },
+      cities: { a: 0 },
+      devVP: { a: 0 },
+      longestRoad: 'a',
+      largestArmy: 'a',
+    };
+    expect(vpFor(input, 'a')).toBe(AWARD_POINTS * 2);
+  });
+
+  it('totals every player from one checkpoint', () => {
+    const input = emptyInput(IDS);
+    input.settlements.a = 2;
+    input.cities.b = 1;
+    expect(totalsFor(input, IDS)).toEqual({ a: 2, b: 2, c: 0, d: 0 });
+  });
+});
+
+describe('scoreRound', () => {
+  it('reports each player’s change since the last checkpoint as the delta', () => {
+    const input = emptyInput(IDS);
+    input.settlements.a = 3; // 3 VP
+    input.cities.b = 2; // 4 VP
+    const before = { a: 1, b: 0, c: 0, d: 0 };
+    expect(scoreRound(input, IDS, before)).toEqual({ a: 2, b: 4, c: 0, d: 0 });
+  });
+
+  it('can produce a negative delta if a total is corrected downward', () => {
+    const input = emptyInput(IDS);
+    input.settlements.a = 1;
+    const before = { a: 5, b: 0, c: 0, d: 0 };
+    expect(scoreRound(input, IDS, before).a).toBe(-4);
+  });
+});
+
+// ── validation ───────────────────────────────────────────────────────────
+describe('validateRound', () => {
+  it('accepts a clean checkpoint', () => {
+    expect(validateRound(emptyInput(IDS), P4)).toBeNull();
+  });
+
+  it('rejects negative settlements', () => {
+    const input = emptyInput(IDS);
+    input.settlements.a = -1;
+    expect(validateRound(input, P4)).toMatch(/negative/);
+  });
+
+  it(`rejects more than ${MAX_SETTLEMENTS} settlements`, () => {
+    const input = emptyInput(IDS);
+    input.settlements.a = MAX_SETTLEMENTS + 1;
+    expect(validateRound(input, P4)).toMatch(/settlement pieces/);
+  });
+
+  it(`rejects more than ${MAX_CITIES} cities`, () => {
+    const input = emptyInput(IDS);
+    input.cities.a = MAX_CITIES + 1;
+    expect(validateRound(input, P4)).toMatch(/city pieces/);
+  });
+
+  it(`rejects more than ${MAX_DEV_VP} Victory Point cards`, () => {
+    const input = emptyInput(IDS);
+    input.devVP.a = MAX_DEV_VP + 1;
+    expect(validateRound(input, P4)).toMatch(/Victory Point cards/);
+  });
+
+  it('rejects an award assigned to a player outside the roster', () => {
+    const input = emptyInput(IDS);
+    input.longestRoad = 'ghost';
+    expect(validateRound(input, P4)).toMatch(/Longest Road/);
+  });
+});
+
+// ── game end ─────────────────────────────────────────────────────────────
+describe('isFinished', () => {
+  it('is false until someone reaches the target', () => {
+    expect(isFinished({ a: 9, b: 5 }, { targetVP: 10 })).toBe(false);
+  });
+  it('is true the instant a total reaches the target', () => {
+    expect(isFinished({ a: 10, b: 5 }, { targetVP: 10 })).toBe(true);
+  });
+  it('honors a raised target (5–6 player expansion)', () => {
+    expect(isFinished({ a: 12 }, { targetVP: 13 })).toBe(false);
+    expect(isFinished({ a: 13 }, { targetVP: 13 })).toBe(true);
+  });
+});
+
+// ── history ──────────────────────────────────────────────────────────────
+describe('describeRound', () => {
+  it('names the current leader and their total', () => {
+    const input = emptyInput(IDS);
+    input.settlements.a = 3;
+    input.cities.b = 1;
+    expect(describeRound(input, P4)).toBe('A 3 VP');
+  });
+
+  it('calls out an award the leader holds', () => {
+    const input = emptyInput(IDS);
+    input.settlements.a = 1;
+    input.longestRoad = 'a';
+    expect(describeRound(input, P4)).toBe('A 3 VP (🛣️ Longest Road)');
+  });
+
+  it('reads "no update" for an all-zero checkpoint', () => {
+    expect(describeRound(emptyInput(IDS), P4)).toBe('no update');
+  });
+});
+
+// ── module wiring ──────────────────────────────────────────────────────────
+describe('catan module', () => {
+  it('exposes the expected identity and player range', () => {
+    expect(catan.id).toBe('catan');
+    expect(catan.minPlayers).toBe(3);
+    expect(catan.maxPlayers).toBe(6);
+  });
+
+  it('scores a round through the module contract', () => {
+    const ctx = {
+      game: { id: 'g', type: 'catan', config: {}, playerIds: IDS, status: 'active' as const, createdAt: 0, roundCount: 0 },
+      players: P4,
+      config: {},
+      roundIndex: 0,
+      totals: { a: 0, b: 0, c: 0, d: 0 },
+      rounds: [],
+    };
+    const input = catan.createRoundInput(ctx) as CatanInput;
+    input.settlements.a = 2;
+    expect(catan.scoreRound(input, ctx)).toEqual({ a: 2, b: 0, c: 0, d: 0 });
+    expect(catan.isFinished?.({ a: 2, b: 0, c: 0, d: 0 }, { config: {}, roundCount: 1, playerCount: 4 })).toBe(
+      false,
+    );
+  });
+});

--- a/src/lib/games/catan/index.ts
+++ b/src/lib/games/catan/index.ts
@@ -1,0 +1,90 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { catanStats } from './stats';
+import {
+  carryForward,
+  describeRound as describeCatanRound,
+  isFinished as catanFinished,
+  scoreRound as scoreCatan,
+  validateRound as validateCatan,
+  type CatanInput,
+} from './logic';
+
+export type { CatanInput, CatanConfig } from './logic';
+
+export const catan: GameModule = {
+  id: 'catan',
+  name: 'Catan',
+  tagline: 'Settle, build, and race to the target — first to the crown wins 🏝️',
+  emoji: '🏝️',
+  keywords: [
+    'settlers of catan',
+    'settlements',
+    'cities',
+    'longest road',
+    'largest army',
+    'victory points',
+    'board game',
+  ],
+  minPlayers: 3,
+  maxPlayers: 6,
+  configFields: [
+    {
+      key: 'targetVP',
+      label: 'Victory points to win',
+      type: 'number',
+      default: 10,
+      min: 5,
+      max: 20,
+      help: '10 is standard for 3–4 players. Playing with the 5–6 Player Expansion? Most groups raise it to 13.',
+    },
+  ],
+
+  // Catan isn't played in discrete rounds — every saved update is a checkpoint of the current
+  // board. Each checkpoint starts from the last one so you're only editing what changed.
+  createRoundInput: (ctx: RoundContext): CatanInput =>
+    carryForward(
+      ctx.players.map((p) => p.id),
+      ctx.rounds[ctx.rounds.length - 1]?.input as CatanInput | undefined,
+    ),
+
+  validateRound: (input: CatanInput, ctx: RoundContext): string | null =>
+    validateCatan(input, ctx.players),
+
+  scoreRound: (input: CatanInput, ctx: RoundContext): Record<ID, number> =>
+    scoreCatan(
+      input,
+      ctx.players.map((p) => p.id),
+      ctx.totals,
+    ),
+
+  isFinished: (totals, { config }) => catanFinished(totals, config),
+
+  describeRound: (round: Round, players): string =>
+    describeCatanRound(round.input as CatanInput | undefined, players),
+
+  help: [
+    'Catan is a race to victory points (VP) — first to the target wins immediately, even mid-turn.',
+    '',
+    'Where VP come from:',
+    '🏠 Settlement — 1 VP each (up to 5 on the board)',
+    '🏰 City — 2 VP each (up to 4; a city replaces a settlement)',
+    '🛣️ Longest Road — 2 VP to whoever holds the longest continuous road (5+ segments).',
+    '   Can change hands if someone builds a longer one.',
+    '⚔️ Largest Army — 2 VP to whoever has played the most Knight cards (3+ minimum).',
+    '   Can also change hands.',
+    '🃏 Victory Point cards — 1 VP each, from the development deck (5 exist in the base game).',
+    '   These are usually kept secret until revealing one wins the game.',
+    '',
+    'This tracker works as a live checkpoint: update everyone\'s current settlements, cities,',
+    'and revealed VP cards, and toggle who holds each award. Score King works out each',
+    'player\'s point change since the last update automatically.',
+    '',
+    'Standard target is 10 VP. Playing 5–6 players with the expansion? Raise the target to 13.',
+  ].join('\n'),
+
+  stats: catanStats,
+
+  RoundEditor,
+  editorLoader: () => import('./CatanEditor.svelte'),
+};

--- a/src/lib/games/catan/logic.ts
+++ b/src/lib/games/catan/logic.ts
@@ -1,0 +1,193 @@
+import type { ID, Player } from '../../types';
+
+/**
+ * Catan (Settlers of Catan) scoring — pure, Svelte-free. `index.ts`, `CatanEditor.svelte` and
+ * `stats.ts` all import from here so the exact math the game plays is the exact math the tests
+ * exercise.
+ *
+ * Real Catan victory points: a settlement is 1 VP, a city is 2 VP, each revealed Victory Point
+ * development card is 1 VP, and the Longest Road and Largest Army cards are each worth 2 VP to
+ * whoever currently holds them (at most one player per award, and an award can change hands
+ * mid-game). First to the target — 10 VP in the base game, commonly 13 with the 5–6 player
+ * expansion — wins immediately, even mid-turn.
+ *
+ * MODELING CHOICE: Catan isn't played in discrete "rounds" the way a card game is — a player's
+ * board (settlements, cities, revealed dev-card VP, and who holds each award) can change on
+ * anyone's turn, and VP dev cards are often kept secret until revealing one wins the game. The
+ * cleanest fit for Score King's round contract (every {@link ../../types Round} stores a
+ * per-player point DELTA) is a **live checkpoint**: each saved round is a snapshot of every
+ * player's CURRENT board — an absolute count, not a change since last time — and
+ * {@link scoreRound} reports `newTotal - before` as the delta the contract expects. That lets
+ * the editor and history show natural, board-accurate numbers (e.g. "2 cities, 1 settlement")
+ * while the stored deltas stay faithful to how every other module works.
+ */
+
+export interface CatanInput {
+  /** Each player's current number of built settlements (1 VP each). Physical cap: 5. */
+  settlements: Record<ID, number>;
+  /** Each player's current number of built cities (2 VP each). Physical cap: 4. */
+  cities: Record<ID, number>;
+  /**
+   * Victory Point development cards a player has revealed so far. Real VP cards are usually
+   * kept secret until showing one wins the game — this only needs updating at that moment (or
+   * whenever a player chooses to reveal one).
+   */
+  devVP: Record<ID, number>;
+  /** Who currently holds the Longest Road card (2 VP) — at most one player, or none yet. */
+  longestRoad: ID | null;
+  /** Who currently holds the Largest Army card (2 VP) — at most one player, or none yet. */
+  largestArmy: ID | null;
+}
+
+export interface CatanConfig {
+  /** First to reach this many VP wins immediately. 10 is standard; 13 for 5–6 players. */
+  targetVP: number;
+}
+
+export const DEFAULT_TARGET_VP = 10;
+export const EXPANSION_TARGET_VP = 13;
+
+/** Real physical piece/card limits, used to keep entries honest to the actual game. */
+export const MAX_SETTLEMENTS = 5;
+export const MAX_CITIES = 4;
+/** The base deck carries exactly 5 Victory Point cards, so no one can reveal more than that. */
+export const MAX_DEV_VP = 5;
+
+export const SETTLEMENT_POINTS = 1;
+export const CITY_POINTS = 2;
+export const DEV_VP_POINTS = 1;
+export const AWARD_POINTS = 2;
+
+function numOr(v: unknown, fallback = 0): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function readConfig(config: Record<string, unknown> = {}): CatanConfig {
+  const targetVP = Math.trunc(numOr(config.targetVP, DEFAULT_TARGET_VP));
+  return { targetVP: Math.max(3, targetVP) };
+}
+
+/** A fresh checkpoint: nobody has built anything yet and neither award is claimed. */
+export function emptyInput(playerIds: readonly ID[]): CatanInput {
+  return {
+    settlements: Object.fromEntries(playerIds.map((id) => [id, 0])),
+    cities: Object.fromEntries(playerIds.map((id) => [id, 0])),
+    devVP: Object.fromEntries(playerIds.map((id) => [id, 0])),
+    longestRoad: null,
+    largestArmy: null,
+  };
+}
+
+/**
+ * A checkpoint that carries the previous one's board state forward, so editing the next update
+ * starts from where the game actually is rather than a blank slate. Falls back to
+ * {@link emptyInput} for the very first checkpoint.
+ */
+export function carryForward(
+  playerIds: readonly ID[],
+  previous: CatanInput | undefined,
+): CatanInput {
+  if (!previous) return emptyInput(playerIds);
+  return {
+    settlements: Object.fromEntries(playerIds.map((id) => [id, numOr(previous.settlements?.[id])])),
+    cities: Object.fromEntries(playerIds.map((id) => [id, numOr(previous.cities?.[id])])),
+    devVP: Object.fromEntries(playerIds.map((id) => [id, numOr(previous.devVP?.[id])])),
+    longestRoad: playerIds.includes(previous.longestRoad ?? '') ? previous.longestRoad! : null,
+    largestArmy: playerIds.includes(previous.largestArmy ?? '') ? previous.largestArmy! : null,
+  };
+}
+
+/** One player's absolute victory-point total from a checkpoint's board state. */
+export function vpFor(input: CatanInput, id: ID): number {
+  const settlements = numOr(input.settlements?.[id]);
+  const cities = numOr(input.cities?.[id]);
+  const devVP = numOr(input.devVP?.[id]);
+  const road = input.longestRoad === id ? AWARD_POINTS : 0;
+  const army = input.largestArmy === id ? AWARD_POINTS : 0;
+  return settlements * SETTLEMENT_POINTS + cities * CITY_POINTS + devVP * DEV_VP_POINTS + road + army;
+}
+
+/** Every player's absolute VP total for this checkpoint, keyed by player id. */
+export function totalsFor(input: CatanInput, playerIds: readonly ID[]): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) out[id] = vpFor(input, id);
+  return out;
+}
+
+/**
+ * Per-player point deltas for the round: each player's new absolute VP total minus their total
+ * going into this checkpoint (`before`, i.e. `ctx.totals`). See the file-level comment for why a
+ * checkpoint model reports deltas this way.
+ */
+export function scoreRound(
+  input: CatanInput,
+  playerIds: readonly ID[],
+  before: Record<ID, number>,
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) out[id] = vpFor(input, id) - numOr(before[id]);
+  return out;
+}
+
+/** Validate a checkpoint. Null when good, else a friendly, specific message. */
+export function validateRound(
+  input: CatanInput,
+  players: readonly Pick<Player, 'id' | 'name'>[],
+): string | null {
+  for (const p of players) {
+    const settlements = numOr(input.settlements?.[p.id]);
+    if (!Number.isInteger(settlements) || settlements < 0) {
+      return `${p.name}: settlements can't be negative.`;
+    }
+    if (settlements > MAX_SETTLEMENTS) {
+      return `${p.name}: only ${MAX_SETTLEMENTS} settlement pieces exist — build a city instead?`;
+    }
+    const cities = numOr(input.cities?.[p.id]);
+    if (!Number.isInteger(cities) || cities < 0) {
+      return `${p.name}: cities can't be negative.`;
+    }
+    if (cities > MAX_CITIES) {
+      return `${p.name}: only ${MAX_CITIES} city pieces exist.`;
+    }
+    const devVP = numOr(input.devVP?.[p.id]);
+    if (!Number.isInteger(devVP) || devVP < 0) {
+      return `${p.name}: Victory Point cards can't be negative.`;
+    }
+    if (devVP > MAX_DEV_VP) {
+      return `${p.name}: only ${MAX_DEV_VP} Victory Point cards exist in the deck.`;
+    }
+  }
+  if (input.longestRoad && !players.some((p) => p.id === input.longestRoad)) {
+    return 'Longest Road is assigned to someone who isn’t in this game.';
+  }
+  if (input.largestArmy && !players.some((p) => p.id === input.largestArmy)) {
+    return 'Largest Army is assigned to someone who isn’t in this game.';
+  }
+  return null;
+}
+
+/** True once any player's total has reached the target — Catan ends the instant it does. */
+export function isFinished(totals: Record<ID, number>, config: Record<string, unknown>): boolean {
+  const { targetVP } = readConfig(config);
+  return Object.values(totals).some((t) => t >= targetVP);
+}
+
+/** A compact one-liner for the round history: the leader and their VP total. */
+export function describeRound(
+  input: CatanInput | undefined,
+  players: readonly Pick<Player, 'id' | 'name'>[],
+): string {
+  if (!input) return 'no update';
+  const ids = players.map((p) => p.id);
+  const totals = totalsFor(input, ids);
+  const ranked = [...players].sort((a, b) => (totals[b.id] ?? 0) - (totals[a.id] ?? 0));
+  const leader = ranked[0];
+  if (!leader || (totals[leader.id] ?? 0) === 0) return 'no update';
+  const total = totals[leader.id] ?? 0;
+  const badges: string[] = [];
+  if (input.longestRoad === leader.id) badges.push('🛣️ Longest Road');
+  if (input.largestArmy === leader.id) badges.push('⚔️ Largest Army');
+  const badge = badges.length ? ` (${badges.join(', ')})` : '';
+  return `${leader.name} ${total} VP${badge}`;
+}

--- a/src/lib/games/catan/stats.ts
+++ b/src/lib/games/catan/stats.ts
@@ -1,0 +1,123 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg, fmtInt } from '../../stats/format';
+import { readConfig, totalsFor, type CatanInput } from './logic';
+
+interface CatanAgg {
+  /** Finished games this member sat for. */
+  games: number;
+  /** Sum of each finished game's final VP total (for an average). */
+  finalVP: number;
+  bestVP: number;
+  /** Games ending with this member holding Longest Road. */
+  longestRoad: number;
+  /** Games ending with this member holding Largest Army. */
+  largestArmy: number;
+  /** Total revealed Victory Point dev cards across finished games. */
+  devVP: number;
+  wins: number;
+}
+
+function blank(): CatanAgg {
+  return { games: 0, finalVP: 0, bestVP: 0, longestRoad: 0, largestArmy: 0, devVP: 0, wins: 0 };
+}
+
+/**
+ * Catan stats, replayed purely from each game's recorded checkpoints. Each finished game's LAST
+ * checkpoint is its board at game end — the source of truth for who held each award, how many
+ * VP cards were revealed, and the final standing. Pure, no I/O. No Svelte.
+ */
+export function catanStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const per = new Map<ID, CatanAgg>();
+  const get = (id: ID): CatanAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = blank();
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let bestVPAnywhere = 0;
+
+  for (const g of games) {
+    if (g.status !== 'finished' || !g.playerIds.length) continue;
+    const gameRounds = rounds.filter((r) => r.gameId === g.id).sort((a, b) => a.index - b.index);
+    const last = gameRounds[gameRounds.length - 1]?.input as CatanInput | undefined;
+    if (!last) continue;
+
+    const cfg = readConfig(g.config);
+    const totals = totalsFor(last, g.playerIds);
+    const winnerScore = Math.max(...Object.values(totals));
+    if (winnerScore < cfg.targetVP) continue; // game abandoned short of the target
+
+    for (const pid of g.playerIds) {
+      const a = get(canonical(pid));
+      const vp = totals[pid] ?? 0;
+      a.games += 1;
+      a.finalVP += vp;
+      if (vp > a.bestVP) a.bestVP = vp;
+      if (vp > bestVPAnywhere) bestVPAnywhere = vp;
+      a.devVP += Number(last.devVP?.[pid]) || 0;
+      if (vp === winnerScore) a.wins += 1;
+    }
+    if (last.longestRoad) get(canonical(last.longestRoad)).longestRoad += 1;
+    if (last.largestArmy) get(canonical(last.largestArmy)).largestArmy += 1;
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.games) {
+      metrics.push({
+        key: 'ct_best',
+        label: 'Best VP total',
+        value: fmtInt(a.bestVP),
+        emoji: '👑',
+      });
+      metrics.push({
+        key: 'ct_avg',
+        label: 'Avg VP at finish',
+        value: fmtAvg(a.finalVP / a.games),
+        emoji: '🔢',
+      });
+    }
+    if (a.longestRoad) {
+      metrics.push({
+        key: 'ct_road',
+        label: 'Longest Road wins',
+        value: fmtInt(a.longestRoad),
+        emoji: '🛣️',
+      });
+    }
+    if (a.largestArmy) {
+      metrics.push({
+        key: 'ct_army',
+        label: 'Largest Army wins',
+        value: fmtInt(a.largestArmy),
+        emoji: '⚔️',
+      });
+    }
+    if (a.devVP) {
+      metrics.push({
+        key: 'ct_devvp',
+        label: 'VP cards revealed',
+        value: fmtInt(a.devVP),
+        emoji: '🃏',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (bestVPAnywhere) {
+    global.push({
+      key: 'ct_best_all',
+      label: 'Best VP total',
+      value: fmtInt(bestVPAnywhere),
+      emoji: '👑',
+    });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Adds a new game module — **Catan** 🏝️ — to Score King, following the existing GameModule conventions (see `hearts/`, `cribbage/`, `wingspan/`).

## Changes

- `src/lib/games/catan/logic.ts` — pure scoring core: settlements (1 VP), cities (2 VP), Victory Point dev cards (1 VP each, up to 5 in the deck), and the two shared 2 VP awards (Longest Road, Largest Army).
- `src/lib/games/catan/index.ts` — GameModule wiring (config, `editorLoader`, help text, stats hook).
- `src/lib/games/catan/CatanEditor.svelte` — live checkpoint editor: award pickers for Longest Road/Largest Army plus steppers per player for settlements/cities/VP cards, with a projected-total delta preview.
- `src/lib/games/catan/stats.ts` — per-player and global stats replayed from each finished game's final checkpoint.
- `src/lib/games/catan/catan.test.ts` — 26 unit tests covering config, scoring, validation, `isFinished`, and module wiring.

**Modeling choice (documented in `logic.ts`):** Catan has no discrete "rounds" — any player's board can change on anyone's turn, and VP dev cards are often kept secret until revealing one wins. Score King's round contract stores a per-player point *delta*, so each saved round is treated as a **live checkpoint**: the editor captures every player's current absolute board state, and `scoreRound` reports `newTotal - before` as the delta. This keeps the editor/history numbers board-accurate while staying faithful to the contract every other module follows.

Victory-point rules were confirmed via web research before implementation (settlement=1, city=2, Longest Road=2, Largest Army=2, VP dev card=1; first to 10 VP wins, 13 commonly used with the 5–6 player expansion).

## Testing

- [x] `npm test -- src/lib/games/catan` — 26/26 passed
- [x] `npm test -- src/lib/games/registry.test.ts` — module auto-discovered correctly, no duplicate ids
- [x] `npm run check` — 0 errors, 0 warnings