### PR TITLE
feat(hearts): track wrong-way moments (#180)

### DIFF
--- a/src/lib/games/hearts/HeartsEditor.svelte
+++ b/src/lib/games/hearts/HeartsEditor.svelte
@@ -18,15 +18,31 @@
     previewDelta,
     readConfig,
     shooter,
+    wrongWayPlayers,
     type HeartsInput,
     type MoonRule,
   } from './logic';
 
   let { input = $bindable(), ctx }: { input: HeartsInput; ctx: RoundContext } = $props();
 
+  if (input.wrongWayPlayerIds == null) input.wrongWayPlayerIds = [];
+
   const cfg = $derived(readConfig(ctx.config));
   const variantJack = $derived(cfg.variantJack);
   const ids = $derived(ctx.players.map((p) => p.id));
+  const wrongWay = $derived(new Set(wrongWayPlayers(input)));
+  const priorWrongWay = $derived.by(() =>
+    ctx.players
+      .map((player) => ({
+        player,
+        rounds: ctx.rounds
+          .filter((round) => round.index !== ctx.roundIndex)
+          .filter((round) => wrongWayPlayers(round.input as HeartsInput).includes(player.id))
+          .map((round) => round.index + 1)
+          .sort((a, b) => a - b),
+      }))
+      .filter((entry) => entry.rounds.length > 0),
+  );
 
   const pass = $derived(
     cfg.passing ? passingFor(ctx.roundIndex, ids.length, cfg.passCardCount) : null,
@@ -66,6 +82,7 @@
   );
 
   let showHelp = $state(false);
+  let showOtherStats = $state(wrongWayPlayers(input).length > 0);
   let moonToken = $state(0);
   let prevMoon: string | null = null;
   let ready = false;
@@ -113,14 +130,24 @@
     input.moonRule = rule;
     haptic('tick');
   }
+  function toggleWrongWay(id: string) {
+    const current = wrongWayPlayers(input);
+    input.wrongWayPlayerIds = current.includes(id)
+      ? current.filter((playerId) => playerId !== id)
+      : [...current, id];
+    haptic('tick');
+  }
   // Whether the draft holds anything worth clearing — gates the "Clear hand" reset
   // so it only appears once you've started entering, never on an untouched round.
-  const dirty = $derived(placed > 0 || input.queen !== null || input.jack !== null);
+  const dirty = $derived(
+    placed > 0 || input.queen !== null || input.jack !== null || wrongWay.size > 0,
+  );
   function clearHand() {
     for (const id of ids) input.hearts[id] = 0;
     input.queen = null;
     input.jack = null;
     input.moonRule = undefined; // drop any per-round moon pick with the rest of the hand
+    input.wrongWayPlayerIds = [];
     haptic('undo'); // a gentle reversal beat — the whole hand goes back to zero
   }
 </script>
@@ -275,6 +302,48 @@
       </div>
     </div>
   {/each}
+
+  <details class="other-stats" bind:open={showOtherStats}>
+    <summary>
+      <span>↩ Other stats</span>
+      <span class="summary-meta">
+        {wrongWay.size > 0 ? `${wrongWay.size} marked` : 'optional'}
+      </span>
+    </summary>
+    <div class="other-stats-body">
+      <p class="muted small">Who tried to keep play moving the wrong way this hand?</p>
+      <div class="wrong-way-players">
+        {#each ctx.players as p (p.id)}
+          <button
+            type="button"
+            class="wrong-way-player"
+            class:on={wrongWay.has(p.id)}
+            aria-pressed={wrongWay.has(p.id)}
+            aria-label={`Mark ${p.name} for a wrong-way moment`}
+            onclick={() => toggleWrongWay(p.id)}
+          >
+            <Avatar name={p.name} color={p.color} size={24} />
+            <span>{p.name}</span>
+            {#if wrongWay.has(p.id)}<span class="check" aria-hidden="true">↩</span>{/if}
+          </button>
+        {/each}
+      </div>
+      {#if priorWrongWay.length > 0}
+        <div class="wrong-way-history">
+          <span class="muted small">Earlier this game</span>
+          {#each priorWrongWay as entry (entry.player.id)}
+            <div class="history-row">
+              <span>{entry.player.name}</span>
+              <span class="muted rounds">
+                {entry.rounds.length === 1 ? 'Round' : 'Rounds'}
+                {entry.rounds.join(', ')}
+              </span>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+  </details>
 </div>
 
 <style>
@@ -464,5 +533,95 @@
     margin: 0;
     font-family: inherit;
     color: var(--muted);
+  }
+  .other-stats {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface-2);
+    padding: 0 12px;
+  }
+  .other-stats summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 46px;
+    cursor: pointer;
+    list-style: none;
+    font-weight: 700;
+  }
+  .other-stats summary::-webkit-details-marker {
+    display: none;
+  }
+  .summary-meta {
+    color: var(--muted);
+    font-size: 0.8rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+  }
+  .other-stats[open] summary {
+    border-bottom: 1px solid var(--border);
+  }
+  .other-stats-body {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px 0 12px;
+  }
+  .other-stats-body p {
+    margin: 0;
+  }
+  .wrong-way-players {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 8px;
+  }
+  .wrong-way-player {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 7px 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 600;
+    text-align: left;
+  }
+  .wrong-way-player.on {
+    border-color: var(--warn);
+    background: color-mix(in srgb, var(--warn) 12%, var(--surface));
+  }
+  .wrong-way-player:hover {
+    background: var(--surface-3);
+  }
+  .other-stats summary:focus-visible,
+  .wrong-way-player:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+  .wrong-way-player .check {
+    margin-left: auto;
+    color: var(--warn);
+    font-weight: 800;
+  }
+  .wrong-way-history {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding-top: 2px;
+  }
+  .history-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 0.9rem;
+  }
+  .rounds {
+    font-variant-numeric: tabular-nums;
+    text-align: right;
   }
 </style>

--- a/src/lib/games/hearts/hearts.test.ts
+++ b/src/lib/games/hearts/hearts.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Player } from '../../types';
 import { hearts } from './index';
+import { heartsStats } from './stats';
 import {
   HEARTS_TOTAL,
   baseDelta,
@@ -17,6 +18,7 @@ import {
   scoreRound,
   shooter,
   validateRound,
+  wrongWayPlayers,
   type HeartsInput,
 } from './logic';
 
@@ -104,6 +106,7 @@ describe('heart tallies', () => {
       hearts: { a: 0, b: 0, c: 0, d: 0 },
       queen: null,
       jack: null,
+      wrongWayPlayerIds: [],
     });
   });
   it('totals and remaining hearts', () => {
@@ -113,6 +116,15 @@ describe('heart tallies', () => {
   });
   it('remaining never goes negative', () => {
     expect(heartsRemaining(input({ a: 20 }))).toBe(0);
+  });
+  it('reads unique wrong-way players while preserving legacy rounds', () => {
+    expect(wrongWayPlayers(input({ a: 13 }))).toEqual([]);
+    expect(
+      wrongWayPlayers({
+        ...input({ a: 13 }),
+        wrongWayPlayerIds: ['a', 'b', 'a'],
+      }),
+    ).toEqual(['a', 'b']);
   });
 });
 
@@ -342,14 +354,96 @@ describe('hearts module', () => {
     expect(hearts.describeRound!(crashed, P4)).toMatch(/☄️ A crashed a moon — 25/);
     const ordinary = { input: input({ a: 4, b: 4, c: 4, d: 1 }, 'd', 'a') } as never;
     expect(hearts.describeRound!(ordinary, P4)).toMatch(/💔 D \+14 · ♦J A/);
+    const wrongWay = {
+      input: {
+        ...input({ a: 4, b: 4, c: 4, d: 1 }, 'd'),
+        wrongWayPlayerIds: ['a', 'b'],
+      },
+    } as never;
+    expect(hearts.describeRound!(wrongWay, P4)).toMatch(/↩ A & B went the wrong way/);
   });
 
-  it('roundCellTone marks the Queen-taker, but not a moon shooter', () => {
+  it('roundCellTone marks Queen and wrong-way moments without changing scoring', () => {
     const ordinary = { input: input({ a: 4, b: 4, c: 4, d: 1 }, 'a') } as never;
     expect(hearts.roundCellTone!(ordinary, 'a')).toMatchObject({ tone: 'bad' });
     expect(hearts.roundCellTone!(ordinary, 'b')).toBeNull();
     // A moon flips scoring, so the Queen-taker (the shooter) isn't flagged.
     const moon = { input: input({ a: 13, b: 0, c: 0, d: 0 }, 'a') } as never;
     expect(hearts.roundCellTone!(moon, 'a')).toBeNull();
+
+    const markedInput = {
+      ...input({ a: 4, b: 4, c: 4, d: 1 }, 'a'),
+      wrongWayPlayerIds: ['a', 'b'],
+    };
+    const marked = { input: markedInput } as never;
+    expect(hearts.roundCellTone!(marked, 'a')).toMatchObject({
+      tone: 'bad',
+      marker: '↩',
+    });
+    expect(hearts.roundCellTone!(marked, 'b')).toMatchObject({
+      label: 'Went the wrong way',
+      marker: '↩',
+    });
+    expect(
+      hearts.scoreRound(markedInput, {
+        game: {} as never,
+        players: P4,
+        config: {},
+        roundIndex: 0,
+        totals: {},
+        rounds: [],
+      }),
+    ).toEqual({ a: 17, b: 4, c: 4, d: 1 });
+  });
+
+  it('aggregates wrong-way moments with player and round details', () => {
+    const game = {
+      id: 'g1',
+      type: 'hearts',
+      playerIds: IDS,
+      status: 'finished',
+      config: {},
+      createdAt: 1,
+      roundCount: 3,
+    } as never;
+    const rounds = [
+      {
+        id: 'r1',
+        gameId: 'g1',
+        index: 0,
+        input: { ...input({ a: 4, b: 4, c: 4, d: 1 }, 'd'), wrongWayPlayerIds: ['a'] },
+        deltas: {},
+        createdAt: 2,
+      },
+      {
+        id: 'r3',
+        gameId: 'g1',
+        index: 2,
+        input: {
+          ...input({ a: 4, b: 4, c: 4, d: 1 }, 'd'),
+          wrongWayPlayerIds: ['a', 'b'],
+        },
+        deltas: {},
+        createdAt: 3,
+      },
+    ] as never;
+
+    const stats = heartsStats({
+      games: [game],
+      rounds,
+      players: P4,
+      canonical: (id) => id,
+    });
+    expect(stats.perPlayer?.a.find((metric) => metric.key === 'h_wrong_way')).toMatchObject({
+      value: '2',
+      sub: 'Rounds 1, 3',
+    });
+    expect(stats.perPlayer?.b.find((metric) => metric.key === 'h_wrong_way')).toMatchObject({
+      value: '1',
+      sub: 'Round 3',
+    });
+    expect(stats.global?.find((metric) => metric.key === 'h_wrong_way_all')).toMatchObject({
+      value: '3',
+    });
   });
 });

--- a/src/lib/games/hearts/index.ts
+++ b/src/lib/games/hearts/index.ts
@@ -8,6 +8,7 @@ import {
   scoreRound as scoreHearts,
   shooter,
   validateRound as validateHearts,
+  wrongWayPlayers,
   type HeartsInput,
 } from './logic';
 
@@ -73,14 +74,22 @@ export const hearts: GameModule = {
   describeRound: (round: Round, players): string =>
     describeHeartsRound(round.input as HeartsInput, players),
 
-  // Per-round scorecard emphasis: mark whoever ate the Queen in coral (a heavy
-  // hand), but not when they shot the moon — a moon flips the round, so the Queen
-  // is a triumph there, not a penalty. Co-signalled by a title/AT label, and only
-  // the per-round view (deltas) asks for it, never the running totals.
+  // Per-round scorecard emphasis: mark whoever ate the Queen in coral, and add a
+  // compact arrow for optional wrong-way metadata. Only the per-round view asks
+  // for these details, never the running totals.
   roundCellTone: (round: Round, playerId: ID) => {
     const input = round.input as HeartsInput | undefined;
-    if (!input || shooter(input)) return null;
-    return input.queen === playerId ? { tone: 'bad', label: 'Took the ♠Q (+13)' } : null;
+    if (!input) return null;
+    const wentWrongWay = wrongWayPlayers(input).includes(playerId);
+    const tookQueen = !shooter(input) && input.queen === playerId;
+    if (tookQueen) {
+      return {
+        tone: 'bad',
+        label: wentWrongWay ? 'Took the ♠Q (+13) and went the wrong way' : 'Took the ♠Q (+13)',
+        marker: wentWrongWay ? '↩' : undefined,
+      };
+    }
+    return wentWrongWay ? { label: 'Went the wrong way', marker: '↩' } : null;
   },
 
   help: [

--- a/src/lib/games/hearts/logic.ts
+++ b/src/lib/games/hearts/logic.ts
@@ -24,6 +24,8 @@ export interface HeartsInput {
    * someone shot the moon; absent on ordinary rounds and legacy saved rounds.
    */
   moonRule?: MoonRule;
+  /** Players who tried to continue play in the wrong direction this round. */
+  wrongWayPlayerIds?: ID[];
 }
 
 export type MoonRule = 'add26' | 'subtract';
@@ -166,7 +168,14 @@ export function emptyInput(playerIds: readonly ID[]): HeartsInput {
     hearts: Object.fromEntries(playerIds.map((id) => [id, 0])),
     queen: null,
     jack: null,
+    wrongWayPlayerIds: [],
   };
+}
+
+/** Valid, unique wrong-way player ids from optional round metadata. */
+export function wrongWayPlayers(input: HeartsInput | undefined): ID[] {
+  if (!Array.isArray(input?.wrongWayPlayerIds)) return [];
+  return [...new Set(input.wrongWayPlayerIds.filter((id): id is ID => typeof id === 'string'))];
 }
 
 /** Hearts placed so far this round. */
@@ -323,9 +332,16 @@ export function describeRound(
 ): string {
   const name = (id: ID | null) => players.find((p) => p.id === id)?.name ?? '?';
   if (!input?.hearts) return 'no cards';
+  const wrongWayNames = wrongWayPlayers(input).map((id) => name(id));
+  const wrongWayNote =
+    wrongWayNames.length === 0
+      ? ''
+      : `↩ ${wrongWayNames.length === 1 ? wrongWayNames[0] : wrongWayNames.join(' & ')} went the wrong way`;
+  const withWrongWay = (summary: string) =>
+    wrongWayNote ? `${summary} · ${wrongWayNote}` : summary;
 
   const moon = shooter(input);
-  if (moon) return `🌙 ${name(moon)} shot the moon`;
+  if (moon) return withWrongWay(`🌙 ${name(moon)} shot the moon`);
 
   const heartsOf = (id: ID) => numOr(input.hearts[id], 0) || 0;
   const jackOn = input.jack != null;
@@ -338,7 +354,7 @@ export function describeRound(
   // Crashed a moon: took the Queen and all but one heart (25 points) — the whole
   // load bar a single card. The most-retold story at any Hearts table.
   if (input.queen && heartsOf(input.queen) >= HEARTS_TOTAL - 1) {
-    return `☄️ ${name(input.queen)} crashed a moon — ${pointsFor(input.queen)}`;
+    return withWrongWay(`☄️ ${name(input.queen)} crashed a moon — ${pointsFor(input.queen)}`);
   }
 
   const parts: string[] = [];
@@ -347,11 +363,11 @@ export function describeRound(
   } else {
     // No Queen on record (legacy/partial round): fall back to the heaviest pile.
     const top = [...players].sort((a, b) => heartsOf(b.id) - heartsOf(a.id))[0];
-    if (top && heartsOf(top.id) > 0) return `♥️ ${name(top.id)} +${heartsOf(top.id)}`;
-    return 'no points';
+    if (top && heartsOf(top.id) > 0) return withWrongWay(`♥️ ${name(top.id)} +${heartsOf(top.id)}`);
+    return withWrongWay('no points');
   }
   if (jackOn) parts.push(`♦J ${name(input.jack)}`);
-  return parts.join(' · ');
+  return withWrongWay(parts.join(' · '));
 }
 
 /** True when any player has reached the end score and the game can wrap. */

--- a/src/lib/games/hearts/stats.ts
+++ b/src/lib/games/hearts/stats.ts
@@ -1,5 +1,5 @@
 import type { ID } from '../../types';
-import { shooter, type HeartsInput } from './logic';
+import { shooter, wrongWayPlayers, type HeartsInput } from './logic';
 import type { GameSpecificStats, GameStatsInput, Metric } from '../../stats/types';
 import { fmtAvg, fmtInt, fmtPct } from '../../stats/format';
 
@@ -14,6 +14,10 @@ interface HeartsAgg {
   points: number;
   /** Most points taken in a single (non-moon) hand. */
   worst: number;
+  wrongWays: number;
+  wrongWayRounds: number[];
+  wrongWayGameIds: Set<ID>;
+  latestWrongWay?: { round: number; createdAt: number };
 }
 
 /**
@@ -28,7 +32,18 @@ export function heartsStats({ games, rounds, canonical }: GameStatsInput): GameS
   const get = (id: ID): HeartsAgg => {
     let a = per.get(id);
     if (!a) {
-      a = { moons: 0, queens: 0, clean: 0, rounds: 0, scored: 0, points: 0, worst: 0 };
+      a = {
+        moons: 0,
+        queens: 0,
+        clean: 0,
+        rounds: 0,
+        scored: 0,
+        points: 0,
+        worst: 0,
+        wrongWays: 0,
+        wrongWayRounds: [],
+        wrongWayGameIds: new Set(),
+      };
       per.set(id, a);
     }
     return a;
@@ -57,12 +72,23 @@ export function heartsStats({ games, rounds, canonical }: GameStatsInput): GameS
       }
     }
     if (moon) get(canonical(moon)).moons += 1;
+    for (const id of new Set(wrongWayPlayers(input).map(canonical))) {
+      const a = get(id);
+      a.wrongWays += 1;
+      a.wrongWayRounds.push(r.index + 1);
+      a.wrongWayGameIds.add(r.gameId);
+      if (!a.latestWrongWay || r.createdAt >= a.latestWrongWay.createdAt) {
+        a.latestWrongWay = { round: r.index + 1, createdAt: r.createdAt };
+      }
+    }
   }
 
   const perPlayer: Record<ID, Metric[]> = {};
   let totMoons = 0;
+  let totWrongWays = 0;
   for (const [id, a] of per) {
     totMoons += a.moons;
+    totWrongWays += a.wrongWays;
     const metrics: Metric[] = [];
     if (a.moons)
       metrics.push({ key: 'h_moon', label: 'Moons shot', value: `${a.moons}`, emoji: '🌙' });
@@ -85,11 +111,33 @@ export function heartsStats({ games, rounds, canonical }: GameStatsInput): GameS
       });
       metrics.push({ key: 'h_worst', label: 'Worst hand', value: fmtInt(a.worst), emoji: '😱' });
     }
+    if (a.wrongWays) {
+      const rounds = [...new Set(a.wrongWayRounds)].sort((x, y) => x - y);
+      const sub =
+        a.wrongWayGameIds.size === 1
+          ? `${rounds.length === 1 ? 'Round' : 'Rounds'} ${rounds.join(', ')}`
+          : `${fmtInt(a.wrongWayGameIds.size)} games · latest in round ${a.latestWrongWay?.round ?? '?'}`;
+      metrics.push({
+        key: 'h_wrong_way',
+        label: 'Wrong-way moments',
+        value: fmtInt(a.wrongWays),
+        sub,
+        emoji: '↩️',
+      });
+    }
     if (metrics.length) perPlayer[id] = metrics;
   }
 
   const global: Metric[] = [];
   if (totMoons)
     global.push({ key: 'h_moon_all', label: 'Moons shot', value: `${totMoons}`, emoji: '🌙' });
+  if (totWrongWays) {
+    global.push({
+      key: 'h_wrong_way_all',
+      label: 'Wrong-way moments',
+      value: fmtInt(totWrongWays),
+      emoji: '↩️',
+    });
+  }
   return { perPlayer, global };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -255,7 +255,7 @@ export interface GameModule {
   roundCellTone?(
     round: Round,
     playerId: ID,
-  ): { tone: 'good' | 'bad' | 'warn'; label?: string } | null;
+  ): { tone?: 'good' | 'bad' | 'warn'; label?: string; marker?: string } | null;
   /**
    * Optional game-specific stats over this game's finished games. Pure, no I/O —
    * mirrors {@link describeRound}: a new game contributes stats the same way it

--- a/src/pages/GamePlay.svelte
+++ b/src/pages/GamePlay.svelte
@@ -693,8 +693,15 @@
                   class:tone-good={cell?.tone === 'good'}
                   class:tone-warn={cell?.tone === 'warn'}
                   title={cell?.label}
-                  >{showRunning ? (runningTotals[r.id]?.[p.id] ?? 0) : fmt(r.deltas[p.id])}</td
                 >
+                  <span
+                    >{showRunning ? (runningTotals[r.id]?.[p.id] ?? 0) : fmt(r.deltas[p.id])}</span
+                  >
+                  {#if cell?.marker}
+                    <span class="cell-marker" aria-hidden="true">{cell.marker}</span>
+                    {#if cell.label}<span class="sr-only"> — {cell.label}</span>{/if}
+                  {/if}
+                </td>
               {/each}
               <td class="acts">
                 {#if game.status === 'active'}
@@ -894,9 +901,8 @@
   .matrix .num {
     font-variant-numeric: tabular-nums;
   }
-  /* Per-round emphasis a game module can request (Hearts flags the Queen-taker).
-     The value itself is the primary signal; the hue reinforces it, and a title
-     on the cell carries the reason for pointer + assistive tech. */
+  /* Per-round emphasis a game module can request. The optional marker makes
+     event metadata visible without relying on the tone alone. */
   .matrix .num.tone-bad {
     color: var(--bad);
   }
@@ -905,6 +911,12 @@
   }
   .matrix .num.tone-warn {
     color: var(--warn);
+  }
+  .cell-marker {
+    margin-left: 3px;
+    color: var(--warn);
+    font-size: 0.8rem;
+    font-weight: 800;
   }
   .matrix tfoot td,
   .matrix tfoot th {


### PR DESCRIPTION
## Summary

Add an unobtrusive, score-neutral tracker for Hearts players who try to continue play in the wrong direction.

## Changes

- add a collapsed “Other stats” drawer with multi-player wrong-way selection
- retain prior round numbers inside the drawer and mark recorded scorecard cells with ↩
- include wrong-way details in Hearts round summaries and game-specific statistics
- preserve compatibility with legacy rounds that lack the optional metadata

## Issues

Closes #180

## Testing

- [x] `npm run check`
- [x] `npm test`
- [x] `npm run build`
- [x] targeted Prettier check for changed files
- [x] rebased onto the merged baseline CI cleanup from #185