### PR TITLE
feat(scrabble): add Scrabble game module

### DIFF
--- a/src/lib/games/scrabble/ScrabbleEditor.svelte
+++ b/src/lib/games/scrabble/ScrabbleEditor.svelte
@@ -1,0 +1,493 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { haptic } from '../../haptics';
+  import { bumpOnChange } from '../../motion';
+  import { scrabble } from './index';
+  import {
+    BINGO_BONUS,
+    LETTER_GROUPS,
+    emptyFinalInput,
+    emptyTurnInput,
+    finalTallySwing,
+    isFinalTally,
+    isTurn,
+    turnTotal,
+    type ScrabbleInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: ScrabbleInput; ctx: RoundContext } = $props();
+
+  const ids = $derived(ctx.players.map((p) => p.id));
+  const byId = $derived(new Map(ctx.players.map((p) => [p.id, p])));
+  const nameOf = (id: string | null) => (id ? (byId.get(id)?.name ?? '?') : '?');
+
+  let showHelp = $state(false);
+  let showLetters = $state(false);
+
+  const chipMultipliers = [1, 5, 10] as const;
+
+  function toTurn() {
+    if (isTurn(input)) return;
+    input = emptyTurnInput(ids, ctx.roundIndex);
+    haptic('tick');
+  }
+  function toFinal() {
+    if (isFinalTally(input)) return;
+    input = emptyFinalInput(ids);
+    haptic('tick');
+  }
+
+  function setPlayer(id: string) {
+    if (!isTurn(input)) return;
+    if (input.playerId === id) return;
+    input.playerId = id;
+    haptic('tick');
+  }
+  function addPoints(amount: number) {
+    if (!isTurn(input)) return;
+    input.points = Math.max(0, (Number(input.points) || 0) + amount);
+    haptic('tick');
+  }
+  function toggleBingo() {
+    if (!isTurn(input)) return;
+    input.bingo = !input.bingo;
+    haptic(input.bingo ? 'win' : 'tick');
+  }
+
+  function setFinisher(id: string) {
+    if (!isFinalTally(input)) return;
+    input.finisherId = input.finisherId === id ? null : id;
+    haptic('tick');
+  }
+
+  const swing = $derived(isFinalTally(input) ? finalTallySwing(input, ids) : 0);
+
+  const dirty = $derived(
+    isTurn(input)
+      ? (input.points ?? 0) > 0 || input.bingo
+      : isFinalTally(input) &&
+          (input.finisherId != null || Object.values(input.remaining ?? {}).some((v) => v)),
+  );
+
+  function clearTurn() {
+    if (isTurn(input)) {
+      input.points = 0;
+      input.bingo = false;
+    } else if (isFinalTally(input)) {
+      for (const id of ids) input.remaining[id] = 0;
+      input.finisherId = null;
+    }
+    haptic('undo');
+  }
+</script>
+
+<div class="stack">
+  <div class="row spread wrap head">
+    <div class="mode-toggle" role="radiogroup" aria-label="What to record">
+      <button
+        type="button"
+        role="radio"
+        aria-checked={isTurn(input)}
+        class="mode-btn"
+        class:on={isTurn(input)}
+        onclick={toTurn}
+      >
+        🔤 Turn {ctx.roundIndex + 1}
+      </button>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={isFinalTally(input)}
+        class="mode-btn"
+        class:on={isFinalTally(input)}
+        onclick={toFinal}
+      >
+        🏁 Final tally
+      </button>
+    </div>
+    <span class="row" style="gap: 8px">
+      {#if dirty}
+        <button type="button" class="btn small ghost" onclick={clearTurn}>Clear</button>
+      {/if}
+      <button type="button" class="btn small ghost" onclick={() => (showHelp = !showHelp)}>
+        {showHelp ? 'Hide rules' : 'How to play'}
+      </button>
+    </span>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{scrabble.help}</pre>
+  {/if}
+
+  {#if isTurn(input)}
+    <section class="panel">
+      <p class="sub">Whose turn was it?</p>
+      <div class="players" role="radiogroup" aria-label="Active player">
+        {#each ctx.players as p (p.id)}
+          {@const on = input.playerId === p.id}
+          <button
+            type="button"
+            role="radio"
+            aria-checked={on}
+            class="player"
+            class:on
+            onclick={() => setPlayer(p.id)}
+          >
+            <Avatar name={p.name} color={p.color} />
+            <span class="pname">{p.name}</span>
+          </button>
+        {/each}
+      </div>
+
+      <div class="entry">
+        <div class="row spread wrap">
+          <span class="plabel">Word value this turn</span>
+          <span class="ptotal" use:bumpOnChange={turnTotal(input)}>{turnTotal(input)}</span>
+        </div>
+        <div class="row" style="gap: 10px; align-items: center; flex-wrap: wrap">
+          <div class="chips">
+            {#each chipMultipliers as m (m)}
+              <button type="button" class="chip" onclick={() => addPoints(m)}>+{m}</button>
+            {/each}
+          </div>
+          <Stepper bind:value={input.points} min={0} max={400} label="Word value" />
+        </div>
+      </div>
+
+      <button type="button" class="bingo" class:on={input.bingo} onclick={toggleBingo}>
+        <span class="bmark" aria-hidden="true">{input.bingo ? '✓' : '🎉'}</span>
+        <span class="btext">
+          <strong>Bingo — all 7 tiles</strong>
+          <span class="bsub">Adds +{BINGO_BONUS} on top of the word value</span>
+        </span>
+      </button>
+
+      <div class="row foot">
+        <button type="button" class="btn small ghost" onclick={() => (showLetters = !showLetters)}>
+          {showLetters ? 'Hide letter values' : '🔤 Letter values'}
+        </button>
+      </div>
+      {#if showLetters}
+        <div class="letters">
+          {#each LETTER_GROUPS as g (g.value)}
+            <div class="lrow">
+              <span class="lval">{g.value}</span>
+              <span class="lletters">{g.letters}</span>
+            </div>
+          {/each}
+          <div class="lrow">
+            <span class="lval">0</span>
+            <span class="lletters">blank</span>
+          </div>
+        </div>
+      {/if}
+    </section>
+  {:else if isFinalTally(input)}
+    {@const fin = input}
+    <section class="panel">
+      <p class="sub">Who went out — emptied their rack, with the bag empty?</p>
+      <div class="players" role="radiogroup" aria-label="Who went out">
+        {#each ctx.players as p (p.id)}
+          {@const on = fin.finisherId === p.id}
+          <button
+            type="button"
+            role="radio"
+            aria-checked={on}
+            class="player"
+            class:on
+            onclick={() => setFinisher(p.id)}
+          >
+            <Avatar name={p.name} color={p.color} />
+            <span class="pname">{p.name}</span>
+            {#if on}<span class="badge">went out</span>{/if}
+          </button>
+        {/each}
+      </div>
+
+      {#if fin.finisherId}
+        <p class="finisher-note">
+          <strong>{nameOf(fin.finisherId)}</strong> gets the sum of everyone else's leftover
+          tiles. Enter what's left on each other rack below.
+        </p>
+        <div class="racks">
+          {#each ctx.players.filter((p) => p.id !== fin.finisherId) as p (p.id)}
+            <div class="rrow">
+              <span class="row" style="gap: 8px; min-width: 0">
+                <Avatar name={p.name} color={p.color} />
+                <strong class="rname">{p.name}</strong>
+              </span>
+              <Stepper
+                bind:value={fin.remaining[p.id]}
+                min={0}
+                max={100}
+                label={`${p.name} unplayed tile value`}
+              />
+            </div>
+          {/each}
+        </div>
+        <p class="swing">
+          <strong>{nameOf(fin.finisherId)}</strong> gains
+          <span class="num" use:bumpOnChange={swing}>+{swing}</span>
+          from everyone else's racks.
+        </p>
+      {:else}
+        <p class="finisher-note muted">Pick the player who finished first.</p>
+      {/if}
+    </section>
+  {/if}
+</div>
+
+<style>
+  .head {
+    align-items: center;
+  }
+  .mode-toggle {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .mode-btn {
+    display: inline-flex;
+    align-items: center;
+    min-height: 46px;
+    padding: 8px 14px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .mode-btn.on {
+    background: var(--surface-3);
+    border-color: var(--primary);
+    box-shadow: inset 0 0 0 1px var(--primary);
+    color: var(--primary);
+  }
+  .mode-btn:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .panel {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .sub {
+    margin: 0;
+    font-weight: 700;
+  }
+  .players {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .player {
+    flex: 1 1 140px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 8px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .player.on {
+    background: var(--surface-3);
+    border-color: var(--primary);
+    box-shadow: inset 3px 0 0 var(--primary);
+  }
+  .player:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .pname {
+    flex: 1;
+    text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .badge {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 3px 8px;
+    border-radius: 999px;
+    background: var(--primary);
+    color: #fff;
+  }
+  .entry {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .plabel {
+    font-weight: 700;
+  }
+  .ptotal {
+    font-weight: 800;
+    font-size: 1.25rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .chips {
+    display: flex;
+    gap: 8px;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 46px;
+    min-height: 46px;
+    padding: 0 12px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface-2);
+    color: var(--text);
+    font: inherit;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    cursor: pointer;
+  }
+  .chip:hover {
+    background: var(--surface-3);
+    border-color: var(--primary);
+  }
+  .chip:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .bingo {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 46px;
+    padding: 8px 12px;
+    text-align: left;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+  }
+  .bingo.on {
+    border-color: var(--accent, var(--good));
+    background: color-mix(in srgb, var(--accent, var(--good)) 16%, var(--surface));
+  }
+  .bingo:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .bmark {
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+  .btext {
+    display: flex;
+    flex-direction: column;
+  }
+  .bsub {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+  .foot {
+    justify-content: flex-end;
+  }
+  .letters {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+    font-size: 0.9rem;
+  }
+  .lrow {
+    display: flex;
+    gap: 10px;
+    align-items: baseline;
+  }
+  .lval {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+    min-width: 1.5em;
+    text-align: right;
+    color: var(--primary);
+  }
+  .lletters {
+    color: var(--muted);
+    letter-spacing: 0.05em;
+  }
+  .finisher-note {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--muted);
+    padding: 9px 12px;
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    border: 1px dashed var(--border);
+  }
+  .finisher-note strong {
+    color: var(--text);
+  }
+  .racks {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .rrow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 10px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    flex-wrap: wrap;
+  }
+  .rname {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .swing {
+    margin: 0;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+  .swing .num {
+    color: var(--good);
+  }
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+    font-size: 0.9rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+  }
+</style>

--- a/src/lib/games/scrabble/index.ts
+++ b/src/lib/games/scrabble/index.ts
@@ -1,0 +1,69 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { scrabbleStats } from './stats';
+import {
+  BINGO_BONUS,
+  describeRound as describeScrabbleRound,
+  emptyInput,
+  isTurn,
+  scoreRound as scoreScrabble,
+  validateRound as validateScrabble,
+  type ScrabbleInput,
+} from './logic';
+
+export type { ScrabbleInput, TurnInput, FinalTallyInput } from './logic';
+export { LETTER_VALUES, LETTER_GROUPS, letterValue, rackValue } from './logic';
+
+export const scrabble: GameModule = {
+  id: 'scrabble',
+  name: 'Scrabble',
+  tagline: 'Rack up word value, chase the bingo bonus.',
+  emoji: '🔤',
+  keywords: ['word game', 'tiles', 'bingo', 'letters', 'board game'],
+  minPlayers: 2,
+  maxPlayers: 4,
+
+  createRoundInput: (ctx: RoundContext): ScrabbleInput => emptyInput(ctx.players.map((p) => p.id), ctx.roundIndex),
+
+  validateRound: (input: ScrabbleInput, ctx: RoundContext): string | null =>
+    validateScrabble(input, ctx.players),
+
+  scoreRound: (input: ScrabbleInput, ctx: RoundContext): Record<ID, number> =>
+    scoreScrabble(
+      input,
+      ctx.players.map((p) => p.id),
+    ),
+
+  describeRound: (round: Round, players): string =>
+    describeScrabbleRound(round.input as ScrabbleInput | undefined, players),
+
+  // Per-round scorecard emphasis: a bingo turn is the single most exciting thing that
+  // can happen at a Scrabble table, so it earns its own tone the moment it's recorded.
+  roundCellTone: (round: Round, playerId: ID) => {
+    const input = round.input as ScrabbleInput | undefined;
+    if (!isTurn(input) || input.playerId !== playerId) return null;
+    return input.bingo ? { tone: 'good', label: `BINGO! +${BINGO_BONUS}` } : null;
+  },
+
+  help: [
+    'Highest total wins. Every turn, the active player forms a word on the board;',
+    'premium squares (double/triple letter or word) are worked out at the table and',
+    'entered here as one number — the total value of the word just played.',
+    '',
+    '🎉 Bingo: used all 7 tiles in a single turn? Toggle it on for an automatic +50.',
+    '',
+    'Letter values:',
+    'A E I O U L N S T R = 1 · D G = 2 · B C M P = 3 · F H V W Y = 4',
+    'K = 5 · J X = 8 · Q Z = 10 · blank = 0',
+    '',
+    '🏁 Final tally: when the bag is empty and a player empties their rack, the game',
+    'ends. Record one last "final tally" round: everyone else subtracts the value of',
+    'the tiles left on their rack from their score, and the player who went out adds',
+    'the sum of everyone else\'s leftover tiles to theirs.',
+  ].join('\n'),
+
+  stats: scrabbleStats,
+
+  RoundEditor,
+  editorLoader: () => import('./ScrabbleEditor.svelte'),
+};

--- a/src/lib/games/scrabble/logic.ts
+++ b/src/lib/games/scrabble/logic.ts
@@ -1,0 +1,213 @@
+import type { ID } from '../../types';
+
+/**
+ * Scrabble scoring — pure, Svelte-free, fully unit-testable. `index.ts` and the editor both
+ * import from here so the exact math the game plays is the exact math the tests exercise.
+ *
+ * Score King can't see the board, so premium squares (double/triple letter or word) are
+ * handled physically at the table and entered here as a single word-value number per turn.
+ * Two things this module *does* compute:
+ *
+ * 1. The bingo bonus — +50 for using all 7 tiles in one turn — a simple toggle per turn.
+ * 2. The end-game rack adjustment — once a player empties their rack and the bag is empty,
+ *    every other player subtracts the value of their unplayed tiles from their own score,
+ *    and the finisher adds the sum of everyone else's unplayed tiles to theirs. That's
+ *    recorded as one special "final tally" round rather than a turn.
+ */
+
+/** Standard English-language Scrabble tile values. Blanks are always worth 0. */
+export const LETTER_VALUES: Record<string, number> = {
+  A: 1,
+  E: 1,
+  I: 1,
+  O: 1,
+  U: 1,
+  L: 1,
+  N: 1,
+  S: 1,
+  T: 1,
+  R: 1,
+  D: 2,
+  G: 2,
+  B: 3,
+  C: 3,
+  M: 3,
+  P: 3,
+  F: 4,
+  H: 4,
+  V: 4,
+  W: 4,
+  Y: 4,
+  K: 5,
+  J: 8,
+  X: 8,
+  Q: 10,
+  Z: 10,
+};
+
+/** Letters grouped by their point value, in ascending order — for the reference table. */
+export const LETTER_GROUPS: { value: number; letters: string }[] = [
+  { value: 1, letters: 'A E I O U L N S T R' },
+  { value: 2, letters: 'D G' },
+  { value: 3, letters: 'B C M P' },
+  { value: 4, letters: 'F H V W Y' },
+  { value: 5, letters: 'K' },
+  { value: 8, letters: 'J X' },
+  { value: 10, letters: 'Q Z' },
+];
+
+/** Bonus for playing every tile in your rack (7) in a single turn. */
+export const BINGO_BONUS = 50;
+
+/** The value of a single tile letter. Blank / unknown characters are worth 0. */
+export function letterValue(letter: string): number {
+  const l = (letter ?? '').trim().toUpperCase();
+  if (l.length !== 1) return 0;
+  return LETTER_VALUES[l] ?? 0;
+}
+
+/** Sum of tile values across a rack of letters (any non-letter character, e.g. a blank
+ * marker like `_` or `?`, contributes 0). Case-insensitive. */
+export function rackValue(letters: string): number {
+  let total = 0;
+  for (const ch of (letters ?? '').toUpperCase()) {
+    total += letterValue(ch);
+  }
+  return total;
+}
+
+export interface TurnInput {
+  kind: 'turn';
+  /** Whose turn this was. */
+  playerId: ID | null;
+  /** The word value scored this turn (premium squares already applied at the table). */
+  points: number;
+  /** Used all 7 tiles this turn — +50. */
+  bingo: boolean;
+}
+
+export interface FinalTallyInput {
+  kind: 'final';
+  /** Who emptied their rack first (the bag was already empty). */
+  finisherId: ID | null;
+  /** Each OTHER player's unplayed tile value, keyed by player id. */
+  remaining: Record<ID, number>;
+}
+
+export type ScrabbleInput = TurnInput | FinalTallyInput;
+
+function numOr(v: unknown, fallback: number): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/** A fresh turn, defaulting to whichever player's turn it is by simple round-robin. */
+export function emptyTurnInput(playerIds: readonly ID[], roundIndex: number): TurnInput {
+  const playerId = playerIds.length
+    ? playerIds[((roundIndex % playerIds.length) + playerIds.length) % playerIds.length]
+    : null;
+  return { kind: 'turn', playerId, points: 0, bingo: false };
+}
+
+/** A fresh final-tally round, zeroed for every player. */
+export function emptyFinalInput(playerIds: readonly ID[]): FinalTallyInput {
+  return {
+    kind: 'final',
+    finisherId: null,
+    remaining: Object.fromEntries(playerIds.map((id) => [id, 0])),
+  };
+}
+
+/** The default round input: an ordinary turn for whoever's up. */
+export function emptyInput(playerIds: readonly ID[], roundIndex: number): ScrabbleInput {
+  return emptyTurnInput(playerIds, roundIndex);
+}
+
+export function isTurn(input: ScrabbleInput | undefined | null): input is TurnInput {
+  return !!input && input.kind === 'turn';
+}
+
+export function isFinalTally(input: ScrabbleInput | undefined | null): input is FinalTallyInput {
+  return !!input && input.kind === 'final';
+}
+
+/** Points a turn is worth: the word value, plus the bingo bonus when it applies. */
+export function turnTotal(input: TurnInput): number {
+  return Math.max(0, Math.trunc(numOr(input.points, 0))) + (input.bingo ? BINGO_BONUS : 0);
+}
+
+/** Total unplayed-tile value the final tally will move, across every other player. */
+export function finalTallySwing(input: FinalTallyInput, playerIds: readonly ID[]): number {
+  let sum = 0;
+  for (const id of playerIds) {
+    if (id === input.finisherId) continue;
+    sum += Math.max(0, Math.trunc(numOr(input.remaining?.[id], 0)));
+  }
+  return sum;
+}
+
+/** Compute per-player point deltas for a round — a turn, or the end-game adjustment. */
+export function scoreRound(input: ScrabbleInput, playerIds: readonly ID[]): Record<ID, number> {
+  const out: Record<ID, number> = Object.fromEntries(playerIds.map((id) => [id, 0]));
+
+  if (isTurn(input)) {
+    if (input.playerId && input.playerId in out) out[input.playerId] = turnTotal(input);
+    return out;
+  }
+
+  if (!input.finisherId || !(input.finisherId in out)) return out;
+  let sum = 0;
+  for (const id of playerIds) {
+    if (id === input.finisherId) continue;
+    const rem = Math.max(0, Math.trunc(numOr(input.remaining?.[id], 0)));
+    out[id] = rem > 0 ? -rem : 0;
+    sum += rem;
+  }
+  out[input.finisherId] += sum;
+  return out;
+}
+
+/** Validate a round. Null when good, else a friendly, specific message. */
+export function validateRound(
+  input: ScrabbleInput,
+  players: readonly { id: ID; name: string }[],
+): string | null {
+  if (isTurn(input)) {
+    if (!input.playerId || !players.some((p) => p.id === input.playerId)) {
+      return 'Choose who just played.';
+    }
+    if (!Number.isFinite(input.points) || input.points < 0) {
+      return "Enter this turn's word value (0 or more).";
+    }
+    return null;
+  }
+  if (!input.finisherId || !players.some((p) => p.id === input.finisherId)) {
+    return 'Choose who went out — emptied their rack with the bag empty.';
+  }
+  return null;
+}
+
+/** A compact one-liner summarizing a saved round, for the round history. */
+export function describeRound(
+  input: ScrabbleInput | undefined,
+  players: readonly { id: ID; name: string }[],
+): string {
+  const name = (id: ID | null) => players.find((p) => p.id === id)?.name ?? '?';
+  if (!input) return 'no turn recorded';
+
+  if (isFinalTally(input)) {
+    const swing = finalTallySwing(
+      input,
+      players.map((p) => p.id),
+    );
+    return swing > 0
+      ? `🏁 ${name(input.finisherId)} went out — +${swing} from opponents' racks`
+      : `🏁 ${name(input.finisherId)} went out`;
+  }
+
+  if (!input.playerId) return 'no turn recorded';
+  const total = turnTotal(input);
+  return input.bingo
+    ? `${name(input.playerId)} scored ${total} (🎉 BINGO! +${BINGO_BONUS})`
+    : `${name(input.playerId)} scored ${total}`;
+}

--- a/src/lib/games/scrabble/scrabble.test.ts
+++ b/src/lib/games/scrabble/scrabble.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round, RoundContext } from '../../types';
+import { defaultWinners } from '../../types';
+import { scrabble } from './index';
+import {
+  BINGO_BONUS,
+  LETTER_VALUES,
+  describeRound,
+  emptyFinalInput,
+  emptyInput,
+  emptyTurnInput,
+  finalTallySwing,
+  isFinalTally,
+  isTurn,
+  letterValue,
+  rackValue,
+  scoreRound,
+  turnTotal,
+  validateRound,
+  type FinalTallyInput,
+  type ScrabbleInput,
+  type TurnInput,
+} from './logic';
+
+// ---- helpers ---------------------------------------------------------------
+
+function player(id: string, name = id): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+
+const A = player('A', 'Ada');
+const B = player('B', 'Bo');
+const C = player('C', 'Cy');
+const players = [A, B, C];
+const ids = players.map((p) => p.id);
+
+function ctx(
+  config: Record<string, unknown> = {},
+  totals: Record<ID, number> = {},
+  roundIndex = 0,
+): RoundContext {
+  return {
+    game: {} as Game,
+    players,
+    config,
+    roundIndex,
+    totals,
+    rounds: [] as Round[],
+  };
+}
+
+function turn(playerId: ID | null, points: number, bingo = false): TurnInput {
+  return { kind: 'turn', playerId, points, bingo };
+}
+
+function final(finisherId: ID | null, remaining: Record<ID, number>): FinalTallyInput {
+  return { kind: 'final', finisherId, remaining };
+}
+
+// ---- letter values ----------------------------------------------------------
+
+describe('letterValue / rackValue', () => {
+  it('matches the standard English tile distribution', () => {
+    expect(letterValue('A')).toBe(1);
+    expect(letterValue('a')).toBe(1);
+    expect(letterValue('D')).toBe(2);
+    expect(letterValue('B')).toBe(3);
+    expect(letterValue('F')).toBe(4);
+    expect(letterValue('K')).toBe(5);
+    expect(letterValue('J')).toBe(8);
+    expect(letterValue('X')).toBe(8);
+    expect(letterValue('Q')).toBe(10);
+    expect(letterValue('Z')).toBe(10);
+  });
+
+  it('treats blanks/unknowns as 0', () => {
+    expect(letterValue('_')).toBe(0);
+    expect(letterValue('?')).toBe(0);
+    expect(letterValue('')).toBe(0);
+    expect(letterValue('AB')).toBe(0);
+  });
+
+  it('every real letter is present exactly once', () => {
+    const letters = Object.keys(LETTER_VALUES);
+    expect(letters).toHaveLength(26);
+  });
+
+  it('sums a whole rack, ignoring blanks/non-letters', () => {
+    expect(rackValue('QUIZ')).toBe(10 + 1 + 1 + 10);
+    expect(rackValue('quiz')).toBe(22);
+    expect(rackValue('CAT_')).toBe(3 + 1 + 1);
+    expect(rackValue('')).toBe(0);
+  });
+});
+
+// ---- turn input / scoring ---------------------------------------------------
+
+describe('emptyTurnInput / emptyInput', () => {
+  it('rotates the active player by round index', () => {
+    expect(emptyTurnInput(ids, 0)).toEqual({ kind: 'turn', playerId: 'A', points: 0, bingo: false });
+    expect(emptyTurnInput(ids, 1).playerId).toBe('B');
+    expect(emptyTurnInput(ids, 2).playerId).toBe('C');
+    expect(emptyTurnInput(ids, 3).playerId).toBe('A');
+  });
+
+  it('handles an empty roster gracefully', () => {
+    expect(emptyTurnInput([], 0).playerId).toBeNull();
+  });
+
+  it('emptyInput defaults to a turn', () => {
+    expect(emptyInput(ids, 0)).toEqual(emptyTurnInput(ids, 0));
+  });
+});
+
+describe('turnTotal', () => {
+  it('is just the word value with no bingo', () => {
+    expect(turnTotal(turn('A', 24))).toBe(24);
+  });
+  it('adds the bingo bonus when toggled on', () => {
+    expect(turnTotal(turn('A', 24, true))).toBe(24 + BINGO_BONUS);
+  });
+  it('never goes negative on garbage points', () => {
+    expect(turnTotal(turn('A', -5))).toBe(0);
+    expect(turnTotal(turn('A', Number.NaN))).toBe(0);
+  });
+});
+
+describe('scoreRound (turns)', () => {
+  it('credits only the active player', () => {
+    expect(scoreRound(turn('B', 18), ids)).toEqual({ A: 0, B: 18, C: 0 });
+  });
+  it('adds the bingo bonus into the same player delta', () => {
+    expect(scoreRound(turn('C', 30, true), ids)).toEqual({ A: 0, B: 0, C: 30 + BINGO_BONUS });
+  });
+  it('scores nothing with no player chosen', () => {
+    expect(scoreRound(turn(null, 40), ids)).toEqual({ A: 0, B: 0, C: 0 });
+  });
+});
+
+describe('validateRound (turns)', () => {
+  it('requires a player', () => {
+    expect(validateRound(turn(null, 10), players)).toMatch(/who just played/);
+  });
+  it('rejects an unknown player id', () => {
+    expect(validateRound(turn('Z', 10), players)).toMatch(/who just played/);
+  });
+  it('requires non-negative points', () => {
+    expect(validateRound(turn('A', -1), players)).toMatch(/word value/);
+  });
+  it('accepts a zero-point pass', () => {
+    expect(validateRound(turn('A', 0), players)).toBeNull();
+  });
+  it('accepts a normal scoring turn', () => {
+    expect(validateRound(turn('A', 24, true), players)).toBeNull();
+  });
+});
+
+// ---- final tally -------------------------------------------------------------
+
+describe('emptyFinalInput', () => {
+  it('zeroes every player', () => {
+    expect(emptyFinalInput(ids)).toEqual({
+      kind: 'final',
+      finisherId: null,
+      remaining: { A: 0, B: 0, C: 0 },
+    });
+  });
+});
+
+describe('finalTallySwing', () => {
+  it('sums every other player\'s remaining tile value', () => {
+    const input = final('A', { A: 0, B: 6, C: 4 });
+    expect(finalTallySwing(input, ids)).toBe(10);
+  });
+  it('ignores the finisher\'s own remaining entry', () => {
+    const input = final('A', { A: 99, B: 6, C: 4 });
+    expect(finalTallySwing(input, ids)).toBe(10);
+  });
+  it('clamps negative/garbage remaining values to 0', () => {
+    const input = final('A', { A: 0, B: -5, C: Number.NaN });
+    expect(finalTallySwing(input, ids)).toBe(0);
+  });
+});
+
+describe('scoreRound (final tally)', () => {
+  it('moves each rack value from its owner to the finisher', () => {
+    const input = final('A', { A: 0, B: 6, C: 4 });
+    expect(scoreRound(input, ids)).toEqual({ A: 10, B: -6, C: -4 });
+  });
+  it('scores nothing with no finisher chosen', () => {
+    const input = final(null, { A: 0, B: 6, C: 4 });
+    expect(scoreRound(input, ids)).toEqual({ A: 0, B: 0, C: 0 });
+  });
+  it('a finisher with no remaining opponents nets zero', () => {
+    const input = final('A', { A: 0, B: 0, C: 0 });
+    expect(scoreRound(input, ids)).toEqual({ A: 0, B: 0, C: 0 });
+  });
+});
+
+describe('validateRound (final tally)', () => {
+  it('requires a finisher', () => {
+    expect(validateRound(final(null, {}), players)).toMatch(/went out/);
+  });
+  it('rejects an unknown finisher id', () => {
+    expect(validateRound(final('Z', {}), players)).toMatch(/went out/);
+  });
+  it('accepts a valid final tally', () => {
+    expect(validateRound(final('A', { B: 6, C: 4 }), players)).toBeNull();
+  });
+});
+
+// ---- type guards --------------------------------------------------------------
+
+describe('isTurn / isFinalTally', () => {
+  it('discriminate correctly', () => {
+    expect(isTurn(turn('A', 1))).toBe(true);
+    expect(isTurn(final('A', {}))).toBe(false);
+    expect(isFinalTally(final('A', {}))).toBe(true);
+    expect(isFinalTally(turn('A', 1))).toBe(false);
+    expect(isTurn(null)).toBe(false);
+    expect(isFinalTally(undefined)).toBe(false);
+  });
+});
+
+// ---- describeRound ------------------------------------------------------------
+
+describe('describeRound', () => {
+  it('summarizes an ordinary turn', () => {
+    expect(describeRound(turn('A', 24), players)).toBe('Ada scored 24');
+  });
+  it('calls out a bingo turn', () => {
+    expect(describeRound(turn('B', 30, true), players)).toBe(
+      `Bo scored ${30 + BINGO_BONUS} (🎉 BINGO! +${BINGO_BONUS})`,
+    );
+  });
+  it('summarizes a final tally with a swing', () => {
+    expect(describeRound(final('A', { B: 6, C: 4 }), players)).toBe(
+      "🏁 Ada went out — +10 from opponents' racks",
+    );
+  });
+  it('summarizes a final tally with nothing left on the racks', () => {
+    expect(describeRound(final('A', { B: 0, C: 0 }), players)).toBe('🏁 Ada went out');
+  });
+  it('handles missing input', () => {
+    expect(describeRound(undefined, players)).toBe('no turn recorded');
+  });
+});
+
+// ---- module wiring -------------------------------------------------------------
+
+describe('scrabble module', () => {
+  it('exposes the expected identity', () => {
+    expect(scrabble.id).toBe('scrabble');
+    expect(scrabble.minPlayers).toBe(2);
+    expect(scrabble.maxPlayers).toBe(4);
+    expect(scrabble.help).toBeTruthy();
+  });
+
+  it('createRoundInput seeds a rotating turn', () => {
+    expect(scrabble.createRoundInput(ctx({}, {}, 1))).toEqual(emptyTurnInput(ids, 1));
+  });
+
+  it('scoreRound and validateRound route through the pure logic', () => {
+    const input: ScrabbleInput = turn('B', 18, true);
+    expect(scrabble.scoreRound(input, ctx())).toEqual({ A: 0, B: 18 + BINGO_BONUS, C: 0 });
+    expect(scrabble.validateRound(turn(null, 0), ctx())).toMatch(/who just played/);
+  });
+
+  it('picks the highest total as winner', () => {
+    const totals = { A: 210, B: 340, C: 180 };
+    expect(defaultWinners(scrabble, totals)).toEqual(['B']);
+  });
+
+  it('describeRound delegates to the pure helper', () => {
+    const round = { input: turn('C', 42) } as unknown as Round;
+    expect(scrabble.describeRound?.(round, players)).toBe('Cy scored 42');
+  });
+
+  it('roundCellTone flags the bingo player only', () => {
+    const round = { input: turn('A', 24, true) } as unknown as Round;
+    expect(scrabble.roundCellTone?.(round, 'A')).toEqual({
+      tone: 'good',
+      label: `BINGO! +${BINGO_BONUS}`,
+    });
+    expect(scrabble.roundCellTone?.(round, 'B')).toBeNull();
+  });
+
+  it('roundCellTone is null for a non-bingo turn and for final-tally rounds', () => {
+    const plain = { input: turn('A', 24) } as unknown as Round;
+    expect(scrabble.roundCellTone?.(plain, 'A')).toBeNull();
+    const finalRound = { input: final('A', { B: 5 }) } as unknown as Round;
+    expect(scrabble.roundCellTone?.(finalRound, 'A')).toBeNull();
+  });
+});

--- a/src/lib/games/scrabble/stats.ts
+++ b/src/lib/games/scrabble/stats.ts
@@ -1,0 +1,138 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtAvg, fmtInt } from '../../stats/format';
+import {
+  BINGO_BONUS,
+  finalTallySwing,
+  isFinalTally,
+  isTurn,
+  turnTotal,
+  type ScrabbleInput,
+} from './logic';
+
+interface ScrabbleAgg {
+  turns: number;
+  points: number;
+  bestTurn: number;
+  bingos: number;
+  finishes: number;
+  rackSwing: number;
+}
+
+function blank(): ScrabbleAgg {
+  return { turns: 0, points: 0, bestTurn: 0, bingos: 0, finishes: 0, rackSwing: 0 };
+}
+
+/**
+ * Scrabble stats, replayed purely from each game's recorded turns and its final tally.
+ * Pure, no I/O — mirrors the module's own scoring so a member's best turn and bingo
+ * count always match what the recorded rounds actually paid out.
+ */
+export function scrabbleStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, ScrabbleAgg>();
+  const get = (id: ID): ScrabbleAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = blank();
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let bestTurnAnywhere = 0;
+  let totalBingos = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as ScrabbleInput | undefined;
+    if (!input) continue;
+
+    if (isTurn(input)) {
+      if (!input.playerId) continue;
+      const id = canonical(input.playerId);
+      const a = get(id);
+      const total = turnTotal(input);
+      a.turns += 1;
+      a.points += total;
+      if (total > a.bestTurn) a.bestTurn = total;
+      if (total > bestTurnAnywhere) bestTurnAnywhere = total;
+      if (input.bingo) {
+        a.bingos += 1;
+        totalBingos += 1;
+      }
+      continue;
+    }
+
+    if (isFinalTally(input) && input.finisherId) {
+      const game = games.find((g) => g.id === r.gameId);
+      const playerIds = game?.playerIds ?? Object.keys(input.remaining ?? {});
+      const swing = finalTallySwing(input, playerIds);
+      const a = get(canonical(input.finisherId));
+      a.finishes += 1;
+      a.rackSwing += swing;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let allTurns = 0;
+  let allPoints = 0;
+
+  for (const [id, a] of per) {
+    allTurns += a.turns;
+    allPoints += a.points;
+
+    const metrics: Metric[] = [];
+    if (a.turns) {
+      metrics.push({
+        key: 'sc_best',
+        label: 'Best turn',
+        value: fmtInt(a.bestTurn),
+        sub: a.bestTurn >= BINGO_BONUS ? 'a monster word' : undefined,
+        emoji: '🔤',
+      });
+      metrics.push({
+        key: 'sc_avg',
+        label: 'Avg per turn',
+        value: fmtAvg(a.points / a.turns),
+        emoji: '🔢',
+      });
+    }
+    if (a.bingos) {
+      metrics.push({ key: 'sc_bingo', label: 'Bingos', value: fmtInt(a.bingos), emoji: '🎉' });
+    }
+    if (a.finishes) {
+      metrics.push({
+        key: 'sc_finish',
+        label: 'Games gone out first',
+        value: fmtInt(a.finishes),
+        sub: a.rackSwing ? `+${fmtInt(a.rackSwing)} from racks` : undefined,
+        emoji: '🏁',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (bestTurnAnywhere) {
+    global.push({
+      key: 'sc_best_all',
+      label: 'Best turn recorded',
+      value: fmtInt(bestTurnAnywhere),
+      emoji: '🔤',
+    });
+  }
+  if (allTurns) {
+    global.push({
+      key: 'sc_avg_all',
+      label: 'Avg per turn',
+      value: fmtAvg(allPoints / allTurns),
+      emoji: '🔢',
+    });
+  }
+  if (totalBingos) {
+    global.push({ key: 'sc_bingo_all', label: 'Bingos played', value: fmtInt(totalBingos), emoji: '🎉' });
+  }
+
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Adds a new Scrabble game module (🔤) to Score King, following the existing per-game module conventions (auto-discovered via `src/lib/games/scrabble/index.ts`).

## Changes

- `logic.ts` — pure scoring: standard letter tile values, per-turn word value + optional +50 bingo bonus, and the end-game final tally (each opponent's unplayed rack value moves to whoever went out first).
- `index.ts` — GameModule wiring (2–4 players, lazy-loaded editor, help text, round-cell tone for bingo turns).
- `ScrabbleEditor.svelte` — round editor with a Turn / Final-tally mode toggle, active-player picker, word-value stepper + quick-add chips, bingo toggle, letter-value reference, and the final-tally rack entry flow.
- `stats.ts` — per-player best turn, average per turn, bingo count, and going-out/rack-swing stats.
- `scrabble.test.ts` — 41 unit tests covering letter values, turn scoring, final-tally scoring/validation, and module wiring.

## Testing

- [x] `npm test -- scrabble` — 41/41 passing
- [x] `npm run check` — 0 errors

Research: confirmed standard English Scrabble letter values and the endgame rack-subtraction rule before implementing.