### PR TITLE
feat(games): add Azul game module

### DIFF
--- a/src/lib/games/azul/AzulEditor.svelte
+++ b/src/lib/games/azul/AzulEditor.svelte
@@ -1,0 +1,328 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { bumpOnChange } from '../../motion';
+  import { haptic } from '../../haptics';
+  import { azul } from './index';
+  import {
+    MAX_FLOOR_TILES,
+    MAX_LINES,
+    bonusTotal,
+    emptyBonus,
+    emptyEntry,
+    entryDelta,
+    floorPenalty,
+    roundTotal,
+    type AzulBonus,
+    type AzulEntry,
+    type AzulInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: AzulInput; ctx: RoundContext } = $props();
+
+  const entryFor = (id: string): AzulEntry => {
+    if (!input.entries[id]) input.entries[id] = emptyEntry();
+    return input.entries[id];
+  };
+  const bonusFor = (id: string): AzulBonus => {
+    if (!input.bonuses[id]) input.bonuses[id] = emptyBonus();
+    return input.bonuses[id];
+  };
+
+  const previews = $derived(
+    Object.fromEntries(ctx.players.map((p) => [p.id, roundTotal(input, p.id)])),
+  );
+  const projected = $derived(
+    Object.fromEntries(
+      ctx.players.map((p) => [
+        p.id,
+        Math.max(0, (ctx.totals[p.id] ?? 0) + (previews[p.id] ?? 0)),
+      ]),
+    ),
+  );
+
+  let showHelp = $state(false);
+
+  function toggleFinal() {
+    input.final = !input.final;
+    haptic('tick');
+  }
+
+  const dirty = $derived(
+    input.final ||
+      ctx.players.some((p) => {
+        const e = input.entries[p.id];
+        return !!e && (e.scored > 0 || e.floorTiles > 0);
+      }),
+  );
+
+  function clearRound() {
+    for (const p of ctx.players) {
+      input.entries[p.id] = emptyEntry();
+      input.bonuses[p.id] = emptyBonus();
+    }
+    input.final = false;
+    haptic('undo');
+  }
+
+  const signed = (v: number) => (v > 0 ? `+${v}` : v < 0 ? `−${Math.abs(v)}` : '0');
+</script>
+
+<div class="stack">
+  <section class="head-card">
+    <div class="row spread wrap head">
+      <h3 class="ttl">🧱 Round {ctx.roundIndex + 1}</h3>
+      <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+        How to score
+      </button>
+    </div>
+
+    <button type="button" class="final-toggle" class:on={input.final} onclick={toggleFinal}>
+      <span class="fmark" aria-hidden="true">{input.final ? '✓' : '🏁'}</span>
+      <span class="ftext">
+        <strong>Final round</strong>
+        <span class="fsub">Someone completed a horizontal row — count end-game bonuses below</span
+        >
+      </span>
+    </button>
+
+    {#if showHelp}
+      <pre class="help">{azul.help}</pre>
+    {/if}
+  </section>
+
+  {#each ctx.players as p (p.id)}
+    {@const entry = entryFor(p.id)}
+    {@const bonus = bonusFor(p.id)}
+    {@const wall = entryDelta(entry)}
+    <section class="prow">
+      <div class="phead row spread wrap">
+        <span class="who row" style="gap: 8px; align-items: center">
+          <Avatar name={p.name} color={p.color} />
+          <strong class="pname">{p.name}</strong>
+        </span>
+        <span class="proj" use:bumpOnChange={previews[p.id]}
+          >{signed(previews[p.id] ?? 0)}</span
+        >
+      </div>
+
+      <div class="pile">
+        <div class="prow2 row spread wrap">
+          <span class="plabel">🧩 Wall points scored</span>
+          <Stepper bind:value={entry.scored} min={0} max={40} label={`${p.name} wall points`} />
+        </div>
+        <div class="prow2 row spread wrap">
+          <span class="plabel">🕳️ Floor tiles</span>
+          <Stepper
+            bind:value={entry.floorTiles}
+            min={0}
+            max={MAX_FLOOR_TILES}
+            label={`${p.name} floor tiles`}
+          />
+        </div>
+        <p class="tally">
+          {entry.scored} scored − {floorPenalty(entry.floorTiles)} floor —
+          <strong>{signed(wall)}</strong>
+        </p>
+      </div>
+
+      {#if input.final}
+        <div class="pile bonus">
+          <div class="prow2 row spread wrap">
+            <span class="plabel">🏆 End-game bonus</span>
+            <span class="ptotal">+{bonusTotal(bonus)}</span>
+          </div>
+          <div class="counts">
+            <label class="f">
+              <span class="flabel">Complete rows <span class="fhint">×2</span></span>
+              <Stepper
+                bind:value={bonus.rows}
+                min={0}
+                max={MAX_LINES}
+                label={`${p.name} complete rows`}
+              />
+            </label>
+            <label class="f">
+              <span class="flabel">Complete columns <span class="fhint">×7</span></span>
+              <Stepper
+                bind:value={bonus.columns}
+                min={0}
+                max={MAX_LINES}
+                label={`${p.name} complete columns`}
+              />
+            </label>
+            <label class="f">
+              <span class="flabel">Complete colors <span class="fhint">×10</span></span>
+              <Stepper
+                bind:value={bonus.colors}
+                min={0}
+                max={MAX_LINES}
+                label={`${p.name} complete colors`}
+              />
+            </label>
+          </div>
+        </div>
+      {/if}
+
+      <p class="ptotal2">
+        Projected total: <strong use:bumpOnChange={projected[p.id]}>{projected[p.id] ?? 0}</strong>
+      </p>
+    </section>
+  {/each}
+
+  {#if dirty}
+    <div class="row foot">
+      <button type="button" class="btn small ghost" onclick={clearRound}>Clear this round</button>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .head-card {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .head {
+    align-items: center;
+  }
+  .ttl {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+  }
+  /* Marking the final round is a selection, not the primary action — filled,
+     bordered state with an explicit checkmark, never colour alone. */
+  .final-toggle {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 46px;
+    padding: 8px 12px;
+    text-align: left;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+  }
+  .final-toggle.on {
+    border-color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 14%, var(--surface));
+  }
+  .final-toggle:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .fmark {
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+  .ftext {
+    display: flex;
+    flex-direction: column;
+  }
+  .fsub {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .phead {
+    align-items: center;
+  }
+  .pname {
+    font-weight: 700;
+  }
+  .proj {
+    font-weight: 800;
+    font-size: 1.25rem;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+  .pile {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .pile.bonus {
+    border-color: color-mix(in srgb, var(--primary) 45%, var(--border));
+  }
+  .prow2 {
+    align-items: center;
+  }
+  .plabel {
+    font-weight: 700;
+  }
+  .ptotal {
+    font-weight: 800;
+    font-size: 1.1rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .counts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 10px;
+  }
+  .f {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .flabel {
+    font-size: 0.9rem;
+    color: var(--muted);
+  }
+  .fhint {
+    font-size: 0.8rem;
+  }
+  .tally {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .tally strong {
+    color: var(--text);
+  }
+  .ptotal2 {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .ptotal2 strong {
+    color: var(--text);
+  }
+  .foot {
+    justify-content: flex-end;
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+    font-size: 0.9rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/azul/azul.test.ts
+++ b/src/lib/games/azul/azul.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FLOOR_PENALTIES,
+  MAX_FLOOR_TILES,
+  MAX_LINES,
+  bonusTotal,
+  describeRound,
+  emptyBonus,
+  emptyEntry,
+  emptyInput,
+  entryDelta,
+  floorPenalty,
+  roundTotal,
+  scoreRound,
+  validateRound,
+  type AzulInput,
+} from './logic';
+import { azul } from './index';
+
+const players = [
+  { id: 'a', name: 'Ada' },
+  { id: 'b', name: 'Blake' },
+];
+
+const fullPlayers = [
+  { id: 'a', name: 'Ada', color: '#111', createdAt: 0 },
+  { id: 'b', name: 'Blake', color: '#222', createdAt: 0 },
+];
+
+function input(overrides: Partial<AzulInput> = {}): AzulInput {
+  const base = emptyInput(players);
+  return { ...base, ...overrides };
+}
+
+// ── floorPenalty ─────────────────────────────────────────────────────────────
+
+describe('floorPenalty', () => {
+  it('is zero for zero tiles', () => {
+    expect(floorPenalty(0)).toBe(0);
+  });
+
+  it('matches the official track: -1, -1, -2, -2, -2, -3, -3', () => {
+    expect(floorPenalty(1)).toBe(1);
+    expect(floorPenalty(2)).toBe(2);
+    expect(floorPenalty(3)).toBe(4);
+    expect(floorPenalty(4)).toBe(6);
+    expect(floorPenalty(5)).toBe(8);
+    expect(floorPenalty(6)).toBe(11);
+    expect(floorPenalty(7)).toBe(14);
+  });
+
+  it('clamps beyond the 7-tile floor line — an 8th tile costs no more', () => {
+    expect(floorPenalty(8)).toBe(14);
+    expect(floorPenalty(100)).toBe(14);
+  });
+
+  it('treats negative input as zero', () => {
+    expect(floorPenalty(-3)).toBe(0);
+  });
+
+  it('FLOOR_PENALTIES has exactly 7 entries summing to 14', () => {
+    expect(FLOOR_PENALTIES).toHaveLength(7);
+    expect(FLOOR_PENALTIES.reduce((a, b) => a + b, 0)).toBe(14);
+  });
+});
+
+// ── bonusTotal ───────────────────────────────────────────────────────────────
+
+describe('bonusTotal', () => {
+  it('is zero with nothing complete', () => {
+    expect(bonusTotal(emptyBonus())).toBe(0);
+  });
+
+  it('scores +2/row, +7/column, +10/color', () => {
+    expect(bonusTotal({ rows: 1, columns: 0, colors: 0 })).toBe(2);
+    expect(bonusTotal({ rows: 0, columns: 1, colors: 0 })).toBe(7);
+    expect(bonusTotal({ rows: 0, columns: 0, colors: 1 })).toBe(10);
+  });
+
+  it('sums across all three categories', () => {
+    expect(bonusTotal({ rows: 2, columns: 1, colors: 1 })).toBe(2 * 2 + 7 + 10);
+  });
+
+  it('a maxed-out wall (5/5/5) is worth 95', () => {
+    expect(bonusTotal({ rows: 5, columns: 5, colors: 5 })).toBe(5 * 2 + 5 * 7 + 5 * 10);
+  });
+
+  it('clamps each category to MAX_LINES', () => {
+    expect(bonusTotal({ rows: 99, columns: 99, colors: 99 })).toBe(
+      MAX_LINES * 2 + MAX_LINES * 7 + MAX_LINES * 10,
+    );
+  });
+
+  it('treats undefined as zero', () => {
+    expect(bonusTotal(undefined)).toBe(0);
+  });
+});
+
+// ── entryDelta / roundTotal ──────────────────────────────────────────────────
+
+describe('entryDelta', () => {
+  it('is the wall points minus the floor penalty', () => {
+    expect(entryDelta({ scored: 10, floorTiles: 2 })).toBe(8);
+  });
+
+  it('can go negative when the floor line outweighs the wall', () => {
+    expect(entryDelta({ scored: 1, floorTiles: 4 })).toBe(1 - 6);
+  });
+
+  it('treats a missing entry as scoreless', () => {
+    expect(entryDelta(undefined)).toBe(0);
+  });
+});
+
+describe('roundTotal', () => {
+  it('is entryDelta alone on a non-final round', () => {
+    const i = input({
+      entries: { a: { scored: 5, floorTiles: 1 }, b: emptyEntry() },
+    });
+    expect(roundTotal(i, 'a')).toBe(4);
+  });
+
+  it('adds the end-game bonus only when final', () => {
+    const i = input({
+      final: true,
+      entries: { a: { scored: 5, floorTiles: 0 }, b: emptyEntry() },
+      bonuses: { a: { rows: 1, columns: 0, colors: 0 }, b: emptyBonus() },
+    });
+    expect(roundTotal(i, 'a')).toBe(5 + 2);
+  });
+
+  it('ignores bonuses when the round is not final', () => {
+    const i = input({
+      final: false,
+      entries: { a: { scored: 5, floorTiles: 0 }, b: emptyEntry() },
+      bonuses: { a: { rows: 1, columns: 1, colors: 1 }, b: emptyBonus() },
+    });
+    expect(roundTotal(i, 'a')).toBe(5);
+  });
+});
+
+// ── scoreRound ───────────────────────────────────────────────────────────────
+
+describe('scoreRound', () => {
+  it('gives each player their net wall/floor points', () => {
+    const i = input({
+      entries: { a: { scored: 6, floorTiles: 1 }, b: { scored: 3, floorTiles: 0 } },
+    });
+    expect(scoreRound(i, players, { a: 0, b: 0 })).toEqual({ a: 5, b: 3 });
+  });
+
+  it('never drops a running total below zero', () => {
+    const i = input({
+      entries: { a: { scored: 0, floorTiles: 7 }, b: emptyEntry() },
+    });
+    // a has 5 already; a -14 delta would go to -9, so it's clamped to exactly 0.
+    expect(scoreRound(i, players, { a: 5, b: 0 })).toEqual({ a: -5, b: 0 });
+  });
+
+  it('adds the final-round bonus into the delta', () => {
+    const i = input({
+      final: true,
+      entries: { a: { scored: 4, floorTiles: 0 }, b: { scored: 2, floorTiles: 0 } },
+      bonuses: {
+        a: { rows: 2, columns: 1, colors: 0 },
+        b: emptyBonus(),
+      },
+    });
+    expect(scoreRound(i, players, { a: 10, b: 10 })).toEqual({ a: 4 + 4 + 7, b: 2 });
+  });
+
+  it('defaults totals to zero when omitted', () => {
+    const i = input({ entries: { a: { scored: 3, floorTiles: 0 }, b: emptyEntry() } });
+    expect(scoreRound(i, players)).toEqual({ a: 3, b: 0 });
+  });
+});
+
+// ── validateRound ────────────────────────────────────────────────────────────
+
+describe('validateRound', () => {
+  it('accepts a well-formed round', () => {
+    const i = input({
+      entries: { a: { scored: 5, floorTiles: 2 }, b: { scored: 0, floorTiles: 0 } },
+    });
+    expect(validateRound(i, players)).toBeNull();
+  });
+
+  it('rejects a missing entry', () => {
+    const i = input({ entries: { a: { scored: 5, floorTiles: 0 } } as any });
+    expect(validateRound(i, players)).toMatch(/Blake/);
+  });
+
+  it('rejects negative wall points', () => {
+    const i = input({
+      entries: { a: { scored: -1, floorTiles: 0 }, b: emptyEntry() },
+    });
+    expect(validateRound(i, players)).toMatch(/wall points/);
+  });
+
+  it('rejects negative floor tiles', () => {
+    const i = input({
+      entries: { a: { scored: 0, floorTiles: -1 }, b: emptyEntry() },
+    });
+    expect(validateRound(i, players)).toMatch(/floor tiles/);
+  });
+
+  it('rejects more than 7 floor tiles', () => {
+    const i = input({
+      entries: { a: { scored: 0, floorTiles: MAX_FLOOR_TILES + 1 }, b: emptyEntry() },
+    });
+    expect(validateRound(i, players)).toMatch(/floor line only holds/);
+  });
+
+  it('validates bonus fields only on a final round', () => {
+    const notFinal = input({
+      final: false,
+      entries: { a: emptyEntry(), b: emptyEntry() },
+      bonuses: { a: { rows: 99, columns: 0, colors: 0 }, b: emptyBonus() },
+    });
+    expect(validateRound(notFinal, players)).toBeNull();
+
+    const final = input({
+      final: true,
+      entries: { a: emptyEntry(), b: emptyEntry() },
+      bonuses: { a: { rows: 99, columns: 0, colors: 0 }, b: emptyBonus() },
+    });
+    expect(validateRound(final, players)).toMatch(/complete rows/);
+  });
+
+  it('rejects an out-of-range bonus value on a final round', () => {
+    const i = input({
+      final: true,
+      entries: { a: emptyEntry(), b: emptyEntry() },
+      bonuses: { a: { rows: 0, columns: -1, colors: 0 }, b: emptyBonus() },
+    });
+    expect(validateRound(i, players)).toMatch(/complete columns/);
+  });
+});
+
+// ── describeRound ────────────────────────────────────────────────────────────
+
+describe('describeRound', () => {
+  it('reads "not recorded" without input', () => {
+    expect(describeRound(undefined, players)).toBe('Round not recorded');
+  });
+
+  it('summarizes each player\'s delta', () => {
+    const i = input();
+    const text = describeRound(i, players, { a: 5, b: -2 });
+    expect(text).toContain('Ada +5');
+    expect(text).toContain('Blake -2');
+  });
+
+  it('flags the final round', () => {
+    const i = input({ final: true });
+    expect(describeRound(i, players, { a: 0, b: 0 })).toContain('final round');
+  });
+});
+
+// ── module wiring ────────────────────────────────────────────────────────────
+
+describe('azul module', () => {
+  it('exposes the expected identity', () => {
+    expect(azul.id).toBe('azul');
+    expect(azul.minPlayers).toBe(2);
+    expect(azul.maxPlayers).toBe(4);
+  });
+
+  it('createRoundInput seeds an entry and bonus for every player', () => {
+    const ctx = {
+      game: {} as any,
+      players: fullPlayers,
+      config: {},
+      roundIndex: 0,
+      totals: { a: 0, b: 0 },
+      rounds: [],
+    };
+    const created = azul.createRoundInput(ctx) as AzulInput;
+    expect(Object.keys(created.entries).sort()).toEqual(['a', 'b']);
+    expect(Object.keys(created.bonuses).sort()).toEqual(['a', 'b']);
+    expect(created.final).toBe(false);
+  });
+
+  it('wires validateRound and scoreRound through the module', () => {
+    const ctx = {
+      game: {} as any,
+      players: fullPlayers,
+      config: {},
+      roundIndex: 0,
+      totals: { a: 0, b: 0 },
+      rounds: [],
+    };
+    const i = input({ entries: { a: { scored: 4, floorTiles: 1 }, b: emptyEntry() } });
+    expect(azul.validateRound(i, ctx)).toBeNull();
+    expect(azul.scoreRound(i, ctx)).toEqual({ a: 3, b: 0 });
+  });
+});

--- a/src/lib/games/azul/index.ts
+++ b/src/lib/games/azul/index.ts
@@ -1,0 +1,68 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { azulStats } from './stats';
+import {
+  describeRound as describeAzulRound,
+  emptyInput,
+  scoreRound as scoreAzul,
+  validateRound as validateAzul,
+  type AzulInput,
+} from './logic';
+
+export type { AzulBonus, AzulEntry, AzulInput } from './logic';
+
+export const azul: GameModule = {
+  id: 'azul',
+  name: 'Azul',
+  tagline: 'Tile the wall, dodge the floor line, chase the end-game bonus.',
+  emoji: '🧱',
+  keywords: ['tiles', 'wall', 'mosaic', 'tessellate', 'floor line', 'abstract'],
+  minPlayers: 2,
+  maxPlayers: 4,
+
+  createRoundInput: (ctx: RoundContext): AzulInput => emptyInput(ctx.players),
+
+  validateRound: (input: AzulInput, ctx: RoundContext): string | null =>
+    validateAzul(input, ctx.players),
+
+  scoreRound: (input: AzulInput, ctx: RoundContext): Record<ID, number> =>
+    scoreAzul(input, ctx.players, ctx.totals),
+
+  describeRound: (round: Round, players): string =>
+    describeAzulRound(round.input as AzulInput | undefined, players, round.deltas ?? {}),
+
+  // The scorecard flags the final round — the one that closes out the game and
+  // carries everyone's end-game bonus — so it reads apart from ordinary rounds.
+  roundCellTone: (round: Round, playerId: ID) => {
+    const input = round.input as AzulInput | undefined;
+    if (!input?.final || round.deltas?.[playerId] == null) return null;
+    return { tone: 'good', label: 'Final round — end-game bonus counted' };
+  },
+
+  help: [
+    'Azul is a tile-drafting game where every round you tile part of your wall —',
+    'this app just tracks the score, not the drafting itself.',
+    '',
+    'Each round, enter for every player:',
+    '• Wall points scored — a tile placed alone is worth 1; otherwise it scores the',
+    '  length of every contiguous line (horizontal AND vertical) it completes.',
+    '• Floor tiles — how many spilled onto the floor line (0–7). The penalty for',
+    '  each is built in: −1, −1, −2, −2, −2, −3, −3. A score can never drop below',
+    '  zero from floor penalties.',
+    '',
+    '🏁 The game ends the round someone completes a full horizontal row of five.',
+    'Mark that round "Final round" and enter each player\'s end-game bonus:',
+    '• +2 for each complete horizontal row',
+    '• +7 for each complete vertical column',
+    '• +10 for each color with all 5 tiles placed',
+    '',
+    'Highest total wins. A tie is normally broken by whoever completed more',
+    "rows — since this app doesn't track the wall grid, settle that one at the",
+    'table and record it as a shared win here.',
+  ].join('\n'),
+
+  stats: azulStats,
+
+  RoundEditor,
+  editorLoader: () => import('./AzulEditor.svelte'),
+};

--- a/src/lib/games/azul/logic.ts
+++ b/src/lib/games/azul/logic.ts
@@ -1,0 +1,175 @@
+import type { ID } from '../../types';
+
+/**
+ * Pure Azul scoring — no Svelte, no I/O, so it's independently unit-testable and
+ * safe for the stats engine to import.
+ *
+ * This app doesn't model the physical wall grid (five rows × five columns), so a
+ * round is entered the way a table actually plays it: each player reports the
+ * wall points they scored placing tiles this round (a tile placed alone is worth
+ * 1; otherwise it's worth the length of every contiguous line — horizontal *and*
+ * vertical — it completes) and how many tiles spilled onto their floor line.
+ * The game ends the round a player first completes a horizontal row of five, and
+ * that final round also carries each player's end-game bonus tally.
+ */
+
+export interface AzulEntry {
+  /** Wall points scored placing tiles this round (alone = 1; else sum of each contiguous line). */
+  scored: number;
+  /** Tiles that spilled onto the floor line this round, 0–7 (an 8th+ tile costs no more). */
+  floorTiles: number;
+}
+
+/** End-game bonus tally, counted only on the round that ends the game. */
+export interface AzulBonus {
+  /** Complete horizontal rows on the wall — max 5, each worth 2. */
+  rows: number;
+  /** Complete vertical columns — max 5, each worth 7. */
+  columns: number;
+  /** Colors with all 5 tiles placed on the wall — max 5, each worth 10. */
+  colors: number;
+}
+
+export interface AzulInput {
+  /** True on the round that ends the game — someone completed a horizontal row. */
+  final: boolean;
+  entries: Record<ID, AzulEntry>;
+  /** End-game bonuses, keyed by player id. Only meaningful (and shown) when `final`. */
+  bonuses: Record<ID, AzulBonus>;
+}
+
+/**
+ * Floor-line penalty by tile count, left to right on the track: −1, −1, −2, −2,
+ * −2, −3, −3. Listed as positive magnitudes here; callers subtract the total.
+ */
+export const FLOOR_PENALTIES: readonly number[] = [1, 1, 2, 2, 2, 3, 3];
+export const MAX_FLOOR_TILES = FLOOR_PENALTIES.length;
+export const MAX_FLOOR_PENALTY = FLOOR_PENALTIES.reduce((a, b) => a + b, 0);
+
+export const ROW_BONUS = 2;
+export const COLUMN_BONUS = 7;
+export const COLOR_BONUS = 10;
+/** A wall has 5 rows, 5 columns and 5 colors — no more can ever be complete. */
+export const MAX_LINES = 5;
+
+function clampInt(v: unknown, min: number, max: number): number {
+  const n = Math.round(Number(v));
+  if (!Number.isFinite(n)) return min;
+  return Math.min(max, Math.max(min, n));
+}
+
+/** Total floor-line penalty for a given tile count (0 tiles = 0 penalty). */
+export function floorPenalty(tiles: number): number {
+  const n = clampInt(tiles, 0, MAX_FLOOR_TILES);
+  let total = 0;
+  for (let i = 0; i < n; i += 1) total += FLOOR_PENALTIES[i];
+  return total;
+}
+
+export function emptyEntry(): AzulEntry {
+  return { scored: 0, floorTiles: 0 };
+}
+
+export function emptyBonus(): AzulBonus {
+  return { rows: 0, columns: 0, colors: 0 };
+}
+
+export function emptyInput(players: readonly { id: ID }[]): AzulInput {
+  const entries: Record<ID, AzulEntry> = {};
+  const bonuses: Record<ID, AzulBonus> = {};
+  for (const p of players) {
+    entries[p.id] = emptyEntry();
+    bonuses[p.id] = emptyBonus();
+  }
+  return { final: false, entries, bonuses };
+}
+
+/** Points a player's end-game bonus tally is worth. */
+export function bonusTotal(b: AzulBonus | undefined): number {
+  if (!b) return 0;
+  const rows = clampInt(b.rows, 0, MAX_LINES);
+  const columns = clampInt(b.columns, 0, MAX_LINES);
+  const colors = clampInt(b.colors, 0, MAX_LINES);
+  return rows * ROW_BONUS + columns * COLUMN_BONUS + colors * COLOR_BONUS;
+}
+
+/** Net wall/floor points for a single entry, before any end-game bonus. */
+export function entryDelta(entry: AzulEntry | undefined): number {
+  const e = entry ?? emptyEntry();
+  const scored = Math.max(0, Math.round(Number(e.scored)) || 0);
+  return scored - floorPenalty(e.floorTiles);
+}
+
+/** Everything one player takes this round: wall/floor net, plus bonus if final. */
+export function roundTotal(input: AzulInput, playerId: ID): number {
+  const base = entryDelta(input.entries?.[playerId]);
+  const bonus = input.final ? bonusTotal(input.bonuses?.[playerId]) : 0;
+  return base + bonus;
+}
+
+/**
+ * Per-player point deltas for the round. A running score can never drop below
+ * zero from floor penalties, so a delta that would take a player negative is
+ * clamped to bring them exactly to zero.
+ */
+export function scoreRound(
+  input: AzulInput,
+  players: readonly { id: ID }[],
+  totals: Record<ID, number> = {},
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const p of players) {
+    const raw = roundTotal(input, p.id);
+    const before = totals[p.id] ?? 0;
+    out[p.id] = before + raw < 0 ? -before : raw;
+  }
+  return out;
+}
+
+/** Null when the round is good to record, otherwise a friendly reason. */
+export function validateRound(
+  input: AzulInput,
+  players: readonly { id: ID; name: string }[],
+): string | null {
+  for (const p of players) {
+    const e = input.entries?.[p.id];
+    if (!e) return `${p.name} is missing a round entry.`;
+    if (!Number.isFinite(Number(e.scored)) || Number(e.scored) < 0) {
+      return `${p.name}: wall points can't be negative.`;
+    }
+    if (!Number.isFinite(Number(e.floorTiles)) || Number(e.floorTiles) < 0) {
+      return `${p.name}: floor tiles can't be negative.`;
+    }
+    if (Number(e.floorTiles) > MAX_FLOOR_TILES) {
+      return `${p.name}: the floor line only holds ${MAX_FLOOR_TILES} tiles.`;
+    }
+    if (input.final) {
+      const b = input.bonuses?.[p.id] ?? emptyBonus();
+      for (const [label, v] of [
+        ['rows', b.rows],
+        ['columns', b.columns],
+        ['colors', b.colors],
+      ] as const) {
+        if (!Number.isFinite(Number(v)) || Number(v) < 0 || Number(v) > MAX_LINES) {
+          return `${p.name}: complete ${label} must be 0–${MAX_LINES}.`;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/** Short, glanceable summary of a recorded round for the history table. */
+export function describeRound(
+  input: AzulInput | undefined,
+  players: readonly { id: ID; name: string }[],
+  deltas: Record<ID, number> = {},
+): string {
+  if (!input) return 'Round not recorded';
+  const parts = players.map((p) => {
+    const d = deltas[p.id] ?? 0;
+    return `${p.name} ${d >= 0 ? '+' : ''}${d}`;
+  });
+  const tag = input.final ? '🏆 final round — ' : '';
+  return `🧱 ${tag}${parts.join(' · ')}`;
+}

--- a/src/lib/games/azul/stats.ts
+++ b/src/lib/games/azul/stats.ts
@@ -1,0 +1,156 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg, fmtInt } from '../../stats/format';
+import { bonusTotal, entryDelta, type AzulInput } from './logic';
+
+interface AzulAgg {
+  rounds: number;
+  wallPoints: number;
+  bestWallRound: number;
+  floorTiles: number;
+  floorPenalty: number;
+  cleanRounds: number; // rounds with zero floor tiles
+  finalRounds: number; // rounds this player ended the game in
+  bonusPoints: number;
+  bestBonus: number;
+}
+
+function blank(): AzulAgg {
+  return {
+    rounds: 0,
+    wallPoints: 0,
+    bestWallRound: 0,
+    floorTiles: 0,
+    floorPenalty: 0,
+    cleanRounds: 0,
+    finalRounds: 0,
+    bonusPoints: 0,
+    bestBonus: 0,
+  };
+}
+
+/**
+ * Azul stats, replayed purely from each game's recorded rounds. No Svelte, no I/O.
+ */
+export function azulStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const per = new Map<ID, AzulAgg>();
+  const get = (id: ID): AzulAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = blank();
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let bestWallAnywhere = 0;
+  let bestBonusAnywhere = 0;
+
+  const gameIds = new Set(games.map((g) => g.id));
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as AzulInput | undefined;
+    if (!input?.entries) continue;
+
+    for (const [pid, entry] of Object.entries(input.entries)) {
+      const a = get(canonical(pid));
+      a.rounds += 1;
+      const wall = Math.max(0, Math.round(Number(entry.scored)) || 0);
+      const tiles = Math.max(0, Math.round(Number(entry.floorTiles)) || 0);
+      a.wallPoints += wall;
+      if (wall > a.bestWallRound) a.bestWallRound = wall;
+      if (wall > bestWallAnywhere) bestWallAnywhere = wall;
+      a.floorTiles += tiles;
+      a.floorPenalty += entryDelta(entry) - wall; // negative or zero
+      if (tiles === 0) a.cleanRounds += 1;
+
+      if (input.final) {
+        a.finalRounds += 1;
+        const bonus = bonusTotal(input.bonuses?.[pid]);
+        a.bonusPoints += bonus;
+        if (bonus > a.bestBonus) a.bestBonus = bonus;
+        if (bonus > bestBonusAnywhere) bestBonusAnywhere = bonus;
+      }
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let allRounds = 0;
+  let allWallPoints = 0;
+
+  for (const [id, a] of per) {
+    allRounds += a.rounds;
+    allWallPoints += a.wallPoints;
+
+    const metrics: Metric[] = [];
+    if (a.rounds) {
+      metrics.push({
+        key: 'az_best_wall',
+        label: 'Best round on the wall',
+        value: fmtInt(a.bestWallRound),
+        emoji: '🧱',
+      });
+      metrics.push({
+        key: 'az_avg_wall',
+        label: 'Avg wall points / round',
+        value: fmtAvg(a.wallPoints / a.rounds),
+        emoji: '🔢',
+      });
+    }
+    if (a.cleanRounds) {
+      metrics.push({
+        key: 'az_clean',
+        label: 'Clean rounds — no floor tiles',
+        value: fmtInt(a.cleanRounds),
+        emoji: '✨',
+      });
+    }
+    if (a.floorPenalty) {
+      metrics.push({
+        key: 'az_floor',
+        label: 'Points lost to the floor line',
+        value: fmtInt(Math.abs(a.floorPenalty)),
+        sub: `${fmtInt(a.floorTiles)} tile${a.floorTiles === 1 ? '' : 's'} total`,
+        emoji: '🕳️',
+      });
+    }
+    if (a.finalRounds) {
+      metrics.push({
+        key: 'az_bonus',
+        label: 'End-game bonus scored',
+        value: fmtInt(a.bonusPoints),
+        sub: a.bestBonus ? `best ${fmtInt(a.bestBonus)}` : undefined,
+        emoji: '🏁',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (bestWallAnywhere) {
+    global.push({
+      key: 'az_best_wall_all',
+      label: 'Best wall round',
+      value: fmtInt(bestWallAnywhere),
+      emoji: '🧱',
+    });
+  }
+  if (allRounds) {
+    global.push({
+      key: 'az_avg_wall_all',
+      label: 'Avg wall points / round',
+      value: fmtAvg(allWallPoints / allRounds),
+      emoji: '🔢',
+    });
+  }
+  if (bestBonusAnywhere) {
+    global.push({
+      key: 'az_best_bonus_all',
+      label: 'Best end-game bonus',
+      value: fmtInt(bestBonusAnywhere),
+      emoji: '🏁',
+    });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Adds a new game module for **Azul** 🧱 following the existing `src/lib/games/<id>/`
auto-discovery conventions.

## Changes

- `logic.ts` — pure scoring: wall points minus floor-line penalty
  (−1, −1, −2, −2, −2, −3, −3, capped at 7 tiles), end-game bonuses
  (+2/complete row, +7/complete column, +10/complete color), and the official
  "a running score never drops below zero" clamp.
- `AzulEditor.svelte` — per-round editor with a "final round" toggle that reveals
  each player's end-game bonus tally (this app doesn't model the physical wall
  grid, so wall points and bonuses are entered the way a table actually plays it).
- `stats.ts` — game-specific stats hook (best wall round, clean rounds, floor-line
  losses, end-game bonus scored).
- `index.ts` — module wiring with lazy `editorLoader`, matching the cribbage/hearts
  pattern.
- `azul.test.ts` — 34 unit tests covering floor penalties, bonus scoring, the
  score-floor clamp, validation, and module wiring.

Ties (which real Azul breaks by counting completed rows) aren't auto-resolved
since this app doesn't track the wall grid; documented in the in-app help as a
manual table call, recorded here as a shared win.

## Issues

Closes #165

## Testing

- [x] `npm test` — azul (34) + registry (5) suites pass
- [x] `npm run check` — 0 errors, 0 warnings