### PR TITLE
feat(ers): add Egyptian Rat Screw game module

### DIFF
--- a/src/lib/games/ers/ErsEditor.svelte
+++ b/src/lib/games/ers/ErsEditor.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+  import type { ID, RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import { haptic } from '../../haptics';
+  import { popIn } from '../../motion';
+  import { handsRemaining, readConfig, type ErsInput } from './logic';
+
+  let { input = $bindable(), ctx }: { input: ErsInput; ctx: RoundContext } = $props();
+
+  const round = $derived(ctx.roundIndex + 1);
+  const cfg = $derived(readConfig(ctx.config));
+
+  function winsBefore(id: ID): number {
+    return Number(ctx.totals[id]) || 0;
+  }
+  // The leader by hands won so far — Crown Gold marks them, and only them.
+  const leaderWins = $derived(Math.max(0, ...ctx.players.map((p) => winsBefore(p.id))));
+  function isLeader(id: ID): boolean {
+    return leaderWins > 0 && winsBefore(id) === leaderWins;
+  }
+
+  function pick(id: ID) {
+    input.winnerId = input.winnerId === id ? null : id;
+    haptic(input.winnerId ? 'win' : 'tick');
+  }
+</script>
+
+<div class="stack ers">
+  <div class="row spread head">
+    <span class="row" style="gap: 8px; flex-wrap: wrap">
+      <span class="pill">Hand {round}</span>
+      {#if cfg.target > 0}
+        <span class="pill">🏆 first to {cfg.target}</span>
+      {/if}
+    </span>
+  </div>
+
+  <span class="fieldlabel">Who took the whole deck?</span>
+  <div class="grid">
+    {#each ctx.players as p (p.id)}
+      {@const wins = winsBefore(p.id)}
+      {@const on = input.winnerId === p.id}
+      {@const togo = handsRemaining(wins, cfg.target)}
+      <button
+        type="button"
+        class="ptile"
+        class:on
+        aria-pressed={on}
+        onclick={() => pick(p.id)}
+      >
+        <span class="row" style="gap: 8px; min-width: 0">
+          <Avatar name={p.name} color={p.color} />
+          <strong class="ellipsis">{p.name}</strong>
+        </span>
+        <span class="row" style="gap: 6px">
+          <span class="wins tabnum" class:leading={isLeader(p.id)}>
+            {#if isLeader(p.id)}<span aria-hidden="true">👑</span>{/if}
+            {wins} {wins === 1 ? 'win' : 'wins'}
+          </span>
+          {#if togo != null}
+            <span class="togo tabnum">{togo} to go</span>
+          {/if}
+        </span>
+        {#if on}<span class="ck" use:popIn aria-hidden="true">🐀</span>{/if}
+      </button>
+    {/each}
+  </div>
+
+  <label class="notefield">
+    <span class="fieldlabel">What sealed it? <span class="muted">(optional)</span></span>
+    <input
+      type="text"
+      class="note-input"
+      autocomplete="off"
+      spellcheck="false"
+      maxlength="80"
+      placeholder="e.g. sandwich on the last flip"
+      bind:value={input.note}
+    />
+  </label>
+</div>
+
+<style>
+  .ers {
+    gap: 12px;
+  }
+  .head {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .fieldlabel {
+    font-weight: 600;
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+  .grid {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .ptile {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 46px;
+    padding: 10px 14px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm, 12px);
+    background: var(--surface-2);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+    text-align: left;
+    transition:
+      background 0.15s ease,
+      border-color 0.15s ease,
+      transform var(--dur-press, 0.09s) ease;
+  }
+  .ptile:hover {
+    background: var(--surface-3);
+  }
+  .ptile:active {
+    transform: scale(0.98);
+  }
+  .ptile:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .ptile.on {
+    background: color-mix(in srgb, var(--primary) 16%, var(--surface-2));
+    border-color: var(--primary);
+  }
+  .ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .tabnum {
+    font-variant-numeric: tabular-nums;
+  }
+  .wins {
+    font-weight: 700;
+    color: var(--muted);
+    white-space: nowrap;
+  }
+  .wins.leading {
+    color: var(--accent-ink, var(--text));
+    font-weight: 800;
+  }
+  .togo {
+    color: var(--muted);
+    font-size: 0.8rem;
+    white-space: nowrap;
+  }
+  .ck {
+    font-size: 1.1rem;
+  }
+
+  .notefield {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .note-input {
+    min-height: 46px;
+    padding: 0 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm, 12px);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+  }
+  .note-input:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ptile {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/games/ers/ers.test.ts
+++ b/src/lib/games/ers/ers.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round, RoundContext } from '../../types';
+import { defaultWinners } from '../../types';
+import { ers } from './index';
+import {
+  ERS_DEFAULTS,
+  createErsInput,
+  describeErs,
+  handsRemaining,
+  isErsFinished,
+  readConfig,
+  scoreErs,
+  validateErs,
+  type ErsInput,
+} from './logic';
+
+// ---- helpers ---------------------------------------------------------------
+
+function player(id: string, name = id): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+
+const A = player('A', 'Ada');
+const B = player('B', 'Bo');
+const C = player('C', 'Cy');
+const players = [A, B, C];
+const ids = players.map((p) => p.id);
+
+function ctx(
+  config: Record<string, unknown> = {},
+  totals: Record<ID, number> = {},
+  roundIndex = 0,
+): RoundContext {
+  return {
+    game: {} as Game,
+    players,
+    config,
+    roundIndex,
+    totals,
+    rounds: [] as Round[],
+  };
+}
+
+function input(partial: Partial<ErsInput> = {}): ErsInput {
+  return { winnerId: null, note: '', ...partial };
+}
+
+// ---- readConfig -------------------------------------------------------------
+
+describe('readConfig', () => {
+  it('defaults to a target of 3', () => {
+    expect(readConfig(undefined)).toEqual(ERS_DEFAULTS);
+    expect(readConfig({})).toEqual({ target: 3 });
+  });
+
+  it('reads and clamps a custom target', () => {
+    expect(readConfig({ target: 5 })).toEqual({ target: 5 });
+    expect(readConfig({ target: -4 })).toEqual({ target: 0 });
+    expect(readConfig({ target: '2.9' })).toEqual({ target: 2 });
+    expect(readConfig({ target: 'garbage' })).toEqual({ target: 0 });
+  });
+});
+
+// ---- createErsInput / validateErs / scoreErs -------------------------------
+
+describe('createErsInput', () => {
+  it('creates an empty, undecided draft', () => {
+    expect(createErsInput()).toEqual({ winnerId: null, note: '' });
+  });
+});
+
+describe('validateErs', () => {
+  it('requires a winner to be picked', () => {
+    expect(validateErs(input(), ids)).toBe('Tap the player who collected the whole deck.');
+  });
+
+  it('rejects a winner who is not seated', () => {
+    expect(validateErs(input({ winnerId: 'ghost' }), ids)).toBe(
+      'The recorded winner is not in this game.',
+    );
+  });
+
+  it('accepts a seated winner', () => {
+    expect(validateErs(input({ winnerId: 'A' }), ids)).toBeNull();
+  });
+});
+
+describe('scoreErs', () => {
+  it('awards the winner a single point and everyone else zero', () => {
+    expect(scoreErs(input({ winnerId: 'B' }), ids)).toEqual({ A: 0, B: 1, C: 0 });
+  });
+
+  it('awards nobody when no winner is recorded', () => {
+    expect(scoreErs(input(), ids)).toEqual({ A: 0, B: 0, C: 0 });
+  });
+});
+
+// ---- isErsFinished / handsRemaining -----------------------------------------
+
+describe('isErsFinished', () => {
+  it('never auto-finishes with no target', () => {
+    expect(isErsFinished({ A: 99 }, { target: 0 })).toBe(false);
+  });
+
+  it('falls back to the default target (3) when config omits it entirely', () => {
+    expect(isErsFinished({ A: 2 }, {})).toBe(false);
+    expect(isErsFinished({ A: 3 }, {})).toBe(true);
+  });
+
+  it('finishes once anyone reaches the target hand-win count', () => {
+    expect(isErsFinished({ A: 2, B: 1 }, { target: 3 })).toBe(false);
+    expect(isErsFinished({ A: 3, B: 1 }, { target: 3 })).toBe(true);
+    expect(isErsFinished({ A: 4, B: 1 }, { target: 3 })).toBe(true);
+  });
+
+  it('never finishes an empty board', () => {
+    expect(isErsFinished({}, { target: 3 })).toBe(false);
+  });
+});
+
+describe('handsRemaining', () => {
+  it('counts down to the target', () => {
+    expect(handsRemaining(1, 3)).toBe(2);
+    expect(handsRemaining(3, 3)).toBeNull();
+    expect(handsRemaining(4, 3)).toBeNull();
+  });
+
+  it('is null with no target', () => {
+    expect(handsRemaining(1, 0)).toBeNull();
+  });
+});
+
+// ---- describeErs -------------------------------------------------------------
+
+describe('describeErs', () => {
+  it('names the winner', () => {
+    expect(describeErs(input({ winnerId: 'A' }), players)).toBe('🐀 Ada took the deck');
+  });
+
+  it('appends an optional note', () => {
+    expect(describeErs(input({ winnerId: 'A', note: 'sandwich!' }), players)).toBe(
+      '🐀 Ada took the deck — sandwich!',
+    );
+  });
+
+  it('falls back to a generic label when undecided', () => {
+    expect(describeErs(input(), players)).toBe('Hand recorded');
+    expect(describeErs(undefined, players)).toBe('Hand recorded');
+  });
+});
+
+// ---- module wiring ----------------------------------------------------------
+
+describe('ers module', () => {
+  it('exposes the expected identity and config fields', () => {
+    expect(ers.id).toBe('ers');
+    expect(ers.minPlayers).toBe(2);
+    expect(ers.maxPlayers).toBe(8);
+    const keys = (ers.configFields ?? []).map((f) => f.key);
+    expect(keys).toEqual(['target']);
+    expect(ers.help).toBeTruthy();
+  });
+
+  it('createRoundInput seeds an empty draft', () => {
+    expect(ers.createRoundInput(ctx())).toEqual({ winnerId: null, note: '' });
+  });
+
+  it('validateRound and scoreRound route through the pure logic', () => {
+    expect(ers.validateRound(input(), ctx())).toBe(
+      'Tap the player who collected the whole deck.',
+    );
+    expect(ers.scoreRound(input({ winnerId: 'C' }), ctx())).toEqual({ A: 0, B: 0, C: 1 });
+  });
+
+  it('isFinished routes through the target config', () => {
+    expect(
+      ers.isFinished?.({ A: 3, B: 1, C: 0 }, { config: { target: 3 }, roundCount: 4, playerCount: 3 }),
+    ).toBe(true);
+    expect(
+      ers.isFinished?.({ A: 2, B: 1, C: 0 }, { config: { target: 3 }, roundCount: 3, playerCount: 3 }),
+    ).toBe(false);
+  });
+
+  it('picks the player with the most hand wins as the winner (default winner logic)', () => {
+    const totals = { A: 1, B: 3, C: 2 };
+    expect(defaultWinners(ers, totals, { target: 3 })).toEqual(['B']);
+  });
+
+  it('describeRound summarises the recorded hand', () => {
+    const round = { input: input({ winnerId: 'B' }) } as unknown as Round;
+    expect(ers.describeRound?.(round, players)).toBe('🐀 Bo took the deck');
+  });
+});

--- a/src/lib/games/ers/index.ts
+++ b/src/lib/games/ers/index.ts
@@ -1,0 +1,86 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { ersStats } from './stats';
+import {
+  createErsInput,
+  describeErs,
+  isErsFinished,
+  scoreErs,
+  validateErs,
+  type ErsInput,
+} from './logic';
+
+export type { ErsInput, ErsConfig } from './logic';
+
+export const ers: GameModule = {
+  id: 'ers',
+  name: 'Egyptian Rat Screw',
+  tagline: 'Slap fast, win the deck',
+  emoji: '🐀',
+  keywords: [
+    'ers',
+    'rat screw',
+    'ratscrew',
+    'slapjack',
+    'slap jack',
+    'cards',
+    'reflexes',
+    'slap',
+  ],
+  minPlayers: 2,
+  maxPlayers: 8,
+  configFields: [
+    {
+      key: 'target',
+      label: 'Hands to take the night',
+      type: 'number',
+      default: 3,
+      min: 0,
+      help: 'First to win this many hands takes the night. 0 = no limit — play until you call it.',
+    },
+  ],
+
+  createRoundInput: (): ErsInput => createErsInput(),
+
+  validateRound: (input: ErsInput, ctx: RoundContext): string | null =>
+    validateErs(input, ctx.players.map((p) => p.id)),
+
+  scoreRound: (input: ErsInput, ctx: RoundContext): Record<ID, number> =>
+    scoreErs(input, ctx.players.map((p) => p.id)),
+
+  isFinished: (totals, { config }) => isErsFinished(totals, config),
+
+  describeRound: (round: Round, players): string =>
+    describeErs(round.input as ErsInput | undefined, players),
+
+  help: [
+    'Egyptian Rat Screw (ERS) 🐀 has no running score — it’s winner-take-all. Deal the whole',
+    'deck out face-down, evenly, no peeking. Players take turns flipping their top card',
+    'face-up onto a shared center pile. This tracker just records who wins each hand; the',
+    'table plays it out and taps the winner when the deck is theirs.',
+    '',
+    'FACE CARD CHALLENGES — playing a face card or Ace forces the next player to answer',
+    'with one of their own within a set number of chances, or the challenger takes the pile:',
+    '• Jack 🃋 — 1 chance',
+    '• Queen 🃍 — 2 chances',
+    '• King 🃎 — 3 chances',
+    '• Ace 🂡 — 4 chances',
+    'Answering with another face card resets the chances for the next player in line.',
+    '',
+    'SLAPS — any player, any time, can slap the pile to claim it on sight of:',
+    '• Doubles — two cards of the same rank in a row (7, 7).',
+    '• Sandwiches — two same-rank cards split by one other (7, 3, 7).',
+    '• Top-bottom — the top card of the pile matches the very bottom card.',
+    'Popular house-rule slaps: Marriage (K + Q together), 10s (two cards adding to 10, Ace = 1),',
+    'and runs of four in a row. Agree on house rules before you deal.',
+    '',
+    'A wrong slap costs a penalty card, usually placed face-up at the bottom of the pile.',
+    'Players who run out of cards stay in and can still slap back in. The hand ends — and',
+    'a winner is recorded — the moment one player holds the entire deck.',
+  ].join('\n'),
+
+  stats: ersStats,
+
+  RoundEditor,
+  editorLoader: () => import('./ErsEditor.svelte'),
+};

--- a/src/lib/games/ers/logic.ts
+++ b/src/lib/games/ers/logic.ts
@@ -1,0 +1,87 @@
+import type { ID } from '../../types';
+
+/**
+ * Pure Egyptian Rat Screw (ERS) tracker logic — no Svelte, no I/O — so it can be exercised
+ * directly by `ers.test.ts` and imported by both `index.ts` and the editor.
+ *
+ * ── Modeling a scoreless, winner-take-all card game inside the point-oriented GameModule ──
+ * ERS has no running point score: a hand is played until one player has slapped and
+ * challenged their way into holding the entire deck. So a *round is a hand*, and the only
+ * thing worth recording is who won it. Each recorded hand awards its winner a single point;
+ * everyone else gets zero. The "scoreboard" the table actually cares about — games won per
+ * player — is exactly that running total, which doubles as a win/match tally. An optional
+ * target ends the night once someone collects enough hands (0 = play until you call it).
+ */
+
+/** The editable draft for a single hand. */
+export interface ErsInput {
+  /** Who won this hand (collected the whole deck). Null while undecided. */
+  winnerId: ID | null;
+  /** Optional flavour: which slap or challenge sealed it ("sandwich!", "4-chance ace"). */
+  note?: string;
+}
+
+/** Normalized, validated config the scorer actually runs on. */
+export interface ErsConfig {
+  /** Hands won needed to take the night (0 = no limit — play until you decide to stop). */
+  target: number;
+}
+
+export const ERS_DEFAULTS: ErsConfig = { target: 3 };
+
+/** Read a raw, possibly-untrusted config bag into a clean {@link ErsConfig}. */
+export function readConfig(config: Record<string, unknown> | undefined): ErsConfig {
+  const c = config ?? {};
+  const target =
+    c.target === undefined ? ERS_DEFAULTS.target : Math.max(0, Math.trunc(Number(c.target)) || 0);
+  return { target };
+}
+
+/** A fresh, empty draft for the next hand. */
+export function createErsInput(): ErsInput {
+  return { winnerId: null, note: '' };
+}
+
+/** Validate a drafted hand. Returns null when valid, else a human-readable message. */
+export function validateErs(input: ErsInput, playerIds: ID[]): string | null {
+  if (!input.winnerId) return 'Tap the player who collected the whole deck.';
+  if (!playerIds.includes(input.winnerId)) {
+    return 'The recorded winner is not in this game.';
+  }
+  return null;
+}
+
+/** Per-player deltas: the hand's winner gets `1`, everyone else `0`. */
+export function scoreErs(input: ErsInput, playerIds: ID[]): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) out[id] = id === input.winnerId ? 1 : 0;
+  return out;
+}
+
+/** The game ends once anyone reaches the target hand-win count (0 = never auto-ends). */
+export function isErsFinished(
+  totals: Record<ID, number>,
+  config: Record<string, unknown> | undefined,
+): boolean {
+  const { target } = readConfig(config);
+  if (target <= 0) return false;
+  return Object.values(totals).some((t) => (Number(t) || 0) >= target);
+}
+
+/** How many more hands a player needs to reach the target. Null with no target or already there. */
+export function handsRemaining(wins: number, target: number): number | null {
+  if (!target || target <= 0) return null;
+  const remaining = target - (Number(wins) || 0);
+  return remaining > 0 ? remaining : null;
+}
+
+/** One-line history summary for a recorded hand. */
+export function describeErs(
+  input: ErsInput | undefined,
+  players: { id: ID; name: string }[],
+): string {
+  if (!input?.winnerId) return 'Hand recorded';
+  const name = players.find((p) => p.id === input.winnerId)?.name ?? 'Someone';
+  const base = `🐀 ${name} took the deck`;
+  return input.note ? `${base} — ${input.note}` : base;
+}

--- a/src/lib/games/ers/stats.ts
+++ b/src/lib/games/ers/stats.ts
@@ -1,0 +1,36 @@
+import type { ID, Round } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import type { ErsInput } from './logic';
+
+/**
+ * Egyptian Rat Screw stats — derived purely from each recorded hand's winner. There is no
+ * running score to aggregate, so the interesting numbers are simply: how many hands were
+ * slapped out, and who's collected the most decks.
+ */
+export function ersStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+
+  const handsWon = new Map<ID, number>();
+  let handsPlayed = 0;
+
+  for (const r of rounds as Round[]) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as ErsInput | undefined;
+    if (!input?.winnerId) continue;
+    handsPlayed += 1;
+    const id = canonical(input.winnerId);
+    handsWon.set(id, (handsWon.get(id) ?? 0) + 1);
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, n] of handsWon) {
+    perPlayer[id] = [{ key: 'ers_hands', label: 'Decks collected', value: `${n}`, emoji: '🐀' }];
+  }
+
+  const global: Metric[] = [];
+  if (handsPlayed) {
+    global.push({ key: 'ers_hands_total', label: 'Hands played', value: `${handsPlayed}`, emoji: '🃏' });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Adds Egyptian Rat Screw (ERS) 🐀 as a new game, modeled as a win/match tracker (like Avalon/Secret Hitler) since ERS has no running point score — players win a hand by collecting the entire deck.

## Changes

- `src/lib/games/ers/logic.ts` — pure scoring/config logic (winner-take-all: each hand's winner gets 1 point, target = hands needed to win the night, 0 = open-ended)
- `src/lib/games/ers/index.ts` — GameModule wiring, help text with researched slap rules (doubles, sandwiches, top-bottom, face-card challenges: J=1/Q=2/K=3/A=4 chances)
- `src/lib/games/ers/ErsEditor.svelte` — one-tap winner selection per hand, optional note, Crown Gold 👑 leader highlight, "N to go" progress
- `src/lib/games/ers/stats.ts` — hands played + decks collected per player
- `src/lib/games/ers/ers.test.ts` — unit tests for scoring/config/finish logic and module wiring
- Auto-discovered via the existing `registry.ts` glob — no registry changes needed

## Issues

Closes #164

## Testing

- [x] `npx vitest run src/lib/games/ers` (23 tests passed)
- [x] `npx vitest run src/lib/games/registry.test.ts` (confirms auto-discovery, 5 tests passed)
- [x] `npm run check` (0 errors, 0 warnings)