### PR TITLE
feat(games): add Dominion game module

### DIFF
--- a/src/lib/games/dominion/DominionEditor.svelte
+++ b/src/lib/games/dominion/DominionEditor.svelte
@@ -1,0 +1,314 @@
+<script lang="ts">
+  import type { RoundContext } from '../../types';
+  import Avatar from '../../components/Avatar.svelte';
+  import Stepper from '../../components/Stepper.svelte';
+  import { leaders } from '../../scoring';
+  import { bumpOnChange, popIn } from '../../motion';
+  import {
+    DOMINION_HELP,
+    emptyRow,
+    gardensValue,
+    scoreRow,
+    type DominionInput,
+  } from './logic';
+
+  let { input = $bindable(), ctx }: { input: DominionInput; ctx: RoundContext } = $props();
+
+  // Guarantee every seated player has a row, even one added after the sheet was created.
+  $effect(() => {
+    for (const p of ctx.players) {
+      if (!input.values[p.id]) input.values[p.id] = emptyRow();
+    }
+  });
+
+  let showHelp = $state(false);
+
+  function total(id: string): number {
+    return scoreRow(input.values[id]);
+  }
+
+  // Live totals + the app's shared "who's pulled ahead" rule, so the grandest estate wears
+  // the crown (and only the crown's Gold) — nobody is crowned at an all-tied-at-zero table.
+  const totals = $derived(Object.fromEntries(ctx.players.map((p) => [p.id, total(p.id)])));
+  const leaderSet = $derived(
+    leaders(
+      totals,
+      ctx.players.map((p) => p.id),
+    ),
+  );
+</script>
+
+<div class="stack">
+  <div class="row spread">
+    <span class="pill">🏰 Count your deck at game end</span>
+    <button
+      type="button"
+      class="btn small ghost"
+      onclick={() => (showHelp = !showHelp)}
+      aria-expanded={showHelp}
+    >
+      Scoring
+    </button>
+  </div>
+
+  {#if showHelp}
+    <pre class="help">{DOMINION_HELP}</pre>
+  {/if}
+
+  {#each ctx.players as p (p.id)}
+    {@const row = input.values[p.id]}
+    {#if row}
+      {@const isLeader = leaderSet.has(p.id)}
+      {@const gValue = gardensValue(row.deckSize)}
+      <div class="prow" class:leader={isLeader}>
+        <div class="row spread phead">
+          <span class="who">
+            <Avatar name={p.name} color={p.color} />
+            <strong>{p.name}</strong>
+            {#if isLeader}
+              <span class="crown" title="Grandest estate" aria-hidden="true" use:popIn>👑</span>
+              <span class="sr-only">Grandest estate</span>
+            {/if}
+          </span>
+          <span class="total" class:lead={isLeader}>
+            <span class="totnum" use:bumpOnChange={total(p.id)}>{total(p.id)}</span><span
+              class="unit">VP</span
+            >
+          </span>
+        </div>
+
+        <div class="grid">
+          <div class="f">
+            <span class="flabel"><span aria-hidden="true">🟩</span> Estates <span class="mult"
+                >×1</span
+              ></span
+            >
+            <Stepper bind:value={row.estates} min={0} label={`${p.name} Estates`} />
+          </div>
+          <div class="f">
+            <span class="flabel"><span aria-hidden="true">🏠</span> Duchies <span class="mult"
+                >×3</span
+              ></span
+            >
+            <Stepper bind:value={row.duchies} min={0} label={`${p.name} Duchies`} />
+          </div>
+          <div class="f">
+            <span class="flabel"><span aria-hidden="true">⭐</span> Provinces <span class="mult"
+                >×6</span
+              ></span
+            >
+            <Stepper bind:value={row.provinces} min={0} label={`${p.name} Provinces`} />
+          </div>
+          <div class="f">
+            <span class="flabel"><span aria-hidden="true">💀</span> Curses <span class="mult"
+                >×-1</span
+              ></span
+            >
+            <Stepper bind:value={row.curses} min={0} label={`${p.name} Curses`} />
+          </div>
+        </div>
+
+        <div class="gardens">
+          <span class="glabel"><span aria-hidden="true">🌿</span> Gardens</span>
+          <div class="gfields">
+            <label class="gfield">
+              <span class="gcap">Gardens owned</span>
+              <Stepper bind:value={row.gardens} min={0} label={`${p.name} Gardens owned`} />
+            </label>
+            <label class="gfield">
+              <span class="gcap">Deck size</span>
+              <input
+                class="pts sm"
+                type="number"
+                min="0"
+                step="1"
+                inputmode="numeric"
+                aria-label={`${p.name} deck size`}
+                bind:value={row.deckSize}
+              />
+            </label>
+            <span class="gsub">= {gValue} VP each</span>
+          </div>
+        </div>
+
+        <div class="grid">
+          <div class="f">
+            <span class="flabel">Other VP</span>
+            <input
+              class="pts"
+              type="number"
+              step="1"
+              inputmode="numeric"
+              aria-label={`${p.name} Other VP`}
+              bind:value={row.otherVP}
+            />
+          </div>
+          <div class="f">
+            <span class="flabel">Turns taken <span class="opt">(tie-break)</span></span>
+            <input
+              class="pts"
+              type="number"
+              min="0"
+              step="1"
+              inputmode="numeric"
+              aria-label={`${p.name} turns taken`}
+              bind:value={row.turns}
+            />
+          </div>
+        </div>
+      </div>
+    {/if}
+  {/each}
+</div>
+
+<style>
+  .prow {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  /* The grandest estate: a restrained Crown-Gold ring around the leader's card — the crown
+     and gold total already carry the meaning, so the ring stays a whisper, never a gold block. */
+  .prow.leader {
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+    background: color-mix(in srgb, var(--accent) 6%, var(--surface-2));
+  }
+  .phead {
+    margin: 0;
+  }
+  .who {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .who strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .crown {
+    flex: none;
+    font-size: 1rem;
+    line-height: 1;
+  }
+  .total {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    flex: none;
+    font-weight: 800;
+    font-size: 1.5rem;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+  /* Gold reserved for the leader/winner number, per the Crown-Gold rule. */
+  .total.lead {
+    color: var(--accent-ink);
+  }
+  .unit {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--muted);
+  }
+
+  .grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 16px;
+  }
+  .f {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .flabel {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+  .mult {
+    font-weight: 700;
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+  }
+  .opt {
+    font-weight: 400;
+    font-style: italic;
+  }
+  .pts {
+    width: 88px;
+    height: 46px;
+    text-align: center;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+  .pts.sm {
+    width: 66px;
+    height: 40px;
+  }
+
+  /* Gardens — a small self-contained panel since its VP depends on deck size, unlike every
+     other category which is a flat multiplier. Collapsed into one quiet strip with a subtotal
+     so it reads as a single idea instead of two near-identical fields. */
+  .gardens {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    border: 1px solid var(--border);
+  }
+  .glabel {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--muted);
+  }
+  .gfields {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+  .gfield {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+  .gcap {
+    white-space: nowrap;
+  }
+  .gsub {
+    margin-left: auto;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .help {
+    white-space: pre-wrap;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+    font-size: 0.85rem;
+    margin: 0;
+    font-family: inherit;
+    color: var(--muted);
+    line-height: 1.5;
+  }
+</style>

--- a/src/lib/games/dominion/dominion.test.ts
+++ b/src/lib/games/dominion/dominion.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+import type { Game, Player, Round, RoundContext } from '../../types';
+import { defaultWinners } from '../../types';
+import {
+  DOMINION_HELP,
+  VP,
+  describeDominion,
+  emptyInput,
+  emptyRow,
+  gardensPoints,
+  gardensValue,
+  scoreDominion,
+  scoreRow,
+  validateDominion,
+  type DominionRow,
+} from './logic';
+import { dominion } from './index';
+
+function player(id: string, name = id): Player {
+  return { id, name, color: '#7c5cff', createdAt: 0 };
+}
+const players = [player('a', 'Ada'), player('b', 'Bo')];
+
+function ctxWith(ps: Player[]): RoundContext {
+  const game: Game = {
+    id: 'g',
+    type: 'dominion',
+    config: {},
+    playerIds: ps.map((p) => p.id),
+    status: 'active',
+    createdAt: 0,
+    roundCount: 0,
+  };
+  return {
+    game,
+    players: ps,
+    config: {},
+    roundIndex: 0,
+    totals: Object.fromEntries(ps.map((p) => [p.id, 0])),
+    rounds: [],
+  };
+}
+
+function row(overrides: Partial<DominionRow> = {}): DominionRow {
+  return { ...emptyRow(), ...overrides };
+}
+
+describe('official VP values', () => {
+  it('matches the rulebook: Estate 1, Duchy 3, Province 6, Curse -1', () => {
+    expect(VP.estate).toBe(1);
+    expect(VP.duchy).toBe(3);
+    expect(VP.province).toBe(6);
+    expect(VP.curse).toBe(-1);
+  });
+});
+
+describe('gardensValue', () => {
+  it('is 1 VP per 10 cards in the deck, rounded down', () => {
+    expect(gardensValue(0)).toBe(0);
+    expect(gardensValue(9)).toBe(0);
+    expect(gardensValue(10)).toBe(1);
+    expect(gardensValue(34)).toBe(3);
+    expect(gardensValue(99)).toBe(9);
+  });
+
+  it('clamps a negative or non-finite deck size to 0', () => {
+    expect(gardensValue(-20)).toBe(0);
+    expect(gardensValue(Number.NaN)).toBe(0);
+    expect(gardensValue(undefined)).toBe(0);
+  });
+});
+
+describe('gardensPoints', () => {
+  it('multiplies Gardens owned by the per-Gardens value', () => {
+    expect(gardensPoints(row({ gardens: 2, deckSize: 34 }))).toBe(6); // 2 * 3
+    expect(gardensPoints(row({ gardens: 3, deckSize: 10 }))).toBe(3); // 3 * 1
+  });
+
+  it('is 0 with no Gardens or an undefined row', () => {
+    expect(gardensPoints(row({ deckSize: 50 }))).toBe(0);
+    expect(gardensPoints(undefined)).toBe(0);
+  });
+});
+
+describe('scoreRow', () => {
+  it('is 0 for an empty or missing row', () => {
+    expect(scoreRow(emptyRow())).toBe(0);
+    expect(scoreRow(undefined)).toBe(0);
+  });
+
+  it('scores basic Victory cards at their official values', () => {
+    expect(scoreRow(row({ estates: 3 }))).toBe(3);
+    expect(scoreRow(row({ duchies: 2 }))).toBe(6);
+    expect(scoreRow(row({ provinces: 4 }))).toBe(24);
+    expect(scoreRow(row({ curses: 2 }))).toBe(-2);
+  });
+
+  it('adds Gardens using the deck-size formula', () => {
+    // 34-card deck: each Gardens is worth floor(34/10) = 3.
+    expect(scoreRow(row({ gardens: 2, deckSize: 34 }))).toBe(6);
+  });
+
+  it('adds free-form Other VP, positive or negative', () => {
+    expect(scoreRow(row({ otherVP: 5 }))).toBe(5);
+    expect(scoreRow(row({ otherVP: -2 }))).toBe(-2);
+  });
+
+  it('ignores turns taken — it is recorded, not scored', () => {
+    expect(scoreRow(row({ estates: 1, turns: 27 }))).toBe(1);
+  });
+
+  it('matches a worked example combining every category', () => {
+    // 4 Estates (4) + 3 Duchies (9) + 2 Provinces (12) + 1 Curse (-1) +
+    // 2 Gardens on a 40-card deck (2*4=8) + 3 Other VP = 35.
+    const example = row({
+      estates: 4,
+      duchies: 3,
+      provinces: 2,
+      curses: 1,
+      gardens: 2,
+      deckSize: 40,
+      otherVP: 3,
+    });
+    expect(scoreRow(example)).toBe(35);
+  });
+
+  it('treats a NaN entry as 0', () => {
+    const r = emptyRow();
+    r.estates = Number.NaN;
+    expect(scoreRow(r)).toBe(0);
+  });
+});
+
+describe('scoreDominion', () => {
+  it('returns each seated player total', () => {
+    const input = emptyInput(players);
+    input.values.a = row({ provinces: 3, estates: 2 });
+    input.values.b = row({ duchies: 1, curses: 1 });
+    expect(scoreDominion(input, players)).toEqual({ a: 20, b: 2 });
+  });
+
+  it('scores a player with no row as 0', () => {
+    const input = emptyInput([players[0]]);
+    input.values.a = row({ provinces: 1 });
+    expect(scoreDominion(input, players)).toEqual({ a: 6, b: 0 });
+  });
+
+  it('is 0 for everyone with an undefined input', () => {
+    expect(scoreDominion(undefined, players)).toEqual({ a: 0, b: 0 });
+  });
+});
+
+describe('validateDominion', () => {
+  it('accepts a fresh or fully-filled sheet', () => {
+    expect(validateDominion(emptyInput(players), players)).toBeNull();
+    const input = emptyInput(players);
+    input.values.a = row({ provinces: 4, gardens: 1, deckSize: 30, otherVP: -2 });
+    expect(validateDominion(input, players)).toBeNull();
+  });
+
+  it('rejects negative card counts, naming the player and category', () => {
+    const input = emptyInput(players);
+    input.values.a.provinces = -1;
+    const err = validateDominion(input, players);
+    expect(err).toContain('Ada');
+    expect(err).toContain('Provinces');
+  });
+
+  it('rejects fractional card counts', () => {
+    const input = emptyInput(players);
+    input.values.b.estates = 2.5;
+    expect(validateDominion(input, players)).toMatch(/whole number/);
+  });
+
+  it('allows Other VP to go negative but not fractional', () => {
+    const input = emptyInput(players);
+    input.values.a.otherVP = -4;
+    expect(validateDominion(input, players)).toBeNull();
+    input.values.a.otherVP = 1.5;
+    expect(validateDominion(input, players)).toMatch(/whole number/);
+  });
+
+  it('treats blank / NaN as 0 rather than an error', () => {
+    const r = emptyRow();
+    r.estates = Number.NaN;
+    expect(validateDominion({ values: { a: r } }, [player('a')])).toBeNull();
+  });
+
+  it('is null for an undefined input or a player with no row', () => {
+    expect(validateDominion(undefined, players)).toBeNull();
+    expect(validateDominion({ values: {} }, players)).toBeNull();
+  });
+});
+
+describe('describeDominion', () => {
+  it('summarises each player total', () => {
+    const input = emptyInput(players);
+    input.values.a = row({ provinces: 4, estates: 2 });
+    input.values.b = row({ duchies: 1 });
+    const rd = { id: 'r', gameId: 'g', index: 0, input, deltas: {}, createdAt: 0 } as Round;
+    expect(describeDominion(rd, players)).toBe('Ada 26 · Bo 3');
+  });
+
+  it('returns empty string when nothing is recorded', () => {
+    const rd = {
+      id: 'r',
+      gameId: 'g',
+      index: 0,
+      input: undefined,
+      deltas: {},
+      createdAt: 0,
+    } as Round;
+    expect(describeDominion(rd, players)).toBe('');
+  });
+});
+
+describe('dominion module', () => {
+  it('declares faithful catalog metadata', () => {
+    expect(dominion.id).toBe('dominion');
+    expect(dominion.name).toBe('Dominion');
+    expect(dominion.emoji).toBe('🏰');
+    expect(dominion.minPlayers).toBe(2);
+    expect(dominion.maxPlayers).toBe(6);
+  });
+
+  it('is a single final scoresheet', () => {
+    expect(dominion.maxRounds?.({}, 4)).toBe(1);
+  });
+
+  it('seeds a zeroed row per player', () => {
+    const input = dominion.createRoundInput(ctxWith(players)) as ReturnType<typeof emptyInput>;
+    expect(Object.keys(input.values).sort()).toEqual(['a', 'b']);
+    for (const p of players) {
+      expect(input.values[p.id]).toEqual(emptyRow());
+    }
+  });
+
+  it('wires scoring and validation to the logic core', () => {
+    const input = emptyInput(players);
+    input.values.a = row({ provinces: 3, estates: 1 });
+    input.values.b = row({ duchies: 2 });
+    expect(dominion.scoreRound(input, ctxWith(players))).toEqual({ a: 19, b: 6 });
+    expect(dominion.validateRound(input, ctxWith(players))).toBeNull();
+    input.values.a.curses = -1;
+    expect(dominion.validateRound(input, ctxWith(players))).toContain('Ada');
+  });
+
+  it('awards the win to the highest total, sharing ties', () => {
+    expect(defaultWinners(dominion, { a: 35, b: 12 })).toEqual(['a']);
+    expect(defaultWinners(dominion, { a: 30, b: 30 }).sort()).toEqual(['a', 'b']);
+  });
+
+  it('ships a scoring help reference that states the official VP values and tie-break', () => {
+    expect(dominion.help).toBe(DOMINION_HELP);
+    expect(dominion.help).toContain('1 VP');
+    expect(dominion.help).toContain('3 VP');
+    expect(dominion.help).toContain('6 VP');
+    expect(dominion.help).toContain('-1 VP');
+    expect(dominion.help).toContain('fewest turns');
+  });
+});

--- a/src/lib/games/dominion/index.ts
+++ b/src/lib/games/dominion/index.ts
@@ -1,0 +1,62 @@
+import type { GameModule, ID, Round, RoundContext } from '../../types';
+import { RoundEditor } from '../editor';
+import { dominionStats } from './stats';
+import {
+  DOMINION_HELP,
+  describeDominion,
+  emptyInput,
+  scoreDominion,
+  validateDominion,
+  type DominionInput,
+} from './logic';
+
+export type { DominionInput, DominionRow } from './logic';
+
+/**
+ * Dominion — a faithful end-game Victory Point scorer for Rio Grande Games' deck-builder
+ * (2008). One final scoresheet per played game: Estates, Duchies, Provinces, Curses,
+ * Gardens (deck-size dependent), and a free "Other VP" catch-all for every kingdom/
+ * variable victory card across the many expansions — summed to a total, highest wins.
+ * All scoring lives in the Svelte-free `logic.ts`; this module just wires it into the
+ * `GameModule` contract, mirroring Finspan's end-game-category scoresheet shape.
+ */
+export const dominion: GameModule = {
+  id: 'dominion',
+  name: 'Dominion',
+  tagline: 'Build your deck, count your castle — most VP wins.',
+  emoji: '🏰',
+  keywords: [
+    'deck builder',
+    'deckbuilding',
+    'kingdom',
+    'estate',
+    'duchy',
+    'province',
+    'curse',
+    'gardens',
+    'victory points',
+    'vp',
+  ],
+  minPlayers: 2,
+  maxPlayers: 6,
+
+  // A single final scoresheet — one round, then the game is complete.
+  maxRounds: () => 1,
+
+  createRoundInput: (ctx: RoundContext): DominionInput => emptyInput(ctx.players),
+
+  validateRound: (input: DominionInput, ctx: RoundContext): string | null =>
+    validateDominion(input, ctx.players),
+
+  scoreRound: (input: DominionInput, ctx: RoundContext): Record<ID, number> =>
+    scoreDominion(input, ctx.players),
+
+  describeRound: (round: Round, players): string => describeDominion(round, players),
+
+  help: DOMINION_HELP,
+
+  stats: dominionStats,
+
+  RoundEditor,
+  editorLoader: () => import('./DominionEditor.svelte'),
+};

--- a/src/lib/games/dominion/logic.ts
+++ b/src/lib/games/dominion/logic.ts
@@ -1,0 +1,187 @@
+import type { ID, Player, Round } from '../../types';
+
+/**
+ * Dominion — the deck-building end-game scorer.
+ * ----------------------------------------------
+ * Dominion (Rio Grande Games / Donald X. Vaccarino, 2008) ends the moment the Province
+ * pile empties (or any three Supply piles do). Every player then totals the Victory
+ * Points across every card in their entire deck — draw pile, discard, hand, everywhere —
+ * and the highest total wins. This module is the pure, Svelte-free scoring core, mirroring
+ * Finspan's end-game-category shape: one final scoresheet per played game, summed to a
+ * total. `dominion.test.ts` exercises the real math without importing the editor.
+ *
+ * Official Victory Point values (base game):
+ *   Estate   =  1 VP each
+ *   Duchy    =  3 VP each
+ *   Province =  6 VP each
+ *   Curse    = -1 VP each
+ *   Gardens  =  1 VP per 10 cards in your deck, rounded down (e.g. 34 cards = 3 VP each)
+ * Everything else — Colonies, Duke, Fairgrounds, and every other kingdom/variable
+ * victory card across the many expansions — is free-form "Other VP", entered directly.
+ *
+ * Official tie-break: the tied player who has taken the fewest turns wins; if that's
+ * still tied, they share the victory. Score King records turns taken per player so the
+ * table can apply that tie-break themselves, but (like every game here) ties in the
+ * recorded VP total are shared rather than auto-resolved from a field outside the score.
+ */
+
+/** Base-game Victory Point values, per card. */
+export const VP = {
+  estate: 1,
+  duchy: 3,
+  province: 6,
+  curse: -1,
+} as const;
+
+/** Per-player row: raw counts entered on the scoresheet. */
+export interface DominionRow {
+  /** Estate cards owned — 1 VP each. */
+  estates: number;
+  /** Duchy cards owned — 3 VP each. */
+  duchies: number;
+  /** Province cards owned — 6 VP each. */
+  provinces: number;
+  /** Curse cards owned — -1 VP each. */
+  curses: number;
+  /** Gardens cards owned — 1 VP per 10 cards in the deck, each. */
+  gardens: number;
+  /** Total cards in the whole deck (draw pile + discard + hand + play area). Only used for Gardens. */
+  deckSize: number;
+  /** Free-form VP from every other victory/kingdom card (Colonies, Duke, Fairgrounds, etc). */
+  otherVP: number;
+  /** Optional: turns taken, recorded for the official fewest-turns tie-break. Not scored. */
+  turns: number;
+}
+
+export interface DominionInput {
+  /** player id -> their scoresheet row. */
+  values: Record<ID, DominionRow>;
+}
+
+/** A fresh, all-zero row. */
+export function emptyRow(): DominionRow {
+  return {
+    estates: 0,
+    duchies: 0,
+    provinces: 0,
+    curses: 0,
+    gardens: 0,
+    deckSize: 0,
+    otherVP: 0,
+    turns: 0,
+  };
+}
+
+/** A fresh scoresheet for the given players. */
+export function emptyInput(players: Player[]): DominionInput {
+  return { values: Object.fromEntries(players.map((p) => [p.id, emptyRow()])) };
+}
+
+/** Coerce any stored value to a finite number (0 when blank / NaN). */
+function num(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** VP each Gardens card is worth for a given deck size: 1 per 10 cards, rounded down. */
+export function gardensValue(deckSize: unknown): number {
+  return Math.floor(Math.max(0, num(deckSize)) / 10);
+}
+
+/** Total points a single row's Gardens cards contribute. */
+export function gardensPoints(row: DominionRow | undefined): number {
+  if (!row) return 0;
+  return num(row.gardens) * gardensValue(row.deckSize);
+}
+
+/** Total VP for one player's row. */
+export function scoreRow(row: DominionRow | undefined): number {
+  if (!row) return 0;
+  return (
+    num(row.estates) * VP.estate +
+    num(row.duchies) * VP.duchy +
+    num(row.provinces) * VP.province +
+    num(row.curses) * VP.curse +
+    gardensPoints(row) +
+    num(row.otherVP)
+  );
+}
+
+/** Per-player VP totals for the whole scoresheet. */
+export function scoreDominion(
+  input: DominionInput | undefined,
+  players: Player[],
+): Record<ID, number> {
+  const out: Record<ID, number> = {};
+  for (const p of players) out[p.id] = scoreRow(input?.values?.[p.id]);
+  return out;
+}
+
+/** Fields that must be whole, non-negative numbers (card/turn counts). */
+const COUNT_FIELDS: { key: keyof DominionRow; label: string }[] = [
+  { key: 'estates', label: 'Estates' },
+  { key: 'duchies', label: 'Duchies' },
+  { key: 'provinces', label: 'Provinces' },
+  { key: 'curses', label: 'Curses' },
+  { key: 'gardens', label: 'Gardens' },
+  { key: 'deckSize', label: 'Deck size' },
+  { key: 'turns', label: 'Turns taken' },
+];
+
+/**
+ * Validate the sheet. Card/turn counts must be whole and non-negative; "Other VP" may be
+ * any whole number (some kingdom cards, like embargo tokens, subtract VP). Null when valid.
+ */
+export function validateDominion(
+  input: DominionInput | undefined,
+  players: Player[],
+): string | null {
+  if (!input?.values) return null;
+  for (const p of players) {
+    const row = input.values[p.id];
+    if (!row) continue;
+    for (const f of COUNT_FIELDS) {
+      const n = Number(row[f.key]);
+      if (!Number.isFinite(n)) continue; // blank -> treated as 0, like scoreRow
+      if (n < 0) return `${p.name}: ${f.label} can't be negative.`;
+      if (!Number.isInteger(n)) return `${p.name}: ${f.label} must be a whole number.`;
+    }
+    const other = Number(row.otherVP);
+    if (Number.isFinite(other) && !Number.isInteger(other)) {
+      return `${p.name}: Other VP must be a whole number.`;
+    }
+  }
+  return null;
+}
+
+/** A concise per-player summary of the recorded scoresheet for the history table. */
+export function describeDominion(round: Round, players: Player[]): string {
+  const input = round.input as DominionInput | undefined;
+  if (!input?.values) return '';
+  const parts: string[] = [];
+  for (const p of players) {
+    if (input.values[p.id]) parts.push(`${p.name} ${scoreRow(input.values[p.id])}`);
+  }
+  return parts.length ? parts.join(' · ') : 'no score';
+}
+
+/** Reference text for the in-game help popover — official VP values, fully spelled out. */
+export const DOMINION_HELP = [
+  'Total your deck when the game ends — most Victory Points wins. 🏰',
+  '',
+  'Estate 🟩: 1 VP each.',
+  'Duchy 🏠: 3 VP each.',
+  'Province ⭐: 6 VP each.',
+  'Curse 💀: -1 VP each.',
+  'Gardens 🌿: 1 VP per 10 cards in your whole deck, rounded down, per Gardens you own',
+  '  (e.g. a 34-card deck makes each Gardens worth 3 VP).',
+  'Other VP: every other victory or kingdom card — Colonies, Duke, Fairgrounds, and',
+  '  anything else your expansions bring. Enter its total directly (can be negative,',
+  '  e.g. embargo tokens).',
+  '',
+  'Count every card in your deck for this: draw pile, discard, hand, everywhere.',
+  '',
+  "Tie? The official rule is fewest turns taken wins — that's why there's a Turns",
+  'field. Score King still shares the win when VP ties; use the recorded turns to',
+  'settle it at the table.',
+].join('\n');

--- a/src/lib/games/dominion/stats.ts
+++ b/src/lib/games/dominion/stats.ts
@@ -1,0 +1,110 @@
+import type { ID } from '../../types';
+import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
+import { fmtInt } from '../../stats/format';
+import { gardensPoints, scoreRow, type DominionInput } from './logic';
+
+interface DomAgg {
+  games: number;
+  sum: number;
+  best: number;
+  provinces: number;
+  curses: number;
+  gardensPts: number;
+}
+
+/**
+ * Dominion stats, derived purely from each game's single final scoresheet. A Dominion
+ * game is one round (the scoresheet), so every recorded round is a full game total.
+ * Pure — no Svelte — so it is independently unit-testable and safe for the engine.
+ */
+export function dominionStats({
+  games,
+  rounds,
+  players,
+  canonical,
+}: GameStatsInput): GameSpecificStats {
+  const gameIds = new Set(games.map((g) => g.id));
+  const nameById = new Map(players.map((p) => [p.id, p.name]));
+  const per = new Map<ID, DomAgg>();
+  const get = (id: ID): DomAgg => {
+    let a = per.get(id);
+    if (!a) {
+      a = { games: 0, sum: 0, best: 0, provinces: 0, curses: 0, gardensPts: 0 };
+      per.set(id, a);
+    }
+    return a;
+  };
+
+  let topScore = -Infinity;
+  let topHolder: ID | undefined;
+  let winSum = 0;
+  let winGames = 0;
+
+  for (const r of rounds) {
+    if (!gameIds.has(r.gameId)) continue;
+    const input = r.input as DominionInput | undefined;
+    if (!input?.values) continue;
+    let gameBest = -Infinity;
+    for (const [pid, row] of Object.entries(input.values)) {
+      const id = canonical(pid);
+      const a = get(id);
+      const total = scoreRow(row);
+      a.games += 1;
+      a.sum += total;
+      if (total > a.best) a.best = total;
+      a.provinces += Number(row?.provinces) || 0;
+      a.curses += Number(row?.curses) || 0;
+      a.gardensPts += gardensPoints(row);
+      if (total > topScore) {
+        topScore = total;
+        topHolder = id;
+      }
+      if (total > gameBest) gameBest = total;
+    }
+    if (gameBest > -Infinity) {
+      winSum += gameBest;
+      winGames += 1;
+    }
+  }
+
+  const perPlayer: Record<ID, Metric[]> = {};
+  for (const [id, a] of per) {
+    if (!a.games) continue;
+    const metrics: Metric[] = [
+      { key: 'dm_avg', label: 'Avg VP', value: fmtInt(a.sum / a.games), emoji: '🏰' },
+      { key: 'dm_best', label: 'Best VP', value: fmtInt(a.best), emoji: '⭐' },
+    ];
+    if (a.provinces) {
+      metrics.push({
+        key: 'dm_provinces',
+        label: 'Provinces claimed',
+        value: fmtInt(a.provinces),
+        emoji: '⭐',
+      });
+    }
+    if (a.curses) {
+      metrics.push({ key: 'dm_curses', label: 'Curses taken', value: fmtInt(a.curses), emoji: '💀' });
+    }
+    perPlayer[id] = metrics;
+  }
+
+  const global: Metric[] = [];
+  if (winGames) {
+    global.push({
+      key: 'dm_avgwin',
+      label: 'Avg winning VP',
+      value: fmtInt(winSum / winGames),
+      emoji: '🏅',
+    });
+  }
+  if (topHolder) {
+    global.push({
+      key: 'dm_top',
+      label: 'Grandest estate',
+      value: fmtInt(topScore),
+      sub: nameById.get(topHolder),
+      emoji: '🏰',
+    });
+  }
+  return { perPlayer, global };
+}


### PR DESCRIPTION
## Summary

Adds a new game module for **Dominion** 🏰 (Rio Grande Games' deck-building game), following the end-game category scoresheet pattern used by Finspan.

## Changes

- `src/lib/games/dominion/logic.ts` — pure scoring core with official VP values: Estate=1, Duchy=3, Province=6, Curse=-1, Gardens=1 VP per 10 cards in the whole deck (rounded down), plus a free-form "Other VP" field for expansion/kingdom victory cards (Colonies, Duke, Fairgrounds, etc).
- `src/lib/games/dominion/stats.ts` — game-specific stats hook (avg/best VP, provinces claimed, curses taken, avg winning VP, grandest estate).
- `src/lib/games/dominion/index.ts` — `GameModule` wiring with lazy `editorLoader` (mirrors cribbage's chunked-editor pattern).
- `src/lib/games/dominion/DominionEditor.svelte` — per-player scoresheet with steppers for card counts, a deck-size field for Gardens, live totals, and the crown/Gold leader treatment.
- `src/lib/games/dominion/dominion.test.ts` — 29 vitest cases covering VP math, Gardens formula, validation, and module wiring.

Single end-game scoresheet (`maxRounds: () => 1`), matching Finspan. Includes an optional "Turns taken" field to support the official fewest-turns tie-break — informational only; VP ties are still shared like every other game in the app. Games are auto-discovered via `registry.ts`'s `import.meta.glob`, so no registry changes were needed.

## Issues

Closes #177

## Testing

- [x] `npx vitest run dominion` — 29/29 passed
- [x] `npm run check` — 0 errors, 0 warnings