### PR TITLE
feat(phase10): add Phase 10 game module

### DIFF
--- a/src/lib/games/phase10/Phase10Editor.svelte
+++ b/src/lib/games/phase10/Phase10Editor.svelte
@@ -1,0 +1,266 @@
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { bumpOnChange } from '../../motion';
+  import { haptic } from '../../haptics';
+  import {
+    PHASE_COUNT,
+    emptyHand,
+    handValue,
+    hasWon,
+    phaseLabel,
+    phasesBefore,
+    type Phase10Input,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: Phase10Input; ctx: RoundContext } = $props();
+
+  const playerIds = $derived(ctx.players.map((p) => p.id));
+
+  // Each player's phase going INTO this hand — replayed from every earlier hand's
+  // `completed` flags (see logic.ts's phasesAfter). Mirrors Spades' bag-count replay:
+  // the running state a game needs beyond the plain point sum the shell tracks.
+  const phasesEntering = $derived(phasesBefore(ctx.rounds, ctx.roundIndex, playerIds));
+
+  // Older rounds (and freshly loaded edits) may not carry the per-kind `hands`
+  // breakdown. Seed one for every seat so the tally UI always has something to
+  // bind to; an old lump sum lands in `low` so its total is preserved and stays editable.
+  $effect(() => {
+    const ids = playerIds;
+    untrack(() => {
+      if (!input.hands) input.hands = {};
+      for (const id of ids) {
+        if (!input.hands[id]) {
+          input.hands[id] = { ...emptyHand(), low: Math.max(0, Number(input.penalty?.[id]) || 0) };
+        }
+      }
+    });
+  });
+
+  // Keep the authoritative `penalty` total in lockstep with the per-kind tally, so
+  // scoring, stats and history all read a plain number and never need to know
+  // about `hands`. Whoever completed their phase this hand played out clean: 0.
+  $effect(() => {
+    for (const id of playerIds) {
+      input.penalty[id] = input.completed[id] ? 0 : handValue(input.hands?.[id]);
+    }
+  });
+
+  function toggleCompleted(id: string) {
+    input.completed[id] = !input.completed[id];
+    if (input.completed[id]) {
+      if (input.hands?.[id]) input.hands[id] = emptyHand();
+      haptic('win');
+    }
+  }
+
+  function handValueOf(id: string): number {
+    return input.completed[id] ? 0 : handValue(input.hands?.[id]);
+  }
+</script>
+
+<div class="stack">
+  <p class="muted prompt">
+    Mark who completed their phase this hand, then tally the cards left in every other hand.
+  </p>
+
+  {#each ctx.players as p (p.id)}
+    {@const phaseBefore = phasesEntering[p.id] ?? 1}
+    {@const wonAlready = hasWon(phaseBefore)}
+    {@const done = !!input.completed[p.id]}
+    <div class="prow" class:done>
+      <div class="row spread head">
+        <span class="row who">
+          <Avatar name={p.name} color={p.color} />
+          <strong class="ellipsis">{p.name}</strong>
+        </span>
+        <span class="badge" class:crown={wonAlready}>
+          {wonAlready ? '🏆 Won' : phaseLabel(phaseBefore)}
+        </span>
+      </div>
+
+      {#if wonAlready}
+        <p class="note">Already cleared Phase 10 — nothing more to track.</p>
+      {:else}
+        <div class="row outrow">
+          <button
+            type="button"
+            class="wentout"
+            class:on={done}
+            aria-pressed={done}
+            onclick={() => toggleCompleted(p.id)}
+          >
+            {done
+              ? phaseBefore >= PHASE_COUNT
+                ? '🏆 Completed · clears Phase 10!'
+                : `✅ Completed · advances to Phase ${phaseBefore + 1}`
+              : 'Completed phase?'}
+          </button>
+        </div>
+
+        {#if done}
+          <p class="note">Clean hand — banks 0 penalty points.</p>
+        {:else}
+          <div class="row spread">
+            <span class="subtotal tnum" use:bumpOnChange={handValueOf(p.id)}
+              >{handValueOf(p.id)}<span class="sub">pts left in hand</span></span
+            >
+          </div>
+          <div class="tally">
+            <label class="f">
+              <span class="klabel">🔢 1–9 <span class="hint">×5</span></span>
+              <Stepper bind:value={input.hands![p.id].low} min={0} label="{p.name} 1 to 9 cards" />
+            </label>
+            <label class="f">
+              <span class="klabel">🔟 10–12 <span class="hint">×10</span></span>
+              <Stepper
+                bind:value={input.hands![p.id].high}
+                min={0}
+                label="{p.name} 10 to 12 cards"
+              />
+            </label>
+            <label class="f">
+              <span class="klabel">⛔ Skip <span class="hint">×15</span></span>
+              <Stepper bind:value={input.hands![p.id].skip} min={0} label="{p.name} skip cards" />
+            </label>
+            <label class="f">
+              <span class="klabel">🌈 Wild <span class="hint">×25</span></span>
+              <Stepper bind:value={input.hands![p.id].wild} min={0} label="{p.name} wild cards" />
+            </label>
+          </div>
+        {/if}
+      {/if}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .prompt {
+    font-size: 0.9rem;
+  }
+
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    transition:
+      background 0.15s ease,
+      border-color 0.15s ease;
+  }
+  /* Completed this hand — the restrained Crown-Gold wash the scoreboard uses,
+     co-signalled by the ✅ label, never colour alone. */
+  .prow.done {
+    background: color-mix(in srgb, var(--accent) 13%, var(--surface-2));
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  }
+  .head {
+    align-items: center;
+  }
+  .who {
+    gap: 8px;
+    min-width: 0;
+  }
+  .ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .badge {
+    flex: none;
+    font-weight: 700;
+    font-size: 0.85rem;
+    color: var(--muted);
+    white-space: nowrap;
+  }
+  .badge.crown {
+    color: var(--accent-ink);
+  }
+
+  .subtotal {
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .subtotal .sub {
+    margin-left: 6px;
+    font-weight: 500;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+
+  .wentout {
+    flex: 1;
+    min-height: 46px;
+    padding: 0 14px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--muted);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease,
+      border-color 0.15s ease;
+  }
+  .wentout:hover {
+    color: var(--text);
+    background: var(--surface-3);
+  }
+  /* Selected = gold-ink + gold border tint, NOT a violet fill — the one violet
+     action on the screen stays the shell's Save. */
+  .wentout.on {
+    background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+    color: var(--accent-ink);
+  }
+  .wentout:active {
+    transform: translateY(1px);
+  }
+  .wentout:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .note {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+
+  .tally {
+    display: flex;
+    gap: 14px;
+    flex-wrap: wrap;
+  }
+  .f {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .klabel {
+    font-size: 0.78rem;
+    color: var(--muted);
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .klabel .hint {
+    font-weight: 500;
+    opacity: 0.85;
+  }
+  .tnum {
+    font-variant-numeric: tabular-nums;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .prow,
+    .wentout {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/games/phase10/index.ts
+++ b/src/lib/games/phase10/index.ts
@@ -1,0 +1,63 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { phase10Stats } from './stats';
+import {
+  PHASE10_HELP,
+  createPhase10Input,
+  isPhase10Finished,
+  pickPhase10Winners,
+  scorePhase10,
+  validatePhase10,
+  type Phase10Input,
+} from './logic';
+
+export type { Phase10Input, Phase10Hand, PhaseDef } from './logic';
+export { PHASES, PHASE_COUNT, CARD_VALUE, phaseLabel, phasesAfter, hasWon } from './logic';
+
+export const phase10: GameModule = {
+  id: 'phase10',
+  name: 'Phase 10',
+  tagline: 'Climb ten phases before anyone else clears the ladder',
+  emoji: '🔟',
+  keywords: ['phase 10', 'phase ten', 'rummy', 'shedding', 'sets', 'runs', 'cards'],
+  minPlayers: 2,
+  maxPlayers: 6,
+  lowerIsBetter: true,
+
+  createRoundInput: (ctx: RoundContext): Phase10Input =>
+    createPhase10Input(ctx.players.map((p) => p.id)),
+
+  validateRound: (input: Phase10Input, ctx: RoundContext): string | null =>
+    validatePhase10(input, ctx.players),
+
+  scoreRound: (input: Phase10Input, ctx: RoundContext): Record<ID, number> =>
+    scorePhase10(
+      input,
+      ctx.players.map((p) => p.id),
+    ),
+
+  // Phase 10's finish line is "someone cleared Phase 10", not a points threshold —
+  // it needs the recorded hand history, not just cumulative totals. See types.ts.
+  isFinished: (totals, { rounds }) => isPhase10Finished(rounds, Object.keys(totals)),
+
+  // The primary criterion is phase progress (who cleared Phase 10 first), not points —
+  // `totals` only breaks a tie between players who finish in the very same hand.
+  pickWinners: (totals, _config, rounds) => pickPhase10Winners(totals, rounds),
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as Phase10Input;
+    if (!input?.completed) return 'no result';
+    const cleared = players.filter((p) => input.completed[p.id]);
+    const points = players.reduce((sum, p) => sum + (Number(input.penalty?.[p.id]) || 0), 0);
+    const names = cleared.map((p) => p.name).join(', ');
+    if (!cleared.length) return points > 0 ? `nobody advanced · ${points} pts on the table` : 'nobody advanced';
+    return points > 0 ? `✅ ${names} advanced · ${points} pts on the table` : `✅ ${names} advanced · clean hand`;
+  },
+
+  help: PHASE10_HELP,
+
+  stats: phase10Stats,
+
+  RoundEditor,
+  editorLoader: () => import('./Phase10Editor.svelte'),
+};

--- a/src/lib/games/phase10/logic.ts
+++ b/src/lib/games/phase10/logic.ts
@@ -1,0 +1,222 @@
+import type { ID, Round } from '../../types';
+
+/**
+ * Phase 10 scoring — pure and Svelte-free so it can be unit-tested directly and
+ * reused by the editor for live previews.
+ *
+ * Each hand, every player either completes their current phase (and advances to
+ * the next one) or doesn't (and repeats it next hand). The hand ends the instant
+ * someone plays their last card ("goes out") — which requires having already
+ * completed their phase that hand. Everyone else scores penalty points for the
+ * cards left in their hand, whether or not they completed their own phase.
+ *
+ * A player's *phase* is not part of the per-round point delta the shell sums
+ * into `totals` — it's a running state derived by replaying every hand's
+ * `completed` flags in order (see {@link phasesAfter}), the same "replay the
+ * whole history" shape Spades uses for bags and Stardew uses for evaluation
+ * categories. That keeps `totals` a clean, honest points column (lower is
+ * better, exactly like Hearts) while the phase ladder — the *real* win
+ * condition — lives alongside it rather than being folded into the same number.
+ */
+
+/** The ten phases, in order, exactly as printed on the official card. */
+export interface PhaseDef {
+  number: number;
+  label: string;
+}
+
+export const PHASES: readonly PhaseDef[] = [
+  { number: 1, label: '2 sets of 3' },
+  { number: 2, label: '1 set of 3 + 1 run of 4' },
+  { number: 3, label: '1 set of 4 + 1 run of 4' },
+  { number: 4, label: '1 run of 7' },
+  { number: 5, label: '1 run of 8' },
+  { number: 6, label: '1 run of 9' },
+  { number: 7, label: '2 sets of 4' },
+  { number: 8, label: '7 cards of one color' },
+  { number: 9, label: '1 set of 5 + 1 set of 2' },
+  { number: 10, label: '1 set of 5 + 1 set of 3' },
+] as const;
+
+export const PHASE_COUNT = PHASES.length;
+
+/** Penalty points for one card left in hand, by kind (official card values). */
+export const CARD_VALUE = {
+  low: 5, // number cards 1–9
+  high: 10, // number cards 10–12
+  skip: 15, // Skip cards
+  wild: 25, // Wild cards
+} as const;
+
+/**
+ * A leftover hand tallied by card kind, so the editor can add cards the way you
+ * actually read a fanned-out hand (by *kind*) instead of pre-summing points in
+ * your head. Purely an entry convenience — {@link Phase10Input.penalty} is
+ * always the authoritative scored value, kept in sync via {@link handValue}.
+ */
+export interface Phase10Hand {
+  /** Count of number cards 1–9 left in hand. */
+  low: number;
+  /** Count of number cards 10–12 left in hand. */
+  high: number;
+  /** Count of Skip cards left in hand. */
+  skip: number;
+  /** Count of Wild cards left in hand. */
+  wild: number;
+}
+
+export interface Phase10Input {
+  /** Did this player complete their current phase this hand (and advance)? */
+  completed: Record<ID, boolean>;
+  /** Penalty points scored this hand for cards left in hand (0 for who went out). */
+  penalty: Record<ID, number>;
+  /** Optional per-kind breakdown behind each player's {@link penalty}. Editing aid only. */
+  hands?: Record<ID, Phase10Hand>;
+}
+
+/** A fresh, empty per-kind hand (no cards counted yet). */
+export function emptyHand(): Phase10Hand {
+  return { low: 0, high: 0, skip: 0, wild: 0 };
+}
+
+/** Points a per-kind hand is worth given the official card values. Clamps to ≥ 0. */
+export function handValue(hand: Phase10Hand | undefined): number {
+  if (!hand) return 0;
+  const low = Math.max(0, Number(hand.low) || 0);
+  const high = Math.max(0, Number(hand.high) || 0);
+  const skip = Math.max(0, Number(hand.skip) || 0);
+  const wild = Math.max(0, Number(hand.wild) || 0);
+  return low * CARD_VALUE.low + high * CARD_VALUE.high + skip * CARD_VALUE.skip + wild * CARD_VALUE.wild;
+}
+
+/** A fresh, zeroed round input for the current roster: nobody completed, no cards tallied. */
+export function createPhase10Input(playerIds: ID[]): Phase10Input {
+  return {
+    completed: Object.fromEntries(playerIds.map((id) => [id, false])),
+    penalty: Object.fromEntries(playerIds.map((id) => [id, 0])),
+    hands: Object.fromEntries(playerIds.map((id) => [id, emptyHand()])),
+  };
+}
+
+/** A player's scored penalty for this hand, clamped to a non-negative number. */
+export function penaltyOf(input: Phase10Input, id: ID): number {
+  return Math.max(0, Number(input.penalty[id]) || 0);
+}
+
+export function validatePhase10(
+  input: Phase10Input,
+  players: { id: ID; name: string }[],
+): string | null {
+  for (const p of players) {
+    const raw = input.penalty[p.id];
+    if (raw == null) continue;
+    const v = Number(raw);
+    if (!Number.isFinite(v) || v < 0) {
+      return `${p.name}'s penalty points must be 0 or more.`;
+    }
+  }
+  return null;
+}
+
+/** Compute per-player point deltas for a hand — just the tallied penalty points. */
+export function scorePhase10(input: Phase10Input, playerIds: ID[]): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const id of playerIds) out[id] = penaltyOf(input, id);
+  return out;
+}
+
+/**
+ * Replay every recorded hand's `completed` flags to find each player's CURRENT
+ * phase (1–10 while still playing; {@link PHASE_COUNT} + 1 once they've cleared
+ * Phase 10 and won). Mirrors Spades' `bagCountsAfter` / Stardew's
+ * `priorCategoryTotals` — the running, non-additive state a game needs beyond
+ * the plain point sum the shell already tracks in `totals`.
+ */
+export function phasesAfter(rounds: readonly Round[], playerIds: readonly ID[]): Record<ID, number> {
+  const phase: Record<ID, number> = {};
+  for (const id of playerIds) phase[id] = 1;
+  const sorted = [...rounds].sort((a, b) => a.index - b.index);
+  for (const r of sorted) {
+    const input = r.input as Phase10Input | undefined;
+    if (!input?.completed) continue;
+    for (const id of playerIds) {
+      if (input.completed[id] && phase[id] <= PHASE_COUNT) phase[id] += 1;
+    }
+  }
+  return phase;
+}
+
+/** Each player's phase strictly BEFORE the hand at `roundIndex` (0-based). */
+export function phasesBefore(
+  rounds: readonly Round[],
+  roundIndex: number,
+  playerIds: readonly ID[],
+): Record<ID, number> {
+  return phasesAfter(
+    rounds.filter((r) => r.index < roundIndex),
+    playerIds,
+  );
+}
+
+/** True once a player has cleared Phase 10 (their phase count has run past it). */
+export function hasWon(phase: number): boolean {
+  return phase > PHASE_COUNT;
+}
+
+/** The label to show for a player's phase — "Phase N" while playing, or a win badge. */
+export function phaseLabel(phase: number): string {
+  if (hasWon(phase)) return '🏆 Phase 10 complete!';
+  const def = PHASES[Math.min(Math.max(phase, 1), PHASE_COUNT) - 1];
+  return `Phase ${phase} · ${def.label}`;
+}
+
+/** Game ends the instant any player's phase (after all recorded hands) clears Phase 10. */
+export function isPhase10Finished(rounds: readonly Round[] | undefined, playerIds: readonly ID[]): boolean {
+  const phases = phasesAfter(rounds ?? [], playerIds);
+  return playerIds.some((id) => hasWon(phases[id]));
+}
+
+/**
+ * Winner(s): whoever completed Phase 10 first. Normally exactly one player, but
+ * the official rule allows a tie when more than one player clears Phase 10 in
+ * the very same hand — broken by the lowest total points. Returns no winner
+ * when the game was finished early, before anyone actually completed Phase 10.
+ */
+export function pickPhase10Winners(
+  totals: Record<ID, number>,
+  rounds: readonly Round[] | undefined,
+): ID[] {
+  const ids = Object.keys(totals);
+  const phases = phasesAfter(rounds ?? [], ids);
+  const finished = ids.filter((id) => hasWon(phases[id]));
+  if (finished.length <= 1) return finished;
+  const best = Math.min(...finished.map((id) => Number(totals[id]) || 0));
+  return finished.filter((id) => (Number(totals[id]) || 0) === best);
+}
+
+export const PHASE10_HELP = [
+  'Race through ten phases, in order. Complete your current phase this hand and',
+  'you advance to the next one; miss it and you repeat the same phase next hand.',
+  '',
+  '1. Two sets of 3',
+  '2. One set of 3 + one run of 4',
+  '3. One set of 4 + one run of 4',
+  '4. One run of 7',
+  '5. One run of 8',
+  '6. One run of 9',
+  '7. Two sets of 4',
+  '8. Seven cards of one color',
+  '9. One set of 5 + one set of 2',
+  '10. One set of 5 + one set of 3',
+  '',
+  'The hand ends the moment someone plays their last card ("goes out") — which',
+  'requires having already completed their phase that hand. Everyone else scores',
+  'penalty points for the cards left in hand:',
+  '• Number cards 1–9 — 5 each',
+  '• Number cards 10–12 — 10 each',
+  '• Skip cards — 15 each',
+  '• Wild cards — 25 each',
+  '',
+  'First to complete Phase 10 wins. Lowest total points breaks a tie between',
+  'players who clear Phase 10 in the very same hand.',
+].join('\n');

--- a/src/lib/games/phase10/phase10.test.ts
+++ b/src/lib/games/phase10/phase10.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, Player, Round, RoundContext } from '../../types';
+import { phase10 } from './index';
+import { phase10Stats } from './stats';
+import {
+  CARD_VALUE,
+  PHASE_COUNT,
+  PHASES,
+  createPhase10Input,
+  emptyHand,
+  handValue,
+  hasWon,
+  isPhase10Finished,
+  phaseLabel,
+  phasesAfter,
+  phasesBefore,
+  pickPhase10Winners,
+  scorePhase10,
+  validatePhase10,
+  type Phase10Input,
+} from './logic';
+
+// ---- helpers ---------------------------------------------------------------
+
+function player(id: string, name = id): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+
+const A = player('A', 'Alice');
+const B = player('B', 'Bob');
+const C = player('C', 'Cy');
+const players = [A, B, C];
+const ids = players.map((p) => p.id);
+
+function ctx(config: Record<string, unknown> = {}, rounds: Round[] = [], roundIndex = 0): RoundContext {
+  return {
+    game: {} as Game,
+    players,
+    config,
+    roundIndex,
+    totals: {},
+    rounds,
+  };
+}
+
+function round(index: number, completed: Record<string, boolean>, penalty: Record<string, number> = {}): Round {
+  const input: Phase10Input = {
+    completed,
+    penalty: { A: 0, B: 0, C: 0, ...penalty },
+  };
+  return {
+    id: `r${index}`,
+    gameId: 'g1',
+    index,
+    input,
+    deltas: scorePhase10(input, ids),
+    createdAt: 0,
+  };
+}
+
+// ---- phase list --------------------------------------------------------------
+
+describe('PHASES', () => {
+  it('has all ten official phases in order', () => {
+    expect(PHASE_COUNT).toBe(10);
+    expect(PHASES.map((p) => p.number)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(PHASES[0].label).toBe('2 sets of 3');
+    expect(PHASES[9].label).toBe('1 set of 5 + 1 set of 3');
+  });
+});
+
+// ---- round input -------------------------------------------------------------
+
+describe('createPhase10Input', () => {
+  it('starts with nobody completed, everyone on zero, and a fresh per-kind hand each', () => {
+    expect(createPhase10Input(ids)).toEqual({
+      completed: { A: false, B: false, C: false },
+      penalty: { A: 0, B: 0, C: 0 },
+      hands: {
+        A: { low: 0, high: 0, skip: 0, wild: 0 },
+        B: { low: 0, high: 0, skip: 0, wild: 0 },
+        C: { low: 0, high: 0, skip: 0, wild: 0 },
+      },
+    });
+  });
+});
+
+// ---- per-kind hand tally -------------------------------------------------------
+
+describe('emptyHand', () => {
+  it('is a zeroed per-kind hand', () => {
+    expect(emptyHand()).toEqual({ low: 0, high: 0, skip: 0, wild: 0 });
+  });
+});
+
+describe('handValue', () => {
+  it('sums card counts × their official point values', () => {
+    expect(handValue({ low: 2, high: 1, skip: 1, wild: 1 })).toBe(
+      2 * CARD_VALUE.low + CARD_VALUE.high + CARD_VALUE.skip + CARD_VALUE.wild,
+    );
+  });
+
+  it('treats a missing hand as zero', () => {
+    expect(handValue(undefined)).toBe(0);
+  });
+
+  it('clamps negative counts to zero', () => {
+    expect(handValue({ low: -5, high: -1, skip: 0, wild: 3 })).toBe(75);
+  });
+});
+
+// ---- scoring -------------------------------------------------------------------
+
+describe('scorePhase10', () => {
+  it('reads the authoritative penalty field for each player', () => {
+    const input = createPhase10Input(ids);
+    input.penalty = { A: 0, B: 20, C: 45 };
+    expect(scorePhase10(input, ids)).toEqual({ A: 0, B: 20, C: 45 });
+  });
+
+  it('clamps negative penalties to zero', () => {
+    const input = createPhase10Input(ids);
+    input.penalty = { A: -10, B: 0, C: 5 };
+    expect(scorePhase10(input, ids)).toEqual({ A: 0, B: 0, C: 5 });
+  });
+});
+
+// ---- validation -----------------------------------------------------------------
+
+describe('validatePhase10', () => {
+  it('rejects a negative penalty, naming the player', () => {
+    const input = createPhase10Input(ids);
+    input.penalty.B = -5;
+    expect(validatePhase10(input, players)).toContain('Bob');
+  });
+
+  it('passes a well-formed hand', () => {
+    const input = createPhase10Input(ids);
+    input.penalty = { A: 0, B: 20, C: 45 };
+    expect(validatePhase10(input, players)).toBeNull();
+  });
+});
+
+// ---- phase replay ---------------------------------------------------------------
+
+describe('phasesAfter', () => {
+  it('starts everyone at phase 1 with no hands recorded', () => {
+    expect(phasesAfter([], ids)).toEqual({ A: 1, B: 1, C: 1 });
+  });
+
+  it('advances only the players who completed their phase that hand', () => {
+    const r0 = round(0, { A: true, B: false, C: true });
+    expect(phasesAfter([r0], ids)).toEqual({ A: 2, B: 1, C: 2 });
+  });
+
+  it('accumulates across many hands, oldest first regardless of input order', () => {
+    const r0 = round(0, { A: true, B: false, C: false });
+    const r1 = round(1, { A: true, B: true, C: false });
+    const r2 = round(2, { A: false, B: true, C: true });
+    // Shuffle the order passed in — phasesAfter must sort by index itself.
+    expect(phasesAfter([r2, r0, r1], ids)).toEqual({ A: 3, B: 3, C: 2 });
+  });
+
+  it('stops advancing once a player clears Phase 10', () => {
+    const rounds = Array.from({ length: 10 }, (_, i) => round(i, { A: true, B: false, C: false }));
+    // After 10 straight completions A has cleared Phase 10 (phase 11).
+    expect(phasesAfter(rounds, ids).A).toBe(11);
+    // An eleventh completion shouldn't push it any higher.
+    const eleventh = round(10, { A: true, B: false, C: false });
+    expect(phasesAfter([...rounds, eleventh], ids).A).toBe(11);
+  });
+});
+
+describe('phasesBefore', () => {
+  it('excludes the hand at roundIndex and everything after it', () => {
+    const r0 = round(0, { A: true, B: false, C: false });
+    const r1 = round(1, { A: true, B: true, C: false });
+    expect(phasesBefore([r0, r1], 1, ids)).toEqual({ A: 2, B: 1, C: 1 });
+    expect(phasesBefore([r0, r1], 0, ids)).toEqual({ A: 1, B: 1, C: 1 });
+  });
+});
+
+describe('hasWon / phaseLabel', () => {
+  it('hasWon is true only once phase exceeds the phase count', () => {
+    expect(hasWon(10)).toBe(false);
+    expect(hasWon(11)).toBe(true);
+  });
+
+  it('phaseLabel names the phase and its requirement', () => {
+    expect(phaseLabel(1)).toBe('Phase 1 · 2 sets of 3');
+    expect(phaseLabel(10)).toBe('Phase 10 · 1 set of 5 + 1 set of 3');
+  });
+
+  it('phaseLabel flags a win distinctly', () => {
+    expect(phaseLabel(11)).toMatch(/complete/i);
+  });
+});
+
+// ---- end condition & winners -----------------------------------------------------
+
+describe('isPhase10Finished', () => {
+  it('is false while nobody has cleared Phase 10', () => {
+    const r0 = round(0, { A: true, B: false, C: false });
+    expect(isPhase10Finished([r0], ids)).toBe(false);
+  });
+
+  it('is true the instant any player clears Phase 10', () => {
+    const rounds = Array.from({ length: 10 }, (_, i) => round(i, { A: true, B: false, C: false }));
+    expect(isPhase10Finished(rounds, ids)).toBe(true);
+  });
+
+  it('handles no recorded rounds', () => {
+    expect(isPhase10Finished(undefined, ids)).toBe(false);
+  });
+});
+
+describe('pickPhase10Winners', () => {
+  it('returns no winner before anyone has cleared Phase 10', () => {
+    const r0 = round(0, { A: true, B: false, C: false });
+    expect(pickPhase10Winners({ A: 5, B: 20, C: 15 }, [r0])).toEqual([]);
+  });
+
+  it('crowns the sole player who cleared Phase 10', () => {
+    const rounds = Array.from({ length: 10 }, (_, i) => round(i, { A: true, B: false, C: false }));
+    expect(pickPhase10Winners({ A: 30, B: 90, C: 60 }, rounds)).toEqual(['A']);
+  });
+
+  it('breaks a simultaneous-finish tie by lowest total points', () => {
+    // A and B both clear Phase 10 on the same, final hand.
+    const rounds = Array.from({ length: 9 }, (_, i) =>
+      round(i, { A: true, B: true, C: false }),
+    );
+    rounds.push(round(9, { A: true, B: true, C: false }));
+    expect(pickPhase10Winners({ A: 40, B: 25, C: 200 }, rounds)).toEqual(['B']);
+  });
+
+  it('crowns both finishers when their points are exactly tied', () => {
+    const rounds = Array.from({ length: 10 }, (_, i) => round(i, { A: true, B: true, C: false }));
+    expect(pickPhase10Winners({ A: 50, B: 50, C: 300 }, rounds)).toEqual(['A', 'B']);
+  });
+});
+
+// ---- module wiring ----------------------------------------------------------------
+
+describe('phase10 module', () => {
+  it('has the expected identity and roster', () => {
+    expect(phase10.id).toBe('phase10');
+    expect(phase10.name).toBe('Phase 10');
+    expect(phase10.minPlayers).toBe(2);
+    expect(phase10.maxPlayers).toBe(6);
+    expect(phase10.lowerIsBetter).toBe(true);
+  });
+
+  it('builds a fresh input and validates/scores through the context', () => {
+    const fresh = phase10.createRoundInput(ctx()) as Phase10Input;
+    expect(fresh.completed).toEqual({ A: false, B: false, C: false });
+    expect(fresh.penalty).toEqual({ A: 0, B: 0, C: 0 });
+
+    const hand: Phase10Input = {
+      completed: { A: true, B: false, C: false },
+      penalty: { A: 0, B: 20, C: 45 },
+    };
+    expect(phase10.validateRound(hand, ctx())).toBeNull();
+    expect(phase10.scoreRound(hand, ctx())).toEqual({ A: 0, B: 20, C: 45 });
+  });
+
+  it('is not finished while nobody has cleared Phase 10', () => {
+    const r0 = round(0, { A: true, B: false, C: false });
+    expect(
+      phase10.isFinished?.(
+        { A: 0, B: 10, C: 5 },
+        { config: {}, roundCount: 1, playerCount: 3, rounds: [r0] },
+      ),
+    ).toBe(false);
+  });
+
+  it('is finished once a player clears Phase 10', () => {
+    const rounds = Array.from({ length: 10 }, (_, i) => round(i, { A: true, B: false, C: false }));
+    expect(
+      phase10.isFinished?.(
+        { A: 0, B: 90, C: 60 },
+        { config: {}, roundCount: 10, playerCount: 3, rounds },
+      ),
+    ).toBe(true);
+  });
+
+  it('pickWinners crowns the player who cleared Phase 10, tie-broken by lowest points', () => {
+    const rounds = Array.from({ length: 10 }, (_, i) => round(i, { A: true, B: true, C: false }));
+    expect(phase10.pickWinners?.({ A: 40, B: 25, C: 200 }, {}, rounds)).toEqual(['B']);
+  });
+
+  it('summarises a recorded round for the history table', () => {
+    const r = round(0, { A: true, B: false, C: false }, { B: 20, C: 5 });
+    expect(phase10.describeRound?.(r, players)).toBe('✅ Alice advanced · 25 pts on the table');
+  });
+
+  it('describes a hand where nobody advanced', () => {
+    const r = round(0, { A: false, B: false, C: false }, { A: 5, B: 20, C: 5 });
+    expect(phase10.describeRound?.(r, players)).toBe('nobody advanced · 30 pts on the table');
+  });
+});
+
+// ---- stats --------------------------------------------------------------------------
+
+describe('phase10Stats', () => {
+  const game: Game = {
+    id: 'g1',
+    type: 'phase10',
+    config: {},
+    playerIds: ids,
+    status: 'finished',
+    createdAt: 0,
+    roundCount: 10,
+  };
+  const rounds = Array.from({ length: 10 }, (_, i) =>
+    round(i, { A: true, B: i === 9, C: false }, { B: 10, C: 15 }),
+  );
+
+  const res = phase10Stats({ games: [game], rounds, players, canonical: (id) => id });
+  const perPlayer = res.perPlayer ?? {};
+  const global = res.global ?? [];
+
+  it('credits the player who cleared Phase 10', () => {
+    const a = perPlayer['A'] ?? [];
+    expect(a.find((m) => m.key === 'p10_clears')?.value).toBe('1');
+    expect(a.find((m) => m.key === 'p10_best')?.value).toBe('Phase 10');
+  });
+
+  it('tracks best phase reached for a player who never finished', () => {
+    const c = perPlayer['C'] ?? [];
+    expect(c.find((m) => m.key === 'p10_clears')).toBeUndefined();
+    expect(c.find((m) => m.key === 'p10_best')?.value).toBe('Phase 1');
+    expect(c.find((m) => m.key === 'p10_penalty')?.value).toBe('150');
+  });
+
+  it('reports the global clear count', () => {
+    expect(global.find((m) => m.key === 'p10_clears_all')?.value).toBe('1');
+  });
+
+  it('ignores rounds from other games', () => {
+    const only = phase10Stats({ games: [], rounds, players, canonical: (id) => id });
+    expect(only.perPlayer ?? {}).toEqual({});
+    expect(only.global ?? []).toEqual([]);
+  });
+});

--- a/src/lib/games/phase10/stats.ts
+++ b/src/lib/games/phase10/stats.ts
@@ -1,0 +1,120 @@
+import type { ID, Round } from '../../types';
+import type { Phase10Input } from './logic';
+import { PHASE_COUNT, hasWon, phasesAfter } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt } from '../../stats/format';
+
+interface Phase10Agg {
+  /** Hands this player advanced a phase. */
+  advances: number;
+  /** Hands this player took part in. */
+  hands: number;
+  /** Total penalty points scored across hands. */
+  penalty: number;
+  /** Games where this player cleared Phase 10 (may include ties). */
+  clears: number;
+  /** Highest phase this player ever reached. */
+  bestPhase: number;
+}
+
+/**
+ * Phase 10 stats replay each finished game's hand history to find how far every
+ * player climbed the phase ladder — mirroring the module's own phase-progress
+ * logic (see `phasesAfter`) so stats and live play never disagree.
+ */
+export function phase10Stats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const roundsByGame = new Map<ID, Round[]>();
+  for (const r of rounds) {
+    if (!roundsByGame.has(r.gameId)) roundsByGame.set(r.gameId, []);
+    roundsByGame.get(r.gameId)!.push(r);
+  }
+
+  const per = new Map<ID, Phase10Agg>();
+  const get = (id: ID): Phase10Agg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { advances: 0, hands: 0, penalty: 0, clears: 0, bestPhase: 1 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let totalClears = 0;
+
+  for (const g of games) {
+    const gRounds = roundsByGame.get(g.id) ?? [];
+    const playerIds = g.playerIds.map((id) => canonical(id));
+    for (const r of gRounds) {
+      const input = r.input as Phase10Input | undefined;
+      if (!input?.completed) continue;
+      for (const pid of g.playerIds) {
+        const id = canonical(pid);
+        const a = get(id);
+        a.hands += 1;
+        if (input.completed[pid]) a.advances += 1;
+        a.penalty += Math.max(0, Number(input.penalty?.[pid]) || 0);
+      }
+    }
+    const phases = phasesAfter(gRounds, playerIds);
+    for (const id of playerIds) {
+      const a = get(id);
+      const phase = phases[id] ?? 1;
+      const capped = Math.min(phase, PHASE_COUNT);
+      if (capped > a.bestPhase) a.bestPhase = capped;
+      if (hasWon(phase)) {
+        a.clears += 1;
+        totalClears += 1;
+      }
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    const metrics: Metric[] = [];
+    if (a.clears) {
+      metrics.push({
+        key: 'p10_clears',
+        label: 'Phase 10 completed',
+        value: fmtInt(a.clears),
+        emoji: '🔟',
+      });
+    }
+    if (a.bestPhase) {
+      metrics.push({
+        key: 'p10_best',
+        label: 'Best phase reached',
+        value: `Phase ${a.bestPhase}`,
+        emoji: '🪜',
+      });
+    }
+    if (a.advances) {
+      metrics.push({
+        key: 'p10_advances',
+        label: 'Hands advanced',
+        value: fmtInt(a.advances),
+        emoji: '✅',
+      });
+    }
+    if (a.penalty) {
+      metrics.push({
+        key: 'p10_penalty',
+        label: 'Penalty points caught holding',
+        value: fmtInt(a.penalty),
+        emoji: '🃏',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totalClears) {
+    global.push({
+      key: 'p10_clears_all',
+      label: 'Times Phase 10 was cleared',
+      value: fmtInt(totalClears),
+      emoji: '🔟',
+    });
+  }
+
+  return { perPlayer, global };
+}

--- a/src/lib/stores/games.ts
+++ b/src/lib/stores/games.ts
@@ -103,7 +103,7 @@ export async function finishGame(game: Game): Promise<Game> {
   if (module) {
     lower = resolveLower(module, game.config);
     winners = module.pickWinners
-      ? module.pickWinners(totals, game.config)
+      ? module.pickWinners(totals, game.config, rounds)
       : defaultWinners(module, totals, game.config);
   }
   const updated: Game = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -206,13 +206,29 @@ export interface GameModule {
 
   /** Fixed number of rounds (e.g. Skull King = 10); null/undefined = open-ended. */
   maxRounds?(config: Record<string, unknown>, playerCount: number): number | null;
-  /** Score-threshold end condition (e.g. Hearts reaches 100). */
+  /**
+   * Score-threshold end condition (e.g. Hearts reaches 100). `totals` alone is
+   * enough for most games; `rounds` (recorded so far, oldest first) is included
+   * for the rare game whose end condition isn't a pure function of cumulative
+   * points — e.g. Phase 10, which needs each hand's own per-phase progress.
+   */
   isFinished?(
     totals: Record<ID, number>,
-    info: { config: Record<string, unknown>; roundCount: number; playerCount: number },
+    info: {
+      config: Record<string, unknown>;
+      roundCount: number;
+      playerCount: number;
+      rounds?: Round[];
+    },
   ): boolean;
-  /** Final winner(s) given totals. Defaults to highest (or lowest) total. */
-  pickWinners?(totals: Record<ID, number>, config: Record<string, unknown>): ID[];
+  /**
+   * Final winner(s) given totals. Defaults to highest (or lowest) total.
+   * `rounds` (recorded so far, oldest first) is passed alongside `totals` for a
+   * game whose win condition isn't reducible to cumulative points alone — e.g.
+   * Phase 10, where the primary criterion is "first to complete Phase 10" and
+   * `totals` (points) only breaks a tie between simultaneous finishers.
+   */
+  pickWinners?(totals: Record<ID, number>, config: Record<string, unknown>, rounds?: Round[]): ID[];
 
   /**
    * Svelte component used to edit a single round (props: RoundEditorProps). Points at the shared

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -129,6 +129,7 @@
         config: game.config,
         roundCount: rounds.length,
         playerCount: game.playerIds.length,
+        rounds,
       });
     }
     return false;


### PR DESCRIPTION
## Summary

Adds **Phase 10** 🔟 as a new game module: 2–6 players race through ten
official phases (sets/runs of increasing difficulty). Completing your
current phase in a hand advances you to the next one; missing it means
you repeat it next hand. Everyone scores penalty points for the cards
left in hand when someone goes out (1–9 = 5pts, 10–12 = 10pts, skip =
15pts, wild = 25pts). First to complete Phase 10 wins; ties among
simultaneous finishers are broken by lowest total points.

## Changes

- `src/lib/games/phase10/logic.ts` — pure scoring + phase-progression
  replay (`phasesAfter`/`phasesBefore`), mirroring the Spades bag-count
  / Stardew category-total "replay round history" pattern.
- `src/lib/games/phase10/index.ts` — `GameModule` wiring with a custom
  `isFinished`/`pickWinners` (phase completion is the primary win
  condition; points only break a simultaneous-finish tie).
- `src/lib/games/phase10/stats.ts` — per-player phase-reached, hands
  advanced, and penalty-point metrics; global Phase 10 clear count.
- `src/lib/games/phase10/Phase10Editor.svelte` — live "Phase N of 10"
  badge per player, a phase-completion toggle, and a per-kind card
  tally (matches Uno's editor pattern) for penalty points.
- `src/lib/games/phase10/phase10.test.ts` — 36 tests covering scoring,
  phase replay, validation, `isFinished`/`pickWinners` (including the
  simultaneous-finish tie-break), module wiring, and stats.
- `src/lib/types.ts`, `src/lib/stores/games.ts`, `src/pages/GamePlay.svelte`
  — extends the shared `GameModule` contract with an optional `rounds`
  param on `isFinished`/`pickWinners`, since Phase 10's win condition
  needs per-hand phase history rather than just cumulative point
  totals. Purely additive/optional — every other game module is
  unaffected.

Game module auto-discovery (`registry.ts`) picks up the new module
with no manual registration required.

## Issues

Closes #171

## Testing

- [x] `npm run check` — 0 errors
- [x] `npx vitest run phase10` — 36/36 passing
- [x] `npx vitest run registry` — structural validation passes (alphabetical order, no duplicate ids, required shape)