### PR TITLE
feat(players): expand profile customization

### DIFF
--- a/src/lib/components/Avatar.svelte
+++ b/src/lib/components/Avatar.svelte
@@ -47,7 +47,6 @@
 <span
   class="avatar"
   class:gradient={style === 'gradient'}
-  class:tie-dye={style === 'tie-dye'}
   class:photo={Boolean(imageSource && !imageFailed)}
   style="--c:{resolved}; --c2:{resolved2}; --ink:{ink}; width:{size}px; height:{size}px; font-size:{Math.round(
     size * 0.38,
@@ -82,22 +81,6 @@
   }
   .avatar.gradient {
     background: linear-gradient(135deg, var(--c) 8%, var(--c2) 92%);
-  }
-  .avatar.tie-dye {
-    background:
-      radial-gradient(circle at 18% 22%, var(--c2) 0 12%, transparent 13% 30%),
-      radial-gradient(
-        circle at 78% 20%,
-        color-mix(in srgb, var(--c) 48%, var(--c2)) 0 14%,
-        transparent 15% 34%
-      ),
-      radial-gradient(circle at 72% 82%, var(--c2) 0 13%, transparent 14% 34%),
-      radial-gradient(
-        circle at 20% 78%,
-        color-mix(in srgb, var(--c) 70%, white) 0 10%,
-        transparent 11% 30%
-      ),
-      var(--c);
   }
   .avatar img {
     width: 100%;

--- a/src/lib/components/Avatar.svelte
+++ b/src/lib/components/Avatar.svelte
@@ -1,26 +1,67 @@
 <script lang="ts">
   import { initials, resolvePlayerColor, textOn } from '../util';
   import { settings } from '../stores/settings';
+  import { players } from '../stores/players';
+  import { sanitizePlayerAppearance } from '../profile';
+  import type { ID, PlayerAppearance } from '../types';
+
   const {
     name,
     color,
+    playerId,
+    appearance,
     size = 28,
     decorative = false,
-  }: { name: string; color: string; size?: number; decorative?: boolean } = $props();
+  }: {
+    name: string;
+    color: string;
+    playerId?: ID;
+    appearance?: PlayerAppearance;
+    size?: number;
+    decorative?: boolean;
+  } = $props();
 
   const resolved = $derived(resolvePlayerColor(color, $settings.colorBlind));
+  const storedAppearance = $derived.by(() => {
+    if (appearance) return appearance;
+    if (playerId) return $players.find((player) => player.id === playerId)?.appearance;
+    const matches = $players.filter((player) => player.name === name && player.color === color);
+    return matches.length === 1 ? matches[0].appearance : undefined;
+  });
+  const profile = $derived(sanitizePlayerAppearance(storedAppearance));
+  const style = $derived(profile?.style ?? 'solid');
+  const resolved2 = $derived(resolvePlayerColor(profile?.color2 ?? color, $settings.colorBlind));
+  const imageSource = $derived(style === 'image' ? profile?.image : undefined);
   const ink = $derived(textOn(resolved));
+  let imageFailed = $state(false);
+
+  $effect(() => {
+    imageSource;
+    imageFailed = false;
+  });
 </script>
 
 <span
   class="avatar"
-  style="--c:{resolved}; --ink:{ink}; width:{size}px; height:{size}px; font-size:{Math.round(
+  class:gradient={style === 'gradient'}
+  class:tie-dye={style === 'tie-dye'}
+  class:photo={Boolean(imageSource && !imageFailed)}
+  style="--c:{resolved}; --c2:{resolved2}; --ink:{ink}; width:{size}px; height:{size}px; font-size:{Math.round(
     size * 0.38,
   )}px"
   title={decorative ? undefined : name}
+  role={decorative ? undefined : 'img'}
+  aria-label={decorative ? undefined : name}
   aria-hidden={decorative ? 'true' : undefined}
 >
-  {initials(name)}
+  {#if imageSource && !imageFailed}
+    <img src={imageSource} alt="" onerror={() => (imageFailed = true)} />
+  {:else}
+    <span class="initials">{initials(name)}</span>
+  {/if}
+  {#if profile?.emoji && size >= 20}
+    <span class="emoji-badge" aria-hidden="true">{profile.emoji}</span>
+  {/if}
 </span>
 
 <style>
@@ -33,6 +74,60 @@
     color: var(--ink);
     font-weight: 700;
     flex: none;
-    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.18);
+    position: relative;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--bg) 55%, transparent);
+  }
+  .avatar.gradient {
+    background: linear-gradient(135deg, var(--c) 8%, var(--c2) 92%);
+  }
+  .avatar.tie-dye {
+    background:
+      radial-gradient(circle at 18% 22%, var(--c2) 0 12%, transparent 13% 30%),
+      radial-gradient(
+        circle at 78% 20%,
+        color-mix(in srgb, var(--c) 48%, var(--c2)) 0 14%,
+        transparent 15% 34%
+      ),
+      radial-gradient(circle at 72% 82%, var(--c2) 0 13%, transparent 14% 34%),
+      radial-gradient(
+        circle at 20% 78%,
+        color-mix(in srgb, var(--c) 70%, white) 0 10%,
+        transparent 11% 30%
+      ),
+      var(--c);
+  }
+  .avatar img {
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+    object-fit: cover;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--bg) 55%, transparent);
+  }
+  .initials {
+    display: grid;
+    place-items: center;
+    width: 72%;
+    height: 72%;
+    border-radius: 50%;
+    background: var(--c);
+    line-height: 1;
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--ink) 16%, transparent);
+  }
+  .emoji-badge {
+    position: absolute;
+    right: -12%;
+    bottom: -10%;
+    display: grid;
+    place-items: center;
+    width: 48%;
+    height: 48%;
+    min-width: 10px;
+    min-height: 10px;
+    border: max(1px, 0.05em) solid var(--surface, #fff);
+    border-radius: 50%;
+    background: var(--surface, #fff);
+    font-size: 0.68em;
+    line-height: 1;
+    box-shadow: 0 2px 5px color-mix(in srgb, var(--bg) 65%, transparent);
   }
 </style>

--- a/src/lib/components/Avatar.svelte
+++ b/src/lib/components/Avatar.svelte
@@ -35,9 +35,12 @@
   const ink = $derived(textOn(resolved));
   let imageFailed = $state(false);
 
-  $effect(() => {
-    imageSource;
+  function resetImageFailure(_source: string | undefined) {
     imageFailed = false;
+  }
+
+  $effect(() => {
+    resetImageFailure(imageSource);
   });
 </script>
 

--- a/src/lib/components/PlayerSelect.svelte
+++ b/src/lib/components/PlayerSelect.svelte
@@ -41,7 +41,14 @@
         aria-pressed={selected.includes(p.id)}
         onclick={() => toggle(p.id)}
       >
-        <Avatar name={p.name} color={p.color} size={22} decorative />
+        <Avatar
+          name={p.name}
+          color={p.color}
+          playerId={p.id}
+          appearance={p.appearance}
+          size={22}
+          decorative
+        />
         {p.name}
         {#if selected.includes(p.id)}<span class="ord" aria-hidden="true"
             >{selected.indexOf(p.id) + 1}</span

--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  firstGrapheme,
+  isProfileColor,
+  profileImageUrlError,
+  readBoundedImageResponse,
+  safeProfileImageSource,
+  sanitizePlayerAppearance,
+} from './profile';
+
+describe('player profile appearance', () => {
+  it('accepts full hex colors and rejects CSS injection', () => {
+    expect(isProfileColor('#7c5cff')).toBe(true);
+    expect(isProfileColor('linear-gradient(red, blue)')).toBe(false);
+  });
+
+  it('keeps one emoji grapheme, including joined emoji', () => {
+    expect(firstGrapheme('  👩‍🚀 ⭐ ')).toBe('👩‍🚀');
+  });
+
+  it('falls an image style back to solid without safe local image data', () => {
+    expect(
+      sanitizePlayerAppearance({
+        style: 'image',
+        image: 'https://tracker.example/avatar.png',
+        emoji: '🎲🎉',
+      }),
+    ).toEqual({ style: 'solid', emoji: '🎲' });
+  });
+
+  it('accepts resized raster data and rejects SVG data', () => {
+    expect(safeProfileImageSource('data:image/webp;base64,AAAA')).toBeTruthy();
+    expect(safeProfileImageSource('data:image/svg+xml;base64,AAAA')).toBeUndefined();
+  });
+});
+
+describe('profile image URL validation', () => {
+  it('accepts http and https URLs', () => {
+    expect(profileImageUrlError('https://example.com/avatar.png')).toBeNull();
+    expect(profileImageUrlError('http://localhost/avatar.jpg')).toBeNull();
+  });
+
+  it('rejects incomplete and active-scheme URLs', () => {
+    expect(profileImageUrlError('example.com/avatar.png')).toBeTruthy();
+    expect(profileImageUrlError('javascript:alert(1)')).toBeTruthy();
+  });
+});
+
+describe('bounded remote profile images', () => {
+  it('reads a valid raster response', async () => {
+    const response = new Response(new Uint8Array([1, 2, 3]), {
+      headers: { 'content-type': 'image/png' },
+    });
+    const blob = await readBoundedImageResponse(response, 4);
+    expect(blob.size).toBe(3);
+    expect(blob.type).toBe('image/png');
+  });
+
+  it('stops a chunked response once it exceeds the byte limit', async () => {
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.enqueue(new Uint8Array([4, 5, 6]));
+          controller.close();
+        },
+      }),
+      { headers: { 'content-type': 'image/webp' } },
+    );
+    await expect(readBoundedImageResponse(response, 4)).rejects.toThrow(
+      'Choose an image smaller than 8 MB.',
+    );
+  });
+});

--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -32,6 +32,13 @@ describe('player profile appearance', () => {
     expect(safeProfileImageSource('data:image/webp;base64,AAAA')).toBeTruthy();
     expect(safeProfileImageSource('data:image/svg+xml;base64,AAAA')).toBeUndefined();
   });
+
+  it('migrates the removed tie-dye style to a two-color gradient', () => {
+    expect(sanitizePlayerAppearance({ style: 'tie-dye', color2: '#0284c7' })).toEqual({
+      style: 'gradient',
+      color2: '#0284c7',
+    });
+  });
 });
 
 describe('profile image URL validation', () => {

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,0 +1,194 @@
+import type { PlayerAppearance, PlayerAvatarStyle } from './types';
+
+export const PROFILE_IMAGE_MAX_INPUT_BYTES = 8 * 1024 * 1024;
+const PROFILE_IMAGE_MAX_STORED_BYTES = 512 * 1024;
+const PROFILE_IMAGE_SIZE = 320;
+const RASTER_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+const STYLES = new Set<PlayerAvatarStyle>(['solid', 'gradient', 'tie-dye', 'image']);
+const HEX_COLOR = /^#[0-9a-f]{6}$/i;
+const SAFE_IMAGE_DATA = /^data:image\/(?:jpeg|png|webp);base64,/i;
+
+export function isProfileColor(value: unknown): value is string {
+  return typeof value === 'string' && HEX_COLOR.test(value);
+}
+
+export function firstGrapheme(value: string): string {
+  const clean = value.trim();
+  if (!clean) return '';
+  if (typeof Intl !== 'undefined' && 'Segmenter' in Intl) {
+    const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+    return segmenter.segment(clean)[Symbol.iterator]().next().value?.segment ?? '';
+  }
+  return Array.from(clean)[0] ?? '';
+}
+
+export function safeProfileImageSource(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !SAFE_IMAGE_DATA.test(value)) return undefined;
+  return value.length <= Math.ceil((PROFILE_IMAGE_MAX_STORED_BYTES * 4) / 3) + 128
+    ? value
+    : undefined;
+}
+
+export function sanitizePlayerAppearance(value: unknown): PlayerAppearance | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const raw = value as Record<string, unknown>;
+  const style =
+    typeof raw.style === 'string' && STYLES.has(raw.style as PlayerAvatarStyle)
+      ? (raw.style as PlayerAvatarStyle)
+      : 'solid';
+  const color2 = isProfileColor(raw.color2) ? raw.color2.toLowerCase() : undefined;
+  const image = safeProfileImageSource(raw.image);
+  const emoji = typeof raw.emoji === 'string' ? firstGrapheme(raw.emoji) || undefined : undefined;
+
+  return {
+    style: style === 'image' && !image ? 'solid' : style,
+    ...(color2 ? { color2 } : {}),
+    ...(image ? { image } : {}),
+    ...(emoji ? { emoji } : {}),
+  };
+}
+
+export function profileImageUrlError(value: string): string | null {
+  const clean = value.trim();
+  if (!clean) return 'Paste an image URL first.';
+  if (clean.length > 2048) return 'That image URL is too long.';
+  try {
+    const url = new URL(clean);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+      return 'Use an http or https image URL.';
+    }
+  } catch {
+    return 'Enter a complete image URL, including https://.';
+  }
+  return null;
+}
+
+function validateImageBlob(blob: Blob): void {
+  if (!RASTER_IMAGE_TYPES.has(blob.type)) {
+    throw new Error('Choose a PNG, JPEG, or WebP image.');
+  }
+  if (blob.size > PROFILE_IMAGE_MAX_INPUT_BYTES) {
+    throw new Error('Choose an image smaller than 8 MB.');
+  }
+}
+
+export async function readBoundedImageResponse(
+  response: Response,
+  maxBytes = PROFILE_IMAGE_MAX_INPUT_BYTES,
+): Promise<Blob> {
+  const mediaType = (response.headers.get('content-type') ?? '').split(';')[0].toLowerCase();
+  if (!RASTER_IMAGE_TYPES.has(mediaType)) {
+    throw new Error('That URL did not return a PNG, JPEG, or WebP image.');
+  }
+
+  const declaredSize = Number(response.headers.get('content-length') ?? 0);
+  if (declaredSize > maxBytes) throw new Error('Choose an image smaller than 8 MB.');
+  if (!response.body) {
+    const blob = await response.blob();
+    if (blob.size > maxBytes) throw new Error('Choose an image smaller than 8 MB.');
+    return blob;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: ArrayBuffer[] = [];
+  let received = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    received += value.byteLength;
+    if (received > maxBytes) {
+      await reader.cancel();
+      throw new Error('Choose an image smaller than 8 MB.');
+    }
+    chunks.push(value.slice().buffer);
+  }
+  return new Blob(chunks, { type: mediaType });
+}
+
+function loadImage(blob: Blob): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const objectUrl = URL.createObjectURL(blob);
+    const image = new Image();
+    image.decoding = 'async';
+    image.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+      resolve(image);
+    };
+    image.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error('That image could not be opened.'));
+    };
+    image.src = objectUrl;
+  });
+}
+
+function canvasBlob(
+  canvas: HTMLCanvasElement,
+  type: 'image/webp' | 'image/jpeg',
+  quality: number,
+): Promise<Blob | null> {
+  return new Promise((resolve) => canvas.toBlob(resolve, type, quality));
+}
+
+function asDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () =>
+      typeof reader.result === 'string'
+        ? resolve(reader.result)
+        : reject(new Error('That image could not be saved.'));
+    reader.onerror = () => reject(new Error('That image could not be saved.'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+/** Crop and compress a user-provided raster image into a small, offline-safe profile image. */
+export async function prepareProfileImage(blob: Blob): Promise<string> {
+  validateImageBlob(blob);
+  const image = await loadImage(blob);
+  const canvas = document.createElement('canvas');
+  canvas.width = PROFILE_IMAGE_SIZE;
+  canvas.height = PROFILE_IMAGE_SIZE;
+  const context = canvas.getContext('2d');
+  if (!context) throw new Error('This browser cannot prepare profile images.');
+
+  const side = Math.min(image.naturalWidth, image.naturalHeight);
+  const sx = (image.naturalWidth - side) / 2;
+  const sy = (image.naturalHeight - side) / 2;
+  context.drawImage(image, sx, sy, side, side, 0, 0, PROFILE_IMAGE_SIZE, PROFILE_IMAGE_SIZE);
+
+  let output = await canvasBlob(canvas, 'image/webp', 0.82);
+  if (!output || output.size > PROFILE_IMAGE_MAX_STORED_BYTES) {
+    output = await canvasBlob(canvas, 'image/jpeg', 0.78);
+  }
+  if (!output || output.size > PROFILE_IMAGE_MAX_STORED_BYTES) {
+    throw new Error('That image is still too large after resizing. Try a simpler image.');
+  }
+  return asDataUrl(output);
+}
+
+/** Download once, then store the same compact local representation used for uploads. */
+export async function prepareRemoteProfileImage(
+  value: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const validationError = profileImageUrlError(value);
+  if (validationError) throw new Error(validationError);
+
+  let response: Response;
+  try {
+    response = await fetch(value.trim(), {
+      credentials: 'omit',
+      referrerPolicy: 'no-referrer',
+      signal,
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new Error('The image took too long to download. Try uploading it instead.');
+    }
+    throw new Error("That site wouldn't let Score King download the image. Try uploading it.");
+  }
+  if (!response.ok) throw new Error(`The image server returned ${response.status}.`);
+
+  return prepareProfileImage(await readBoundedImageResponse(response));
+}

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -4,7 +4,7 @@ export const PROFILE_IMAGE_MAX_INPUT_BYTES = 8 * 1024 * 1024;
 const PROFILE_IMAGE_MAX_STORED_BYTES = 512 * 1024;
 const PROFILE_IMAGE_SIZE = 320;
 const RASTER_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
-const STYLES = new Set<PlayerAvatarStyle>(['solid', 'gradient', 'tie-dye', 'image']);
+const STYLES = new Set<PlayerAvatarStyle>(['solid', 'gradient', 'image']);
 const HEX_COLOR = /^#[0-9a-f]{6}$/i;
 const SAFE_IMAGE_DATA = /^data:image\/(?:jpeg|png|webp);base64,/i;
 
@@ -33,9 +33,11 @@ export function sanitizePlayerAppearance(value: unknown): PlayerAppearance | und
   if (!value || typeof value !== 'object') return undefined;
   const raw = value as Record<string, unknown>;
   const style =
-    typeof raw.style === 'string' && STYLES.has(raw.style as PlayerAvatarStyle)
-      ? (raw.style as PlayerAvatarStyle)
-      : 'solid';
+    raw.style === 'tie-dye'
+      ? 'gradient'
+      : typeof raw.style === 'string' && STYLES.has(raw.style as PlayerAvatarStyle)
+        ? (raw.style as PlayerAvatarStyle)
+        : 'solid';
   const color2 = isProfileColor(raw.color2) ? raw.color2.toLowerCase() : undefined;
   const image = safeProfileImageSource(raw.image);
   const emoji = typeof raw.emoji === 'string' ? firstGrapheme(raw.emoji) || undefined : undefined;

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -184,9 +184,13 @@ export async function prepareRemoteProfileImage(
     });
   } catch (error) {
     if (error instanceof DOMException && error.name === 'AbortError') {
-      throw new Error('The image took too long to download. Try uploading it instead.');
+      throw new Error('The image took too long to download. Try uploading it instead.', {
+        cause: error,
+      });
     }
-    throw new Error("That site wouldn't let Score King download the image. Try uploading it.");
+    throw new Error("That site wouldn't let Score King download the image. Try uploading it.", {
+      cause: error,
+    });
   }
   if (!response.ok) throw new Error(`The image server returned ${response.status}.`);
 

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -2,6 +2,7 @@ import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
 import type { Game, ID, Player, Round } from '../types';
 import type { CustomGameDef } from '../games/custom/types';
 import { uid, cleanName } from '../util';
+import { sanitizePlayerAppearance } from '../profile';
 import { markDataChanged } from './changes';
 import { reportStorageError } from '../stores/storage';
 
@@ -59,7 +60,12 @@ function db(): Promise<IDBPDatabase<ScoreKingDB>> {
 // ---- Players ----
 /** Default identity fields that legacy records (pre-Member) won't have on disk. */
 function normalizePlayer(p: Player): Player {
-  return { ...p, claimed: p.claimed ?? true, archived: p.archived ?? false };
+  return {
+    ...p,
+    appearance: sanitizePlayerAppearance(p.appearance),
+    claimed: p.claimed ?? true,
+    archived: p.archived ?? false,
+  };
 }
 
 export async function getAllPlayers(): Promise<Player[]> {

--- a/src/lib/stores/players.ts
+++ b/src/lib/stores/players.ts
@@ -1,8 +1,9 @@
 import { writable, derived, get } from 'svelte/store';
-import type { Player, ID } from '../types';
+import type { Player, ID, PlayerAppearance } from '../types';
 import type { BackupSettings } from './settings';
 import * as db from '../storage/db';
 import { pickColor, generateHandle, cleanName, sameName } from '../util';
+import { isProfileColor, sanitizePlayerAppearance } from '../profile';
 import { pruneDeletedPlayers } from './presets';
 import { reportStorageError } from './storage';
 
@@ -54,8 +55,18 @@ export async function renamePlayer(player: Player, name: string): Promise<void> 
   await refreshPlayers();
 }
 
-export async function recolorPlayer(player: Player, color: string): Promise<void> {
-  await db.updatePlayer({ ...player, color });
+export async function updatePlayerProfile(
+  player: Player,
+  profile: { name: string; color: string; appearance?: PlayerAppearance },
+): Promise<void> {
+  const color = isProfileColor(profile.color) ? profile.color.toLowerCase() : player.color;
+  await db.updatePlayer({
+    ...player,
+    name: cleanName(profile.name),
+    color,
+    appearance: sanitizePlayerAppearance(profile.appearance),
+    claimed: true,
+  });
   await refreshPlayers();
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,12 +4,12 @@ import type { BackupSettings } from './stores/settings';
 
 export type ID = string;
 
-export type PlayerAvatarStyle = 'solid' | 'gradient' | 'tie-dye' | 'image';
+export type PlayerAvatarStyle = 'solid' | 'gradient' | 'image';
 
 /** Optional visual treatment layered over a player's durable identifying color. */
 export interface PlayerAppearance {
   style: PlayerAvatarStyle;
-  /** Second color used by gradient and tie-dye treatments. */
+  /** Second color used by gradient treatments. */
   color2?: string;
   /** Locally cached, resized raster image data. */
   image?: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,19 @@ import type { BackupSettings } from './stores/settings';
 
 export type ID = string;
 
+export type PlayerAvatarStyle = 'solid' | 'gradient' | 'tie-dye' | 'image';
+
+/** Optional visual treatment layered over a player's durable identifying color. */
+export interface PlayerAppearance {
+  style: PlayerAvatarStyle;
+  /** Second color used by gradient and tie-dye treatments. */
+  color2?: string;
+  /** Locally cached, resized raster image data. */
+  image?: string;
+  /** Optional single-grapheme badge layered over the avatar. */
+  emoji?: string;
+}
+
 /**
  * A gamer — the unified "Member" entity from ARCHITECTURE.md (one record for a
  * person: their seat in a game *and* their identity). Named `Player` because that's
@@ -14,6 +27,8 @@ export interface Player {
   /** Display handle. Auto-generated and whimsical until the gamer claims it. */
   name: string;
   color: string;
+  /** Expressive avatar styling. Absent records render as the legacy solid-color avatar. */
+  appearance?: PlayerAppearance;
   createdAt: number;
   /** True once the gamer renames the auto-generated handle to claim this identity. */
   claimed?: boolean;

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -42,20 +42,22 @@ export function rosterFor(playerIds: ID[], roster: Player[]): Player[] {
   );
 }
 
-export const PALETTE = [
-  '#7c5cff',
-  '#34d399',
-  '#f87171',
-  '#fbbf24',
-  '#38bdf8',
-  '#fb7185',
-  '#a78bfa',
-  '#4ade80',
-  '#f59e0b',
-  '#22d3ee',
-  '#e879f9',
-  '#facc15',
+export const PLAYER_COLOR_CHOICES: ReadonlyArray<{ name: string; value: string }> = [
+  { name: 'Royal Violet', value: '#7c5cff' },
+  { name: 'Emerald', value: '#34d399' },
+  { name: 'Coral', value: '#f87171' },
+  { name: 'Marigold', value: '#fbbf24' },
+  { name: 'Sky', value: '#38bdf8' },
+  { name: 'Watermelon', value: '#fb7185' },
+  { name: 'Lavender', value: '#a78bfa' },
+  { name: 'Meadow', value: '#4ade80' },
+  { name: 'Tangerine', value: '#f59e0b' },
+  { name: 'Lagoon', value: '#22d3ee' },
+  { name: 'Orchid', value: '#e879f9' },
+  { name: 'Sunbeam', value: '#facc15' },
 ];
+
+export const PALETTE = PLAYER_COLOR_CHOICES.map(({ value }) => value);
 
 /**
  * Color-blind-friendly counterparts to PALETTE, index-for-index, drawn from the

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -44,17 +44,17 @@ export function rosterFor(playerIds: ID[], roster: Player[]): Player[] {
 
 export const PLAYER_COLOR_CHOICES: ReadonlyArray<{ name: string; value: string }> = [
   { name: 'Royal Violet', value: '#7c5cff' },
-  { name: 'Emerald', value: '#34d399' },
-  { name: 'Coral', value: '#f87171' },
-  { name: 'Marigold', value: '#fbbf24' },
-  { name: 'Sky', value: '#38bdf8' },
-  { name: 'Watermelon', value: '#fb7185' },
-  { name: 'Lavender', value: '#a78bfa' },
-  { name: 'Meadow', value: '#4ade80' },
-  { name: 'Tangerine', value: '#f59e0b' },
-  { name: 'Lagoon', value: '#22d3ee' },
-  { name: 'Orchid', value: '#e879f9' },
-  { name: 'Sunbeam', value: '#facc15' },
+  { name: 'Cobalt', value: '#1d4ed8' },
+  { name: 'Ocean', value: '#0284c7' },
+  { name: 'Teal', value: '#0f766e' },
+  { name: 'Forest', value: '#15803d' },
+  { name: 'Lime', value: '#65a30d' },
+  { name: 'Ochre', value: '#b7791f' },
+  { name: 'Tangerine', value: '#ea580c' },
+  { name: 'Scarlet', value: '#dc2626' },
+  { name: 'Raspberry', value: '#db2777' },
+  { name: 'Orchid', value: '#c026d3' },
+  { name: 'Cocoa', value: '#8b5e3c' },
 ];
 
 export const PALETTE = PLAYER_COLOR_CHOICES.map(({ value }) => value);
@@ -66,17 +66,17 @@ export const PALETTE = PLAYER_COLOR_CHOICES.map(({ value }) => value);
  */
 export const CVD_PALETTE = [
   '#332288',
+  '#0077bb',
+  '#66ccee',
   '#44aa99',
+  '#117733',
+  '#999933',
+  '#ddcc77',
+  '#d55e00',
   '#cc6677',
-  '#e69f00',
-  '#56b4e9',
   '#882255',
   '#aa4499',
-  '#117733',
-  '#d55e00',
-  '#88ccee',
-  '#ddcc77',
-  '#999933',
+  '#8c613c',
 ];
 
 export function pickColor(used: string[]): string {

--- a/src/pages/Players.svelte
+++ b/src/pages/Players.svelte
@@ -39,7 +39,36 @@
   let imageRequestId = 0;
   let showArchived = $state(false);
   let confirmDeleteId = $state<string | null>(null);
-  const emojiChoices = ['👑', '🎲', '🐉', '🦊', '🌈', '⭐', '🔥', '🦄'];
+  const emojiChoices = [
+    { emoji: '👑', name: 'Crown' },
+    { emoji: '🎲', name: 'Dice' },
+    { emoji: '🃏', name: 'Playing card' },
+    { emoji: '🏆', name: 'Trophy' },
+    { emoji: '⭐', name: 'Star' },
+    { emoji: '🔥', name: 'Fire' },
+    { emoji: '🌈', name: 'Rainbow' },
+    { emoji: '✨', name: 'Sparkles' },
+    { emoji: '⚡', name: 'Lightning' },
+    { emoji: '🎯', name: 'Bullseye' },
+    { emoji: '💎', name: 'Gem' },
+    { emoji: '🚀', name: 'Rocket' },
+    { emoji: '🐉', name: 'Dragon' },
+    { emoji: '🦊', name: 'Fox' },
+    { emoji: '🐸', name: 'Frog' },
+    { emoji: '🐙', name: 'Octopus' },
+    { emoji: '🦄', name: 'Unicorn' },
+    { emoji: '🐧', name: 'Penguin' },
+    { emoji: '🦖', name: 'Dinosaur' },
+    { emoji: '🐝', name: 'Bee' },
+    { emoji: '👻', name: 'Ghost' },
+    { emoji: '👽', name: 'Alien' },
+    { emoji: '🍕', name: 'Pizza' },
+    { emoji: '🍄', name: 'Mushroom' },
+    { emoji: '🌵', name: 'Cactus' },
+    { emoji: '🍒', name: 'Cherries' },
+    { emoji: '⚽', name: 'Soccer ball' },
+    { emoji: '🎮', name: 'Game controller' },
+  ] as const;
 
   const archived = $derived($players.filter((p) => p.archived));
   // Live hint while typing so a duplicate is caught before it lands on the board.
@@ -65,7 +94,7 @@
     editColor2 =
       p.appearance?.color2 ??
       PLAYER_COLOR_CHOICES.find(({ value }) => value !== p.color)?.value ??
-      '#22d3ee';
+      '#0284c7';
     editStyle = p.appearance?.style ?? 'solid';
     editImage = p.appearance?.image;
     editEmoji = p.appearance?.emoji ?? '';
@@ -95,7 +124,7 @@
   function draftAppearance(): PlayerAppearance {
     return {
       style: editStyle === 'image' && !editImage ? 'solid' : editStyle,
-      ...(['gradient', 'tie-dye'].includes(editStyle) ? { color2: editColor2 } : {}),
+      ...(editStyle === 'gradient' ? { color2: editColor2 } : {}),
       ...(editStyle === 'image' && editImage ? { image: editImage } : {}),
       ...(firstGrapheme(editEmoji) ? { emoji: firstGrapheme(editEmoji) } : {}),
     };
@@ -301,17 +330,6 @@
                 <button
                   type="button"
                   class="style-choice"
-                  class:sel={editStyle === 'tie-dye'}
-                  aria-pressed={editStyle === 'tie-dye'}
-                  onclick={() => (editStyle = 'tie-dye')}
-                >
-                  <span class="style-sample tie-dye" style="--c:{editColor}; --c2:{editColor2}"
-                  ></span>
-                  Tie-dye
-                </button>
-                <button
-                  type="button"
-                  class="style-choice"
                   class:sel={editStyle === 'image'}
                   aria-pressed={editStyle === 'image'}
                   onclick={() => (editStyle = 'image')}
@@ -348,7 +366,7 @@
               </div>
             </fieldset>
 
-            {#if editStyle === 'gradient' || editStyle === 'tie-dye'}
+            {#if editStyle === 'gradient'}
               <fieldset class="profile-section">
                 <legend>Second color</legend>
                 <div class="swatches" role="group" aria-label="Second player color">
@@ -441,14 +459,15 @@
                   aria-pressed={!editEmoji}
                   onclick={() => (editEmoji = '')}>None</button
                 >
-                {#each emojiChoices as emoji (emoji)}
+                {#each emojiChoices as choice (choice.emoji)}
                   <button
                     type="button"
                     class="emoji-choice"
-                    class:sel={firstGrapheme(editEmoji) === emoji}
-                    aria-label={`Use ${emoji} badge`}
-                    aria-pressed={firstGrapheme(editEmoji) === emoji}
-                    onclick={() => (editEmoji = emoji)}>{emoji}</button
+                    class:sel={firstGrapheme(editEmoji) === choice.emoji}
+                    aria-label={`Use ${choice.name} badge`}
+                    aria-pressed={firstGrapheme(editEmoji) === choice.emoji}
+                    title={choice.name}
+                    onclick={() => (editEmoji = choice.emoji)}>{choice.emoji}</button
                   >
                 {/each}
                 <input
@@ -570,7 +589,7 @@
   }
   @media (min-width: 440px) {
     .style-grid {
-      grid-template-columns: repeat(4, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
   .style-choice {
@@ -601,11 +620,6 @@
   }
   .style-sample.gradient {
     background: linear-gradient(135deg, var(--c), var(--c2));
-  }
-  .style-sample.tie-dye {
-    background:
-      radial-gradient(circle at 20% 25%, var(--c2) 0 14%, transparent 15% 34%),
-      radial-gradient(circle at 75% 70%, var(--c2) 0 16%, transparent 17% 36%), var(--c);
   }
   .style-sample.photo {
     display: grid;

--- a/src/pages/Players.svelte
+++ b/src/pages/Players.svelte
@@ -4,25 +4,42 @@
     activePlayers,
     createPlayer,
     generatePlayer,
-    renamePlayer,
-    recolorPlayer,
+    updatePlayerProfile,
     archivePlayer,
     restorePlayer,
     removePlayer,
     nameExists,
   } from '../lib/stores/players';
   import { leadMember, setLeadMember } from '../lib/stores/identity';
-  import { PALETTE, resolvePlayerColor, MAX_NAME_LEN } from '../lib/util';
+  import { PLAYER_COLOR_CHOICES, resolvePlayerColor, MAX_NAME_LEN } from '../lib/util';
+  import {
+    firstGrapheme,
+    prepareProfileImage,
+    prepareRemoteProfileImage,
+    profileImageUrlError,
+  } from '../lib/profile';
   import { settings } from '../lib/stores/settings';
   import { showToast } from '../lib/stores/toast';
   import Avatar from '../lib/components/Avatar.svelte';
-  import type { Player } from '../lib/types';
+  import type { Player, PlayerAppearance, PlayerAvatarStyle } from '../lib/types';
 
   let newName = $state('');
   let editingId = $state<string | null>(null);
   let editName = $state('');
+  let editColor = $state('#7c5cff');
+  let editColor2 = $state('#22d3ee');
+  let editStyle = $state<PlayerAvatarStyle>('solid');
+  let editImage = $state<string | undefined>();
+  let editEmoji = $state('');
+  let imageUrl = $state('');
+  let imageError = $state('');
+  let imageBusy = $state(false);
+  let imageFileInput = $state<HTMLInputElement>();
+  let imageAbortController: AbortController | undefined;
+  let imageRequestId = 0;
   let showArchived = $state(false);
   let confirmDeleteId = $state<string | null>(null);
+  const emojiChoices = ['👑', '🎲', '🐉', '🦊', '🌈', '⭐', '🔥', '🦄'];
 
   const archived = $derived($players.filter((p) => p.archived));
   // Live hint while typing so a duplicate is caught before it lands on the board.
@@ -41,12 +58,107 @@
     if (dup) showToast(`Two players named “${n}” — rename one to tell them apart.`);
   }
   function startEdit(p: Player) {
+    cancelImageRequest();
     editingId = p.id;
     editName = p.name;
+    editColor = p.color;
+    editColor2 =
+      p.appearance?.color2 ??
+      PLAYER_COLOR_CHOICES.find(({ value }) => value !== p.color)?.value ??
+      '#22d3ee';
+    editStyle = p.appearance?.style ?? 'solid';
+    editImage = p.appearance?.image;
+    editEmoji = p.appearance?.emoji ?? '';
+    imageUrl = '';
+    imageError = '';
   }
   async function saveEdit(p: Player) {
-    if (editName.trim()) await renamePlayer(p, editName);
+    if (!editName.trim() || imageBusy) return;
+    await updatePlayerProfile(p, {
+      name: editName,
+      color: editColor,
+      appearance: draftAppearance(),
+    });
     editingId = null;
+  }
+  function cancelEdit() {
+    cancelImageRequest();
+    editingId = null;
+    imageError = '';
+  }
+  function cancelImageRequest() {
+    imageRequestId += 1;
+    imageAbortController?.abort();
+    imageAbortController = undefined;
+    imageBusy = false;
+  }
+  function draftAppearance(): PlayerAppearance {
+    return {
+      style: editStyle === 'image' && !editImage ? 'solid' : editStyle,
+      ...(['gradient', 'tie-dye'].includes(editStyle) ? { color2: editColor2 } : {}),
+      ...(editStyle === 'image' && editImage ? { image: editImage } : {}),
+      ...(firstGrapheme(editEmoji) ? { emoji: firstGrapheme(editEmoji) } : {}),
+    };
+  }
+  async function useImage(blob: Blob) {
+    const playerId = editingId;
+    const requestId = ++imageRequestId;
+    imageAbortController?.abort();
+    imageAbortController = undefined;
+    imageBusy = true;
+    imageError = '';
+    try {
+      const image = await prepareProfileImage(blob);
+      if (requestId === imageRequestId && editingId === playerId) {
+        editImage = image;
+        editStyle = 'image';
+      }
+    } catch (error) {
+      if (requestId === imageRequestId && editingId === playerId) {
+        imageError = error instanceof Error ? error.message : 'That image could not be prepared.';
+      }
+    } finally {
+      if (requestId === imageRequestId) imageBusy = false;
+    }
+  }
+  async function chooseImage(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    if (file) await useImage(file);
+    input.value = '';
+  }
+  async function useImageUrl() {
+    const validationError = profileImageUrlError(imageUrl);
+    if (validationError) {
+      imageError = validationError;
+      return;
+    }
+    const playerId = editingId;
+    const requestId = ++imageRequestId;
+    imageAbortController?.abort();
+    imageBusy = true;
+    imageError = '';
+    const controller = new AbortController();
+    imageAbortController = controller;
+    const timeout = window.setTimeout(() => controller.abort(), 12_000);
+    try {
+      const image = await prepareRemoteProfileImage(imageUrl, controller.signal);
+      if (requestId === imageRequestId && editingId === playerId) {
+        editImage = image;
+        editStyle = 'image';
+        imageUrl = '';
+      }
+    } catch (error) {
+      if (requestId === imageRequestId && editingId === playerId) {
+        imageError = error instanceof Error ? error.message : 'That image could not be downloaded.';
+      }
+    } finally {
+      window.clearTimeout(timeout);
+      if (requestId === imageRequestId) {
+        imageAbortController = undefined;
+        imageBusy = false;
+      }
+    }
   }
   function toggleLead(p: Player) {
     setLeadMember($leadMember?.id === p.id ? null : p.id);
@@ -111,7 +223,13 @@
       <div class="card" class:lead={$leadMember?.id === p.id} class:editing={editingId === p.id}>
         <div class="row spread">
           <span class="row grow" style="gap: 10px; min-width: 0">
-            <Avatar name={p.name} color={p.color} size={34} />
+            <Avatar
+              name={editingId === p.id ? editName || p.name : p.name}
+              color={editingId === p.id ? editColor : p.color}
+              playerId={p.id}
+              appearance={editingId === p.id ? draftAppearance() : p.appearance}
+              size={editingId === p.id ? 52 : 34}
+            />
             {#if editingId === p.id}
               <input
                 class="grow"
@@ -149,30 +267,211 @@
                 class="iconbtn"
                 onclick={() => startEdit(p)}
                 aria-label="Edit player"
-                title="Rename & recolour">✎</button
+                title="Edit profile">✎</button
               >
             </span>
           {/if}
         </div>
         {#if editingId === p.id}
           <div class="editpanel">
-            <div class="row wrap swatches" role="group" aria-label="Player colour">
-              {#each PALETTE as c (c)}
+            <fieldset class="profile-section">
+              <legend>Avatar style</legend>
+              <div class="style-grid">
                 <button
-                  class="dot"
-                  class:sel={p.color === c}
-                  style="background: {resolvePlayerColor(c, $settings.colorBlind)}"
-                  onclick={() => recolorPlayer(p, c)}
-                  aria-label="Set colour"
-                  aria-pressed={p.color === c}
-                ></button>
-              {/each}
-            </div>
+                  type="button"
+                  class="style-choice"
+                  class:sel={editStyle === 'solid'}
+                  aria-pressed={editStyle === 'solid'}
+                  onclick={() => (editStyle = 'solid')}
+                >
+                  <span class="style-sample solid" style="--c:{editColor}"></span>
+                  Solid
+                </button>
+                <button
+                  type="button"
+                  class="style-choice"
+                  class:sel={editStyle === 'gradient'}
+                  aria-pressed={editStyle === 'gradient'}
+                  onclick={() => (editStyle = 'gradient')}
+                >
+                  <span class="style-sample gradient" style="--c:{editColor}; --c2:{editColor2}"
+                  ></span>
+                  Gradient
+                </button>
+                <button
+                  type="button"
+                  class="style-choice"
+                  class:sel={editStyle === 'tie-dye'}
+                  aria-pressed={editStyle === 'tie-dye'}
+                  onclick={() => (editStyle = 'tie-dye')}
+                >
+                  <span class="style-sample tie-dye" style="--c:{editColor}; --c2:{editColor2}"
+                  ></span>
+                  Tie-dye
+                </button>
+                <button
+                  type="button"
+                  class="style-choice"
+                  class:sel={editStyle === 'image'}
+                  aria-pressed={editStyle === 'image'}
+                  onclick={() => (editStyle = 'image')}
+                >
+                  <span class="style-sample photo" aria-hidden="true">📷</span>
+                  Image
+                </button>
+              </div>
+            </fieldset>
+
+            <fieldset class="profile-section">
+              <legend>{editStyle === 'image' ? 'Fallback color' : 'Primary color'}</legend>
+              <div class="swatches" role="group" aria-label="Player color">
+                {#each PLAYER_COLOR_CHOICES as choice (choice.value)}
+                  <button
+                    type="button"
+                    class="dot"
+                    class:sel={editColor.toLowerCase() === choice.value}
+                    style="--swatch:{resolvePlayerColor(choice.value, $settings.colorBlind)}"
+                    onclick={() => (editColor = choice.value)}
+                    aria-label={choice.name}
+                    aria-pressed={editColor.toLowerCase() === choice.value}
+                    title={choice.name}
+                  ></button>
+                {/each}
+                <label class="custom-color">
+                  <input
+                    type="color"
+                    bind:value={editColor}
+                    aria-label="Choose any primary color"
+                  />
+                  <span>Any color</span>
+                </label>
+              </div>
+            </fieldset>
+
+            {#if editStyle === 'gradient' || editStyle === 'tie-dye'}
+              <fieldset class="profile-section">
+                <legend>Second color</legend>
+                <div class="swatches" role="group" aria-label="Second player color">
+                  {#each PLAYER_COLOR_CHOICES as choice (choice.value)}
+                    <button
+                      type="button"
+                      class="dot"
+                      class:sel={editColor2.toLowerCase() === choice.value}
+                      style="--swatch:{resolvePlayerColor(choice.value, $settings.colorBlind)}"
+                      onclick={() => (editColor2 = choice.value)}
+                      aria-label={choice.name}
+                      aria-pressed={editColor2.toLowerCase() === choice.value}
+                      title={choice.name}
+                    ></button>
+                  {/each}
+                  <label class="custom-color">
+                    <input
+                      type="color"
+                      bind:value={editColor2}
+                      aria-label="Choose any second color"
+                    />
+                    <span>Any color</span>
+                  </label>
+                </div>
+              </fieldset>
+            {/if}
+
+            {#if editStyle === 'image'}
+              <fieldset class="profile-section image-section" aria-busy={imageBusy}>
+                <legend>Profile image</legend>
+                <p class="section-help">
+                  Images are cropped, resized, and saved with your profile for offline play.
+                </p>
+                <div class="row wrap">
+                  <button
+                    type="button"
+                    class="btn small"
+                    disabled={imageBusy}
+                    onclick={() => imageFileInput?.click()}
+                  >
+                    {editImage ? 'Replace upload' : 'Upload image'}
+                  </button>
+                  {#if editImage}
+                    <button
+                      type="button"
+                      class="btn small ghost"
+                      onclick={() => {
+                        editImage = undefined;
+                        editStyle = 'solid';
+                      }}>Remove image</button
+                    >
+                  {/if}
+                </div>
+                <input
+                  bind:this={imageFileInput}
+                  class="file-input"
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp"
+                  onchange={chooseImage}
+                />
+                <div class="url-row">
+                  <input
+                    type="url"
+                    inputmode="url"
+                    placeholder="https://example.com/photo.jpg"
+                    aria-label="Image URL"
+                    bind:value={imageUrl}
+                  />
+                  <button
+                    type="button"
+                    class="btn small"
+                    disabled={imageBusy || !imageUrl.trim()}
+                    onclick={useImageUrl}>{imageBusy ? 'Loading…' : 'Use URL'}</button
+                  >
+                </div>
+                {#if imageError}
+                  <p class="image-error" role="alert">{imageError}</p>
+                {/if}
+              </fieldset>
+            {/if}
+
+            <fieldset class="profile-section">
+              <legend>Emoji badge <span class="optional">(optional)</span></legend>
+              <div class="emoji-row" role="group" aria-label="Emoji badge">
+                <button
+                  type="button"
+                  class="emoji-choice clear"
+                  class:sel={!editEmoji}
+                  aria-label="No emoji badge"
+                  aria-pressed={!editEmoji}
+                  onclick={() => (editEmoji = '')}>None</button
+                >
+                {#each emojiChoices as emoji (emoji)}
+                  <button
+                    type="button"
+                    class="emoji-choice"
+                    class:sel={firstGrapheme(editEmoji) === emoji}
+                    aria-label={`Use ${emoji} badge`}
+                    aria-pressed={firstGrapheme(editEmoji) === emoji}
+                    onclick={() => (editEmoji = emoji)}>{emoji}</button
+                  >
+                {/each}
+                <input
+                  class="emoji-input"
+                  type="text"
+                  maxlength="16"
+                  placeholder="Your emoji"
+                  aria-label="Custom emoji badge"
+                  bind:value={editEmoji}
+                  onblur={() => (editEmoji = firstGrapheme(editEmoji))}
+                />
+              </div>
+            </fieldset>
+
             <div class="row spread editactions">
               <button class="btn small ghost danger" onclick={() => archive(p)}>Archive</button>
               <span class="row" style="gap: 6px">
-                <button class="btn small ghost" onclick={() => (editingId = null)}>Cancel</button>
-                <button class="btn small primary" onclick={() => saveEdit(p)}>Save</button>
+                <button class="btn small ghost" onclick={cancelEdit}>Cancel</button>
+                <button
+                  class="btn small"
+                  onclick={() => saveEdit(p)}
+                  disabled={!editName.trim() || imageBusy}>Save profile</button
+                >
               </span>
             </div>
           </div>
@@ -194,7 +493,13 @@
         <div class="card arch">
           <div class="row spread">
             <span class="row" style="gap: 10px">
-              <Avatar name={p.name} color={p.color} size={28} />
+              <Avatar
+                name={p.name}
+                color={p.color}
+                playerId={p.id}
+                appearance={p.appearance}
+                size={28}
+              />
               <span class="muted">{p.name}</span>
             </span>
             {#if confirmDeleteId === p.id}
@@ -243,24 +548,194 @@
     border-top: 1px solid var(--border);
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 16px;
+  }
+  .profile-section {
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+  }
+  .profile-section legend {
+    margin-bottom: 8px;
+    padding: 0;
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--muted);
+  }
+  .style-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+  @media (min-width: 440px) {
+    .style-grid {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+  .style-choice {
+    min-height: 58px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 650;
+  }
+  .style-choice.sel,
+  .emoji-choice.sel {
+    border-color: var(--primary);
+    background: color-mix(in srgb, var(--primary) 13%, var(--surface-2));
+  }
+  .style-sample {
+    width: 30px;
+    height: 30px;
+    flex: none;
+    border-radius: 50%;
+    background: var(--c);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--bg) 55%, transparent);
+  }
+  .style-sample.gradient {
+    background: linear-gradient(135deg, var(--c), var(--c2));
+  }
+  .style-sample.tie-dye {
+    background:
+      radial-gradient(circle at 20% 25%, var(--c2) 0 14%, transparent 15% 34%),
+      radial-gradient(circle at 75% 70%, var(--c2) 0 16%, transparent 17% 36%), var(--c);
+  }
+  .style-sample.photo {
+    display: grid;
+    place-items: center;
+    background: var(--surface-3);
+    font-size: 1rem;
   }
   .swatches {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(46px, 1fr));
     gap: 8px;
   }
   .dot {
-    width: 26px;
-    height: 26px;
+    min-width: 46px;
+    height: 46px;
     border-radius: 50%;
-    border: 2px solid transparent;
+    border: 3px solid transparent;
+    background: var(--swatch);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--bg) 55%, transparent);
     cursor: pointer;
-    transition: transform 0.12s ease;
+    transition: transform var(--dur-fast) var(--ease-out);
   }
   .dot:hover {
     transform: scale(1.12);
   }
   .dot.sel {
     border-color: var(--text);
+    box-shadow:
+      inset 0 0 0 2px var(--surface),
+      0 0 0 1px var(--text);
+  }
+  .custom-color {
+    min-width: 96px;
+    min-height: 58px;
+    display: grid;
+    grid-template-columns: 46px 1fr;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 8px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font-size: 0.8rem;
+    font-weight: 650;
+  }
+  .custom-color input {
+    width: 46px;
+    height: 46px;
+    padding: 0;
+    border: 0;
+    border-radius: 50%;
+    background: none;
+    cursor: pointer;
+  }
+  .custom-color input::-webkit-color-swatch-wrapper {
+    padding: 0;
+  }
+  .custom-color input::-webkit-color-swatch {
+    border: 1px solid var(--border);
+    border-radius: 50%;
+  }
+  .section-help {
+    margin: -2px 0 10px;
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+  .file-input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+  }
+  .url-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    margin-top: 10px;
+  }
+  .url-row input[type='url'] {
+    width: 100%;
+    min-width: 0;
+    min-height: 46px;
+    padding: 11px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+  }
+  .url-row input[type='url']:focus {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .image-error {
+    margin: 8px 0 0;
+    color: var(--bad);
+    font-size: 0.9rem;
+  }
+  .emoji-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .emoji-choice {
+    min-width: 46px;
+    min-height: 46px;
+    padding: 6px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font-size: 1.25rem;
+  }
+  .emoji-choice.clear {
+    padding-inline: 10px;
+    font-size: 0.8rem;
+    font-weight: 650;
+  }
+  .emoji-input {
+    width: 116px !important;
+    flex: 1 1 116px;
+  }
+  .optional {
+    font-weight: 500;
+  }
+  .editpanel .btn.small {
+    min-height: 46px;
   }
   .card.lead {
     border-color: var(--accent);
@@ -282,7 +757,8 @@
   }
   @media (prefers-reduced-motion: reduce) {
     .card,
-    .dot {
+    .dot,
+    .style-choice {
       transition: none;
     }
     .dot:hover {


### PR DESCRIPTION
## Summary

Add expressive, offline-safe player profile customization while preserving existing solid-color profiles.

## Changes

- add a more widely separated 12-color default palette plus full custom color pickers
- support solid, two-color gradient, and image avatars; legacy tie-dye profiles migrate safely to gradients
- support uploaded and URL-sourced raster images, cropped and compressed into bounded local profile data
- expand optional emoji badges to 28 named game-night, animal, food, space, and playful choices
- add accessible avatar naming, resilient contrast treatments, and 46px touch targets without mobile overflow
- persist appearance metadata through the existing player backup and sync model
- guard remote downloads, stale async edits, unsafe imported appearance data, and image failures

## Issues

Closes #181

## Testing

- [x] `npm run check`
- [x] `npm test` — 70 files, 2,030 tests
- [x] `npm run build`
- [x] Prettier check for changed files
- [x] Desktop and 342px-wide browser interaction passes for editing, saving, error handling, overflow, touch targets, and rendering in game setup
- [x] PR Web CI, lint, performance, security, relay, config-integrity, and semantic-title checks