### PR TITLE
feat(games): add Kings Corners game module

### DIFF
--- a/src/lib/games/kingscorners/KingsCornersEditor.svelte
+++ b/src/lib/games/kingscorners/KingsCornersEditor.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { haptic } from '../../haptics';
+  import { kingscorners } from './index';
+  import { MAX_KINGS, penaltyFor, wentOutIds, type KingsCornersInput } from './logic';
+
+  let { input = $bindable(), ctx }: { input: KingsCornersInput; ctx: RoundContext } = $props();
+
+  const ids = $derived(ctx.players.map((p) => p.id));
+  const outs = $derived(new Set(wentOutIds(input, ids)));
+
+  function penalty(id: string): number {
+    return penaltyFor(input, id);
+  }
+
+  function markWentOut(id: string) {
+    input.kingsLeft[id] = 0;
+    input.othersLeft[id] = 0;
+    haptic('win'); // a clean hand is the round's own small victory
+  }
+
+  // Whether the draft holds anything worth clearing — gates the "Clear hand" reset so it
+  // only appears once you've started entering, never on an untouched round.
+  const dirty = $derived(ids.some((id) => penalty(id) > 0));
+  function clearHand() {
+    for (const id of ids) {
+      input.kingsLeft[id] = 0;
+      input.othersLeft[id] = 0;
+    }
+    haptic('undo');
+  }
+
+  let showHelp = $state(false);
+</script>
+
+<div class="stack">
+  <div class="row spread wrap">
+    <span class="muted hint">Fewer points is better — race to empty your hand.</span>
+    <span class="row" style="gap: 8px">
+      {#if dirty}
+        <button type="button" class="btn small ghost" onclick={clearHand}>Clear hand</button>
+      {/if}
+      <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+        {showHelp ? 'Hide rules' : 'How to play'}
+      </button>
+    </span>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{kingscorners.help}</pre>
+  {/if}
+
+  {#each ctx.players as p (p.id)}
+    {@const went = outs.has(p.id)}
+    {@const pts = penalty(p.id)}
+    <div class="prow" class:went-out={went}>
+      <div class="row spread" style="margin-bottom: 10px">
+        <span class="row" style="gap: 8px; min-width: 0">
+          <Avatar name={p.name} color={p.color} />
+          <strong class="pname">{p.name}</strong>
+        </span>
+        <span class="preview-wrap">
+          <span class="preview" class:score-good={pts === 0} class:score-bad={pts > 0}
+            >{pts}</span
+          >
+          {#if went}
+            <span class="outcome score-good">👑 went out</span>
+          {:else if pts > 0}
+            <span class="outcome">🂡 {pts} left</span>
+          {/if}
+        </span>
+      </div>
+
+      <div class="steppers">
+        <div class="stepper-field">
+          <span class="field-label">Kings left</span>
+          <Stepper
+            bind:value={input.kingsLeft[p.id]}
+            min={0}
+            max={MAX_KINGS}
+            label={`${p.name} Kings left`}
+          />
+        </div>
+        <div class="stepper-field">
+          <span class="field-label">Other cards left</span>
+          <Stepper
+            bind:value={input.othersLeft[p.id]}
+            min={0}
+            max={51}
+            label={`${p.name} other cards left`}
+          />
+        </div>
+      </div>
+
+      <button
+        type="button"
+        class="btn small ghost grow"
+        onclick={() => markWentOut(p.id)}
+        disabled={went}
+      >
+        👑 {p.name} went out (0 cards left)
+      </button>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .hint {
+    font-size: 0.85rem;
+  }
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  /* A clean, zero-penalty hand is the round's own small win — semantic green,
+     never Crown Gold (reserved for the game's overall leader/winner). */
+  .prow.went-out {
+    border-color: color-mix(in srgb, var(--good) 55%, var(--border));
+    background: color-mix(in srgb, var(--good) 8%, var(--surface-2));
+  }
+  .pname {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .preview-wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+    flex: none;
+  }
+  .preview {
+    font-weight: 800;
+    font-size: 1.1rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .outcome {
+    font-size: 0.74rem;
+    font-weight: 700;
+    color: var(--muted);
+    text-align: right;
+    white-space: nowrap;
+  }
+  .steppers {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  .stepper-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .field-label {
+    font-size: 0.74rem;
+    font-weight: 600;
+    color: var(--muted);
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/kingscorners/index.ts
+++ b/src/lib/games/kingscorners/index.ts
@@ -1,0 +1,84 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { kingsCornersStats } from './stats';
+import {
+  describeRound as describeKingsCornersRound,
+  emptyInput,
+  isFinished as kingsCornersFinished,
+  scoreRound as scoreKingsCorners,
+  validateRound as validateKingsCorners,
+  wentOutIds,
+  type KingsCornersInput,
+} from './logic';
+
+export type { KingsCornersInput, KingsCornersConfig } from './logic';
+
+export const kingscorners: GameModule = {
+  id: 'kingscorners',
+  name: 'Kings Corners',
+  tagline: 'Empty your hand before the Kings pile up',
+  emoji: '👑',
+  keywords: ['kings in the corner', 'solitaire', 'cards', 'corners', 'layout'],
+  minPlayers: 2,
+  maxPlayers: 4,
+  lowerIsBetter: true,
+  configFields: [
+    {
+      key: 'endScore',
+      label: 'End the game when a player reaches',
+      type: 'number',
+      default: 25,
+      min: 10,
+      help: '25 is the classic finish line; some tables play to 50 for a longer night.',
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): KingsCornersInput =>
+    emptyInput(ctx.players.map((p) => p.id)),
+
+  validateRound: (input: KingsCornersInput, ctx: RoundContext): string | null =>
+    validateKingsCorners(input, ctx.players, ctx.config),
+
+  scoreRound: (input: KingsCornersInput, ctx: RoundContext): Record<ID, number> =>
+    scoreKingsCorners(
+      input,
+      ctx.players.map((p) => p.id),
+    ),
+
+  isFinished: (totals, { config }) => kingsCornersFinished(totals, config),
+
+  describeRound: (round: Round, players): string =>
+    describeKingsCornersRound(round.input as KingsCornersInput, players),
+
+  // Per-round scorecard emphasis: flag whoever went out (a clean, penalty-free hand) so
+  // the round-by-round view celebrates the round's winner, never colour alone.
+  roundCellTone: (round: Round, playerId: ID) => {
+    const input = round.input as KingsCornersInput | undefined;
+    if (!input?.kingsLeft) return null;
+    const ids = Object.keys(input.kingsLeft);
+    if (!wentOutIds(input, ids).includes(playerId)) return null;
+    return { tone: 'good', label: 'Went out — zero cards left' };
+  },
+
+  help: [
+    'Kings Corners deals a hand to every player and fans four piles into a cross around a',
+    'central stock, with the four corners reserved for Kings. On your turn, play a card of',
+    'the opposite color one rank lower onto any of the four arms — or start a fresh pile in',
+    'an empty corner with a King. Whole piles can be picked up and moved onto a valid card',
+    'elsewhere, and an empty non-corner spot can be filled from the stock or the top of any',
+    'pile. Draw back up to your hand size (or as your table agrees) each turn.',
+    '',
+    'The round ends the instant a player plays their last card — they go out clean.',
+    'Everyone else counts what is stuck in their hand: 👑 Kings cost 10 points each, every',
+    'other card costs 1. Lower is better, so the player who went out banks a clean 0.',
+    '',
+    'Play continues, round after round, until someone\'s running total reaches the end',
+    'score (25 by default, or 50 for a longer game). Whoever has the LOWEST total at that',
+    'point wins the crown.',
+  ].join('\n'),
+
+  stats: kingsCornersStats,
+
+  RoundEditor,
+  editorLoader: () => import('./KingsCornersEditor.svelte'),
+};

--- a/src/lib/games/kingscorners/kingscorners.test.ts
+++ b/src/lib/games/kingscorners/kingscorners.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import type { Player } from '../../types';
+import { kingscorners } from './index';
+import {
+  DEFAULT_CONFIG,
+  KING_PENALTY,
+  CARD_PENALTY,
+  describeRound,
+  emptyInput,
+  isFinished,
+  penaltyFor,
+  readConfig,
+  scoreRound,
+  validateRound,
+  wentOutIds,
+  type KingsCornersInput,
+} from './logic';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+function player(id: string): Player {
+  return { id, name: id.toUpperCase(), color: '#7c5cff', createdAt: 0 };
+}
+const P4 = ['a', 'b', 'c', 'd'].map(player);
+const IDS = P4.map((p) => p.id);
+
+function input(
+  kingsLeft: Record<string, number>,
+  othersLeft: Record<string, number>,
+): KingsCornersInput {
+  return { kingsLeft, othersLeft };
+}
+
+// ── config ───────────────────────────────────────────────────────────────
+describe('readConfig', () => {
+  it('applies defaults', () => {
+    expect(readConfig({})).toEqual(DEFAULT_CONFIG);
+  });
+  it('reads an override', () => {
+    expect(readConfig({ endScore: 50 })).toEqual({ endScore: 50 });
+  });
+  it('never lets the end score fall below 1', () => {
+    expect(readConfig({ endScore: -5 }).endScore).toBe(1);
+    expect(readConfig({ endScore: 'nope' }).endScore).toBe(25);
+  });
+});
+
+// ── empty input ────────────────────────────────────────────────────────────
+describe('emptyInput', () => {
+  it('seeds every player at zero cards left', () => {
+    expect(emptyInput(IDS)).toEqual({
+      kingsLeft: { a: 0, b: 0, c: 0, d: 0 },
+      othersLeft: { a: 0, b: 0, c: 0, d: 0 },
+    });
+  });
+});
+
+// ── penalty math ───────────────────────────────────────────────────────────
+describe('penaltyFor', () => {
+  it('charges 10 per King and 1 per other card', () => {
+    const i = input({ a: 2 }, { a: 3 });
+    expect(penaltyFor(i, 'a')).toBe(2 * KING_PENALTY + 3 * CARD_PENALTY);
+  });
+  it('treats a missing/garbage entry as zero', () => {
+    const i = input({}, {});
+    expect(penaltyFor(i, 'z')).toBe(0);
+  });
+});
+
+describe('wentOutIds', () => {
+  it('finds the player(s) holding zero cards', () => {
+    const i = input({ a: 0, b: 1, c: 0, d: 2 }, { a: 0, b: 2, c: 0, d: 1 });
+    expect(wentOutIds(i, IDS)).toEqual(['a', 'c']);
+  });
+  it('returns none when nobody is empty', () => {
+    const i = input({ a: 1 }, { a: 0 });
+    expect(wentOutIds(i, ['a'])).toEqual([]);
+  });
+});
+
+// ── validation ─────────────────────────────────────────────────────────────
+describe('validateRound', () => {
+  it('requires someone to have gone out', () => {
+    const i = input({ a: 1, b: 0, c: 0, d: 0 }, { a: 0, b: 3, c: 4, d: 2 });
+    expect(validateRound(i, P4, {})).toMatch(/Mark who went out/);
+  });
+  it('rejects an all-zero round (nobody actually holding cards)', () => {
+    const i = emptyInput(IDS);
+    expect(validateRound(i, P4, {})).toMatch(/Everyone can't be at zero/);
+  });
+  it('passes a well-formed round with exactly one player at zero', () => {
+    const i = input({ a: 0, b: 1, c: 0, d: 0 }, { a: 0, b: 5, c: 2, d: 3 });
+    expect(validateRound(i, P4, {})).toBeNull();
+  });
+});
+
+// ── scoring ──────────────────────────────────────────────────────────────
+describe('scoreRound', () => {
+  it('scores each seat its own penalty; the empty hand banks zero', () => {
+    const i = input({ a: 0, b: 1, c: 1, d: 2 }, { a: 0, b: 3, c: 4, d: 1 });
+    expect(scoreRound(i, IDS)).toEqual({ a: 0, b: 13, c: 14, d: 21 });
+  });
+
+  it('delegates identically through the module', () => {
+    const ctx = {
+      game: {} as never,
+      players: P4,
+      config: {},
+      roundIndex: 0,
+      totals: {},
+      rounds: [],
+    };
+    const i = input({ a: 0, b: 1, c: 1, d: 2 }, { a: 0, b: 3, c: 4, d: 1 });
+    expect(kingscorners.scoreRound(i, ctx)).toEqual({ a: 0, b: 13, c: 14, d: 21 });
+    expect(kingscorners.validateRound(i, ctx)).toBeNull();
+  });
+});
+
+// ── end condition ──────────────────────────────────────────────────────────
+describe('isFinished', () => {
+  it('ends when a player reaches the end score (25 default)', () => {
+    expect(isFinished({ a: 25, b: 10 }, {})).toBe(true);
+    expect(isFinished({ a: 24, b: 10 }, {})).toBe(false);
+    expect(isFinished({ a: 55, b: 40 }, { endScore: 50 })).toBe(true);
+  });
+});
+
+// ── round storytelling ─────────────────────────────────────────────────────
+describe('describeRound', () => {
+  it('names who went out and the heaviest hand', () => {
+    const i = input({ a: 0, b: 1, c: 1, d: 2 }, { a: 0, b: 3, c: 4, d: 1 });
+    expect(describeRound(i, P4)).toMatch(/👑 A went out — D \+21/);
+  });
+  it('celebrates a clean sweep when everyone else is also at zero', () => {
+    const i = input({ a: 0, b: 0 }, { a: 0, b: 0 });
+    expect(describeRound(i, P4.slice(0, 2))).toMatch(/clean sweep/);
+  });
+  it('handles a missing/legacy input', () => {
+    expect(describeRound(undefined, P4)).toBe('no cards');
+  });
+});
+
+// ── module wiring ──────────────────────────────────────────────────────────
+describe('kingscorners module', () => {
+  it('is configured for 2-4 players, lower-is-better', () => {
+    expect(kingscorners.minPlayers).toBe(2);
+    expect(kingscorners.maxPlayers).toBe(4);
+    expect(kingscorners.lowerIsBetter).toBe(true);
+  });
+
+  it('createRoundInput seeds every seat', () => {
+    const ctx = {
+      game: {} as never,
+      players: P4,
+      config: {},
+      roundIndex: 0,
+      totals: {},
+      rounds: [],
+    };
+    expect(kingscorners.createRoundInput(ctx)).toEqual(emptyInput(IDS));
+  });
+
+  it('roundCellTone marks whoever went out this round, and no one else', () => {
+    const i = input({ a: 0, b: 1, c: 0, d: 2 }, { a: 0, b: 3, c: 0, d: 1 });
+    const round = { input: i } as never;
+    expect(kingscorners.roundCellTone!(round, 'a')).toMatchObject({ tone: 'good' });
+    expect(kingscorners.roundCellTone!(round, 'b')).toBeNull();
+  });
+
+  it('isFinished mirrors the shared logic', () => {
+    expect(kingscorners.isFinished!({ a: 25 }, { config: {}, roundCount: 3, playerCount: 4 })).toBe(
+      true,
+    );
+  });
+});

--- a/src/lib/games/kingscorners/logic.ts
+++ b/src/lib/games/kingscorners/logic.ts
@@ -1,0 +1,128 @@
+import type { ID } from '../../types';
+
+/**
+ * Kings Corners scoring — pure, Svelte-free. Everything the module, its editor, and its
+ * tests need to turn a recorded round into per-player point deltas lives here.
+ *
+ * Kings Corners (Kings in the Corner) is a Solitaire-family layout game: a cross of four
+ * piles fans out from a central stock, with the four corners reserved for Kings. Play
+ * continues around the table until one player empties their hand — the instant that
+ * happens, the round ends and everyone else counts the penalty value of the cards still
+ * stuck in their hand: 10 per King, 1 for every other card. Lower is better — you're
+ * racing to empty your hand and dodging penalty cards left over, not chasing points. The
+ * match runs until someone's running total reaches a threshold (25 by default, 50 for a
+ * longer game); the LOWEST total at that point wins.
+ */
+
+export interface KingsCornersInput {
+  /** Kings still stuck in each player's hand this round (10 pts each). */
+  kingsLeft: Record<ID, number>;
+  /** Every other card still stuck in each player's hand this round (1 pt each). */
+  othersLeft: Record<ID, number>;
+}
+
+export interface KingsCornersConfig {
+  /** End the game the moment any total reaches this. */
+  endScore: number;
+}
+
+export const DEFAULT_CONFIG: KingsCornersConfig = { endScore: 25 };
+
+/** Penalty value of a King left in hand. */
+export const KING_PENALTY = 10;
+/** Penalty value of any other card left in hand. */
+export const CARD_PENALTY = 1;
+/** Kings in a standard deck — the stepper ceiling for "Kings left". */
+export const MAX_KINGS = 4;
+
+function numOr(v: unknown, fallback: number): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function readConfig(config: Record<string, unknown> = {}): KingsCornersConfig {
+  return {
+    endScore: Math.max(1, numOr(config.endScore, DEFAULT_CONFIG.endScore)),
+  };
+}
+
+/** A fresh, empty round with every player holding zero penalty cards. */
+export function emptyInput(playerIds: readonly ID[]): KingsCornersInput {
+  return {
+    kingsLeft: Object.fromEntries(playerIds.map((id) => [id, 0])),
+    othersLeft: Object.fromEntries(playerIds.map((id) => [id, 0])),
+  };
+}
+
+/** This player's penalty for the round: 10 per King left, 1 per other card left. */
+export function penaltyFor(input: KingsCornersInput, id: ID): number {
+  const kings = numOr(input.kingsLeft?.[id], 0) || 0;
+  const others = numOr(input.othersLeft?.[id], 0) || 0;
+  return kings * KING_PENALTY + others * CARD_PENALTY;
+}
+
+/**
+ * The player(s) recorded with an empty hand (zero Kings, zero other cards) this round —
+ * normally just the one player whose empty hand ended the round. Order follows `playerIds`.
+ */
+export function wentOutIds(input: KingsCornersInput, playerIds: readonly ID[]): ID[] {
+  return playerIds.filter((id) => penaltyFor(input, id) === 0);
+}
+
+/** Per-player point deltas for a round — a direct pass-through of each seat's penalty. */
+export function scoreRound(
+  input: KingsCornersInput,
+  playerIds: readonly ID[],
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) out[id] = penaltyFor(input, id);
+  return out;
+}
+
+/** Validate a round. Null when good, else a friendly, specific message. */
+export function validateRound(
+  input: KingsCornersInput,
+  players: readonly { id: ID; name: string }[],
+  _config: Record<string, unknown>,
+): string | null {
+  const ids = players.map((p) => p.id);
+  if (ids.length === 0) return null;
+  const outs = wentOutIds(input, ids);
+  if (outs.length === 0) {
+    return 'Mark who went out — one player must be left holding zero cards.';
+  }
+  if (outs.length === ids.length) {
+    return "Everyone can't be at zero — enter the penalty cards left for the rest of the table.";
+  }
+  return null;
+}
+
+/** True once any total has reached the end score — the match's finish line. */
+export function isFinished(totals: Record<ID, number>, config: Record<string, unknown>): boolean {
+  const end = readConfig(config).endScore;
+  return Object.values(totals).some((t) => t >= end);
+}
+
+/**
+ * A compact one-liner summarizing a saved round, for the round history. Pure; the
+ * module's `describeRound` just resolves ids to names through this.
+ */
+export function describeRound(
+  input: KingsCornersInput | undefined,
+  players: readonly { id: ID; name: string }[],
+): string {
+  if (!input?.kingsLeft) return 'no cards';
+  const name = (id: ID) => players.find((p) => p.id === id)?.name ?? '?';
+  const ids = players.map((p) => p.id);
+  const outs = wentOutIds(input, ids);
+  const outNames = outs.map(name).join(' & ');
+
+  const heaviest = [...ids]
+    .filter((id) => !outs.includes(id))
+    .sort((a, b) => penaltyFor(input, b) - penaltyFor(input, a))[0];
+
+  if (!heaviest || penaltyFor(input, heaviest) === 0) {
+    return outNames ? `👑 ${outNames} went out — clean sweep` : 'no cards recorded';
+  }
+  return `👑 ${outNames} went out — ${name(heaviest)} +${penaltyFor(input, heaviest)}`;
+}

--- a/src/lib/games/kingscorners/stats.ts
+++ b/src/lib/games/kingscorners/stats.ts
@@ -1,0 +1,74 @@
+import type { ID } from '../../types';
+import { penaltyFor, wentOutIds, type KingsCornersInput } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg, fmtInt, fmtPct } from '../../stats/format';
+
+interface KingsCornersAgg {
+  rounds: number;
+  wentOut: number;
+  points: number;
+  worst: number;
+}
+
+/**
+ * Kings Corners stats from each round's recorded Kings/other-card counts. Lower-is-better,
+ * so "went out" (zero penalty) is the round's best outcome. Pure; mirrors the module's own
+ * `wentOutIds()`/`penaltyFor()`.
+ */
+export function kingsCornersStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, KingsCornersAgg>();
+  const get = (id: ID): KingsCornersAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { rounds: 0, wentOut: 0, points: 0, worst: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as KingsCornersInput | undefined;
+    if (!input?.kingsLeft) continue;
+    const rawIds = Object.keys(input.kingsLeft);
+    const outs = new Set(wentOutIds(input, rawIds).map(canonical));
+    for (const pid of rawIds) {
+      const id = canonical(pid);
+      const a = get(id);
+      a.rounds += 1;
+      const points = penaltyFor(input, pid);
+      a.points += points;
+      if (points > a.worst) a.worst = points;
+      if (outs.has(id)) a.wentOut += 1;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let totWentOut = 0;
+  for (const [id, a] of per) {
+    totWentOut += a.wentOut;
+    const metrics: Metric[] = [];
+    if (a.rounds) {
+      metrics.push({
+        key: 'kc_out_pct',
+        label: 'Went out',
+        value: fmtPct(a.wentOut / a.rounds),
+        emoji: '👑',
+      });
+      metrics.push({
+        key: 'kc_avg',
+        label: 'Avg penalty',
+        value: fmtAvg(a.points / a.rounds),
+        emoji: '🂡',
+      });
+      metrics.push({ key: 'kc_worst', label: 'Worst hand', value: fmtInt(a.worst), emoji: '😱' });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totWentOut)
+    global.push({ key: 'kc_out_all', label: 'Times gone out', value: `${totWentOut}`, emoji: '👑' });
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Adds a new game module — **Kings Corners** 👑 (Kings in the Corner) — a Solitaire-family layout card game, following the established `GameModule` conventions.

## Changes

- `src/lib/games/kingscorners/logic.ts` — pure scoring/validation logic (Kings = 10pt penalty, other cards = 1pt each, lower-is-better, configurable end score)
- `src/lib/games/kingscorners/index.ts` — GameModule wiring (lazy `editorLoader`, help text, round-cell tone for who went out)
- `src/lib/games/kingscorners/stats.ts` — went-out %, avg penalty, worst hand
- `src/lib/games/kingscorners/KingsCornersEditor.svelte` — per-player Kings-left/other-cards-left steppers + a "went out" toggle
- `src/lib/games/kingscorners/kingscorners.test.ts` — unit tests for scoring, validation, describeRound, and module wiring

Auto-discovered by the games registry — no other files touched.

## Issues

Closes #158

## Testing

- [x] `npx vitest run src/lib/games/kingscorners` — 21/21 passed
- [x] `npx vitest run src/lib/games/registry.test.ts` — confirms auto-discovery
- [x] `npm run check` — 0 errors, 0 warnings