### PR TITLE
feat(games): add Canasta game module

### DIFF
--- a/src/lib/games/canasta/CanastaEditor.svelte
+++ b/src/lib/games/canasta/CanastaEditor.svelte
@@ -1,0 +1,332 @@
+<script lang="ts">
+  import type { Player, RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { canasta } from './index';
+  import {
+    handScore,
+    leadingTeam,
+    minimumInitialMeld,
+    targetFromConfig,
+    teamTotals,
+    toTarget,
+    type CanastaHand,
+    type CanastaInput,
+    type TeamIndex,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: CanastaInput; ctx: RoundContext } = $props();
+
+  let showRules = $state(false);
+
+  const byId = $derived(new Map(ctx.players.map((p) => [p.id, p])));
+  const target = $derived(targetFromConfig(ctx.config));
+
+  function members(idx: TeamIndex): Player[] {
+    return (input.teams[idx] ?? []).map((id) => byId.get(id)).filter((p): p is Player => !!p);
+  }
+  function teamLabel(idx: TeamIndex): string {
+    const names = members(idx).map((p) => p.name);
+    return names.length ? names.join(' & ') : `Team ${idx + 1}`;
+  }
+
+  // Race to the target: team totals BEFORE this hand, and who's out front.
+  const scoresBefore = $derived(teamTotals(input.teams, ctx.totals));
+  const leader = $derived(leadingTeam(scoresBefore));
+  const minMeld = $derived(scoresBefore.map((s) => minimumInitialMeld(s)) as [number, number]);
+
+  // This hand's computed team scores, live as the scorer fills in each field.
+  const handScores = $derived([handScore(input.hands[0]), handScore(input.hands[1])] as [
+    number,
+    number,
+  ]);
+
+  function toggleWentOut(idx: TeamIndex) {
+    const hand = input.hands[idx];
+    const turningOn = !hand.wentOut;
+    hand.wentOut = turningOn;
+    if (!turningOn) hand.concealedOut = false;
+    // Only one team can go out — clear the other team's flag.
+    if (turningOn) {
+      const other = input.hands[idx === 0 ? 1 : 0];
+      other.wentOut = false;
+      other.concealedOut = false;
+    }
+  }
+  function toggleConcealed(idx: TeamIndex) {
+    const hand = input.hands[idx];
+    hand.concealedOut = !hand.concealedOut;
+    if (hand.concealedOut) hand.wentOut = true;
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="muted hint">Enter each team's canastas, red threes, and card points.</span>
+    <button type="button" class="btn small ghost" onclick={() => (showRules = !showRules)}>
+      Rules
+    </button>
+  </div>
+
+  {#if showRules}
+    <pre class="help">{canasta.help}</pre>
+  {/if}
+
+  <div class="race" aria-label="Race to {target}">
+    {#each [0, 1] as idx (idx)}
+      {@const ti = idx as TeamIndex}
+      {@const s = scoresBefore[ti]}
+      {@const ahead = leader === ti}
+      <div class="racerow" class:lead={ahead}>
+        <div class="racetop">
+          <span class="racename">
+            {#if ahead}<span class="crown" aria-hidden="true">👑</span>{/if}
+            {teamLabel(ti)}
+          </span>
+          <span class="racescore" class:lead={ahead}>{s}</span>
+        </div>
+        <div class="bar" aria-hidden="true">
+          <span
+            class="fill"
+            class:gold={ahead}
+            style="width: {Math.min(100, (s / target) * 100)}%"
+          ></span>
+        </div>
+        <span class="tobarn">
+          {#if s >= target}🏁 past the target{:else}{toTarget(s, target)} to the target{/if}
+        </span>
+      </div>
+    {/each}
+  </div>
+
+  {#each [0, 1] as idx (idx)}
+    {@const ti = idx as TeamIndex}
+    {@const hand = input.hands[ti] as CanastaHand}
+    <div class="team">
+      <div class="teamhead">
+        <span class="avatars">
+          {#each members(ti) as p (p.id)}
+            <Avatar name={p.name} color={p.color} size={26} />
+          {/each}
+        </span>
+        <strong class="teamname">{teamLabel(ti)}</strong>
+        <span class="teamscore" class:score-good={handScores[ti] > 0} class:score-bad={handScores[ti] < 0}>
+          {handScores[ti] > 0 ? '+' : ''}{handScores[ti]}
+        </span>
+      </div>
+      <div class="minmeld muted">First meld this hand needs {minMeld[ti]}+ points.</div>
+
+      <div class="fields">
+        <label class="f">
+          Natural canastas
+          <Stepper
+            bind:value={hand.naturalCanastas}
+            min={0}
+            max={4}
+            label={`${teamLabel(ti)} natural canastas`}
+          />
+        </label>
+        <label class="f">
+          Mixed canastas
+          <Stepper
+            bind:value={hand.mixedCanastas}
+            min={0}
+            max={4}
+            label={`${teamLabel(ti)} mixed canastas`}
+          />
+        </label>
+        <label class="f">
+          Red threes
+          <Stepper bind:value={hand.redThrees} min={0} max={4} label={`${teamLabel(ti)} red threes`} />
+        </label>
+        <label class="f">
+          Melded points
+          <Stepper
+            bind:value={hand.meldPoints}
+            min={0}
+            step={5}
+            label={`${teamLabel(ti)} melded points`}
+          />
+        </label>
+        <label class="f">
+          Points left in hand
+          <Stepper
+            bind:value={hand.handPoints}
+            min={0}
+            step={5}
+            label={`${teamLabel(ti)} points left in hand`}
+          />
+        </label>
+      </div>
+
+      <div class="outrow">
+        <button
+          type="button"
+          class="toggle"
+          class:on={hand.wentOut}
+          aria-pressed={hand.wentOut}
+          onclick={() => toggleWentOut(ti)}
+        >
+          🏁 Went out
+        </button>
+        <button
+          type="button"
+          class="toggle"
+          class:on={hand.concealedOut}
+          disabled={!hand.wentOut && !hand.concealedOut}
+          aria-pressed={hand.concealedOut}
+          onclick={() => toggleConcealed(ti)}
+        >
+          🥷 Concealed
+        </button>
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .hint {
+    font-size: 0.85rem;
+  }
+
+  .race {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+  }
+  .racerow {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .racetop {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .racename {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 700;
+    min-width: 0;
+  }
+  .crown {
+    font-size: 0.95rem;
+    line-height: 1;
+  }
+  .racescore {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .racescore.lead {
+    color: var(--accent-ink);
+  }
+  .bar {
+    height: 8px;
+    border-radius: var(--radius-pill, 999px);
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    overflow: hidden;
+  }
+  .fill {
+    display: block;
+    height: 100%;
+    background: var(--muted);
+  }
+  .fill.gold {
+    background: var(--accent);
+  }
+  .tobarn {
+    font-size: 0.72rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .team {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface-2);
+  }
+  .teamhead {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .avatars {
+    display: flex;
+  }
+  .avatars :global(.avatar:not(:first-child)) {
+    margin-left: -8px;
+  }
+  .teamname {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .teamscore {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .minmeld {
+    font-size: 0.72rem;
+  }
+
+  .fields {
+    display: flex;
+    gap: 14px;
+    flex-wrap: wrap;
+  }
+  .f {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+
+  .outrow {
+    display: flex;
+    gap: 8px;
+  }
+  .toggle {
+    flex: 1 1 0;
+    min-height: 46px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+  }
+  .toggle.on {
+    background: color-mix(in srgb, var(--good) 20%, var(--surface));
+    border-color: var(--good);
+    color: var(--text);
+  }
+  .toggle:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-chip);
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/canasta/canasta.test.ts
+++ b/src/lib/games/canasta/canasta.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it } from 'vitest';
+import type { ID, RoundContext, Round, Game } from '../../types';
+import { canasta } from './index';
+import { canastaStats } from './stats';
+import {
+  type CanastaHand,
+  type CanastaInput,
+  canastaBonus,
+  describeHand,
+  emptyHand,
+  handScore,
+  leadingTeam,
+  minimumInitialMeld,
+  outBonus,
+  pairingFromConfig,
+  redThreeBonus,
+  resolveTeams,
+  scoreCanasta,
+  targetFromConfig,
+  teamTotals,
+  toTarget,
+  validateCanasta,
+} from './logic';
+
+const players4 = [
+  { id: 'a', name: 'Ann', color: '#111', createdAt: 0 },
+  { id: 'b', name: 'Bo', color: '#222', createdAt: 0 },
+  { id: 'c', name: 'Cy', color: '#333', createdAt: 0 },
+  { id: 'd', name: 'Di', color: '#444', createdAt: 0 },
+];
+
+const players2 = [
+  { id: 'a', name: 'Ann', color: '#111', createdAt: 0 },
+  { id: 'b', name: 'Bo', color: '#222', createdAt: 0 },
+];
+
+const ADJACENT: [ID[], ID[]] = [
+  ['a', 'b'],
+  ['c', 'd'],
+];
+
+function hand(partial: Partial<CanastaHand> = {}): CanastaHand {
+  return { ...emptyHand(), ...partial };
+}
+
+function mk(partial: Partial<CanastaInput> = {}): CanastaInput {
+  return {
+    teams: ADJACENT,
+    hands: [emptyHand(), emptyHand()],
+    ...partial,
+  };
+}
+
+function ctx(config: Record<string, unknown> = {}, players = players4): RoundContext {
+  return { players, config } as unknown as RoundContext;
+}
+
+describe('resolveTeams', () => {
+  it('pairs adjacent picks (1&2 vs 3&4)', () => {
+    expect(resolveTeams(players4, 'adjacent')).toEqual([
+      ['a', 'b'],
+      ['c', 'd'],
+    ]);
+  });
+
+  it('pairs across picks (1&3 vs 2&4)', () => {
+    expect(resolveTeams(players4, 'across')).toEqual([
+      ['a', 'c'],
+      ['b', 'd'],
+    ]);
+  });
+
+  it('gives each of two players their own team', () => {
+    expect(resolveTeams(players2, 'adjacent')).toEqual([['a'], ['b']]);
+    expect(resolveTeams(players2, 'across')).toEqual([['a'], ['b']]);
+  });
+});
+
+describe('canastaBonus', () => {
+  it('is 500 per natural and 300 per mixed canasta', () => {
+    expect(canastaBonus(hand({ naturalCanastas: 2, mixedCanastas: 1 }))).toBe(1300);
+    expect(canastaBonus(hand())).toBe(0);
+  });
+});
+
+describe('redThreeBonus', () => {
+  it('is 100 each below four', () => {
+    expect(redThreeBonus(0)).toBe(0);
+    expect(redThreeBonus(1)).toBe(100);
+    expect(redThreeBonus(3)).toBe(300);
+  });
+
+  it('is 800 (not 400) for all four', () => {
+    expect(redThreeBonus(4)).toBe(800);
+  });
+
+  it('clamps out-of-range input', () => {
+    expect(redThreeBonus(-2)).toBe(0);
+    expect(redThreeBonus(9)).toBe(800);
+  });
+});
+
+describe('outBonus', () => {
+  it('is 0 when the team did not go out', () => {
+    expect(outBonus(hand())).toBe(0);
+  });
+  it('is 100 for going out, 200 concealed', () => {
+    expect(outBonus(hand({ wentOut: true }))).toBe(100);
+    expect(outBonus(hand({ wentOut: true, concealedOut: true }))).toBe(200);
+  });
+});
+
+describe('handScore', () => {
+  it('combines bonuses plus melded points minus hand points', () => {
+    const h = hand({
+      naturalCanastas: 2,
+      mixedCanastas: 1,
+      redThrees: 3,
+      meldPoints: 100,
+      handPoints: 20,
+      wentOut: true,
+      concealedOut: true,
+    });
+    // 1000 + 300 (canastas) + 300 (red threes) + 200 (concealed out) + 100 - 20
+    expect(handScore(h)).toBe(1880);
+  });
+
+  it('is zero for an untouched hand', () => {
+    expect(handScore(emptyHand())).toBe(0);
+  });
+
+  it('can go negative when only hand points are entered', () => {
+    expect(handScore(hand({ handPoints: 40 }))).toBe(-40);
+  });
+
+  it('treats negative/garbage numeric fields as zero', () => {
+    expect(handScore(hand({ meldPoints: -50, handPoints: -10 }))).toBe(0);
+  });
+});
+
+describe('scoreCanasta', () => {
+  it('gives both partners their team hand score', () => {
+    const input = mk({
+      hands: [hand({ naturalCanastas: 1 }), hand({ meldPoints: 40 })],
+    });
+    expect(scoreCanasta(input)).toEqual({ a: 500, b: 500, c: 40, d: 40 });
+  });
+
+  it('mirrors to a single "team" of one for a 2-player game', () => {
+    const input: CanastaInput = {
+      teams: [['a'], ['b']],
+      hands: [hand({ meldPoints: 30 }), hand({ handPoints: 15 })],
+    };
+    expect(scoreCanasta(input)).toEqual({ a: 30, b: -15 });
+  });
+
+  it('returns all-zero deltas for two fully empty hands', () => {
+    expect(scoreCanasta(mk())).toEqual({ a: 0, b: 0, c: 0, d: 0 });
+  });
+});
+
+describe('validateCanasta', () => {
+  it('accepts a normal recorded hand', () => {
+    expect(validateCanasta(mk({ hands: [hand({ meldPoints: 50 }), hand()] }))).toBeNull();
+  });
+
+  it('requires at least two players', () => {
+    expect(validateCanasta(mk({ teams: [[], []] }))).toMatch(/at least two players/i);
+  });
+
+  it('rejects more than one team going out', () => {
+    expect(
+      validateCanasta(mk({ hands: [hand({ wentOut: true }), hand({ wentOut: true })] })),
+    ).toMatch(/only one team/i);
+  });
+
+  it('rejects concealed without went-out', () => {
+    expect(validateCanasta(mk({ hands: [hand({ concealedOut: true }), hand()] }))).toMatch(
+      /concealed/i,
+    );
+  });
+
+  it('rejects out-of-range red threes', () => {
+    expect(validateCanasta(mk({ hands: [hand({ redThrees: 5 }), hand()] }))).toMatch(
+      /red threes/i,
+    );
+    expect(validateCanasta(mk({ hands: [hand({ redThrees: -1 }), hand()] }))).toMatch(
+      /red threes/i,
+    );
+  });
+
+  it('rejects negative canasta counts and point totals', () => {
+    expect(validateCanasta(mk({ hands: [hand({ naturalCanastas: -1 }), hand()] }))).toMatch(
+      /canasta counts/i,
+    );
+    expect(validateCanasta(mk({ hands: [hand({ meldPoints: -5 }), hand()] }))).toMatch(
+      /melded points/i,
+    );
+    expect(validateCanasta(mk({ hands: [hand({ handPoints: -5 }), hand()] }))).toMatch(
+      /points left in hand/i,
+    );
+  });
+});
+
+describe('describeHand', () => {
+  it('summarises a plain hand with both team scores', () => {
+    const input = mk({ hands: [hand({ meldPoints: 60 }), hand({ meldPoints: 10 })] });
+    expect(describeHand(input, players4)).toBe('🃏 Ann & Bo 60 — Cy & Di 10');
+  });
+
+  it('calls out the team that went out', () => {
+    const input = mk({ hands: [hand({ wentOut: true, meldPoints: 100 }), hand()] });
+    expect(describeHand(input, players4)).toBe('🏁 Ann & Bo goes out — 200 (Cy & Di 0)');
+  });
+
+  it('flags a concealed out', () => {
+    const input = mk({
+      hands: [hand(), hand({ wentOut: true, concealedOut: true, meldPoints: 50 })],
+    });
+    expect(describeHand(input, players4)).toBe('🥷 Cy & Di goes out concealed — 250 (Ann & Bo 0)');
+  });
+
+  it('accepts pre-computed scores from stored deltas', () => {
+    const input = mk({ hands: [hand({ meldPoints: 60 }), hand({ meldPoints: 10 })] });
+    expect(describeHand(input, players4, [999, 1])).toBe('🃏 Ann & Bo 999 — Cy & Di 1');
+  });
+});
+
+describe('race to the target', () => {
+  it('reads each team total from the mirrored partner scores', () => {
+    expect(teamTotals(ADJACENT, { a: 700, b: 700, c: 400, d: 400 })).toEqual([700, 400]);
+  });
+
+  it('names the leading team, or null on a tie', () => {
+    expect(leadingTeam([700, 400])).toBe(0);
+    expect(leadingTeam([400, 700])).toBe(1);
+    expect(leadingTeam([0, 0])).toBeNull();
+  });
+
+  it('counts points still needed, never below zero', () => {
+    expect(toTarget(4500, 5000)).toBe(500);
+    expect(toTarget(5000, 5000)).toBe(0);
+    expect(toTarget(5200, 5000)).toBe(0);
+  });
+});
+
+describe('minimumInitialMeld', () => {
+  it('follows the classic sliding scale', () => {
+    expect(minimumInitialMeld(-100)).toBe(15);
+    expect(minimumInitialMeld(0)).toBe(50);
+    expect(minimumInitialMeld(1499)).toBe(50);
+    expect(minimumInitialMeld(1500)).toBe(90);
+    expect(minimumInitialMeld(2999)).toBe(90);
+    expect(minimumInitialMeld(3000)).toBe(120);
+    expect(minimumInitialMeld(6000)).toBe(120);
+  });
+});
+
+describe('config coercion', () => {
+  it('pairing defaults to adjacent', () => {
+    expect(pairingFromConfig({})).toBe('adjacent');
+    expect(pairingFromConfig({ pairing: 'across' })).toBe('across');
+  });
+
+  it('target defaults to 5000 and ignores junk', () => {
+    expect(targetFromConfig({})).toBe(5000);
+    expect(targetFromConfig({ target: 3000 })).toBe(3000);
+    expect(targetFromConfig({ target: 0 })).toBe(5000);
+    expect(targetFromConfig({ target: -10 })).toBe(5000);
+  });
+});
+
+describe('canasta module', () => {
+  it('declares itself a flexible-partnership 2–4 player game', () => {
+    expect(canasta.id).toBe('canasta');
+    expect(canasta.teams).toBe(true);
+    expect(canasta.minPlayers).toBe(2);
+    expect(canasta.maxPlayers).toBe(4);
+    expect(canasta.lowerIsBetter).toBeFalsy();
+  });
+
+  it('creates a round input with teams resolved from pick order + pairing', () => {
+    const input = canasta.createRoundInput(ctx({ pairing: 'across' })) as CanastaInput;
+    expect(input.teams).toEqual([
+      ['a', 'c'],
+      ['b', 'd'],
+    ]);
+    expect(input.hands).toHaveLength(2);
+    expect(input.hands[0]).toEqual(emptyHand());
+  });
+
+  it('scores through the module', () => {
+    const input = mk({
+      hands: [hand({ naturalCanastas: 1, meldPoints: 50 }), hand({ handPoints: 30 })],
+    });
+    expect(canasta.scoreRound(input, ctx())).toEqual({ a: 550, b: 550, c: -30, d: -30 });
+  });
+
+  it('validates through the module', () => {
+    expect(canasta.validateRound(mk(), ctx())).toBeNull();
+    expect(
+      canasta.validateRound(mk({ hands: [hand({ redThrees: 9 }), hand()] }), ctx()),
+    ).toMatch(/red threes/i);
+  });
+
+  it('finishes once a team reaches the configured target', () => {
+    const info = (config: Record<string, unknown>) => ({ config, roundCount: 3, playerCount: 4 });
+    expect(canasta.isFinished!({ a: 5000, b: 5000, c: 1200, d: 1200 }, info({}))).toBe(true);
+    expect(canasta.isFinished!({ a: 4999, b: 4999, c: 1200, d: 1200 }, info({}))).toBe(false);
+    expect(canasta.isFinished!({ a: 3000, b: 3000, c: 0, d: 0 }, info({ target: 3000 }))).toBe(
+      true,
+    );
+  });
+
+  it('describes a recorded round from its stored deltas', () => {
+    const round = {
+      input: mk({ hands: [hand({ wentOut: true, meldPoints: 100 }), hand()] }),
+      deltas: { a: 200, b: 200, c: 0, d: 0 },
+    } as unknown as Round;
+    expect(canasta.describeRound!(round, players4)).toBe('🏁 Ann & Bo goes out — 200 (Cy & Di 0)');
+  });
+
+  it('plays a full 2-player game to the target', () => {
+    const p2ctx = ctx({}, players2);
+    const input1 = canasta.createRoundInput(p2ctx) as CanastaInput;
+    input1.hands[0] = hand({ naturalCanastas: 3, meldPoints: 200, wentOut: true, concealedOut: true });
+    input1.hands[1] = hand({ handPoints: 50 });
+    const totals: Record<ID, number> = { a: 0, b: 0 };
+    const d1 = canasta.scoreRound(input1, p2ctx);
+    for (const id of Object.keys(totals)) totals[id] += d1[id] ?? 0;
+    expect(totals.a).toBe(1900); // 1500 canastas + 200 concealed-out + 200 meld
+    expect(totals.b).toBe(-50);
+    expect(canasta.isFinished!(totals, { config: {}, roundCount: 1, playerCount: 2 })).toBe(false);
+  });
+});
+
+describe('canastaStats', () => {
+  const games: Game[] = [
+    {
+      id: 'g',
+      type: 'canasta',
+      config: {},
+      playerIds: ['a', 'b', 'c', 'd'],
+      status: 'finished',
+      createdAt: 0,
+      roundCount: 2,
+    } as Game,
+  ];
+  const mkRound = (index: number, input: CanastaInput): Round =>
+    ({ id: `r${index}`, gameId: 'g', index, input, deltas: {}, createdAt: 0 }) as Round;
+  const rounds: Round[] = [
+    mkRound(
+      0,
+      mk({
+        hands: [
+          hand({ naturalCanastas: 1, mixedCanastas: 1, redThrees: 4, wentOut: true }),
+          hand(),
+        ],
+      }),
+    ),
+    mkRound(1, mk({ hands: [hand({ mixedCanastas: 1 }), hand({ mixedCanastas: 1, concealedOut: true, wentOut: true })] })),
+  ];
+  const out = canastaStats({ games, rounds, players: [], canonical: (id: ID) => id });
+
+  const metric = (id: ID, key: string) => out.perPlayer?.[id]?.find((m) => m.key === key);
+  const g = (key: string) => out.global?.find((m) => m.key === key);
+
+  it('credits canastas to both partners', () => {
+    expect(metric('a', 'ca_canastas')?.value).toBe('3');
+    expect(metric('b', 'ca_canastas')?.value).toBe('3');
+    expect(metric('c', 'ca_canastas')?.value).toBe('1');
+  });
+
+  it('tracks a full set of red threes', () => {
+    expect(metric('a', 'ca_redthrees')?.value).toBe('4');
+    expect(metric('a', 'ca_redthrees')?.sub).toMatch(/1 full set/);
+  });
+
+  it('counts went-out and concealed-out hands', () => {
+    expect(metric('a', 'ca_wentout')?.value).toBe('1');
+    expect(metric('d', 'ca_concealed')?.value).toBe('1');
+    expect(metric('c', 'ca_concealed')?.value).toBe('1');
+  });
+
+  it('reports global canasta totals', () => {
+    expect(g('ca_canastas_all')?.value).toBe('4');
+    expect(g('ca_concealed_all')?.value).toBe('1');
+  });
+});

--- a/src/lib/games/canasta/index.ts
+++ b/src/lib/games/canasta/index.ts
@@ -1,0 +1,112 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { canastaStats } from './stats';
+import {
+  type CanastaInput,
+  describeHand,
+  emptyHand,
+  handScore,
+  pairingFromConfig,
+  resolveTeams,
+  scoreCanasta,
+  targetFromConfig,
+  validateCanasta,
+} from './logic';
+
+export type { CanastaHand, CanastaInput } from './logic';
+export {
+  canastaBonus,
+  emptyHand,
+  handScore,
+  leadingTeam,
+  minimumInitialMeld,
+  outBonus,
+  pairingFromConfig,
+  redThreeBonus,
+  resolveTeams,
+  targetFromConfig,
+  teamTotals,
+  toTarget,
+} from './logic';
+
+export const canasta: GameModule = {
+  id: 'canasta',
+  name: 'Canasta',
+  tagline: 'Meld sevens, stack canastas, race to 5000.',
+  emoji: '🃏',
+  keywords: ['rummy', 'melds', 'partners', 'teams', 'cards', 'wild cards', 'red threes'],
+  minPlayers: 2,
+  maxPlayers: 4,
+  teams: true,
+  configFields: [
+    {
+      key: 'pairing',
+      label: 'Partnerships (4 players)',
+      type: 'select',
+      default: 'adjacent',
+      options: [
+        { value: 'adjacent', label: 'Teams: 1 & 2  vs  3 & 4' },
+        { value: 'across', label: 'Teams: 1 & 3  vs  2 & 4' },
+      ],
+      help: 'How four players split into two partnerships (by pick order). Ignored with two players.',
+    },
+    {
+      key: 'target',
+      label: 'Play to',
+      type: 'number',
+      default: 5000,
+      min: 500,
+      step: 100,
+      help: 'First team past this score at the end of a hand wins. Classic Canasta is 5000.',
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): CanastaInput => ({
+    teams: resolveTeams(ctx.players, pairingFromConfig(ctx.config)),
+    hands: [emptyHand(), emptyHand()],
+  }),
+
+  validateRound: (input: CanastaInput): string | null => validateCanasta(input),
+
+  scoreRound: (input: CanastaInput): Record<ID, number> => scoreCanasta(input),
+
+  isFinished: (totals, { config }) => {
+    const target = targetFromConfig(config);
+    return Object.values(totals).some((t) => t >= target);
+  },
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as CanastaInput;
+    const deltas = round.deltas ?? {};
+    const scoreOf = (idx: 0 | 1): number => {
+      const id = input.teams?.[idx]?.[0];
+      return id != null ? (deltas[id] ?? handScore(input.hands[idx])) : handScore(input.hands[idx]);
+    };
+    return describeHand(input, players, [scoreOf(0), scoreOf(1)]);
+  },
+
+  help: [
+    'Canasta — 4 players in two fixed partnerships (2 players also works, each their own team).',
+    'Melds are 3+ cards of the same rank; a canasta is a meld of 7 or more.',
+    '',
+    'Card points (for melded cards, and for cards left in hand):',
+    '• Jokers 50 · Aces & 2s 20 · Kings–8s 10 · 7s–4s & black 3s 5',
+    '',
+    'Each hand a team scores:',
+    '• +500 per natural (pure) canasta, +300 per mixed canasta (has a wild card).',
+    '• +100 per red three melded — or +800 for collecting all four.',
+    '• +100 for going out, +200 for going out concealed (all cards laid down at once).',
+    '• + the point value of every card melded on the table.',
+    '• − the point value of every card still in hand.',
+    '',
+    "A team's very first meld each hand must clear a minimum, based on their score",
+    'before the hand: below 0 → 15 · 0–1,495 → 50 · 1,500–2,995 → 90 · 3,000+ → 120.',
+    '',
+    'First team past the target score (5000 classic) at the end of a hand wins.',
+  ].join('\n'),
+
+  stats: canastaStats,
+
+  RoundEditor,
+  editorLoader: () => import('./CanastaEditor.svelte'),
+};

--- a/src/lib/games/canasta/logic.ts
+++ b/src/lib/games/canasta/logic.ts
@@ -1,0 +1,204 @@
+import type { ID } from '../../types';
+
+/**
+ * Pure Canasta scoring — no Svelte, no I/O, so it's independently unit-testable and
+ * safe for the stats engine to import.
+ *
+ * Canasta is a fixed-partnership rummy: classically 4 players in two teams of two,
+ * though 2 players (each their own "team") is common too. Score King's shell has no
+ * partnership model of its own (the `teams` flag is only declared), so — exactly like
+ * Euchre — team play lives *inside this module*: every partner on a team receives the
+ * team's hand score, so each partner's running total equals the team score and the
+ * generic scoreboard / leader / winner / target-finish all read as team semantics with
+ * no shell changes.
+ *
+ * Scoring per hand, per team (see help text in ./index.ts for the full published rules):
+ *   + 500 for each natural (pure, no wild cards) canasta
+ *   + 300 for each mixed canasta (at least one wild card)
+ *   + 100 for each red three melded, or 800 if all four are collected
+ *   + 100 for going out this hand, or 200 for going out concealed
+ *   + the point value of every card the team has melded on the table
+ *   − the point value of every card left in the team's hand(s)
+ */
+
+export type TeamIndex = 0 | 1;
+export type Pairing = 'adjacent' | 'across';
+
+/** One team's tally for a single hand. Every field is entered directly by the scorer. */
+export interface CanastaHand {
+  /** Natural (pure) canastas — no wild cards — worth 500 each. */
+  naturalCanastas: number;
+  /** Mixed canastas — at least one wild card — worth 300 each. */
+  mixedCanastas: number;
+  /** Red threes melded this hand (0–4). All four together are worth 800, not 400. */
+  redThrees: number;
+  /** Total point value of every card the team melded on the table this hand. */
+  meldPoints: number;
+  /** Total point value of cards left stranded in the team's hand(s) — subtracted. */
+  handPoints: number;
+  /** This team went out (emptied their hand) and ended the round. */
+  wentOut: boolean;
+  /** Went out concealed — laid down their entire hand in one go. Implies `wentOut`. */
+  concealedOut: boolean;
+}
+
+export interface CanastaInput {
+  /** Resolved partnerships (one or more player ids each), fixed for the whole game. */
+  teams: [ID[], ID[]];
+  /** This hand's tally for each team, indexed the same as `teams`. */
+  hands: [CanastaHand, CanastaHand];
+}
+
+/** A fresh, unscored hand for one team. */
+export function emptyHand(): CanastaHand {
+  return {
+    naturalCanastas: 0,
+    mixedCanastas: 0,
+    redThrees: 0,
+    meldPoints: 0,
+    handPoints: 0,
+    wentOut: false,
+    concealedOut: false,
+  };
+}
+
+/** Split picked players into two partnerships. Two players are simply their own teams. */
+export function resolveTeams<T extends { id: ID }>(players: T[], pairing: Pairing): [ID[], ID[]] {
+  const ids = players.map((p) => p.id);
+  if (ids.length <= 2) return [ids.slice(0, 1), ids.slice(1, 2)];
+  const pick = (...idx: number[]): ID[] => idx.map((i) => ids[i]).filter((x): x is ID => x != null);
+  return pairing === 'across' ? [pick(0, 2), pick(1, 3)] : [pick(0, 1), pick(2, 3)];
+}
+
+/** A safe, non-negative number from possibly-dirty draft input. */
+function nonNeg(n: unknown): number {
+  const v = Number(n);
+  return Number.isFinite(v) && v > 0 ? v : 0;
+}
+
+/** Canasta bonuses: 500 a natural, 300 a mixed. */
+export function canastaBonus(hand: CanastaHand): number {
+  return nonNeg(hand.naturalCanastas) * 500 + nonNeg(hand.mixedCanastas) * 300;
+}
+
+/** Red-three bonus: 100 each, or 800 for the full set of four. */
+export function redThreeBonus(redThrees: number): number {
+  const n = Math.max(0, Math.min(4, Math.round(Number(redThrees) || 0)));
+  return n >= 4 ? 800 : n * 100;
+}
+
+/** Going-out bonus: 100, or 200 if the team went out concealed. */
+export function outBonus(hand: CanastaHand): number {
+  if (!hand.wentOut) return 0;
+  return hand.concealedOut ? 200 : 100;
+}
+
+/** A team's full score for one hand — bonuses plus melded points, minus points left in hand. */
+export function handScore(hand: CanastaHand): number {
+  return (
+    canastaBonus(hand) +
+    redThreeBonus(hand.redThrees) +
+    outBonus(hand) +
+    nonNeg(hand.meldPoints) -
+    nonNeg(hand.handPoints)
+  );
+}
+
+/** Per-player point deltas for a hand: every teammate shares their team's hand score. */
+export function scoreCanasta(input: CanastaInput): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const team of input.teams) for (const id of team) out[id] = 0;
+  const scores: [number, number] = [handScore(input.hands[0]), handScore(input.hands[1])];
+  input.teams.forEach((team, idx) => {
+    for (const id of team) out[id] = scores[idx];
+  });
+  return out;
+}
+
+/** Null when the hand is valid to record, otherwise a human-readable reason. */
+export function validateCanasta(input: CanastaInput): string | null {
+  const flat = input.teams.flat();
+  if (flat.length < 2) return 'Canasta needs at least two players split into two teams.';
+  const outCount = input.hands.filter((h) => h.wentOut).length;
+  if (outCount > 1) return 'Only one team can go out in a hand.';
+  for (const h of input.hands) {
+    if (h.concealedOut && !h.wentOut) return 'Concealed only applies to the team that went out.';
+    if (h.redThrees < 0 || h.redThrees > 4) return 'Red threes must be between 0 and 4.';
+    if (h.naturalCanastas < 0 || h.mixedCanastas < 0) return 'Canasta counts can’t be negative.';
+    if (h.meldPoints < 0) return 'Melded points can’t be negative.';
+    if (h.handPoints < 0) return 'Points left in hand can’t be negative.';
+  }
+  return null;
+}
+
+/**
+ * Short, glanceable summary of a recorded hand for the history table. `scores` are the
+ * points each team actually got this hand (read from stored deltas when available so the
+ * text always matches the recorded score); when omitted they're derived from the input.
+ */
+export function describeHand(
+  input: CanastaInput,
+  players: { id: ID; name: string }[],
+  scores?: [number, number],
+): string {
+  const name = (id: ID): string => players.find((p) => p.id === id)?.name ?? '?';
+  const teamLabel = (idx: TeamIndex): string =>
+    (input.teams[idx] ?? []).map((id) => name(id)).join(' & ') || `Team ${idx + 1}`;
+  const s = scores ?? [handScore(input.hands[0]), handScore(input.hands[1])];
+
+  const outIdx = input.hands.findIndex((h) => h.wentOut) as TeamIndex | -1;
+  if (outIdx === 0 || outIdx === 1) {
+    const other = (outIdx === 0 ? 1 : 0) as TeamIndex;
+    const concealed = input.hands[outIdx].concealedOut;
+    return `${concealed ? '🥷' : '🏁'} ${teamLabel(outIdx)} goes out${
+      concealed ? ' concealed' : ''
+    } — ${s[outIdx]} (${teamLabel(other)} ${s[other]})`;
+  }
+  return `🃏 ${teamLabel(0)} ${s[0]} — ${teamLabel(1)} ${s[1]}`;
+}
+
+// --- race to the target: team totals + who's leading, for the race bar ---
+
+/**
+ * Each team's running score. Both partners mirror the team total (see {@link scoreCanasta}),
+ * so the max across a team's members is the team score and is robust to a missing id.
+ */
+export function teamTotals(teams: [ID[], ID[]], totals: Record<ID, number>): [number, number] {
+  const score = (team: ID[]): number =>
+    team.length ? Math.max(...team.map((id) => totals[id] ?? 0)) : 0;
+  return [score(teams[0] ?? []), score(teams[1] ?? [])];
+}
+
+/** The team in front, or null on a tie (including 0–0). */
+export function leadingTeam(scores: [number, number]): TeamIndex | null {
+  if (scores[0] === scores[1]) return null;
+  return scores[0] > scores[1] ? 0 : 1;
+}
+
+/** Points a team still needs to hit the target (never negative). */
+export function toTarget(score: number, target: number): number {
+  return Math.max(0, target - score);
+}
+
+// --- config coercion (config values arrive as `unknown` from stored game config) ---
+
+export function pairingFromConfig(config: Record<string, unknown>): Pairing {
+  return config.pairing === 'across' ? 'across' : 'adjacent';
+}
+
+export function targetFromConfig(config: Record<string, unknown>): number {
+  const t = Number(config.target);
+  return Number.isFinite(t) && t > 0 ? t : 5000;
+}
+
+/**
+ * The minimum point value a team's very first meld of the game must reach, based on
+ * their cumulative score *before* the hand — the classic sliding scale. Below zero is
+ * the easiest (15); the bar rises as a team's score climbs.
+ */
+export function minimumInitialMeld(scoreBefore: number): number {
+  if (scoreBefore < 0) return 15;
+  if (scoreBefore < 1500) return 50;
+  if (scoreBefore < 3000) return 90;
+  return 120;
+}

--- a/src/lib/games/canasta/stats.ts
+++ b/src/lib/games/canasta/stats.ts
@@ -1,0 +1,141 @@
+import type { ID } from '../../types';
+import type { CanastaInput } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt, fmtPct } from '../../stats/format';
+
+interface CaAgg {
+  /** Hands this player's team played (any recorded hand). */
+  hands: number;
+  /** Natural (pure) canastas built. */
+  naturalCanastas: number;
+  /** Mixed canastas built. */
+  mixedCanastas: number;
+  /** Red threes collected across the game. */
+  redThrees: number;
+  /** Hands where this player's team collected all four red threes. */
+  fullRedThrees: number;
+  /** Hands this player's team went out. */
+  wentOut: number;
+  /** Hands this player's team went out concealed. */
+  concealedOuts: number;
+}
+
+/**
+ * Canasta stats, derived purely from each hand's recorded team tallies. Team events are
+ * credited to every partner, exactly like Euchre's stats — so a canasta or a concealed
+ * out shows up on both members of the team that built it. Pure — no Svelte — so it's
+ * unit-testable and safe for the stats engine to import.
+ */
+export function canastaStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, CaAgg>();
+  const get = (id: ID): CaAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = {
+        hands: 0,
+        naturalCanastas: 0,
+        mixedCanastas: 0,
+        redThrees: 0,
+        fullRedThrees: 0,
+        wentOut: 0,
+        concealedOuts: 0,
+      };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let hands = 0;
+  let totalCanastas = 0;
+  let concealedOuts = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as CanastaInput | undefined;
+    if (!input?.teams || !input.hands) continue;
+
+    hands += 1;
+    input.teams.forEach((team, idx) => {
+      const hand = input.hands[idx];
+      if (!hand) return;
+      const canastas = (Number(hand.naturalCanastas) || 0) + (Number(hand.mixedCanastas) || 0);
+      totalCanastas += canastas;
+      if (hand.concealedOut) concealedOuts += 1;
+
+      for (const pid of team) {
+        const a = get(canonical(pid));
+        a.hands += 1;
+        a.naturalCanastas += Number(hand.naturalCanastas) || 0;
+        a.mixedCanastas += Number(hand.mixedCanastas) || 0;
+        a.redThrees += Math.max(0, Math.min(4, Number(hand.redThrees) || 0));
+        if (Number(hand.redThrees) >= 4) a.fullRedThrees += 1;
+        if (hand.wentOut) a.wentOut += 1;
+        if (hand.concealedOut) a.concealedOuts += 1;
+      }
+    });
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    const totalCa = a.naturalCanastas + a.mixedCanastas;
+    if (totalCa) {
+      metrics.push({
+        key: 'ca_canastas',
+        label: 'Canastas built',
+        value: fmtInt(totalCa),
+        sub: `${a.naturalCanastas} natural · ${a.mixedCanastas} mixed`,
+        emoji: '🃏',
+      });
+    }
+    if (a.redThrees) {
+      metrics.push({
+        key: 'ca_redthrees',
+        label: 'Red threes collected',
+        value: fmtInt(a.redThrees),
+        sub: a.fullRedThrees ? `${a.fullRedThrees} full set` : undefined,
+        emoji: '🔴',
+      });
+    }
+    if (a.wentOut) {
+      metrics.push({
+        key: 'ca_wentout',
+        label: 'Went out',
+        value: fmtInt(a.wentOut),
+        sub: a.hands ? fmtPct(a.wentOut / a.hands) : undefined,
+        emoji: '🏁',
+      });
+    }
+    if (a.concealedOuts) {
+      metrics.push({
+        key: 'ca_concealed',
+        label: 'Concealed outs',
+        value: fmtInt(a.concealedOuts),
+        emoji: '🥷',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (hands) {
+    global.push({
+      key: 'ca_canastas_all',
+      label: 'Canastas built',
+      value: fmtInt(totalCanastas),
+      sub: `${fmtInt(totalCanastas / hands)} avg/hand`,
+      emoji: '🃏',
+    });
+    if (concealedOuts) {
+      global.push({
+        key: 'ca_concealed_all',
+        label: 'Concealed outs',
+        value: fmtInt(concealedOuts),
+        emoji: '🥷',
+      });
+    }
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Adds a new game module — **Canasta** 🃏 — to Score King, following the established
auto-discovered game-module conventions (Euchre's `teams: true` partnership pattern,
lazy-loaded editor chunk).

## Changes

- `src/lib/games/canasta/logic.ts` — pure scoring: natural/mixed canasta bonuses,
  red-three bonuses (100 each, 800 for all four), going-out bonuses (100/200
  concealed), melded/hand card-point totals, team resolution for 2 or 4 players,
  minimum initial-meld thresholds
- `src/lib/games/canasta/index.ts` — `GameModule` wiring (config fields for
  partnerships + target score, help text, lazy `CanastaEditor` chunk)
- `src/lib/games/canasta/stats.ts` — per-player/global canasta, red-three, and
  going-out stats
- `src/lib/games/canasta/CanastaEditor.svelte` — round editor: race-to-target bar,
  per-team steppers for canastas/red threes/points, went-out/concealed toggles
- `src/lib/games/canasta/canasta.test.ts` — unit tests for scoring, validation,
  team resolution, module wiring, and stats

## Issues

Closes #160

## Testing

- [x] `npm test -- src/lib/games/canasta/canasta.test.ts src/lib/games/registry.test.ts` — 48 passed
- [x] `npm run check` — 0 errors