### PR TITLE
feat(ginrummy): add Gin Rummy game module (#169)

### DIFF
--- a/src/lib/games/ginrummy/GinRummyEditor.svelte
+++ b/src/lib/games/ginrummy/GinRummyEditor.svelte
@@ -1,0 +1,408 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { bumpOnChange } from '../../motion';
+  import { haptic } from '../../haptics';
+  import { ginRummy } from './index';
+  import {
+    boxCounts,
+    opponentOf,
+    readConfig,
+    scoreHand,
+    scoreRound,
+    type GinRummyInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: GinRummyInput; ctx: RoundContext } = $props();
+
+  const cfg = $derived(readConfig(ctx.config));
+  const byId = $derived(new Map(ctx.players.map((p) => [p.id, p])));
+  const opponentId = $derived(opponentOf(ctx.players, input.knockerId ?? null));
+
+  const hand = $derived(scoreHand(input, ctx.players, ctx.config));
+  const priorRounds = $derived(
+    ctx.rounds.filter((r) => r.index < ctx.roundIndex).sort((a, b) => a.index - b.index),
+  );
+  const deltas = $derived(scoreRound(input, ctx.players, ctx.config, ctx.totals, priorRounds));
+  const boxes = $derived(boxCounts(priorRounds, ctx.players, ctx.config));
+
+  const rawTotals = $derived(
+    Object.fromEntries(
+      ctx.players.map((p) => [p.id, (ctx.totals[p.id] ?? 0) + (hand?.deltas[p.id] ?? 0)]),
+    ),
+  );
+  /** Whether recording this hand ends the whole game (crosses the target). */
+  const gameEnds = $derived(cfg.target > 0 && Object.values(rawTotals).some((t) => t >= cfg.target));
+  const settlementAdded = $derived(
+    gameEnds
+      ? Object.fromEntries(
+          ctx.players.map((p) => [p.id, (deltas[p.id] ?? 0) - (hand?.deltas[p.id] ?? 0)]),
+        )
+      : null,
+  );
+
+  let showHelp = $state(false);
+
+  function setKnocker(id: string) {
+    if (input.knockerId === id) return;
+    input.knockerId = id;
+    haptic('tick');
+  }
+
+  function toggleGin() {
+    input.gin = !input.gin;
+    if (input.gin && input.knockerId) input.deadwood[input.knockerId] = 0;
+    haptic('tick');
+  }
+
+  const dirty = $derived(
+    !!input.knockerId || Object.values(input.deadwood ?? {}).some((v) => (v ?? 0) > 0),
+  );
+
+  function clearHand() {
+    input.knockerId = null;
+    input.gin = false;
+    for (const p of ctx.players) input.deadwood[p.id] = 0;
+    haptic('undo');
+  }
+
+  /** A player's total boxes (hands won) through and including this hand. */
+  function boxesFor(id: string): number {
+    return (boxes[id] ?? 0) + ((hand?.deltas[id] ?? 0) > 0 ? 1 : 0);
+  }
+
+  const outcomeLabel = $derived.by(() => {
+    if (!hand) return null;
+    if (hand.outcome === 'gin') return { emoji: '💅', text: 'Gin!' };
+    if (hand.outcome === 'knock') return { emoji: '🚪', text: 'Knocked' };
+    return { emoji: '🔁', text: 'Undercut!' };
+  });
+</script>
+
+<div class="stack">
+  <section class="deal">
+    <div class="row spread wrap head">
+      <h3 class="ttl">🍸 Hand {ctx.roundIndex + 1} — who knocked?</h3>
+      <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+        How to score
+      </button>
+    </div>
+
+    <div class="knockers" role="radiogroup" aria-label="Who knocked or went gin">
+      {#each ctx.players as p (p.id)}
+        {@const on = input.knockerId === p.id}
+        <button
+          type="button"
+          role="radio"
+          aria-checked={on}
+          class="knocker"
+          class:on
+          onclick={() => setKnocker(p.id)}
+        >
+          <Avatar name={p.name} color={p.color} />
+          <span class="kname">{p.name}</span>
+          {#if on}<span class="badge">knocked</span>{/if}
+        </button>
+      {/each}
+    </div>
+
+    <button
+      type="button"
+      class="gin"
+      class:on={input.gin}
+      disabled={!input.knockerId}
+      onclick={toggleGin}
+    >
+      <span class="gmark" aria-hidden="true">{input.gin ? '✓' : '💅'}</span>
+      <span class="gtext">
+        <strong>Went gin</strong>
+        <span class="gsub">Zero deadwood — no lay-offs, +{cfg.ginBonus} bonus</span>
+      </span>
+    </button>
+
+    {#if showHelp}
+      <pre class="help">{ginRummy.help}</pre>
+    {/if}
+  </section>
+
+  {#if input.knockerId}
+    <section class="deadwood">
+      <h4 class="dttl">Deadwood</h4>
+      <div class="dgrid">
+        {#each ctx.players as p (p.id)}
+          {@const isKnocker = p.id === input.knockerId}
+          {@const forcedZero = isKnocker && input.gin}
+          <div class="drow">
+            <span class="dwho row wrap">
+              <Avatar name={p.name} color={p.color} />
+              <span>{p.name}</span>
+            </span>
+            {#if forcedZero}
+              <span class="dzero">0 — gin</span>
+            {:else}
+              <Stepper
+                bind:value={input.deadwood[p.id]}
+                min={0}
+                max={100}
+                label={`${p.name} deadwood`}
+              />
+            {/if}
+          </div>
+        {/each}
+      </div>
+      {#if !input.gin}
+        <p class="hint">
+          Knocking is only legal with {cfg.maxKnockDeadwood} or fewer deadwood — mark Gin instead
+          if {byId.get(input.knockerId)?.name ?? 'the knocker'} melded everything.
+        </p>
+      {/if}
+    </section>
+  {/if}
+
+  {#if hand && outcomeLabel}
+    <section class="result" class:gin={hand.outcome === 'gin'} class:cut={hand.outcome === 'undercut'}>
+      <p class="rline" use:bumpOnChange={hand.margin}>
+        <span aria-hidden="true">{outcomeLabel.emoji}</span>
+        <strong>{outcomeLabel.text}</strong>
+        {#if hand.outcome === 'undercut'}
+          {byId.get(opponentId ?? '')?.name ?? 'Opponent'} takes the hand — +{hand.margin}
+        {:else}
+          {byId.get(hand.knockerId)?.name ?? 'Knocker'} scores +{hand.margin}
+        {/if}
+      </p>
+      {#if gameEnds && settlementAdded}
+        <p class="settle">
+          🏆 That's the game! Settlement bonuses land now:
+          {#each ctx.players as p (p.id)}
+            {@const added = settlementAdded[p.id] ?? 0}
+            {#if added > 0}
+              <span class="sitem"
+                >{p.name} +{added} ({boxesFor(p.id)} box{boxesFor(p.id) === 1 ? '' : 'es'})</span
+              >
+            {/if}
+          {/each}
+        </p>
+      {/if}
+      <p class="totals">
+        {#each ctx.players as p (p.id)}
+          <span class="tline">
+            {p.name}: {ctx.totals[p.id] ?? 0} → <strong>{(ctx.totals[p.id] ?? 0) + (deltas[p.id] ?? 0)}</strong>
+          </span>
+        {/each}
+      </p>
+    </section>
+  {/if}
+
+  {#if dirty}
+    <div class="row foot">
+      <button type="button" class="btn small ghost" onclick={clearHand}>Clear this hand</button>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .deal {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .head {
+    align-items: center;
+  }
+  .ttl {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+  }
+  .knockers {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .knocker {
+    flex: 1 1 140px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 8px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background var(--dur-base) var(--ease-standard);
+  }
+  .knocker:hover {
+    background: var(--surface-3);
+  }
+  .knocker.on {
+    background: var(--surface-3);
+    border-color: var(--primary);
+    box-shadow: inset 3px 0 0 var(--primary);
+  }
+  .knocker:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .kname {
+    flex: 1;
+    text-align: left;
+  }
+  .badge {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 3px 8px;
+    border-radius: 999px;
+    background: var(--primary);
+    color: #fff;
+  }
+  .gin {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 46px;
+    padding: 8px 12px;
+    text-align: left;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+  }
+  .gin:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .gin.on {
+    border-color: var(--good);
+    background: color-mix(in srgb, var(--good) 12%, var(--surface));
+  }
+  .gin:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .gmark {
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+  .gtext {
+    display: flex;
+    flex-direction: column;
+  }
+  .gsub {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .deadwood {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .dttl {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 700;
+  }
+  .dgrid {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .drow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 10px;
+  }
+  .dwho {
+    gap: 8px;
+    align-items: center;
+    font-weight: 600;
+  }
+  .dzero {
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--good);
+  }
+  .hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  .result {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .result.gin {
+    border-color: color-mix(in srgb, var(--good) 45%, var(--border));
+  }
+  .result.cut {
+    border-color: color-mix(in srgb, var(--warn) 45%, var(--border));
+  }
+  .rline {
+    margin: 0;
+    font-size: 0.95rem;
+  }
+  .settle {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .sitem {
+    font-weight: 600;
+    color: var(--text);
+  }
+  .totals {
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 0.9rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--muted);
+  }
+  .totals strong {
+    color: var(--text);
+  }
+  .foot {
+    justify-content: flex-end;
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+    font-size: 0.9rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/ginrummy/ginrummy.test.ts
+++ b/src/lib/games/ginrummy/ginrummy.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest';
+import type { ID, Round, RoundContext } from '../../types';
+import { defaultWinners } from '../../types';
+import { ginRummy } from './index';
+import { ginRummyStats } from './stats';
+import {
+  DEFAULT_CONFIG,
+  boxCounts,
+  describeHand,
+  isFinished,
+  opponentOf,
+  readConfig,
+  scoreHand,
+  scoreRound,
+  validateRound,
+  type GinRummyInput,
+} from './logic';
+
+const players = [
+  { id: 'a', name: 'Ada', color: '#111', createdAt: 0 },
+  { id: 'b', name: 'Bo', color: '#222', createdAt: 0 },
+];
+
+function mk(partial: Partial<GinRummyInput> = {}): GinRummyInput {
+  return { knockerId: null, gin: false, deadwood: { a: 0, b: 0 }, ...partial };
+}
+
+function round(index: number, input: GinRummyInput, deltas: Record<ID, number>): Round {
+  return { id: `r${index}`, gameId: 'g1', index, input, deltas, createdAt: 0 };
+}
+
+describe('readConfig', () => {
+  it('falls back to defaults for missing/garbage values', () => {
+    expect(readConfig({})).toEqual(DEFAULT_CONFIG);
+    expect(readConfig({ target: -5, ginBonus: 'nope' })).toEqual(DEFAULT_CONFIG);
+  });
+
+  it('reads valid overrides', () => {
+    expect(readConfig({ target: 200, shutoutDoubling: false })).toMatchObject({
+      target: 200,
+      shutoutDoubling: false,
+    });
+  });
+});
+
+describe('opponentOf', () => {
+  it('returns the other seat', () => {
+    expect(opponentOf(players, 'a')).toBe('b');
+    expect(opponentOf(players, 'b')).toBe('a');
+  });
+  it('returns null for a null or unknown id', () => {
+    expect(opponentOf(players, null)).toBeNull();
+    expect(opponentOf(players, 'z')).toBeNull();
+  });
+});
+
+describe('scoreHand', () => {
+  it('returns null while no one has knocked', () => {
+    expect(scoreHand(mk(), players, {})).toBeNull();
+  });
+
+  it('scores a plain knock as the deadwood difference', () => {
+    const hand = scoreHand(mk({ knockerId: 'a', deadwood: { a: 4, b: 15 } }), players, {});
+    expect(hand).toMatchObject({ outcome: 'knock', margin: 11, deltas: { a: 11, b: 0 } });
+  });
+
+  it('scores gin as opponent deadwood plus the gin bonus', () => {
+    const hand = scoreHand(mk({ knockerId: 'a', gin: true, deadwood: { a: 0, b: 18 } }), players, {});
+    expect(hand).toMatchObject({ outcome: 'gin', margin: 18 + 25, deltas: { a: 43, b: 0 } });
+  });
+
+  it('ignores a nonzero knocker deadwood entry when gin is marked', () => {
+    const hand = scoreHand(mk({ knockerId: 'a', gin: true, deadwood: { a: 7, b: 18 } }), players, {});
+    expect(hand?.knockerDeadwood).toBe(0);
+    expect(hand?.margin).toBe(18 + 25);
+  });
+
+  it('flips to an undercut when the opponent matches the knocker exactly', () => {
+    const hand = scoreHand(mk({ knockerId: 'a', deadwood: { a: 8, b: 8 } }), players, {});
+    expect(hand).toMatchObject({ outcome: 'undercut', margin: 20, deltas: { a: 0, b: 20 } });
+  });
+
+  it('flips to an undercut when the opponent beats the knocker', () => {
+    const hand = scoreHand(mk({ knockerId: 'a', deadwood: { a: 9, b: 3 } }), players, {});
+    expect(hand).toMatchObject({ outcome: 'undercut', margin: 9 - 3 + 20, deltas: { a: 0, b: 26 } });
+  });
+
+  it('honors custom gin/undercut bonuses from config', () => {
+    const gin = scoreHand(
+      mk({ knockerId: 'a', gin: true, deadwood: { a: 0, b: 10 } }),
+      players,
+      { ginBonus: 40 },
+    );
+    expect(gin?.margin).toBe(50);
+
+    const cut = scoreHand(mk({ knockerId: 'a', deadwood: { a: 5, b: 5 } }), players, {
+      undercutBonus: 5,
+    });
+    expect(cut?.margin).toBe(5);
+  });
+});
+
+describe('validateRound', () => {
+  it('requires exactly two players', () => {
+    expect(validateRound(mk({ knockerId: 'a' }), [players[0]], {})).toMatch(/two-handed/);
+  });
+
+  it('requires a knocker', () => {
+    expect(validateRound(mk(), players, {})).toMatch(/knocked/);
+  });
+
+  it('rejects negative deadwood', () => {
+    expect(
+      validateRound(mk({ knockerId: 'a', deadwood: { a: -1, b: 4 } }), players, {}),
+    ).toMatch(/negative/);
+  });
+
+  it('rejects a knock with too much deadwood', () => {
+    expect(
+      validateRound(mk({ knockerId: 'a', deadwood: { a: 15, b: 20 } }), players, {}),
+    ).toMatch(/too much to knock/);
+  });
+
+  it('allows any knocker deadwood when gin is marked', () => {
+    expect(
+      validateRound(mk({ knockerId: 'a', gin: true, deadwood: { a: 0, b: 20 } }), players, {}),
+    ).toBeNull();
+  });
+
+  it('accepts a legal knock', () => {
+    expect(
+      validateRound(mk({ knockerId: 'a', deadwood: { a: 10, b: 20 } }), players, {}),
+    ).toBeNull();
+  });
+
+  it('honors a custom knock ceiling', () => {
+    expect(
+      validateRound(mk({ knockerId: 'a', deadwood: { a: 12, b: 20 } }), players, {
+        maxKnockDeadwood: 15,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('scoreRound — mid-game (no settlement)', () => {
+  it('returns the raw hand deltas when nobody has reached the target', () => {
+    const input = mk({ knockerId: 'a', deadwood: { a: 4, b: 15 } });
+    const deltas = scoreRound(input, players, {}, { a: 0, b: 0 }, []);
+    expect(deltas).toEqual({ a: 11, b: 0 });
+  });
+});
+
+describe('scoreRound — settlement at game end', () => {
+  it('adds the game bonus and line bonuses once the target is crossed', () => {
+    const prior: Round[] = [
+      round(0, mk({ knockerId: 'a', deadwood: { a: 2, b: 20 } }), { a: 18, b: 0 }), // a wins box 1
+      round(1, mk({ knockerId: 'b', deadwood: { b: 3, a: 25 } }), { a: 0, b: 22 }), // b wins box 1
+    ];
+    // a is at 18, b is at 22 going into this hand. a goes gin for 18+25=43,
+    // pushing a to 61 — short of the default target (100), so no settlement yet.
+    const midInput = mk({ knockerId: 'a', gin: true, deadwood: { a: 0, b: 18 } });
+    const mid = scoreRound(midInput, players, {}, { a: 18, b: 22 }, prior);
+    expect(mid).toEqual({ a: 43, b: 0 });
+
+    // Now a knocks big enough to cross 100 from 61: deadwood gap of 40+ does it.
+    const finishing = round(2, midInput, mid);
+    const finalInput = mk({ knockerId: 'a', deadwood: { a: 0, b: 45 } });
+    const final = scoreRound(finalInput, players, {}, { a: 61, b: 22 }, [...prior, finishing]);
+
+    // Raw hand margin: 45. a now has 2 prior boxes + this hand = 3 boxes * 25 = 75.
+    // b has 1 prior box * 25 = 25. a also gets the +100 game bonus (no shutout,
+    // b has non-zero raw total).
+    expect(final.a).toBe(45 + 75 + 100);
+    expect(final.b).toBe(25);
+  });
+
+  it('doubles the game bonus on a shutout (loser scored zero)', () => {
+    // b never scores a single hand-point; a gins for exactly the target.
+    const input = mk({ knockerId: 'a', gin: true, deadwood: { a: 0, b: 75 } });
+    const deltas = scoreRound(input, players, {}, { a: 0, b: 0 }, []);
+    // margin = 75 + 25 = 100, hits the target in one hand. b's raw total is 0 → shutout.
+    expect(deltas.a).toBe(100 + 25 /* one box */ + 200 /* doubled game bonus */);
+    expect(deltas.b).toBe(0);
+  });
+
+  it('does not double the bonus when shutoutDoubling is disabled', () => {
+    const input = mk({ knockerId: 'a', gin: true, deadwood: { a: 0, b: 75 } });
+    const deltas = scoreRound(input, players, { shutoutDoubling: false }, { a: 0, b: 0 }, []);
+    expect(deltas.a).toBe(100 + 25 + 100);
+  });
+});
+
+describe('boxCounts', () => {
+  it('replays winners from stored inputs, ignoring bonus-laden deltas', () => {
+    const rounds: Round[] = [
+      round(0, mk({ knockerId: 'a', deadwood: { a: 2, b: 20 } }), { a: 18, b: 0 }),
+      round(1, mk({ knockerId: 'b', deadwood: { b: 3, a: 25 } }), { a: 0, b: 22 }),
+      // A settlement-laden hand where b's stored delta (line bonus for prior
+      // boxes) happens to exceed a's raw hand delta — boxCounts must still
+      // credit the hand to whoever actually won it (a, via gin).
+      round(2, mk({ knockerId: 'a', gin: true, deadwood: { a: 0, b: 10 } }), { a: 5, b: 999 }),
+    ];
+    expect(boxCounts(rounds, players, {})).toEqual({ a: 2, b: 1 });
+  });
+});
+
+describe('isFinished', () => {
+  it('is true once any total reaches the target', () => {
+    expect(isFinished({ a: 99, b: 0 }, {})).toBe(false);
+    expect(isFinished({ a: 100, b: 0 }, {})).toBe(true);
+  });
+});
+
+describe('describeHand', () => {
+  it('describes gin, knock and undercut hands', () => {
+    expect(
+      describeHand(mk({ knockerId: 'a', gin: true }), players, { a: 43, b: 0 }),
+    ).toMatch(/gin/i);
+    expect(
+      describeHand(mk({ knockerId: 'a', deadwood: { a: 2, b: 10 } }), players, { a: 8, b: 0 }),
+    ).toMatch(/knocked/i);
+    expect(
+      describeHand(mk({ knockerId: 'a', deadwood: { a: 8, b: 2 } }), players, { a: 0, b: 26 }),
+    ).toMatch(/undercut/i);
+    expect(describeHand(undefined, players)).toMatch(/not recorded/i);
+  });
+});
+
+describe('ginRummy module', () => {
+  function ctx(config: Record<string, unknown> = {}, overrides: Partial<RoundContext> = {}) {
+    return {
+      game: { id: 'g1', type: 'ginrummy', config, playerIds: ['a', 'b'], status: 'active' },
+      players,
+      config,
+      roundIndex: 0,
+      totals: { a: 0, b: 0 },
+      rounds: [],
+      ...overrides,
+    } as unknown as RoundContext;
+  }
+
+  it('creates an empty input for both seats', () => {
+    const input = ginRummy.createRoundInput(ctx()) as GinRummyInput;
+    expect(input.knockerId).toBeNull();
+    expect(input.deadwood).toEqual({ a: 0, b: 0 });
+  });
+
+  it('validates and scores a hand end to end', () => {
+    const input: GinRummyInput = { knockerId: 'a', gin: false, deadwood: { a: 3, b: 20 } };
+    expect(ginRummy.validateRound(input, ctx())).toBeNull();
+    expect(ginRummy.scoreRound(input, ctx())).toEqual({ a: 17, b: 0 });
+  });
+
+  it('rejects a game with more than two players', () => {
+    const threePlayers = [...players, { id: 'c', name: 'Cy', color: '#333', createdAt: 0 }];
+    const input: GinRummyInput = { knockerId: 'a', gin: false, deadwood: { a: 3, b: 20 } };
+    expect(
+      ginRummy.validateRound(input, ctx({}, { players: threePlayers } as Partial<RoundContext>)),
+    ).toMatch(/two-handed/);
+  });
+
+  it('reports finished once a total reaches the target', () => {
+    expect(ginRummy.isFinished?.({ a: 100, b: 0 }, { config: {}, roundCount: 1, playerCount: 2 })).toBe(
+      true,
+    );
+    expect(ginRummy.isFinished?.({ a: 40, b: 0 }, { config: {}, roundCount: 1, playerCount: 2 })).toBe(
+      false,
+    );
+  });
+
+  it('picks the higher-total player as the default winner', () => {
+    expect(defaultWinners(ginRummy, { a: 130, b: 40 })).toEqual(['a']);
+  });
+
+  it('flags a gin hand as good and an undercut as warn in the scorecard', () => {
+    const ginInput: GinRummyInput = { knockerId: 'a', gin: true, deadwood: { a: 0, b: 10 } };
+    const ginRound = round(0, ginInput, { a: 35, b: 0 });
+    expect(ginRummy.roundCellTone?.(ginRound, 'a')).toMatchObject({ tone: 'good' });
+
+    const cutInput: GinRummyInput = { knockerId: 'a', gin: false, deadwood: { a: 5, b: 5 } };
+    const cutRound = round(1, cutInput, { a: 0, b: 20 });
+    expect(ginRummy.roundCellTone?.(cutRound, 'b')).toMatchObject({ tone: 'warn' });
+  });
+
+  it('describes a recorded round', () => {
+    const input: GinRummyInput = { knockerId: 'a', gin: true, deadwood: { a: 0, b: 10 } };
+    const r = round(0, input, { a: 35, b: 0 });
+    expect(ginRummy.describeRound?.(r, players)).toMatch(/gin/i);
+  });
+});
+
+describe('ginRummyStats', () => {
+  it('tallies gins, knocks, undercuts and games won across a finished game', () => {
+    const game = {
+      id: 'g1',
+      type: 'ginrummy',
+      config: {},
+      playerIds: ['a', 'b'] as ID[],
+      status: 'finished' as const,
+      createdAt: 0,
+      roundCount: 2,
+    };
+    const rounds: Round[] = [
+      round(0, mk({ knockerId: 'a', deadwood: { a: 2, b: 20 } }), { a: 18, b: 0 }),
+      round(
+        1,
+        mk({ knockerId: 'a', gin: true, deadwood: { a: 0, b: 30 } }),
+        { a: 55 + 100, b: 0 },
+      ),
+    ];
+    const result = ginRummyStats({
+      games: [game],
+      rounds,
+      players,
+      canonical: (id) => id,
+    });
+    expect(result.perPlayer?.a).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'gr_games' })]),
+    );
+    expect(result.perPlayer?.a).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'gr_gins' })]),
+    );
+    expect(result.global).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'gr_gins_all' })]),
+    );
+  });
+});

--- a/src/lib/games/ginrummy/index.ts
+++ b/src/lib/games/ginrummy/index.ts
@@ -1,0 +1,147 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { ginRummyStats } from './stats';
+import {
+  DEFAULT_CONFIG,
+  describeHand,
+  emptyInput,
+  isFinished as ginFinished,
+  scoreRound as scoreGin,
+  validateRound as validateGin,
+  type GinRummyInput,
+} from './logic';
+
+export type { GinRummyConfig, GinRummyInput, HandResult, Outcome } from './logic';
+export { DEFAULT_CONFIG, boxCounts, opponentOf, scoreHand } from './logic';
+
+/** This game's rounds already recorded, strictly before the one being scored. */
+function priorRounds(ctx: RoundContext): Round[] {
+  return ctx.rounds.filter((r) => r.index < ctx.roundIndex).sort((a, b) => a.index - b.index);
+}
+
+export const ginRummy: GameModule = {
+  id: 'ginrummy',
+  name: 'Gin Rummy',
+  tagline: 'Knock, go gin, or get undercut — race to 100.',
+  emoji: '🍸',
+  keywords: ['gin', 'rummy', 'knock', 'deadwood', 'cards', 'two player', 'melds'],
+  minPlayers: 2,
+  maxPlayers: 2,
+
+  configFields: [
+    {
+      key: 'target',
+      label: 'Points to win',
+      type: 'number',
+      default: DEFAULT_CONFIG.target,
+      min: 25,
+      step: 25,
+      help: 'First to this many hand-score points ends the game — settlement bonuses land on that hand.',
+    },
+    {
+      key: 'ginBonus',
+      label: 'Gin bonus',
+      type: 'number',
+      default: DEFAULT_CONFIG.ginBonus,
+      min: 0,
+      step: 5,
+      help: 'Extra points for going gin (zero deadwood), on top of the opponent\u2019s deadwood.',
+      advanced: true,
+    },
+    {
+      key: 'undercutBonus',
+      label: 'Undercut bonus',
+      type: 'number',
+      default: DEFAULT_CONFIG.undercutBonus,
+      min: 0,
+      step: 5,
+      help: 'Extra points for undercutting a knock (matching or beating the knocker\u2019s deadwood).',
+      advanced: true,
+    },
+    {
+      key: 'maxKnockDeadwood',
+      label: 'Max deadwood to knock',
+      type: 'number',
+      default: DEFAULT_CONFIG.maxKnockDeadwood,
+      min: 0,
+      max: 20,
+      help: 'The classic limit is 10 — knock with more than this and it isn\u2019t a legal knock.',
+      advanced: true,
+    },
+    {
+      key: 'gameBonus',
+      label: 'Game-winner bonus',
+      type: 'number',
+      default: DEFAULT_CONFIG.gameBonus,
+      min: 0,
+      step: 25,
+      help: 'Settled onto whoever wins the whole game, the hand it\u2019s won.',
+      advanced: true,
+    },
+    {
+      key: 'lineBonus',
+      label: 'Per-hand "line" bonus',
+      type: 'number',
+      default: DEFAULT_CONFIG.lineBonus,
+      min: 0,
+      step: 5,
+      help: 'Added for every hand a player has won across the game, settled at the finish.',
+      advanced: true,
+    },
+    {
+      key: 'shutoutDoubling',
+      label: 'Double the game bonus on a shutout',
+      type: 'boolean',
+      default: DEFAULT_CONFIG.shutoutDoubling,
+      help: 'If the loser never scored a single hand-point all game, the game bonus doubles.',
+      advanced: true,
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): GinRummyInput => emptyInput(ctx.players),
+
+  validateRound: (input: GinRummyInput, ctx: RoundContext): string | null =>
+    validateGin(input, ctx.players, ctx.config),
+
+  scoreRound: (input: GinRummyInput, ctx: RoundContext): Record<ID, number> =>
+    scoreGin(input, ctx.players, ctx.config, ctx.totals, priorRounds(ctx)),
+
+  isFinished: (totals, { config }) => ginFinished(totals, config),
+
+  describeRound: (round: Round, players): string =>
+    describeHand(round.input as GinRummyInput | undefined, players, round.deltas ?? {}),
+
+  roundCellTone: (round: Round, playerId: ID) => {
+    const input = round.input as GinRummyInput | undefined;
+    const delta = round.deltas?.[playerId];
+    if (!input?.knockerId || delta == null || delta <= 0) return null;
+    if (input.gin && input.knockerId === playerId) return { tone: 'good', label: 'Gin!' };
+    if (input.knockerId !== playerId) return { tone: 'warn', label: 'Undercut!' };
+    return null;
+  },
+
+  help: [
+    'Gin Rummy is a two-handed race to meld all ten cards into sets and runs,',
+    'leaving as little "deadwood" (unmelded points) as possible.',
+    '',
+    'Card values: face cards are 10, the ace is 1, everything else is its pip value.',
+    '',
+    '\u{1F6AA} KNOCK: with 10 or fewer deadwood points, end the hand. You score the',
+    '   difference between your deadwood and your opponent\u2019s.',
+    '\u{1F485} GIN: end the hand with zero deadwood. You score your opponent\u2019s full',
+    '   deadwood, plus a gin bonus (25 by default).',
+    '\u{1F501} UNDERCUT: if your opponent\u2019s deadwood is equal to or less than yours',
+    '   after you knock, *they* score the difference plus an undercut bonus (20 by',
+    '   default) \u2014 and you get nothing. Ouch.',
+    '',
+    'First to the target (100 by default) wins the game. At that point, settlement',
+    'bonuses land on the last hand: +25 for every hand each side has won (the',
+    '"line"), and +100 to the game winner \u2014 doubled if the loser never scored a',
+    'single hand-point all game (a shutout).',
+  ].join('\n'),
+
+  stats: ginRummyStats,
+
+  RoundEditor,
+  editorLoader: () => import('./GinRummyEditor.svelte'),
+};

--- a/src/lib/games/ginrummy/logic.ts
+++ b/src/lib/games/ginrummy/logic.ts
@@ -1,0 +1,299 @@
+import type { ID, Round } from '../../types';
+
+/**
+ * Pure Gin Rummy scoring — no Svelte, no I/O, so it's independently unit-testable
+ * and safe for the stats engine to import.
+ *
+ * Gin Rummy is strictly two-handed. Each hand, a player races to meld their ten
+ * cards into sets and runs; whoever holds 10 or fewer unmelded points ("deadwood")
+ * may KNOCK to end the hand, or go GIN with zero deadwood. The editor only ever
+ * asks for three things: who knocked, whether it was gin, and each side's deadwood
+ * count — everything else (the margin, the bonuses, who wins the whole game) is
+ * derived from that.
+ *
+ * Two totals matter, and they're deliberately kept apart:
+ * - The *hand* score — the knock/gin/undercut margin — is what races toward the
+ *   target and is all {@link scoreHand} ever returns.
+ * - The *settlement* bonuses (game bonus, per-hand "line" bonus, the shutout
+ *   double) only exist once the game actually ends, so {@link scoreRound} folds
+ *   them into the delta of the one hand that crosses the target — exactly like a
+ *   real score pad, where the bonuses get totted up in a single pass at the end.
+ */
+
+export type Outcome = 'gin' | 'knock' | 'undercut';
+
+export interface GinRummyInput {
+  /** Who ended the hand — by knocking or going gin. Null while undecided. */
+  knockerId: ID | null;
+  /** The knocker melded all ten cards — no lay-offs, no deadwood of their own. */
+  gin: boolean;
+  /** Each player's deadwood count, keyed by id. The knocker's reads as 0 on gin. */
+  deadwood: Record<ID, number>;
+}
+
+export function emptyInput(players: readonly { id: ID }[]): GinRummyInput {
+  const deadwood: Record<ID, number> = {};
+  for (const p of players) deadwood[p.id] = 0;
+  return { knockerId: null, gin: false, deadwood };
+}
+
+export interface GinRummyConfig {
+  /** Points to reach before the game ends and settlement bonuses apply. */
+  target: number;
+  /** Bonus for going gin, added on top of the opponent's deadwood. */
+  ginBonus: number;
+  /** Bonus for undercutting a knock (matching or beating the knocker's deadwood). */
+  undercutBonus: number;
+  /** Deadwood must be at or below this to knock without going gin. */
+  maxKnockDeadwood: number;
+  /** Bonus to whoever wins the whole game, applied the hand it's won. */
+  gameBonus: number;
+  /** Bonus per hand won across the game ("boxes"), settled at game end. */
+  lineBonus: number;
+  /** Double the game bonus when the loser's hand-score total is still zero. */
+  shutoutDoubling: boolean;
+}
+
+export const DEFAULT_CONFIG: GinRummyConfig = {
+  target: 100,
+  ginBonus: 25,
+  undercutBonus: 20,
+  maxKnockDeadwood: 10,
+  gameBonus: 100,
+  lineBonus: 25,
+  shutoutDoubling: true,
+};
+
+function positiveInt(v: unknown, fallback: number): number {
+  const n = Math.round(Number(v));
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+export function readConfig(config: Record<string, unknown> = {}): GinRummyConfig {
+  return {
+    target: positiveInt(config.target, DEFAULT_CONFIG.target) || DEFAULT_CONFIG.target,
+    ginBonus: positiveInt(config.ginBonus, DEFAULT_CONFIG.ginBonus),
+    undercutBonus: positiveInt(config.undercutBonus, DEFAULT_CONFIG.undercutBonus),
+    maxKnockDeadwood: positiveInt(config.maxKnockDeadwood, DEFAULT_CONFIG.maxKnockDeadwood),
+    gameBonus: positiveInt(config.gameBonus, DEFAULT_CONFIG.gameBonus),
+    lineBonus: positiveInt(config.lineBonus, DEFAULT_CONFIG.lineBonus),
+    shutoutDoubling: config.shutoutDoubling !== false,
+  };
+}
+
+function whole(v: unknown): number {
+  const n = Math.round(Number(v));
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/** The other seat at a two-handed table, or null if `id` isn't one of the two. */
+export function opponentOf(players: readonly { id: ID }[], id: ID | null): ID | null {
+  if (!id || !players.some((p) => p.id === id)) return null;
+  const other = players.find((p) => p.id !== id);
+  return other?.id ?? null;
+}
+
+export interface HandResult {
+  outcome: Outcome;
+  knockerId: ID;
+  opponentId: ID;
+  knockerDeadwood: number;
+  opponentDeadwood: number;
+  /** The knock/gin/undercut margin, before any settlement bonus. */
+  margin: number;
+  /** Per-player hand deltas — the raw race score, no settlement bonuses. */
+  deltas: Record<ID, number>;
+}
+
+/**
+ * Score one hand from who-knocked + deadwood alone. Returns null while the hand
+ * isn't fully decided yet (no knocker chosen).
+ */
+export function scoreHand(
+  input: GinRummyInput | null | undefined,
+  players: readonly { id: ID }[],
+  config: Record<string, unknown> = {},
+): HandResult | null {
+  if (!input?.knockerId) return null;
+  const knockerId = input.knockerId;
+  const opponentId = opponentOf(players, knockerId);
+  if (!opponentId) return null;
+
+  const cfg = readConfig(config);
+  const opponentDeadwood = whole(input.deadwood?.[opponentId]);
+  const knockerDeadwood = input.gin ? 0 : whole(input.deadwood?.[knockerId]);
+
+  const deltas: Record<ID, number> = { [knockerId]: 0, [opponentId]: 0 };
+
+  if (input.gin) {
+    const margin = opponentDeadwood + cfg.ginBonus;
+    deltas[knockerId] = margin;
+    return {
+      outcome: 'gin',
+      knockerId,
+      opponentId,
+      knockerDeadwood,
+      opponentDeadwood,
+      margin,
+      deltas,
+    };
+  }
+
+  if (opponentDeadwood > knockerDeadwood) {
+    const margin = opponentDeadwood - knockerDeadwood;
+    deltas[knockerId] = margin;
+    return {
+      outcome: 'knock',
+      knockerId,
+      opponentId,
+      knockerDeadwood,
+      opponentDeadwood,
+      margin,
+      deltas,
+    };
+  }
+
+  // The opponent matched or beat the knocker's own deadwood: an undercut. The
+  // knocker gets nothing — the whole margin (plus the bonus) flips to the
+  // opponent, who never even knocked.
+  const margin = knockerDeadwood - opponentDeadwood + cfg.undercutBonus;
+  deltas[opponentId] = margin;
+  return {
+    outcome: 'undercut',
+    knockerId,
+    opponentId,
+    knockerDeadwood,
+    opponentDeadwood,
+    margin,
+    deltas,
+  };
+}
+
+/** Null when a hand is valid to record, otherwise a human-readable reason. */
+export function validateRound(
+  input: GinRummyInput,
+  players: readonly { id: ID; name: string }[],
+  config: Record<string, unknown> = {},
+): string | null {
+  if (players.length !== 2) return 'Gin Rummy is strictly two-handed.';
+  if (!input?.knockerId) return 'Tap whoever knocked (or went gin) to end the hand.';
+  const opponentId = opponentOf(players, input.knockerId);
+  if (!opponentId) return "That player isn't in this game.";
+
+  const cfg = readConfig(config);
+  for (const p of players) {
+    const v = Number(input.deadwood?.[p.id] ?? 0);
+    if (!Number.isFinite(v) || v < 0) return `${p.name}: deadwood can't be negative.`;
+  }
+
+  if (!input.gin) {
+    const knockerDeadwood = whole(input.deadwood?.[input.knockerId]);
+    if (knockerDeadwood > cfg.maxKnockDeadwood) {
+      const who = players.find((p) => p.id === input.knockerId)?.name ?? 'The knocker';
+      return `${who} has ${knockerDeadwood} deadwood — too much to knock (max ${cfg.maxKnockDeadwood}). Mark Gin, or lower the count.`;
+    }
+  }
+  return null;
+}
+
+/**
+ * A hand's winner, replayed from its own recorded `input` (not the stored
+ * deltas) so a settlement-bonus-laden final hand never gets misattributed —
+ * the raw knock/gin/undercut margin alone decides who actually won the hand.
+ */
+function boxWinner(
+  round: Round,
+  players: readonly { id: ID }[],
+  config: Record<string, unknown>,
+): ID | null {
+  const hand = scoreHand(round.input as GinRummyInput | undefined, players, config);
+  if (!hand) return null;
+  return hand.deltas[hand.knockerId] > 0 ? hand.knockerId : hand.opponentId;
+}
+
+/** Hands ("boxes") each player has won across a game's recorded rounds so far. */
+export function boxCounts(
+  rounds: readonly Round[],
+  players: readonly { id: ID }[],
+  config: Record<string, unknown> = {},
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const r of rounds) {
+    const winner = boxWinner(r, players, config);
+    if (winner) out[winner] = (out[winner] ?? 0) + 1;
+  }
+  return out;
+}
+
+/**
+ * Per-player point deltas for a hand, including settlement bonuses the moment
+ * the hand pushes a player's *hand-score* total to the target. `priorRounds` are
+ * this game's rounds already recorded (strictly before the one being scored),
+ * used only to tally each side's box count for the line bonus.
+ */
+export function scoreRound(
+  input: GinRummyInput,
+  players: readonly { id: ID }[],
+  config: Record<string, unknown> = {},
+  totalsBefore: Record<ID, number> = {},
+  priorRounds: readonly Round[] = [],
+): Record<ID, number> {
+  const hand = scoreHand(input, players, config);
+  if (!hand) return Object.fromEntries(players.map((p) => [p.id, 0]));
+
+  const cfg = readConfig(config);
+  const deltas: Record<ID, number> = { ...hand.deltas };
+  const rawTotals: Record<ID, number> = {};
+  for (const p of players) rawTotals[p.id] = (totalsBefore[p.id] ?? 0) + (deltas[p.id] ?? 0);
+
+  const ids = players.map((p) => p.id);
+  const reached = ids.filter((id) => rawTotals[id] >= cfg.target);
+  if (reached.length === 0) return deltas;
+
+  // The game ends this hand: settle boxes for both sides, plus the game bonus
+  // (doubled on a shutout) for whoever has the higher hand-score total.
+  const winnerId = ids.reduce((a, b) => (rawTotals[b] > rawTotals[a] ? b : a));
+  const loserId = ids.find((id) => id !== winnerId) ?? winnerId;
+
+  const boxes = boxCounts(priorRounds, players, config);
+  for (const id of ids) {
+    // This hand's own winner (if any) picks up their box too.
+    const wonThisHand = hand.deltas[id] > 0;
+    const boxCount = (boxes[id] ?? 0) + (wonThisHand ? 1 : 0);
+    deltas[id] = (deltas[id] ?? 0) + boxCount * cfg.lineBonus;
+  }
+
+  const shutout = cfg.shutoutDoubling && rawTotals[loserId] === 0;
+  const gameBonus = cfg.gameBonus * (shutout ? 2 : 1);
+  deltas[winnerId] = (deltas[winnerId] ?? 0) + gameBonus;
+
+  return deltas;
+}
+
+export function isFinished(totals: Record<ID, number>, config: Record<string, unknown>): boolean {
+  const { target } = readConfig(config);
+  return Object.values(totals).some((t) => t >= target);
+}
+
+/** Short, glanceable summary of a recorded hand for the history table. */
+export function describeHand(
+  input: GinRummyInput | undefined,
+  players: readonly { id: ID; name: string }[],
+  deltas: Record<ID, number> = {},
+): string {
+  if (!input?.knockerId) return 'Hand not recorded';
+  const name = (id: ID | null): string =>
+    (id != null && players.find((p) => p.id === id)?.name) || '?';
+  const knocker = name(input.knockerId);
+  const opponentId = opponentOf(players, input.knockerId);
+
+  if (input.gin) {
+    return `💅 ${knocker} went gin! +${deltas[input.knockerId] ?? 0}`;
+  }
+  const opponentDeadwood = whole(input.deadwood?.[opponentId ?? '']);
+  const knockerDeadwood = whole(input.deadwood?.[input.knockerId]);
+  if (opponentDeadwood > knockerDeadwood) {
+    return `🚪 ${knocker} knocked — +${deltas[input.knockerId] ?? 0}`;
+  }
+  return `🔁 ${knocker} knocked and got undercut by ${name(opponentId)} — +${deltas[opponentId ?? ''] ?? 0}`;
+}

--- a/src/lib/games/ginrummy/stats.ts
+++ b/src/lib/games/ginrummy/stats.ts
@@ -1,0 +1,160 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt } from '../../stats/format';
+import { scoreHand, type GinRummyInput } from './logic';
+
+interface GinRummyAgg {
+  hands: number;
+  gins: number;
+  knocksWon: number;
+  undercutsPulled: number;
+  timesUndercut: number;
+  bestMargin: number;
+  gamesWon: number;
+  shutoutsDealt: number;
+}
+
+function blank(): GinRummyAgg {
+  return {
+    hands: 0,
+    gins: 0,
+    knocksWon: 0,
+    undercutsPulled: 0,
+    timesUndercut: 0,
+    bestMargin: 0,
+    gamesWon: 0,
+    shutoutsDealt: 0,
+  };
+}
+
+/**
+ * Gin Rummy stats, replayed purely from each game's recorded hands. Every hand
+ * is re-scored from its own `input` via {@link scoreHand} rather than trusting
+ * the stored deltas, so a settlement-bonus-laden final hand never muddies who
+ * actually won it. No Svelte, no I/O.
+ */
+export function ginRummyStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const per = new Map<ID, GinRummyAgg>();
+  const get = (id: ID): GinRummyAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = blank();
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let bestMarginAnywhere = 0;
+  let totalGins = 0;
+
+  for (const g of games) {
+    const seats = g.playerIds.map((id) => ({ id }));
+    if (seats.length !== 2) continue;
+    const gameRounds = rounds.filter((r) => r.gameId === g.id).sort((a, b) => a.index - b.index);
+    if (!gameRounds.length) continue;
+
+    const rawTotals: Record<ID, number> = { [seats[0].id]: 0, [seats[1].id]: 0 };
+
+    for (const r of gameRounds) {
+      const input = r.input as GinRummyInput | undefined;
+      const hand = scoreHand(input, seats, g.config);
+      if (!hand) continue;
+
+      rawTotals[hand.knockerId] = (rawTotals[hand.knockerId] ?? 0) + hand.deltas[hand.knockerId];
+      rawTotals[hand.opponentId] =
+        (rawTotals[hand.opponentId] ?? 0) + hand.deltas[hand.opponentId];
+
+      const winner = hand.deltas[hand.knockerId] > 0 ? hand.knockerId : hand.opponentId;
+      const loser = winner === hand.knockerId ? hand.opponentId : hand.knockerId;
+
+      const wa = get(canonical(winner));
+      wa.hands += 1;
+      get(canonical(loser)).hands += 1;
+      if (hand.margin > wa.bestMargin) wa.bestMargin = hand.margin;
+      if (hand.margin > bestMarginAnywhere) bestMarginAnywhere = hand.margin;
+
+      if (hand.outcome === 'gin') {
+        wa.gins += 1;
+        totalGins += 1;
+      } else if (hand.outcome === 'knock') {
+        wa.knocksWon += 1;
+      } else {
+        wa.undercutsPulled += 1;
+        get(canonical(loser)).timesUndercut += 1;
+      }
+    }
+
+    // The finish: whoever's hand-score total reached the target this game.
+    const keys = Object.keys(rawTotals);
+    if (keys.length < 2) continue;
+    const [a, b] = keys;
+    if (rawTotals[a] === rawTotals[b]) continue;
+    const winnerKey = rawTotals[a] > rawTotals[b] ? a : b;
+    const loserKey = winnerKey === a ? b : a;
+    get(canonical(winnerKey)).gamesWon += 1;
+    if (rawTotals[loserKey] === 0) get(canonical(winnerKey)).shutoutsDealt += 1;
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.gamesWon) {
+      metrics.push({ key: 'gr_games', label: 'Games won', value: fmtInt(a.gamesWon), emoji: '\u{1F3C6}' });
+    }
+    if (a.gins) {
+      metrics.push({
+        key: 'gr_gins',
+        label: 'Gins',
+        value: fmtInt(a.gins),
+        sub: a.hands ? `of ${a.hands} hands` : undefined,
+        emoji: '\u{1F485}',
+      });
+    }
+    if (a.knocksWon) {
+      metrics.push({ key: 'gr_knocks', label: 'Knocks won', value: fmtInt(a.knocksWon), emoji: '\u{1F6AA}' });
+    }
+    if (a.undercutsPulled) {
+      metrics.push({
+        key: 'gr_undercuts',
+        label: 'Undercuts pulled off',
+        value: fmtInt(a.undercutsPulled),
+        emoji: '\u{1F501}',
+      });
+    }
+    if (a.timesUndercut) {
+      metrics.push({
+        key: 'gr_undercut_by',
+        label: 'Times undercut',
+        value: fmtInt(a.timesUndercut),
+        emoji: '\u{1F62C}',
+      });
+    }
+    if (a.bestMargin) {
+      metrics.push({ key: 'gr_best', label: 'Best hand margin', value: fmtInt(a.bestMargin), emoji: '\u2728' });
+    }
+    if (a.shutoutsDealt) {
+      metrics.push({
+        key: 'gr_shutouts',
+        label: 'Shutouts dealt',
+        value: fmtInt(a.shutoutsDealt),
+        emoji: '\u{1F9F9}',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (bestMarginAnywhere) {
+    global.push({
+      key: 'gr_best_all',
+      label: 'Best hand margin',
+      value: fmtInt(bestMarginAnywhere),
+      emoji: '\u2728',
+    });
+  }
+  if (totalGins) {
+    global.push({ key: 'gr_gins_all', label: 'Gins', value: fmtInt(totalGins), emoji: '\u{1F485}' });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Adds a new Gin Rummy 🍸 game module to the catalog, following the existing auto-discovered `GameModule` conventions (see `cribbage/`, `spades/`, `euchre/`).

## Changes

- `src/lib/games/ginrummy/logic.ts` — pure scoring: knock/gin/undercut margins from deadwood, config-driven bonuses, and end-of-game settlement (game bonus, per-hand "line" bonus, shutout doubling) folded into the delta of the hand that crosses the target.
- `src/lib/games/ginrummy/index.ts` — the `GameModule` (2-player only, config fields for target/bonuses, help text, lazy `editorLoader`).
- `src/lib/games/ginrummy/GinRummyEditor.svelte` — round editor: pick who knocked, mark gin, enter deadwood, live settlement preview.
- `src/lib/games/ginrummy/stats.ts` — gins, knocks won, undercuts, best margin, games won, shutouts dealt.
- `src/lib/games/ginrummy/ginrummy.test.ts` — unit tests for scoring, validation, settlement math, box-count replay, and the module contract.

Rules verified against published Gin Rummy references (deadwood values, knock ceiling of 10, gin bonus 25, undercut bonus 20); all bonus amounts are configurable per the module's `configFields`.

## Issues

Closes #169

## Testing

- [x] `npm run check`
- [x] `npm test -- ginrummy registry` (38 tests passing)