### PR TITLE
feat(games): add Rummy game module

### DIFF
--- a/src/lib/games/rummy/RummyEditor.svelte
+++ b/src/lib/games/rummy/RummyEditor.svelte
@@ -1,0 +1,432 @@
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { bumpOnChange } from '../../motion';
+  import { haptic } from '../../haptics';
+  import { aceValue, handValue, opponentsTotal, readConfig, type RummyInput } from './logic';
+
+  let { input = $bindable(), ctx }: { input: RummyInput; ctx: RoundContext } = $props();
+
+  const cfg = $derived(readConfig(ctx.config));
+  const playerIds = $derived(ctx.players.map((p) => p.id));
+  const deadwood = $derived(opponentsTotal(input, playerIds));
+  const scoop = $derived(cfg.allowRummyBonus && input.wentRummy ? deadwood * 2 : deadwood);
+
+  // Race-to-target header. Totals here are cumulative BEFORE this round. Highest total wins.
+  const totalsBefore = $derived(ctx.totals ?? {});
+  const maxTotal = $derived(
+    playerIds.reduce((m, id) => Math.max(m, Number(totalsBefore[id]) || 0), 0),
+  );
+  const pct = $derived(
+    cfg.target > 0 ? Math.min(100, Math.round((maxTotal / cfg.target) * 100)) : 0,
+  );
+  const leaderId = $derived.by(() => {
+    const vals = playerIds.map((id) => Number(totalsBefore[id]) || 0);
+    if (!vals.length || vals.every((v) => v === 0)) return null;
+    const best = Math.max(...vals);
+    const i = vals.findIndex((v) => v === best);
+    return i >= 0 ? playerIds[i] : null;
+  });
+  const leaderName = $derived(
+    leaderId ? (ctx.players.find((p) => p.id === leaderId)?.name ?? '?') : null,
+  );
+  const leaderTotal = $derived(leaderId ? Number(totalsBefore[leaderId]) || 0 : 0);
+
+  // Older rounds (and freshly loaded edits) may not carry the per-kind `hands` breakdown.
+  // Seed one for every seat so the tally UI always has something to bind to; an old lump
+  // sum lands in `pips` so its total is preserved and stays editable.
+  $effect(() => {
+    const ids = playerIds;
+    untrack(() => {
+      if (!input.hands) input.hands = {};
+      for (const id of ids) {
+        if (!input.hands[id]) {
+          input.hands[id] = {
+            pips: Math.max(0, Number(input.left?.[id]) || 0),
+            faces: 0,
+            aces: 0,
+          };
+        }
+      }
+    });
+  });
+
+  // Keep the authoritative `left` total in lockstep with the per-kind tally, so scoring,
+  // stats and history all read a plain number and never need to know about `hands`.
+  $effect(() => {
+    const c = cfg;
+    const out = input.out;
+    for (const id of playerIds) {
+      input.left[id] = out === id ? 0 : handValue(input.hands?.[id], c);
+    }
+  });
+
+  // Bump a token so the go-out burst replays on the row that just went out.
+  let outToken = $state(0);
+
+  function handValueOf(id: string): number {
+    return input.out === id ? 0 : handValue(input.hands?.[id], cfg);
+  }
+
+  function goOut(id: string) {
+    if (input.out === id) {
+      input.out = null;
+      input.wentRummy = false;
+    } else {
+      input.out = id;
+      if (input.hands?.[id]) input.hands[id] = { pips: 0, faces: 0, aces: 0 };
+      outToken += 1;
+      haptic('win');
+    }
+  }
+</script>
+
+<div class="stack">
+  <div class="rummy-head">
+    <span class="fan" aria-hidden="true">
+      <span class="mini"></span>
+      <span class="mini"></span>
+      <span class="mini"></span>
+    </span>
+    <div class="mode">
+      <strong class="modeline">🎴 Winner scoops the deadwood</strong>
+      <span class="sub">Highest total wins</span>
+    </div>
+  </div>
+
+  {#if cfg.target > 0}
+    <div class="race" role="group" aria-label="Race to {cfg.target} points">
+      <div class="row spread racetop">
+        <span class="racelead">
+          {#if leaderName}
+            👑 <strong class="ellipsis">{leaderName}</strong>
+            <span class="tnum lead" use:bumpOnChange={leaderTotal}>{leaderTotal}</span>
+          {:else}
+            <span class="sub">Nobody's pulled ahead yet</span>
+          {/if}
+        </span>
+        <span class="sub">ends at <span class="tnum">{cfg.target}</span></span>
+      </div>
+      <div class="track"><div class="fill" style="width: {pct}%"></div></div>
+    </div>
+  {/if}
+
+  <div class="row spread">
+    <span class="muted prompt">
+      {input.out
+        ? 'Now tally the deadwood left in every other hand.'
+        : 'Who went out (emptied their hand) this round?'}
+    </span>
+    {#if input.out}
+      <span class="pill take"><span class="tnum" use:bumpOnChange={scoop}>🎴 +{scoop}</span></span>
+    {/if}
+  </div>
+
+  {#each ctx.players as p (p.id)}
+    {@const isOut = input.out === p.id}
+    <div class="prow" class:out={isOut}>
+      <div class="row spread head">
+        <span class="row who">
+          <Avatar name={p.name} color={p.color} />
+          <strong class="ellipsis">{p.name}</strong>
+        </span>
+        {#if isOut}
+          <span class="badge sweep">🎴 Went out</span>
+        {:else}
+          <span class="subtotal tnum" aria-label="{p.name} is holding {handValueOf(p.id)} points">
+            {handValueOf(p.id)}<span class="sub">pts</span>
+          </span>
+        {/if}
+      </div>
+
+      <div class="row outrow">
+        <button
+          type="button"
+          class="wentout"
+          class:on={isOut}
+          aria-pressed={isOut}
+          onclick={() => goOut(p.id)}
+        >
+          {isOut ? '🎴 Went out' : 'Went out?'}
+        </button>
+      </div>
+
+      {#if isOut}
+        <p class="note">
+          Scoops the table's deadwood · +{deadwood} point{deadwood === 1 ? '' : 's'}
+        </p>
+        {#if cfg.allowRummyBonus}
+          <label class="rummy-toggle">
+            <input type="checkbox" bind:checked={input.wentRummy} />
+            <span>✨ Went Rummy — no prior melds, double the score</span>
+          </label>
+        {/if}
+      {:else}
+        <div class="tally">
+          <label class="f">
+            <span class="klabel">🔢 Numbers <span class="hint">2–10, face value</span></span>
+            <input
+              type="number"
+              min="0"
+              inputmode="numeric"
+              aria-label="{p.name} number-card face value"
+              bind:value={input.hands![p.id].pips}
+            />
+          </label>
+          <label class="f">
+            <span class="klabel">👑 Face cards <span class="hint">×10</span></span>
+            <Stepper
+              bind:value={input.hands![p.id].faces}
+              min={0}
+              label="{p.name} face cards (J, Q, K)"
+            />
+          </label>
+          <label class="f">
+            <span class="klabel">🂡 Aces <span class="hint">×{aceValue(cfg)}</span></span>
+            <Stepper bind:value={input.hands![p.id].aces} min={0} label="{p.name} aces" />
+          </label>
+        </div>
+      {/if}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .rummy-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  /* A tiny fanned card deck — pure costume, sits behind the mode copy. */
+  .fan {
+    flex: none;
+    display: inline-flex;
+    width: 40px;
+    height: 34px;
+    position: relative;
+  }
+  .mini {
+    position: absolute;
+    top: 4px;
+    left: 8px;
+    width: 16px;
+    height: 24px;
+    border-radius: 4px;
+    border: 1.5px solid var(--surface);
+    background: var(--surface-3);
+    transform-origin: bottom center;
+  }
+  .mini:nth-child(1) {
+    transform: rotate(-14deg);
+  }
+  .mini:nth-child(2) {
+    left: 12px;
+    transform: rotate(0deg);
+  }
+  .mini:nth-child(3) {
+    left: 16px;
+    transform: rotate(14deg);
+  }
+  .modeline {
+    display: block;
+    font-size: 1rem;
+  }
+  .mode .sub {
+    font-size: 0.82rem;
+  }
+
+  .race {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 10px 12px;
+  }
+  .racetop {
+    align-items: baseline;
+  }
+  .racelead {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    min-width: 0;
+    font-weight: 700;
+  }
+  .lead {
+    color: var(--accent-ink);
+  }
+  .track {
+    height: 6px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    overflow: hidden;
+  }
+  .fill {
+    height: 100%;
+    border-radius: 999px;
+    background: var(--muted);
+  }
+
+  .prompt {
+    font-size: 0.9rem;
+  }
+
+  .prow {
+    position: relative;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    transition:
+      background 0.15s ease,
+      border-color 0.15s ease;
+  }
+  /* The player who went out is the round's winner — the restrained Crown-Gold wash the
+     scoreboard uses, co-signalled by the 🎴 badge, never colour alone. */
+  .prow.out {
+    background: color-mix(in srgb, var(--accent) 13%, var(--surface-2));
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  }
+  .head {
+    align-items: center;
+  }
+  .who {
+    gap: 8px;
+    min-width: 0;
+  }
+  .ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .subtotal {
+    flex: none;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+  }
+  .subtotal .sub {
+    margin-left: 3px;
+    font-weight: 500;
+    font-size: 0.72rem;
+    color: var(--muted);
+  }
+  .badge.sweep {
+    flex: none;
+    font-weight: 700;
+    color: var(--accent-ink);
+  }
+
+  .wentout {
+    flex: 1;
+    min-height: 46px;
+    padding: 0 14px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--muted);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease,
+      border-color 0.15s ease;
+  }
+  .wentout:hover {
+    color: var(--text);
+    background: var(--surface-3);
+  }
+  /* Selected = gold-ink + gold border tint (marks the round winner), NOT a violet fill —
+     the one violet action on the screen stays the shell's Save. */
+  .wentout.on {
+    background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+    color: var(--accent-ink);
+  }
+  .wentout:active {
+    transform: translateY(1px);
+  }
+  .wentout:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .note {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+
+  .rummy-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 8px 4px;
+    font-size: 0.9rem;
+    cursor: pointer;
+  }
+  .rummy-toggle input {
+    width: 20px;
+    height: 20px;
+  }
+
+  .tally {
+    display: flex;
+    gap: 14px;
+    flex-wrap: wrap;
+  }
+  .f {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .klabel {
+    font-size: 0.78rem;
+    color: var(--muted);
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .klabel .hint {
+    font-weight: 500;
+    opacity: 0.85;
+  }
+  .f input {
+    width: 92px;
+    min-height: 46px;
+    padding: 11px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+  .f input:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .take {
+    color: var(--good);
+    border-color: color-mix(in srgb, var(--good) 40%, var(--border));
+    font-weight: 700;
+  }
+  .tnum {
+    font-variant-numeric: tabular-nums;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .prow,
+    .wentout,
+    .fill {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/games/rummy/index.ts
+++ b/src/lib/games/rummy/index.ts
@@ -1,0 +1,89 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { rummyStats } from './stats';
+import {
+  createRummyInput,
+  isRummyFinished,
+  opponentsTotal,
+  scoreRummy,
+  validateRummy,
+  type RummyInput,
+} from './logic';
+
+export type { RummyInput, RummyConfig, RummyHand } from './logic';
+
+export const rummy: GameModule = {
+  id: 'rummy',
+  name: 'Rummy',
+  tagline: 'Meld your hand, then stick everyone else with their deadwood',
+  emoji: '🎴',
+  keywords: ['rummy', 'gin rummy', 'melds', 'sets', 'runs', 'cards', 'deadwood'],
+  minPlayers: 2,
+  maxPlayers: 6,
+  configFields: [
+    { key: 'target', label: 'Play to (points)', type: 'number', default: 100, min: 1, step: 10 },
+    {
+      key: 'aceHigh',
+      label: 'Aces score high (15, not 1)',
+      type: 'boolean',
+      default: false,
+      help: 'Classic Rummy counts a leftover Ace as 1 point. Flip this on to count it as 15 instead.',
+    },
+    {
+      key: 'allowRummyBonus',
+      label: 'Allow "Rummy" double bonus',
+      type: 'boolean',
+      default: true,
+      help: 'Going out in one turn with no prior melds laid down doubles that hand\u2019s score.',
+    },
+  ],
+
+  createRoundInput: (ctx: RoundContext): RummyInput => createRummyInput(ctx.players.map((p) => p.id)),
+
+  validateRound: (input: RummyInput, ctx: RoundContext): string | null =>
+    validateRummy(input, ctx.players),
+
+  scoreRound: (input: RummyInput, ctx: RoundContext): Record<ID, number> =>
+    scoreRummy(
+      input,
+      ctx.players.map((p) => p.id),
+      ctx.config,
+    ),
+
+  isFinished: (totals, { config }) => isRummyFinished(totals, config),
+
+  describeRound: (round: Round, players): string => {
+    const input = round.input as RummyInput;
+    if (!input?.out) return 'no result';
+    const winner = players.find((p) => p.id === input.out)?.name ?? '?';
+    const onTable = opponentsTotal(
+      input,
+      players.map((p) => p.id),
+    );
+    const bonus = input.wentRummy ? ' · went Rummy! ×2' : '';
+    return onTable > 0
+      ? `🎴 ${winner} out · ${onTable} deadwood left${bonus}`
+      : `🎴 ${winner} out · clean sweep${bonus}`;
+  },
+
+  help: [
+    'Meld sets (3–4 of a rank) and runs (3+ in sequence, same suit) from your hand.',
+    'Draw a card, optionally meld or lay off, then discard to end your turn.',
+    '',
+    'Empty your hand to go out and end the round. You score the deadwood left in',
+    'everyone else\u2019s hand:',
+    '• Number cards (2\u201310) \u2014 face value',
+    '• Face cards (J, Q, K) \u2014 10 each',
+    '• Aces \u2014 1 (low) or 15 (high), per your table\u2019s house rule',
+    '',
+    'Went "Rummy"? Going out in a single turn with no melds laid down beforehand',
+    'doubles your score for that hand (optional house rule).',
+    '',
+    'First player to the target score (default 100) wins.',
+  ].join('\n'),
+
+  stats: rummyStats,
+
+  RoundEditor,
+  editorLoader: () => import('./RummyEditor.svelte'),
+};

--- a/src/lib/games/rummy/logic.ts
+++ b/src/lib/games/rummy/logic.ts
@@ -1,0 +1,183 @@
+import type { ID } from '../../types';
+
+/**
+ * Rummy scoring — pure and Svelte-free so it can be unit-tested directly and reused by
+ * the editor for live previews (see README "Adding a game").
+ *
+ * Classic (basic) Rummy: play in melds/sets/runs until one player goes out (empties
+ * their hand). That player scores the value of every card left in EVERYONE ELSE's
+ * hand — the deadwood. Card values:
+ *  - Number cards (2–10): pip/face value.
+ *  - Face cards (J, Q, K): 10 each.
+ *  - Aces: `aceHigh` config — 1 (low, classic) or 15 (high, some house rules).
+ *
+ * Optional house rule: going "Rummy" — going out in a single turn with no prior melds
+ * laid down — doubles the winner's score for that hand. It's a per-round flag the
+ * scorekeeper sets, gated by the `allowRummyBonus` config toggle.
+ *
+ * Card values are counted by the scorekeeper into a single leftover total per player
+ * (pips = summed number-card value, faces = count of face cards, aces = count of
+ * aces), so the stored round is just "who went out" + "how many points each hand
+ * held" + "was it a Rummy" — scoring is a pure function of that, which keeps history
+ * re-scorable and the logic trivially pure.
+ */
+
+export interface RummyConfig {
+  /** Race-to score that ends the game (default 100). 0 = play forever. */
+  target: number;
+  /** Ace value: low = 1 point each (classic), high = 15 points each (house rule). */
+  aceHigh: boolean;
+  /** Whether the "went Rummy" (no prior melds) double-bonus is offered in the editor. */
+  allowRummyBonus: boolean;
+}
+
+/**
+ * A leftover hand tallied by card kind, so the editor can add cards by *type* (the way
+ * you actually read a fanned-out hand) instead of pre-summing points in your head:
+ *  - `pips`: the summed face value of the number cards (2–10) left in hand
+ *  - `faces`: how many face cards (J, Q, K) are left
+ *  - `aces`: how many Aces are left
+ * Purely an entry convenience — the authoritative points value is always {@link RummyInput.left},
+ * which the editor keeps in sync via {@link handValue}. Absent on rounds saved before the
+ * per-kind tally existed, which still score fine from `left` alone.
+ */
+export interface RummyHand {
+  pips: number;
+  faces: number;
+  aces: number;
+}
+
+export interface RummyInput {
+  /** The player who emptied their hand to end the round. */
+  out: ID | null;
+  /** Each player's leftover card points at round end. The player who went out holds 0. */
+  left: Record<ID, number>;
+  /**
+   * Optional per-kind breakdown behind each player's {@link left} total, so re-opening a
+   * round restores the exact card counts. `left` stays authoritative for scoring; this is
+   * a display/editing aid only and may be absent (older rounds, or a hand typed as a lump).
+   */
+  hands?: Record<ID, RummyHand>;
+  /**
+   * Whether the winner went "Rummy" this hand — went out in one turn with no melds laid
+   * down beforehand. Doubles the scored points when `allowRummyBonus` is on. Ignored (and
+   * never applied) with no winner.
+   */
+  wentRummy?: boolean;
+}
+
+export const RUMMY_DEFAULTS: RummyConfig = {
+  target: 100,
+  aceHigh: false,
+  allowRummyBonus: true,
+};
+
+/** Read a raw config bag into a validated {@link RummyConfig}, falling back on defaults. */
+export function readConfig(config: Record<string, unknown> | undefined): RummyConfig {
+  const c = config ?? {};
+  const num = (v: unknown, d: number): number => {
+    if (v === null || v === undefined || v === '') return d;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : d;
+  };
+  const bool = (v: unknown, d: boolean): boolean => (typeof v === 'boolean' ? v : d);
+  return {
+    target: num(c.target, RUMMY_DEFAULTS.target),
+    aceHigh: bool(c.aceHigh, RUMMY_DEFAULTS.aceHigh),
+    allowRummyBonus: bool(c.allowRummyBonus, RUMMY_DEFAULTS.allowRummyBonus),
+  };
+}
+
+/** Points a single Ace is worth given the configured ace value. */
+export function aceValue(cfg: Pick<RummyConfig, 'aceHigh'>): number {
+  return cfg.aceHigh ? 15 : 1;
+}
+
+/** A fresh, zeroed round input for the current roster. */
+export function createRummyInput(playerIds: ID[]): RummyInput {
+  return {
+    out: null,
+    left: Object.fromEntries(playerIds.map((id) => [id, 0])),
+    hands: Object.fromEntries(playerIds.map((id) => [id, emptyHand()])),
+    wentRummy: false,
+  };
+}
+
+/** A fresh, empty per-kind hand (no cards counted yet). */
+export function emptyHand(): RummyHand {
+  return { pips: 0, faces: 0, aces: 0 };
+}
+
+/** Points a per-kind hand is worth given the card values in play. Clamps to ≥ 0. */
+export function handValue(
+  hand: RummyHand | undefined,
+  cfg: Pick<RummyConfig, 'aceHigh'>,
+): number {
+  if (!hand) return 0;
+  const pips = Math.max(0, Number(hand.pips) || 0);
+  const faces = Math.max(0, Number(hand.faces) || 0);
+  const aces = Math.max(0, Number(hand.aces) || 0);
+  return pips + faces * 10 + aces * aceValue(cfg);
+}
+
+/** A player's leftover points, clamped to a non-negative number. */
+export function leftOf(input: RummyInput, id: ID): number {
+  return Math.max(0, Number(input.left[id]) || 0);
+}
+
+/** Sum of the leftover points held by everyone except the player who went out. */
+export function opponentsTotal(input: RummyInput, playerIds: ID[]): number {
+  return playerIds.reduce((sum, id) => (id === input.out ? sum : sum + leftOf(input, id)), 0);
+}
+
+export function validateRummy(
+  input: RummyInput,
+  players: { id: ID; name: string }[],
+): string | null {
+  if (!input.out) return 'Tap the player who went out (emptied their hand).';
+  if (!players.some((p) => p.id === input.out)) {
+    return 'The player who went out is not in this game.';
+  }
+  for (const p of players) {
+    const raw = input.left[p.id];
+    if (raw == null) continue;
+    const v = Number(raw);
+    if (!Number.isFinite(v) || v < 0) {
+      return `${p.name}'s leftover points must be 0 or more.`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Compute per-player point deltas for a hand. The player who went out scoops every
+ * opponent's leftover deadwood; a "went Rummy" hand (no prior melds) doubles it when
+ * the house rule is enabled.
+ */
+export function scoreRummy(
+  input: RummyInput,
+  playerIds: ID[],
+  config: Record<string, unknown> | undefined,
+): Record<ID, number> {
+  const cfg = readConfig(config);
+  const out: Record<ID, number> = {};
+  if (!input.out) {
+    for (const id of playerIds) out[id] = 0;
+    return out;
+  }
+  let scooped = opponentsTotal(input, playerIds);
+  if (cfg.allowRummyBonus && input.wentRummy) scooped *= 2;
+  for (const id of playerIds) out[id] = id === input.out ? scooped : 0;
+  return out;
+}
+
+/** Game ends when any total reaches the target. */
+export function isRummyFinished(
+  totals: Record<ID, number>,
+  config: Record<string, unknown> | undefined,
+): boolean {
+  const { target } = readConfig(config);
+  if (target <= 0) return false;
+  const vals = Object.values(totals);
+  return vals.length > 0 && vals.some((t) => t >= target);
+}

--- a/src/lib/games/rummy/rummy.test.ts
+++ b/src/lib/games/rummy/rummy.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, ID, Player, Round, RoundContext } from '../../types';
+import { defaultWinners } from '../../types';
+import { rummy } from './index';
+import { rummyStats } from './stats';
+import {
+  aceValue,
+  createRummyInput,
+  emptyHand,
+  handValue,
+  isRummyFinished,
+  opponentsTotal,
+  readConfig,
+  scoreRummy,
+  validateRummy,
+  type RummyInput,
+} from './logic';
+
+// ---- helpers ---------------------------------------------------------------
+
+function player(id: string, name = id): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+
+const A = player('A', 'Alice');
+const B = player('B', 'Bob');
+const C = player('C', 'Cy');
+const players = [A, B, C];
+const ids = players.map((p) => p.id);
+
+function ctx(config: Record<string, unknown>): RoundContext {
+  return {
+    game: {} as Game,
+    players,
+    config,
+    roundIndex: 0,
+    totals: {},
+    rounds: [],
+  };
+}
+
+function input(out: ID | null, left: Record<ID, number>, wentRummy = false): RummyInput {
+  return { out, left, wentRummy };
+}
+
+// ---- config ------------------------------------------------------------------
+
+describe('readConfig', () => {
+  it('fills defaults when empty', () => {
+    expect(readConfig({})).toEqual({ target: 100, aceHigh: false, allowRummyBonus: true });
+  });
+
+  it('honours overrides and coerces numeric strings', () => {
+    const c = readConfig({ target: '500', aceHigh: true, allowRummyBonus: false });
+    expect(c).toEqual({ target: 500, aceHigh: true, allowRummyBonus: false });
+  });
+
+  it('falls back on garbage values', () => {
+    const c = readConfig({ target: 'nope', aceHigh: 'yes', allowRummyBonus: 'no' });
+    expect(c).toEqual({ target: 100, aceHigh: false, allowRummyBonus: true });
+  });
+});
+
+describe('aceValue', () => {
+  it('is 1 when low (default)', () => {
+    expect(aceValue({ aceHigh: false })).toBe(1);
+  });
+
+  it('is 15 when high', () => {
+    expect(aceValue({ aceHigh: true })).toBe(15);
+  });
+});
+
+// ---- round input -------------------------------------------------------------
+
+describe('createRummyInput', () => {
+  it('starts with nobody out, everyone on zero, and a fresh per-kind hand each', () => {
+    expect(createRummyInput(ids)).toEqual({
+      out: null,
+      left: { A: 0, B: 0, C: 0 },
+      hands: {
+        A: { pips: 0, faces: 0, aces: 0 },
+        B: { pips: 0, faces: 0, aces: 0 },
+        C: { pips: 0, faces: 0, aces: 0 },
+      },
+      wentRummy: false,
+    });
+  });
+});
+
+// ---- per-kind hand tally -------------------------------------------------------
+
+describe('emptyHand', () => {
+  it('is a zeroed per-kind hand', () => {
+    expect(emptyHand()).toEqual({ pips: 0, faces: 0, aces: 0 });
+  });
+});
+
+describe('handValue', () => {
+  const cfg = { aceHigh: false };
+
+  it('sums pips plus 10 per face card plus ace value per ace', () => {
+    expect(handValue({ pips: 12, faces: 2, aces: 1 }, cfg)).toBe(12 + 20 + 1);
+  });
+
+  it('treats a missing hand as zero', () => {
+    expect(handValue(undefined, cfg)).toBe(0);
+  });
+
+  it('clamps negative counts to zero', () => {
+    expect(handValue({ pips: -5, faces: -1, aces: 3 }, cfg)).toBe(3);
+  });
+
+  it('honours ace-high scoring', () => {
+    expect(handValue({ pips: 0, faces: 1, aces: 2 }, { aceHigh: true })).toBe(10 + 30);
+  });
+});
+
+// ---- helpers: opponentsTotal ---------------------------------------------------
+
+describe('opponentsTotal', () => {
+  it('sums everyone except the player who went out and clamps negatives', () => {
+    expect(opponentsTotal(input('A', { A: 100, B: 25, C: 40 }), ids)).toBe(65);
+    expect(opponentsTotal(input('A', { A: 0, B: -5, C: 40 }), ids)).toBe(40);
+  });
+});
+
+// ---- validation -----------------------------------------------------------------
+
+describe('validateRummy', () => {
+  it('requires a player to have gone out', () => {
+    expect(validateRummy(input(null, { A: 0, B: 0, C: 0 }), players)).toMatch(/went out/i);
+  });
+
+  it('rejects a winner who is not in the game', () => {
+    expect(validateRummy(input('Z', { A: 0, B: 0, C: 0 }), players)).toMatch(/not in this game/i);
+  });
+
+  it('rejects negative leftovers, naming the player', () => {
+    expect(validateRummy(input('A', { A: 0, B: -1, C: 0 }), players)).toContain('Bob');
+  });
+
+  it('passes a well-formed hand', () => {
+    expect(validateRummy(input('A', { A: 0, B: 20, C: 5 }), players)).toBeNull();
+  });
+});
+
+// ---- scoring ---------------------------------------------------------------------
+
+describe('scoreRummy', () => {
+  it('gives the player who went out the sum of the others’ deadwood', () => {
+    const out = scoreRummy(input('A', { A: 0, B: 25, C: 40 }), ids, {});
+    expect(out).toEqual({ A: 65, B: 0, C: 0 });
+  });
+
+  it('scores nothing while no winner is chosen yet', () => {
+    expect(scoreRummy(input(null, { A: 5, B: 5, C: 5 }), ids, {})).toEqual({
+      A: 0,
+      B: 0,
+      C: 0,
+    });
+  });
+
+  it('ignores any stray leftover on the player who went out', () => {
+    const out = scoreRummy(input('A', { A: 999, B: 10, C: 10 }), ids, {});
+    expect(out).toEqual({ A: 20, B: 0, C: 0 });
+  });
+
+  it('doubles the score for a "went Rummy" hand when the bonus is allowed', () => {
+    const out = scoreRummy(input('A', { A: 0, B: 25, C: 40 }, true), ids, {
+      allowRummyBonus: true,
+    });
+    expect(out).toEqual({ A: 130, B: 0, C: 0 });
+  });
+
+  it('ignores the "went Rummy" flag when the bonus is disabled', () => {
+    const out = scoreRummy(input('A', { A: 0, B: 25, C: 40 }, true), ids, {
+      allowRummyBonus: false,
+    });
+    expect(out).toEqual({ A: 65, B: 0, C: 0 });
+  });
+});
+
+// ---- end condition ----------------------------------------------------------------
+
+describe('isRummyFinished', () => {
+  it('ends when any total reaches the target', () => {
+    expect(isRummyFinished({ A: 100, B: 40 }, { target: 100 })).toBe(true);
+    expect(isRummyFinished({ A: 99, B: 40 }, { target: 100 })).toBe(false);
+  });
+
+  it('never ends when the target is 0', () => {
+    expect(isRummyFinished({ A: 9999 }, { target: 0 })).toBe(false);
+  });
+
+  it('defaults to a target of 100', () => {
+    expect(isRummyFinished({ A: 100 }, {})).toBe(true);
+    expect(isRummyFinished({ A: 99 }, {})).toBe(false);
+  });
+});
+
+// ---- module wiring -----------------------------------------------------------------
+
+describe('rummy module', () => {
+  it('has the expected identity and roster', () => {
+    expect(rummy.id).toBe('rummy');
+    expect(rummy.name).toBe('Rummy');
+    expect(rummy.minPlayers).toBe(2);
+    expect(rummy.maxPlayers).toBe(6);
+  });
+
+  it('builds a fresh input and validates/scores through the context', () => {
+    const fresh = rummy.createRoundInput(ctx({})) as RummyInput;
+    expect(fresh).toEqual({
+      out: null,
+      left: { A: 0, B: 0, C: 0 },
+      hands: {
+        A: { pips: 0, faces: 0, aces: 0 },
+        B: { pips: 0, faces: 0, aces: 0 },
+        C: { pips: 0, faces: 0, aces: 0 },
+      },
+      wentRummy: false,
+    });
+
+    const hand = input('A', { A: 0, B: 25, C: 40 });
+    expect(rummy.validateRound(hand, ctx({}))).toBeNull();
+    expect(rummy.scoreRound(hand, ctx({}))).toEqual({ A: 65, B: 0, C: 0 });
+  });
+
+  it('ends the game via isFinished at the target', () => {
+    expect(
+      rummy.isFinished?.({ A: 110, B: 60 }, { config: {}, roundCount: 4, playerCount: 3 }),
+    ).toBe(true);
+  });
+
+  it('crowns the highest total (default winner logic)', () => {
+    const totals = { A: 80, B: 110, C: 40 };
+    expect(defaultWinners(rummy, totals, {})).toEqual(['B']);
+  });
+
+  it('summarises a recorded round for the history table', () => {
+    const round = { input: input('A', { A: 0, B: 25, C: 40 }) } as Round;
+    expect(rummy.describeRound?.(round, players)).toBe('🎴 Alice out · 65 deadwood left');
+  });
+
+  it('describes a hand where everyone else was empty as a clean sweep', () => {
+    const round = { input: input('B', { A: 0, B: 0, C: 0 }) } as Round;
+    expect(rummy.describeRound?.(round, players)).toBe('🎴 Bob out · clean sweep');
+  });
+
+  it('flags a "went Rummy" round in the history summary', () => {
+    const round = { input: input('A', { A: 0, B: 25, C: 40 }, true) } as Round;
+    expect(rummy.describeRound?.(round, players)).toBe(
+      '🎴 Alice out · 65 deadwood left · went Rummy! ×2',
+    );
+  });
+});
+
+// ---- stats ------------------------------------------------------------------------
+
+describe('rummyStats', () => {
+  const game: Game = {
+    id: 'g1',
+    type: 'rummy',
+    config: {},
+    playerIds: ids,
+    status: 'finished',
+    createdAt: 0,
+    roundCount: 2,
+  };
+  const rounds = [
+    {
+      id: 'r1',
+      gameId: 'g1',
+      index: 0,
+      input: input('A', { A: 0, B: 20, C: 35 }),
+      deltas: {},
+      createdAt: 0,
+    },
+    {
+      id: 'r2',
+      gameId: 'g1',
+      index: 1,
+      input: input('B', { A: 5, B: 0, C: 50 }, true),
+      deltas: {},
+      createdAt: 0,
+    },
+  ] as Round[];
+
+  const res = rummyStats({ games: [game], rounds, players, canonical: (id) => id });
+  const perPlayer = res.perPlayer ?? {};
+  const global = res.global ?? [];
+
+  it('counts go-outs and go-out rate per player', () => {
+    const a = perPlayer['A'] ?? [];
+    expect(a.find((m) => m.key === 'r_out')?.value).toBe('1');
+    expect(a.find((m) => m.key === 'r_rate')?.value).toBe('50%');
+  });
+
+  it('omits the go-out metric for a player who never went out', () => {
+    const c = perPlayer['C'] ?? [];
+    expect(c.find((m) => m.key === 'r_out')).toBeUndefined();
+    expect(c.find((m) => m.key === 'r_stuck')?.value).toBe('85');
+  });
+
+  it('counts went-Rummy bonuses for the winner', () => {
+    const b = perPlayer['B'] ?? [];
+    expect(b.find((m) => m.key === 'r_rummy')?.value).toBe('1');
+  });
+
+  it('reports totals, the biggest hand (doubled), and rummy bonuses globally', () => {
+    expect(global.find((m) => m.key === 'r_out_all')?.value).toBe('2');
+    expect(global.find((m) => m.key === 'r_scoop')?.value).toBe('110');
+    expect(global.find((m) => m.key === 'r_rummy_all')?.value).toBe('1');
+  });
+
+  it('ignores rounds from other games', () => {
+    const only = rummyStats({ games: [], rounds, players, canonical: (id) => id });
+    expect(only.perPlayer ?? {}).toEqual({});
+    expect(only.global ?? []).toEqual([]);
+  });
+});

--- a/src/lib/games/rummy/stats.ts
+++ b/src/lib/games/rummy/stats.ts
@@ -1,0 +1,127 @@
+import type { ID } from '../../types';
+import type { RummyInput } from './logic';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt, fmtPct } from '../../stats/format';
+
+interface RummyAgg {
+  /** Hands this player went out (emptied their hand) to end the round. */
+  outs: number;
+  /** Hands this player took part in. */
+  rounds: number;
+  /** Total leftover (deadwood) points this player was caught holding across hands. */
+  stuck: number;
+  /** Most points scooped in a single go-out. */
+  bigScoop: number;
+  /** Hands won by going "Rummy" (no prior melds, double bonus). */
+  rummies: number;
+}
+
+/**
+ * Rummy stats from each hand's recorded "who went out" + leftover totals. Pure;
+ * mirrors the module's own scoring so a game contributes stats the same way it
+ * contributes points.
+ */
+export function rummyStats({ games, rounds, canonical }: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const per = new Map<ID, RummyAgg>();
+  const get = (id: ID): RummyAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { outs: 0, rounds: 0, stuck: 0, bigScoop: 0, rummies: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as RummyInput | undefined;
+    if (!input?.left) continue;
+    const outId = input.out ? canonical(input.out) : null;
+    let scoop = 0;
+    for (const [pid, raw] of Object.entries(input.left)) {
+      const id = canonical(pid);
+      const a = get(id);
+      a.rounds += 1;
+      const left = Math.max(0, Number(raw) || 0);
+      if (id === outId) {
+        a.outs += 1;
+      } else {
+        scoop += left;
+        a.stuck += left;
+      }
+    }
+    if (outId) {
+      const a = get(outId);
+      const total = input.wentRummy ? scoop * 2 : scoop;
+      if (total > a.bigScoop) a.bigScoop = total;
+      if (input.wentRummy) a.rummies += 1;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  let totalOuts = 0;
+  let biggest = 0;
+  let totalRummies = 0;
+  for (const [id, a] of per) {
+    totalOuts += a.outs;
+    totalRummies += a.rummies;
+    if (a.bigScoop > biggest) biggest = a.bigScoop;
+    const metrics: Metric[] = [];
+    if (a.outs) {
+      metrics.push({ key: 'r_out', label: 'Hands gone out', value: fmtInt(a.outs), emoji: '🎴' });
+    }
+    if (a.rounds) {
+      metrics.push({
+        key: 'r_rate',
+        label: 'Go-out rate',
+        value: fmtPct(a.outs / a.rounds),
+        emoji: '🏃',
+      });
+    }
+    if (a.stuck) {
+      metrics.push({
+        key: 'r_stuck',
+        label: 'Deadwood caught holding',
+        value: fmtInt(a.stuck),
+        emoji: '🪵',
+      });
+    }
+    if (a.rummies) {
+      metrics.push({
+        key: 'r_rummy',
+        label: 'Went Rummy (double bonus)',
+        value: fmtInt(a.rummies),
+        emoji: '✨',
+      });
+    }
+    if (metrics.length) perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (totalOuts) {
+    global.push({
+      key: 'r_out_all',
+      label: 'Hands played out',
+      value: fmtInt(totalOuts),
+      emoji: '🎴',
+    });
+  }
+  if (biggest) {
+    global.push({
+      key: 'r_scoop',
+      label: 'Biggest hand counted',
+      value: fmtInt(biggest),
+      emoji: '💰',
+    });
+  }
+  if (totalRummies) {
+    global.push({
+      key: 'r_rummy_all',
+      label: 'Rummy double-bonuses',
+      value: fmtInt(totalRummies),
+      emoji: '✨',
+    });
+  }
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Adds Rummy 🎴 (classic/basic Rummy) as a new game module, following the auto-discovered `GameModule` conventions (see `src/lib/games/cribbage/`, `src/lib/games/uno/`).

## Rules

- 2–6 players, race to a target score (default 100).
- The player who goes out (empties their hand) scores the deadwood value left in every opponent's hand.
- Card values: number cards (2–10) = face value, face cards (J/Q/K) = 10, Aces = configurable low (1, default) or high (15).
- Optional "went Rummy" house rule (config toggle): going out in one turn with no prior melds doubles the hand's score.

## Changes

- `src/lib/games/rummy/logic.ts` — pure scoring/config logic
- `src/lib/games/rummy/stats.ts` — per-player + global stats hook
- `src/lib/games/rummy/index.ts` — `GameModule` wiring with lazy `editorLoader` (`registry.ts` untouched — auto-discovered)
- `src/lib/games/rummy/RummyEditor.svelte` — round editor UI (Royal Violet/Crown Gold tokens, tabular-nums, ≥46px targets, reduced-motion respected)
- `src/lib/games/rummy/rummy.test.ts` — vitest coverage of config, scoring, validation, stats, module wiring

## Issues

Closes #175

## Testing

- [x] `npm test -- src/lib/games/rummy` (36 tests passing)
- [x] `npm run check` (0 errors, 0 warnings)